### PR TITLE
feat(core): add Claude Code CLI provider

### DIFF
--- a/openspec/changes/add-claude-code-provider/proposal.md
+++ b/openspec/changes/add-claude-code-provider/proposal.md
@@ -1,0 +1,19 @@
+# Change: Add Claude Code CLI provider
+
+## Why
+AgentV supports evaluating AI coding agents via Codex CLI and Pi Coding Agent providers. Users should also be able to evaluate Claude Code (Anthropic's official CLI) using the same framework, enabling unified benchmarking across all major coding agents.
+
+## What Changes
+- Add a new `claude-code` provider type that invokes the `claude` CLI with proper arguments
+- Parse JSONL streaming output (`--output-format stream-json`) to extract messages, tool calls, and usage metrics
+- Support model selection, system prompts, custom arguments, and timeout configuration
+- Include stream logging similar to Codex and Pi providers for debugging
+
+## Impact
+- Affected specs: `evaluation` (new provider kind)
+- Affected code:
+  - `packages/core/src/evaluation/providers/claude-code.ts` (new)
+  - `packages/core/src/evaluation/providers/claude-code-log-tracker.ts` (new)
+  - `packages/core/src/evaluation/providers/targets.ts` (add config)
+  - `packages/core/src/evaluation/providers/index.ts` (export)
+  - `packages/core/src/evaluation/providers/types.ts` (add kind)

--- a/openspec/changes/add-claude-code-provider/specs/evaluation/spec.md
+++ b/openspec/changes/add-claude-code-provider/specs/evaluation/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: Claude Code CLI provider
+
+The system SHALL integrate with the Claude Code CLI (`claude`) as a first-class provider for evaluating Claude Code agent outputs.
+
+#### Scenario: Claude Code provider invocation
+
+- **WHEN** a target uses `provider: claude-code`
+- **THEN** the system ensures the Claude executable is discoverable (respecting `settings.executable`, defaulting to `claude`)
+- **AND** runs `claude -p --output-format stream-json --verbose` with the prompt on stdin (plus any configured args)
+- **AND** parses the JSONL streaming output to extract the result and assistant messages
+- **AND** returns the final assistant text as the candidate answer with `outputMessages` containing the conversation history
+
+#### Scenario: Claude Code model configuration
+
+- **WHEN** a `claude-code` target specifies a `model` field
+- **THEN** the system passes `--model <value>` to the Claude CLI
+- **AND** supports both aliases (`sonnet`, `opus`, `haiku`) and full model names (`claude-sonnet-4-5-20250929`)
+
+#### Scenario: Claude Code system prompt configuration
+
+- **WHEN** a `claude-code` target specifies a `system_prompt` field
+- **THEN** the system passes `--system-prompt <value>` to the Claude CLI
+- **AND** uses a default prompt instructing the agent to return code in its response when not configured
+
+#### Scenario: Claude Code working directory
+
+- **WHEN** a `claude-code` target specifies a `cwd` field
+- **THEN** the CLI is executed in that directory
+- **AND** creates a temporary workspace when not specified
+
+#### Scenario: Claude Code timeout handling
+
+- **WHEN** a `claude-code` target specifies `timeout_seconds`
+- **THEN** the provider terminates the process after that duration
+- **AND** returns an error indicating the timeout occurred
+
+#### Scenario: Claude Code custom arguments
+
+- **WHEN** a `claude-code` target specifies an `args` array
+- **THEN** those arguments are passed to the Claude CLI after the built-in flags
+- **AND** can be used to configure tools, permissions, or other CLI options
+
+#### Scenario: Claude Code stream logging
+
+- **WHEN** Claude Code execution is in progress
+- **THEN** the provider streams stdout/stderr to a log file in `.agentv/logs/claude-code/`
+- **AND** the log file path is included in the provider response metadata
+- **AND** logging can be disabled via `AGENTV_CLAUDE_CODE_STREAM_LOGS=false`
+
+#### Scenario: Claude Code JSONL output parsing
+
+- **WHEN** the Claude CLI exits successfully
+- **THEN** the provider parses each JSONL line from stdout
+- **AND** extracts the `result` message type for the final answer
+- **AND** extracts `assistant` message types for `outputMessages` with tool calls
+- **AND** preserves usage metrics and cost information in the response metadata
+
+#### Scenario: Claude Code error handling
+
+- **WHEN** the Claude CLI exits with a non-zero code
+- **THEN** the provider returns an error with the exit code, stderr content, and relevant stdout context
+- **AND** the log file (if enabled) contains the full execution trace for debugging
+
+#### Scenario: Claude Code input files
+
+- **WHEN** a `claude-code` target receives a request with `inputFiles`
+- **THEN** the provider includes the file contents in the prompt using preread format
+- **AND** file paths are resolved relative to the working directory

--- a/openspec/changes/add-claude-code-provider/tasks.md
+++ b/openspec/changes/add-claude-code-provider/tasks.md
@@ -1,0 +1,68 @@
+## 1. Provider Implementation
+
+- [ ] 1.1 Create `packages/core/src/evaluation/providers/claude-code.ts`
+  - Implement `ClaudeCodeProvider` class with `Provider` interface
+  - Handle executable resolution (similar to Codex provider)
+  - Build CLI arguments with `--output-format stream-json --verbose -p`
+  - Support model, system prompt, cwd, timeout, and custom args
+  - Parse JSONL streaming output
+
+- [ ] 1.2 Create `packages/core/src/evaluation/providers/claude-code-log-tracker.ts`
+  - Implement log entry tracking similar to `codex-log-tracker.ts`
+  - Support `consumeClaudeCodeLogEntries` and `subscribeToClaudeCodeLogEntries`
+
+- [ ] 1.3 Implement JSONL output parsing in `claude-code.ts`
+  - Parse `system` init message for metadata
+  - Parse `assistant` messages for tool calls and content
+  - Parse `result` message for final answer and usage metrics
+  - Extract `outputMessages` in AgentV format from Claude message stream
+
+- [ ] 1.4 Implement stream logging in `claude-code.ts`
+  - Create `ClaudeCodeStreamLogger` class
+  - Write timestamped logs to `.agentv/logs/claude-code/`
+  - Support `AGENTV_CLAUDE_CODE_STREAM_LOGS` environment variable
+
+## 2. Target Configuration
+
+- [ ] 2.1 Add `ClaudeCodeResolvedConfig` interface in `targets.ts`
+  - Define fields: `executable`, `model`, `systemPrompt`, `args`, `cwd`, `timeoutMs`, `logDir`, `logFormat`
+
+- [ ] 2.2 Add `claude-code` case to `ResolvedTarget` union in `targets.ts`
+
+- [ ] 2.3 Implement `resolveClaudeCodeConfig` function in `targets.ts`
+  - Handle snake_case/camelCase normalization
+  - Support environment variable resolution with `${{ VAR }}` syntax
+  - Default executable to `claude`
+
+- [ ] 2.4 Add `claude-code` case to `resolveTargetDefinition` switch in `targets.ts`
+
+## 3. Provider Registration
+
+- [ ] 3.1 Add `'claude-code'` to `ProviderKind` type in `types.ts`
+
+- [ ] 3.2 Import and export `ClaudeCodeProvider` in `index.ts`
+
+- [ ] 3.3 Add `claude-code` case to `createProvider` switch in `index.ts`
+
+- [ ] 3.4 Export `ClaudeCodeResolvedConfig` type from `index.ts`
+
+- [ ] 3.5 Export log tracker functions from `index.ts`
+
+## 4. Testing
+
+- [ ] 4.1 Create `packages/core/test/evaluation/providers/claude-code.test.ts`
+  - Test JSONL output parsing for various message types
+  - Test error handling for timeouts and non-zero exit codes
+  - Test argument building with model, system prompt, and custom args
+  - Test `outputMessages` extraction from Claude message stream
+
+- [ ] 4.2 Add integration test with mock Claude CLI
+  - Verify end-to-end provider invocation
+  - Test log file creation and content
+
+## 5. Validation
+
+- [ ] 5.1 Run `bun run build` - verify compilation
+- [ ] 5.2 Run `bun run typecheck` - verify type safety
+- [ ] 5.3 Run `bun run lint` - verify code style
+- [ ] 5.4 Run `bun test` - verify all tests pass


### PR DESCRIPTION
## Summary
- Add OpenSpec change proposal for Claude Code CLI (`claude`) as a new provider type
- Similar to existing Codex and Pi Coding Agent providers
- Parses JSONL streaming output for messages, tool calls, and usage metrics

## Test plan
- [ ] Review proposal in `openspec/changes/add-claude-code-provider/`
- [ ] Validate with `openspec validate add-claude-code-provider --strict`
- [ ] Approve proposal before implementation begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)