### PR TITLE
refactor: remove unused rawAspects field from evaluation types

### DIFF
--- a/apps/cli/test/fixtures/mock-run-evaluation.ts
+++ b/apps/cli/test/fixtures/mock-run-evaluation.ts
@@ -31,7 +31,6 @@ interface EvaluationResultLike {
   readonly target: string;
   readonly timestamp: string;
   readonly reasoning?: string;
-  readonly rawAspects?: readonly string[];
 }
 
 function buildResults(targetName: string): EvaluationResultLike[] {
@@ -47,7 +46,6 @@ function buildResults(targetName: string): EvaluationResultLike[] {
       target: targetName,
       timestamp: baseTime.toISOString(),
       reasoning: 'Alpha reasoning',
-      rawAspects: ['alpha'],
     },
     {
       evalId: 'case-beta',
@@ -59,7 +57,6 @@ function buildResults(targetName: string): EvaluationResultLike[] {
       target: targetName,
       timestamp: new Date(baseTime.getTime() + 60_000).toISOString(),
       reasoning: 'Beta reasoning',
-      rawAspects: ['beta', 'gamma', 'delta'],
     },
   ];
 }

--- a/packages/core/src/evaluation/evaluators.ts
+++ b/packages/core/src/evaluation/evaluators.ts
@@ -78,7 +78,6 @@ export interface EvaluationScore {
   readonly misses: readonly string[];
   readonly expectedAspectCount: number;
   readonly reasoning?: string;
-  readonly rawAspects?: readonly string[];
   readonly evaluatorRawRequest?: JsonObject;
   readonly evaluatorResults?: readonly ChildEvaluatorResult[];
 }

--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -671,7 +671,6 @@ async function evaluateCandidate(options: {
     candidateAnswer: candidate,
     target: target.name,
     reasoning: score.reasoning,
-    rawAspects: score.rawAspects,
     agentProviderRequest: agentProviderRequest,
     lmProviderRequest: lmProviderRequest,
     evaluatorProviderRequest: evaluatorResults ? undefined : score.evaluatorRawRequest,
@@ -986,7 +985,6 @@ async function runEvaluatorList(options: {
     (total, entry) => total + (entry.score.expectedAspectCount ?? 0),
     0,
   );
-  const rawAspects = scored.flatMap((entry) => entry.score.rawAspects ?? []);
   const reasoningParts = scored
     .map((entry) => (entry.score.reasoning ? `${entry.name}: ${entry.score.reasoning}` : undefined))
     .filter(isNonEmptyString);
@@ -999,7 +997,6 @@ async function runEvaluatorList(options: {
     misses,
     expectedAspectCount,
     reasoning,
-    rawAspects: rawAspects.length > 0 ? rawAspects : undefined,
   };
 
   return { score, evaluatorResults };
@@ -1220,7 +1217,6 @@ function buildErrorResult(
     misses: [`Error: ${message}`],
     candidateAnswer: `Error occurred: ${message}`,
     target: targetName,
-    rawAspects: [],
     agentProviderRequest: agentProviderRequest,
     lmProviderRequest: lmProviderRequest,
     error: message,

--- a/packages/core/src/evaluation/types.ts
+++ b/packages/core/src/evaluation/types.ts
@@ -248,7 +248,6 @@ export interface EvaluationResult {
   readonly candidateAnswer: string;
   readonly target: string;
   readonly reasoning?: string;
-  readonly rawAspects?: readonly string[];
   readonly agentProviderRequest?: JsonObject;
   readonly lmProviderRequest?: JsonObject;
   readonly evaluatorProviderRequest?: JsonObject;


### PR DESCRIPTION
## Summary
- Removed `rawAspects` field from `EvaluationScore` interface in `evaluators.ts`
- Removed `rawAspects` field from `EvaluationResult` type in `types.ts`
- Removed aggregation logic for `rawAspects` in `orchestrator.ts`
- Updated test fixtures to remove `rawAspects` references

## Motivation
The `rawAspects` field was never populated by any evaluator - it was dead code that added confusion to the data model. The existing `hits`/`misses` arrays serve the purpose of tracking evaluation results.

## Test plan
- [x] Build passes (`bun run build`)
- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (`bun run lint`)
- [x] All 182 tests pass (`bun test`)

Resolves #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)