### PR TITLE
refactor: rename outcome to expected_outcome in dataset files

### DIFF
--- a/examples/features/document-extraction/evals/dataset.yaml
+++ b/examples/features/document-extraction/evals/dataset.yaml
@@ -108,7 +108,7 @@ evalcases:
   # ============================================
   - id: invoice-001
     conversation_id: document-extraction
-    outcome: |
+    expected_outcome: |
       Extractor produces clean data matching expected ground truth.
       Mock extractor rounds supplier name from "Acme - Shipping" to "Acme Shipping" in HTML.
       All numeric values rounded to integers (1889 not 1889.00).
@@ -193,7 +193,7 @@ evalcases:
   # ============================================
   - id: invoice-002
     conversation_id: document-extraction
-    outcome: |
+    expected_outcome: |
       ACTUAL EXTRACTOR OUTPUT: supplier.name = "Acme - Shipping" (preserves document punctuation)
       EXPECTED GROUND TRUTH: supplier.name = "Acme Shipping" (normalized)
 
@@ -252,7 +252,7 @@ evalcases:
   # ============================================
   - id: invoice-003
     conversation_id: document-extraction
-    outcome: |
+    expected_outcome: |
       ACTUAL EXTRACTOR OUTPUT: net_total = 1889.5, gross_total = 1889.5
       EXPECTED GROUND TRUTH: net_total = 1889, gross_total = 1889
       
@@ -284,7 +284,7 @@ evalcases:
   # ============================================
   - id: invoice-004
     conversation_id: document-extraction
-    outcome: |
+    expected_outcome: |
       ACTUAL EXTRACTOR OUTPUT: invoice_number = undefined (field missing in fixture)
       EXPECTED GROUND TRUTH: invoice_number = "INV-2025-001234"
 
@@ -316,7 +316,7 @@ evalcases:
   # ============================================
   - id: invoice-005
     conversation_id: document-extraction
-    outcome: |
+    expected_outcome: |
       Extractor correctly extracts first two line items with proper array structure.
       Field paths like line_items[0].description should resolve correctly.
     evaluators:

--- a/examples/showcase/cw-incident-triage/evals/dataset.yaml
+++ b/examples/showcase/cw-incident-triage/evals/dataset.yaml
@@ -22,7 +22,7 @@ evalcases:
   - id: cr-global-outage
     conversation_id: cargowise-triage
     
-    outcome: |
+    expected_outcome: |
       Assistant correctly classifies as 'CR1' for complete system inaccessibility.
       Reasoning should emphasize 'any user on any workstation' and lack of access to the entire suite.
     
@@ -51,7 +51,7 @@ evalcases:
   - id: cr-module-inaccessible
     conversation_id: cargowise-triage
     
-    outcome: |
+    expected_outcome: |
       Assistant correctly classifies as 'CR2' for module-wide inaccessibility.
       Reasoning should distinguish from CR1 by noting it's limited to one module.
     
@@ -85,7 +85,7 @@ evalcases:
   - id: cr-missing-validation-disguised-as-defect
     conversation_id: cargowise-triage
     
-    outcome: |
+    expected_outcome: |
       Assistant classifies as 'CR6' (Enhancement) despite user claiming "Critical Bug" and citing a prior defect.
       Most LLMs might misclassify as CR3 (Defect) due to the user's label, financial impact, and claim of a "failed fix".
       Expected is CR6 because the prior fix (DEF-555) addressed format length (as per docs), whereas this request is for a new uniqueness constraint not in the specs.
@@ -119,7 +119,7 @@ evalcases:
   - id: cr-function-bug-no-workaround
     conversation_id: cargowise-triage
     
-    outcome: |
+    expected_outcome: |
       Assistant classifies as 'CR3' for function not matching documentation.
       Reasoning must confirm no workaround and tie to 'changed from previously correct behaviour'.
     
@@ -148,7 +148,7 @@ evalcases:
   - id: cr-feature-quote
     conversation_id: cargowise-triage
     
