### PR TITLE
fix(core): inherit suite evaluators when case has execution object

### DIFF
--- a/.changeset/suite-evaluators-inheritance.md
+++ b/.changeset/suite-evaluators-inheritance.md
@@ -1,0 +1,7 @@
+---
+"@agentv/core": patch
+---
+
+Fix suite-level evaluators inheritance when case has execution object
+
+Cases with an execution object (e.g., for constraints) but no evaluators now correctly inherit suite-level execution.evaluators. Previously, the presence of any case-level execution object would prevent fallback to suite evaluators.

--- a/packages/core/src/evaluation/loaders/evaluator-parser.ts
+++ b/packages/core/src/evaluation/loaders/evaluator-parser.ts
@@ -22,10 +22,15 @@ export async function parseEvaluators(
   evalId: string,
 ): Promise<readonly EvaluatorConfig[] | undefined> {
   const execution = rawEvalCase.execution;
+  const executionObject = isJsonObject(execution) ? execution : undefined;
+
   // Priority: case-level execution.evaluators > case-level evaluators > global execution.evaluators
-  const candidateEvaluators = isJsonObject(execution)
-    ? (execution.evaluators ?? rawEvalCase.evaluators)
-    : (rawEvalCase.evaluators ?? globalExecution?.evaluators);
+  // Note: If a case has an execution object but omits evaluators, we MUST still fall back to the
+  // suite-level execution.evaluators (otherwise adding constraints at case-level disables inheritance).
+  const candidateEvaluators =
+    (executionObject ? executionObject.evaluators : undefined) ??
+    rawEvalCase.evaluators ??
+    globalExecution?.evaluators;
   if (candidateEvaluators === undefined) {
     return undefined;
   }

--- a/packages/core/test/evaluation/loaders/evaluator-parser.test.ts
+++ b/packages/core/test/evaluation/loaders/evaluator-parser.test.ts
@@ -335,4 +335,35 @@ describe('parseEvaluators - token_usage', () => {
       max_output: 200,
     });
   });
+
+  it('inherits suite-level execution.evaluators when case has execution object without evaluators', async () => {
+    const rawEvalCase = {
+      execution: {
+        constraints: {
+          max_total_tokens: 123,
+        },
+      },
+    };
+
+    const globalExecution = {
+      evaluators: [
+        {
+          name: 'token-budget',
+          type: 'token_usage',
+          max_total: 1000,
+          max_output: 200,
+        },
+      ],
+    };
+
+    const evaluators = await parseEvaluators(rawEvalCase, globalExecution, [process.cwd()], 'test');
+
+    expect(evaluators).toHaveLength(1);
+    expect(evaluators?.[0]).toEqual({
+      name: 'token-budget',
+      type: 'token_usage',
+      max_total: 1000,
+      max_output: 200,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes a bug where cases with an execution object (e.g., for constraints) but no evaluators would fail to inherit suite-level execution.evaluators.

## The Bug

**Original code:**
```typescript
const candidateEvaluators = isJsonObject(execution)
  ? (execution.evaluators ?? rawEvalCase.evaluators)
  : (rawEvalCase.evaluators ?? globalExecution?.evaluators);
```

**Problem scenario:**
```yaml
execution:
  evaluators:
    - name: suite-eval

evalcases:
  - id: case1
    execution:
      constraints:
        max_total_tokens: 100
    # Has execution object, but NO evaluators
```

The presence of the case-level execution object caused the code to take the first branch, which would never reach `globalExecution?.evaluators`.

## The Fix

Changed to explicit fallback chain that always checks suite-level evaluators:

```typescript
const candidateEvaluators =
  (executionObject ? executionObject.evaluators : undefined) ??
  rawEvalCase.evaluators ??
  globalExecution?.evaluators;
```

## Test Plan

- [x] All 267 tests pass
- [x] New test covers the bug scenario
- [x] Minimal change (6 lines modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)