### PR TITLE
fix(core): support suite-level evaluators_mode inheritance

### DIFF
--- a/.changeset/evaluators-mode-inheritance.md
+++ b/.changeset/evaluators-mode-inheritance.md
@@ -1,0 +1,8 @@
+---
+"@agentv/core": patch
+---
+
+Fix evaluators_mode to support suite-level inheritance and remove undocumented "merge" alias
+
+- Suite-level `evaluators_mode` now properly cascades to cases that don't specify their own
+- Removed undocumented "merge" alias; only "append" is now accepted (consistent with schema)

--- a/.claude/skills/agentv-eval-builder/references/eval-schema.json
+++ b/.claude/skills/agentv-eval-builder/references/eval-schema.json
@@ -20,6 +20,11 @@
           "type": "string",
           "description": "Default target configuration name (e.g., default, azure_base, vscode_projectx). Can be overridden per eval case."
         },
+        "evaluators_mode": {
+          "type": "string",
+          "enum": ["replace", "append"],
+          "description": "How per-case evaluators interact with suite-level execution.evaluators. 'replace' (default) uses the case evaluators if provided; 'append' combines suite evaluators with case evaluators (case wins on name collision)."
+        },
         "evaluators": {
           "type": "array",
           "description": "Default evaluators for all eval cases (code-based and LLM judges)",
@@ -178,6 +183,11 @@
               "target": {
                 "type": "string",
                 "description": "Override target for this specific eval case"
+              },
+              "evaluators_mode": {
+                "type": "string",
+                "enum": ["replace", "append"],
+                "description": "How this case's evaluators interact with suite-level execution.evaluators. 'replace' (default) uses only the case evaluators; 'append' combines suite + case evaluators (case wins on name collision)."
               },
               "evaluators": {
                 "type": "array",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -14,10 +14,7 @@
   "bin": {
     "agentv": "./dist/cli.js"
   },
-  "files": [
-    "dist",
-    "README.md"
-  ],
+  "files": ["dist", "README.md"],
   "scripts": {
     "dev": "bun --watch src/index.ts",
     "build": "tsup && bun run copy-readme",

--- a/examples/features/code-judge-with-llm-calls/scripts/contextual-recall.ts
+++ b/examples/features/code-judge-with-llm-calls/scripts/contextual-recall.ts
@@ -40,8 +40,7 @@ export default defineCodeJudge(async (input) => {
       score: 0,
       hits: [],
       misses: ['No expected_outcome provided'],
-      reasoning:
-        'Contextual Recall requires expected_outcome to extract statements from.',
+      reasoning: 'Contextual Recall requires expected_outcome to extract statements from.',
     };
   }
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
   "private": true,
   "description": "AgentV monorepo workspace",
   "packageManager": "bun@1.3.3",
-  "workspaces": [
-    "apps/*",
-    "packages/*"
-  ],
+  "workspaces": ["apps/*", "packages/*"],
   "scripts": {
     "build": "bun --filter @agentv/core build && bun --filter @agentv/eval build && bun --filter agentv build",
     "verify": "bun run build && bun run typecheck && bun run lint && bun run test",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,10 +36,7 @@
     "test:watch": "bun test --watch",
     "diagnostics:azure": "bun src/diagnostics/azure-deployment-diag.ts"
   },
-  "files": [
-    "dist",
-    "README.md"
-  ],
+  "files": ["dist", "README.md"],
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.53",
     "@ai-sdk/azure": "^2.0.78",

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -29,10 +29,7 @@
     "fix": "biome check --write .",
     "test": "bun test"
   },
-  "files": [
-    "dist",
-    "README.md"
-  ],
+  "files": ["dist", "README.md"],
   "dependencies": {
     "zod": "^3.23.8"
   }


### PR DESCRIPTION
## Summary
- Suite-level `evaluators_mode` now properly cascades to cases that don't specify their own
- Removed undocumented "merge" alias; only "append" is accepted (consistent with schema)
- Added test coverage for suite-level inheritance behavior

## Test Plan
- [x] All 269 tests pass
- [x] New test verifies suite-level `evaluators_mode` inheritance
- [x] Build, typecheck, and lint all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)