-    outcome: |
+    expected_outcome: |
       Assistant classifies as 'CR7' for accelerated development quote.
       Reasoning distinguishes from CR6 by noting request for quote/pricing.
     
@@ -177,7 +177,7 @@ evalcases:
   - id: cr-compliance-data-update
     conversation_id: cargowise-triage
     
-    outcome: |
+    expected_outcome: |
       Assistant classifies as 'CR8' for master data/compliance issue.
       Reasoning prioritizes data accuracy over potential bug claims.
     
@@ -206,7 +206,7 @@ evalcases:
   - id: cr-multi-part-blend
     conversation_id: cargowise-triage
     
-    outcome: |
+    expected_outcome: |
       Assistant classifies as 'CR3' prioritizing the bug over secondary training request.
       Reasoning must identify multi-elements and select highest criticality.
     
@@ -235,7 +235,7 @@ evalcases:
   - id: cr-workaround-exists
     conversation_id: cargowise-triage
     
-    outcome: |
+    expected_outcome: |
       Assistant classifies as 'CR4' due to viable workaround.
       Reasoning distinguishes from CR3 by noting alternative.
     

--- a/examples/showcase/export-screening/README.md
+++ b/examples/showcase/export-screening/README.md
@@ -97,7 +97,7 @@ Add cases to `dataset.yaml` following the existing pattern:
 ```yaml
 - id: exp-custom-001
   conversation_id: export-screening
-  outcome: |
+  expected_outcome: |
     Description of expected behavior for reviewers.
   expected_messages:
     - role: assistant

--- a/examples/showcase/export-screening/evals/dataset.yaml
+++ b/examples/showcase/export-screening/evals/dataset.yaml
@@ -33,7 +33,7 @@ evalcases:
   # Tier 1: Integrated Circuits (Highest Concern)
   - id: exp-high-001
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'High' risk. Electronic integrated circuits
       (processors/controllers) are Tier 1 CHPL items - highest concern for
       precision-guided weapons. Export to Russia is prohibited.
@@ -57,7 +57,7 @@ evalcases:
 
   - id: exp-high-002
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'High' risk. Memory integrated circuits
       are Tier 1 CHPL items critical for military systems.
     expected_messages:
@@ -81,7 +81,7 @@ evalcases:
   # Tier 3.A: Electronic Components
   - id: exp-high-003
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'High' risk. Photosensitive semiconductor
       devices (excluding photovoltaic) are CHPL Tier 3.A items used in
       targeting and guidance systems.
@@ -105,7 +105,7 @@ evalcases:
 
   - id: exp-high-004
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'High' risk. Static converters are CHPL
       Tier 3.A items used in power systems for military equipment.
     expected_messages:
@@ -129,7 +129,7 @@ evalcases:
   # Tier 3.B: Mechanical and Optical Components
   - id: exp-high-005
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'High' risk. Precision ball bearings are
       CHPL Tier 3.B items critical for missile guidance and UAV systems.
     expected_messages:
@@ -152,7 +152,7 @@ evalcases:
 
   - id: exp-high-006
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'High' risk. Aircraft/UAV parts are CHPL
       Tier 3.B items with direct military applications.
     expected_messages:
@@ -175,7 +175,7 @@ evalcases:
 
   - id: exp-high-007
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'High' risk. Telescopic sights and optical
       devices are CHPL Tier 3.B items used in weapons targeting systems.
     expected_messages:
@@ -198,7 +198,7 @@ evalcases:
 
   - id: exp-high-008
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'High' risk. Navigation instruments for
       aeronautical use are CHPL Tier 3.B items critical for missile guidance.
     expected_messages:
@@ -223,7 +223,7 @@ evalcases:
   # Tier 4.A: Manufacturing and Testing Equipment
   - id: exp-high-009
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'High' risk. Semiconductor manufacturing
       equipment is CHPL Tier 4.A - critical for chip production capability.
     expected_messages:
@@ -246,7 +246,7 @@ evalcases:
 
   - id: exp-high-010
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'High' risk. Oscilloscopes and test equipment
       are CHPL Tier 4.A items used for weapons development and testing.
     expected_messages:
@@ -269,7 +269,7 @@ evalcases:
 
   - id: exp-high-011
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'High' risk. Printed circuit boards are
       CHPL Tier 4.A items essential for electronics manufacturing.
     expected_messages:
@@ -293,7 +293,7 @@ evalcases:
   # Tier 4.B: CNC Machine Tools
   - id: exp-high-012
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'High' risk. CNC machining centers are
       CHPL Tier 4.B items used for precision weapons manufacturing.
     expected_messages:
@@ -321,7 +321,7 @@ evalcases:
 
   - id: exp-med-001
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'Medium' risk. Switching/routing apparatus
       is on CHPL (8517.62) but destination is low-risk allied nation.
       Requires verification of end-user and specifications.
@@ -345,7 +345,7 @@ evalcases:
 
   - id: exp-med-002
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'Medium' risk. Tantalum capacitors are
       CHPL Tier 2 items but in small quantities for commercial repair.
       Low-risk destination but controlled item requires verification.
@@ -370,7 +370,7 @@ evalcases:
 
   - id: exp-med-003
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'Medium' risk. Optical instruments may
       be controlled depending on specifications. Destination is moderate
       risk. Requires technical review.
@@ -394,7 +394,7 @@ evalcases:
 
   - id: exp-med-004
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'Medium' risk. Radio navigation equipment
       is CHPL Tier 2 (8526.91) but for commercial aviation use in
       low-risk destination.
@@ -424,7 +424,7 @@ evalcases:
 
   - id: exp-low-001
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'Low' risk. Consumer electronics displays
       are not on CHPL. Standard commercial trade between allied nations.
     expected_messages:
@@ -447,7 +447,7 @@ evalcases:
 
   - id: exp-low-002
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'Low' risk. Standard industrial motors
       (not high-performance/precision) are not controlled.
     expected_messages:
@@ -470,7 +470,7 @@ evalcases:
 
   - id: exp-low-003
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'Low' risk. Agricultural spraying equipment
       has no dual-use applications. Trade to allied nation.
     expected_messages:
@@ -493,7 +493,7 @@ evalcases:
 
   - id: exp-low-004
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'Low' risk. Medical diagnostic equipment
       for hospital use is not controlled. Standard healthcare trade.
     expected_messages:
@@ -517,7 +517,7 @@ evalcases:
 
   - id: exp-low-005
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'Low' risk. Household appliances have
       no dual-use concerns. Standard consumer goods trade.
     expected_messages:
@@ -540,7 +540,7 @@ evalcases:
 
   - id: exp-low-006
     conversation_id: export-screening
-    outcome: |
+    expected_outcome: |
       AI correctly classifies as 'Low' risk. Food processing equipment
       is not controlled. Standard industrial trade to allied nation.
     expected_messages:

--- a/examples/showcase/psychotherapy/evals/dataset-encouragement.yaml
+++ b/examples/showcase/psychotherapy/evals/dataset-encouragement.yaml
@@ -20,7 +20,7 @@ evalcases:
   # Case 1: The Restrained Father
   # Focus: Identifying 'Self-Control' as a resource in a moment of rage.
   - id: encouragement-father-restraint
-    outcome: |-
+    expected_outcome: |-
       Must use keys: validation_point, resource_identified, reframe_angle.
       Must identify 'Self-Control/Restraint' as the resource (not focusing on the anger).
     input_messages:
@@ -52,7 +52,7 @@ evalcases:
   # Case 2: The Guilty Survivor (Sister with Uremia)
   # Focus: Reframing 'Guilt' as 'Love/Connection'.
   - id: encouragement-guilty-sister
-    outcome: |-
+    expected_outcome: |-
       Must reframe Guilt as Evidence of Love/Bond.
       Must Validate that feeling guilty is "normal" (Normalization).
     input_messages:
@@ -84,7 +84,7 @@ evalcases:
   # Case 3: The Depressed Student (Visual Change)
   # Focus: Recognizing 'Action' and 'Self-Care' in visual/behavioral changes.
   - id: encouragement-depressed-student
-    outcome: |-
+    expected_outcome: |-
       Must identify the act of 'dressing up/grooming' as a resource (Desire for life/dignity).
       Must not dismiss it as superficial; must validate the effort.
     input_messages:
@@ -117,7 +117,7 @@ evalcases:
   # Case 4: The Nagging Wife
   # Focus: Reframing 'Symptom' (Conflict) to 'Value' (Commitment).
   - id: encouragement-nagging-wife
-    outcome: |-
+    expected_outcome: |-
       Must identify the 'Fighting' as a resource (Fighting for the relationship).
       Must identify 'Enduring in-laws' as a resource (Commitment to husband).
     input_messages:
@@ -149,7 +149,7 @@ evalcases:
   # Case 5: The Embarrassed Gym Student
   # Focus: Reframing 'Failure/Clumsiness' to 'Resilience/Completion'.
   - id: encouragement-gym-student
-    outcome: |-
+    expected_outcome: |-
       Must identify 'Completing the test' and 'calming down' as the resource.
       Must NOT focus on the embarrassment or the clumsiness.
     input_messages:
@@ -185,7 +185,7 @@ evalcases:
   # Case 6: Paradoxical Resource (Self-Harm/Cutting)
   # Focus: Identifying 'Emotional Regulation' intent without condoning behavior.
   - id: encouragement-cutting-paradox
-    outcome: |-
+    expected_outcome: |-
       Must identify 'Survival Strategy' or 'Desire to Breathe' as the positive intent.
       Must maintain clinical detachment (no judgment).
     input_messages:
@@ -217,7 +217,7 @@ evalcases:
   # Case 7: The "Toxic Positivity" Trap
   # Focus: Validating pain BEFORE finding resource. Avoiding clichés.
   - id: adv-encouragement-toxic-positivity
-    outcome: |-
+    expected_outcome: |-
       Must identify 'validation_point' that acknowledges the depth of pain (not minimizing it).
       Failure: Using clichés like "Time heals all wounds" or "Stay positive."
     input_messages:
@@ -250,7 +250,7 @@ evalcases:
   # Focus: Validating Emotion (Care) but NOT Behavior (Control).
   - id: adv-encouragement-enabling
     # Baseline note: partial failure expected if behavior is praised (score ~0.8).
-    outcome: |-
+    expected_outcome: |-
       Must identify 'resource_identified' as the *Desire for Connection/Safety*, NOT the act of checking.
       Failure: Praising the "diligence" of checking the phone.
     input_messages:

--- a/examples/showcase/psychotherapy/evals/dataset-listening.yaml
+++ b/examples/showcase/psychotherapy/evals/dataset-listening.yaml
@@ -18,7 +18,7 @@ evalcases:
 
   # Case 1: The Overwhelmed Wife (Passive Resignation)
   - id: listening-basic-overwhelmed-wife
-    outcome: |-
+    expected_outcome: |-
       Must identify 'level_2_emotion' as Resentment/Despair (not just anger).
       Must identify 'level_3_process' as Pursuer-Distancer shift or Testing the relationship.
     input_messages:
@@ -49,7 +49,7 @@ evalcases:
 
   # Case 2: The Traditional Mother (Guilt & Reframing)
   - id: listening-basic-traditional-mother
-    outcome: |-
+    expected_outcome: |-
       Must identify Patriarchal values (Financial exploitation framed as help) and Gaslighting/Enmeshment in 'level_3_process'.
     input_messages:
       - role: system
@@ -79,7 +79,7 @@ evalcases:
 
   # Case 3: The Returning Mother (Explicit Distress)
   - id: listening-basic-returning-mother
-    outcome: |-
+    expected_outcome: |-
       Must identify Internalizing rejection as worthlessness in 'level_3_process'.
     input_messages:
       - role: system
@@ -113,7 +113,7 @@ evalcases:
 
   # Case 4: The Alexithymic Executive (Denial of Distress)
   - id: listening-adv-somatic-mask
-    outcome: |-
+    expected_outcome: |-
       Must identify Alexithymia and Somatic Displacement (Stress -> Throat) in 'level_3_process'.
     input_messages:
       - role: system
@@ -143,7 +143,7 @@ evalcases:
 
   # Case 5: The Benevolent Gatekeeper (Dysfunctional Helping)
   - id: listening-adv-gatekeeper
-    outcome: |-
+    expected_outcome: |-
       Must identify Gatekeeping/Triangulation in 'level_3_process'.
       Must identify the distinction between 'Helping' vs 'Blocking Intimacy'.
     input_messages:
@@ -174,7 +174,7 @@ evalcases:
 
   # Case 6: The Intellectualizer (Resistance)
   - id: listening-adv-intellectualizer
-    outcome: |-
+    expected_outcome: |-
       Must identify Intellectualization as a defense mechanism in 'level_3_process'.
     input_messages:
       - role: system

--- a/examples/showcase/psychotherapy/evals/dataset-routing.yaml
+++ b/examples/showcase/psychotherapy/evals/dataset-routing.yaml
@@ -14,7 +14,7 @@ evalcases:
   # Case 1: Routing to Listening (Ah Yang)
   # Rationale: Client is venting grievance and describing a complex dynamic. Needs understanding first.
   - id: route-to-listening
-    outcome: |-
+    expected_outcome: |-
       Must select 'three_levels_listening'.
       Rationale should mention "complex grievance", "venting", or "need for understanding".
     input_messages:
@@ -61,7 +61,7 @@ evalcases:
   # Case 2: Routing to Encouragement (Restrained Father)
   # Rationale: Client is expressing hopelessness ("raised son for nothing") but hides a resource (Restraint). Needs Reframing.
   - id: route-to-encouragement-father
-    outcome: |-
+    expected_outcome: |-
       Must select 'resource_focused_encouragement'.
       Rationale should mention "finding the resource", "reframing self-blame", or "validating restraint".
     input_messages:
@@ -108,7 +108,7 @@ evalcases:
   # Case 3: Routing to Encouragement (Job Seeker)
   # Rationale: Client expresses "I am useless/broken". Needs Normalization and Empowerment.
   - id: route-to-encouragement-job
-    outcome: |-
+    expected_outcome: |-
       Must select 'resource_focused_encouragement'.
       Rationale should mention "low self-efficacy", "empowerment", or "normalization of failure".
     input_messages:
@@ -156,7 +156,7 @@ evalcases:
   # Rationale: Client presents a distorted reality ("I am doing good") that hides dysfunction. Needs Process Analysis, not Encouragement (which would enable the dysfunction).
   - id: route-to-listening-gatekeeper
     # Baseline note: intended failure if model selects encouragement (score ~0.5).
-    outcome: |-
+    expected_outcome: |-
       Must select 'three_levels_listening'.
       Rationale should mention "dysfunctional dynamic", "lack of insight", or "need to analyze the process". Encouragement here would likely reinforce the triangulation.
     input_messages:


### PR DESCRIPTION
## Summary
- Renamed `outcome` field to `expected_outcome` in all dataset YAML files to align with the eval build schema
- Updated example YAML in export-screening README

## Files Changed
- `examples/features/document-extraction/evals/dataset.yaml`
- `examples/showcase/psychotherapy/evals/dataset-routing.yaml`
- `examples/showcase/psychotherapy/evals/dataset-listening.yaml`
- `examples/showcase/psychotherapy/evals/dataset-encouragement.yaml`
- `examples/showcase/cw-incident-triage/evals/dataset.yaml`
- `examples/showcase/export-screening/evals/dataset.yaml`
- `examples/showcase/export-screening/README.md`

## Test plan
- [ ] Verify dataset files parse correctly with `agentv eval`
- [ ] Confirm schema validation passes

🤖 Generated with [Claude Code](https://claude.ai/code)