### PR TITLE
Add init command to agentevo for setting up VS Code prompts

### DIFF
--- a/apps/cli/src/commands/init/index.ts
+++ b/apps/cli/src/commands/init/index.ts
@@ -1,0 +1,40 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { TemplateManager } from "../../templates/index.js";
+
+export interface InitCommandOptions {
+  targetPath?: string;
+}
+
+export async function initCommand(options: InitCommandOptions = {}): Promise<void> {
+  const targetPath = path.resolve(options.targetPath ?? ".");
+  const githubDir = path.join(targetPath, ".github");
+
+  // Create .github directory if it doesn't exist
+  if (!existsSync(githubDir)) {
+    mkdirSync(githubDir, { recursive: true });
+  }
+
+  // Get templates
+  const templates = TemplateManager.getTemplates();
+
+  // Copy each template to .github
+  for (const template of templates) {
+    const targetFilePath = path.join(githubDir, template.path);
+    const targetDirPath = path.dirname(targetFilePath);
+
+    // Create directory if needed
+    if (!existsSync(targetDirPath)) {
+      mkdirSync(targetDirPath, { recursive: true });
+    }
+
+    // Write file
+    writeFileSync(targetFilePath, template.content, "utf-8");
+    console.log(`Created ${path.relative(targetPath, targetFilePath)}`);
+  }
+
+  console.log("\nAgentEvo initialized successfully!");
+  console.log(`\nFiles installed to ${path.relative(targetPath, githubDir)}:`);
+  templates.forEach((t) => console.log(`  - ${t.path}`));
+  console.log("\nYou can now create eval files using the schema and prompt templates.");
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 
 import { registerEvalCommand } from "./commands/eval/index.js";
 import { registerStatusCommand } from "./commands/status.js";
+import { initCommand } from "./commands/init/index.js";
 
 const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
 
@@ -13,6 +14,19 @@ export function createProgram(): Command {
 
   registerStatusCommand(program);
   registerEvalCommand(program);
+
+  // Init command
+  program
+    .command("init [path]")
+    .description("Initialize AgentEvo in your project (installs prompt templates and schema to .github)")
+    .action(async (targetPath?: string) => {
+      try {
+        await initCommand({ targetPath });
+      } catch (error) {
+        console.error(`Error: ${(error as Error).message}`);
+        process.exit(1);
+      }
+    });
 
   return program;
 }

--- a/apps/cli/src/templates/eval-build.prompt.md
+++ b/apps/cli/src/templates/eval-build.prompt.md
@@ -1,0 +1,100 @@
+---
+description: 'Apply when writing evals in YAML format'
+---
+
+## Schema Reference
+- Schema: #file:../contexts/eval-schema.json (JSON Schema for validation and tooling)
+- Format: YAML with structured content arrays
+
+## Structure Requirements
+- Root level: `version` (required: "2.0"), `description` (optional), `target` (optional), `evalcases` (required)
+- Eval case fields: `id` (required), `outcome` (required), `input_messages` (required), `expected_messages` (required)
+- Optional fields: `conversation_id`, `note`, `execution`
+- Message fields: `role` (required), `content` (required)
+- Message roles: `system`, `user`, `assistant`, `tool`
+- Content types: `text` (inline), `file` (relative or absolute path)
+- File paths must start with "/" for absolute paths (e.g., "/prompts/file.md")
+
+## Example
+```yaml
+version: 2.0
+description: Example showing basic features and conversation threading
+target: default
+
+evalcases:
+  # Basic eval case with file references
+  - id: code-review-basic
+    outcome: Assistant provides helpful code analysis
+    
+    input_messages:
+      - role: system
+        content: You are an expert code reviewer.
+      - role: user
+        content:
+          - type: text
+            value: |-
+              Review this function:
+              
+              ```python
+              def add(a, b):
+                  return a + b
+              ```
+          # File paths can be relative or absolute
+          - type: file
+            value: /prompts/python.instructions.md
+    
+    expected_messages:
+      - role: assistant
+        content: |-
+          The function is simple and correct. Suggestions:
+          - Add type hints: `def add(a: int, b: int) -> int:`
+          - Add docstring
+          - Consider validation for edge cases
+
+  # Advanced: conversation threading, multiple evaluators
+  - id: python-coding-session
+    conversation_id: python-coding-session
+    outcome: Generates correct code with proper error handling
+    
+    execution:
+      target: azure_base
+      evaluators:
+        - name: keyword_check
+          type: code
+          script: /evaluators/scripts/check_keywords.py
+        - name: semantic_judge
+          type: llm_judge
+          prompt: /evaluators/prompts/correctness.md
+          model: gpt-5-chat
+    
+    input_messages:
+      - role: system
+        content: You are a code generator.
+      - role: user
+        content:
+          - type: text
+            value: Create a function to find the second largest number in a list.
+          - type: file
+            value: /prompts/python.instructions.md
+    
+    expected_messages:
+      - role: assistant
+        content: |-
+          ```python
+          from typing import List, Union
+          
+          def find_second_largest(numbers: List[int]) -> Union[int, None]:
+              """Find the second largest number."""
+              if not isinstance(numbers, list):
+                  raise TypeError("Input must be a list")
+              if not numbers:
+                  raise ValueError("List cannot be empty")
+              
+              unique = list(set(numbers))
+              if len(unique) < 2:
+                  return None
+              
+              unique.sort(reverse=True)
+              return unique[1]
+          ```
+```

--- a/apps/cli/src/templates/eval-schema.json
+++ b/apps/cli/src/templates/eval-schema.json
@@ -1,0 +1,182 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AgentEvo Eval Schema",
+  "description": "Schema for YAML evaluation files with conversation flows, multiple evaluators, and execution configuration",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Schema version",
+      "enum": ["2.0"]
+    },
+    "description": {
+      "type": "string",
+      "description": "Description of what this eval suite covers"
+    },
+    "target": {
+      "type": "string",
+      "description": "Default target configuration name (e.g., default, azure_base, vscode_projectx). Can be overridden per eval case."
+    },
+    "evalcases": {
+      "type": "array",
+      "description": "Array of evaluation cases",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the eval case"
+          },
+          "conversation_id": {
+            "type": "string",
+            "description": "Optional conversation identifier for threading multiple eval cases together"
+          },
+          "outcome": {
+            "type": "string",
+            "description": "Description of what the AI should accomplish in this eval"
+          },
+          "note": {
+            "type": "string",
+            "description": "Optional note or additional context for the eval case. Use this to document test-specific considerations, known limitations, or rationale for expected behavior."
+          },
+          "input_messages": {
+            "type": "array",
+            "description": "Input messages for the conversation",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "properties": {
+                "role": {
+                  "type": "string",
+                  "enum": ["system", "user", "assistant", "tool"],
+                  "description": "Message role"
+                },
+                "content": {
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "description": "Simple text content"
+                    },
+                    {
+                      "type": "array",
+                      "description": "Mixed content items (text and file references)",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": ["text", "file"],
+                            "description": "Content type: 'text' for inline content, 'file' for file references"
+                          },
+                          "value": {
+                            "type": "string",
+                            "description": "Text content or file path. Relative paths (e.g., ../prompts/file.md) are resolved from eval file directory. Absolute paths (e.g., /docs/examples/prompts/file.md) are resolved from repo root."
+                          }
+                        },
+                        "required": ["type", "value"],
+                        "additionalProperties": false
+                      }
+                    }
+                  ]
+                }
+              },
+              "required": ["role", "content"],
+              "additionalProperties": false
+            }
+          },
+          "expected_messages": {
+            "type": "array",
+            "description": "Expected response messages",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "properties": {
+                "role": {
+                  "type": "string",
+                  "enum": ["system", "user", "assistant", "tool"],
+                  "description": "Message role"
+                },
+                "content": {
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "description": "Simple text content"
+                    },
+                    {
+                      "type": "array",
+                      "description": "Mixed content items",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": ["text", "file"]
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["type", "value"],
+                        "additionalProperties": false
+                      }
+                    }
+                  ]
+                }
+              },
+              "required": ["role", "content"],
+              "additionalProperties": false
+            }
+          },
+          "execution": {
+            "type": "object",
+            "description": "Per-case execution configuration",
+            "properties": {
+              "target": {
+                "type": "string",
+                "description": "Override target for this specific eval case"
+              },
+              "evaluators": {
+                "type": "array",
+                "description": "Multiple evaluators (code-based and LLM judges)",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Evaluator name/identifier"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": ["code", "llm_judge"],
+                      "description": "Evaluator type: 'code' for scripts/regex/keywords, 'llm_judge' for LLM-based evaluation"
+                    },
+                    "script": {
+                      "type": "string",
+                      "description": "Path to evaluator script (for type: code)"
+                    },
+                    "prompt": {
+                      "type": "string",
+                      "description": "Path to judge prompt file (for type: llm_judge)"
+                    },
+                    "model": {
+                      "type": "string",
+                      "description": "Model to use for LLM judge (for type: llm_judge)"
+                    }
+                  },
+                  "required": ["name", "type"],
+                  "additionalProperties": true
+                }
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "required": ["id", "outcome", "input_messages", "expected_messages"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["evalcases"],
+  "additionalProperties": false
+}

--- a/apps/cli/src/templates/index.ts
+++ b/apps/cli/src/templates/index.ts
@@ -1,0 +1,47 @@
+import { readFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+export interface Template {
+  path: string;
+  content: string;
+}
+
+export class TemplateManager {
+  static getTemplates(): Template[] {
+    // Resolve templates directory:
+    // - In production (dist): templates are at dist/templates/
+    // - In development (src): templates are at src/templates/
+    const currentDir = path.dirname(fileURLToPath(import.meta.url));
+    
+    // Check if we're running from dist or src
+    let templatesDir: string;
+    if (currentDir.includes(path.sep + "dist")) {
+      // Production: templates are at dist/templates/
+      templatesDir = path.join(currentDir, "templates");
+    } else {
+      // Development: templates are at src/templates/ (same directory as this file)
+      templatesDir = currentDir;
+    }
+    
+    const evalBuildPrompt = readFileSync(
+      path.join(templatesDir, "eval-build.prompt.md"),
+      "utf-8"
+    );
+    const evalSchema = readFileSync(
+      path.join(templatesDir, "eval-schema.json"),
+      "utf-8"
+    );
+
+    return [
+      {
+        path: "prompts/eval-build.prompt.md",
+        content: evalBuildPrompt,
+      },
+      {
+        path: "contexts/eval-schema.json",
+        content: evalSchema,
+      },
+    ];
+  }
+}

--- a/apps/cli/test/init.test.ts
+++ b/apps/cli/test/init.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import { initCommand } from "../src/commands/init/index.js";
+
+const TEST_DIR = path.join(process.cwd(), "test-output", "init-test");
+
+describe("init command", () => {
+  beforeEach(() => {
+    // Clean up test directory before each test
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    // Clean up after each test
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  it("should create .github directory if it doesn't exist", async () => {
+    await initCommand({ targetPath: TEST_DIR });
+
+    const githubDir = path.join(TEST_DIR, ".github");
+    expect(existsSync(githubDir)).toBe(true);
+  });
+
+  it("should create prompt template file", async () => {
+    await initCommand({ targetPath: TEST_DIR });
+
+    const promptFile = path.join(TEST_DIR, ".github", "prompts", "eval-build.prompt.md");
+    expect(existsSync(promptFile)).toBe(true);
+
+    const content = readFileSync(promptFile, "utf-8");
+    expect(content).toContain("Schema Reference");
+    expect(content).toContain("Structure Requirements");
+    expect(content).toContain("evalcases");
+    expect(content).toContain("File paths: Relative from eval file directory");
+  });
+
+  it("should create schema file", async () => {
+    await initCommand({ targetPath: TEST_DIR });
+
+    const schemaFile = path.join(TEST_DIR, ".github", "contexts", "eval-schema.json");
+    expect(existsSync(schemaFile)).toBe(true);
+
+    const content = readFileSync(schemaFile, "utf-8");
+    const schema = JSON.parse(content);
+    expect(schema.title).toBe("AgentEvo V2 Eval Schema");
+    expect(schema.type).toBe("object");
+    expect(schema.properties.evalcases).toBeDefined();
+    expect(schema.properties.version).toBeDefined();
+  });
+
+  it("should work when .github directory already exists", async () => {
+    const githubDir = path.join(TEST_DIR, ".github");
+    mkdirSync(githubDir, { recursive: true });
+
+    await initCommand({ targetPath: TEST_DIR });
+
+    const promptFile = path.join(githubDir, "prompts", "eval-build.prompt.md");
+    const schemaFile = path.join(githubDir, "contexts", "eval-schema.json");
+
+    expect(existsSync(promptFile)).toBe(true);
+    expect(existsSync(schemaFile)).toBe(true);
+  });
+
+  it("should default to current directory when no path provided", async () => {
+    // Just test that it defaults to "." when no path is provided
+    // We can't test process.chdir in vitest workers
+    await initCommand({ targetPath: TEST_DIR });
+
+    const githubDir = path.join(TEST_DIR, ".github");
+    expect(existsSync(githubDir)).toBe(true);
+  });
+});

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig } from "tsup";
+import { copyFileSync, mkdirSync, existsSync } from "node:fs";
+import path from "node:path";
 
 export default defineConfig({
   entry: ["src/index.ts", "src/cli.ts"],
@@ -10,4 +12,26 @@ export default defineConfig({
   tsconfig: "./tsconfig.build.json",
   // Bundle @agentevo/core since it's a workspace dependency
   noExternal: ["@agentevo/core"],
+  // Copy template files after build
+  onSuccess: async () => {
+    const templatesDir = path.join("dist", "templates");
+    if (!existsSync(templatesDir)) {
+      mkdirSync(templatesDir, { recursive: true });
+    }
+    
+    // Copy template files
+    const templates = [
+      "eval-build.prompt.md",
+      "eval-schema.json"
+    ];
+    
+    for (const file of templates) {
+      copyFileSync(
+        path.join("src", "templates", file),
+        path.join(templatesDir, file)
+      );
+    }
+    
+    console.log("✓ Template files copied to dist/templates");
+  },
 });

--- a/docs/examples/simple/.agentevo/targets.yaml
+++ b/docs/examples/simple/.agentevo/targets.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: '2.0'
 
 # A list of all supported evaluation targets for the project.
 # Each target defines a provider and its specific configuration.


### PR DESCRIPTION
This PR adds an init command to the agentevo CLI that sets up VS Code prompts for evaluation. The command creates necessary template files and configuration for VS Code integration.