### PR TITLE
refactor(core): extract parseInlineRubrics to shared method

### DIFF
--- a/.changeset/shared-inline-rubrics.md
+++ b/.changeset/shared-inline-rubrics.md
@@ -1,0 +1,5 @@
+---
+"@agentv/core": patch
+---
+
+Refactor: Extract inline rubrics parsing to shared `parseInlineRubrics` function

--- a/packages/core/src/evaluation/loaders/evaluator-parser.ts
+++ b/packages/core/src/evaluation/loaders/evaluator-parser.ts
@@ -904,3 +904,92 @@ function parseScoreRanges(
 
   return ranges;
 }
+
+/**
+ * Parse inline rubrics field (syntactic sugar at eval case level).
+ * Supports:
+ * - String shorthand: "Must be polite" -> { id: "rubric-1", expected_outcome: "Must be polite", weight: 1.0, required: true }
+ * - Object form with expected_outcome, weight, required, score_ranges, required_min_score
+ *
+ * Returns an LlmJudgeEvaluatorConfig to prepend to evaluators, or undefined if no valid rubrics.
+ */
+export function parseInlineRubrics(
+  rawRubrics: readonly unknown[],
+): import('../types.js').LlmJudgeEvaluatorConfig | undefined {
+  const rubricItems = rawRubrics
+    .filter((r): r is JsonObject | string => isJsonObject(r) || typeof r === 'string')
+    .map((rubric, index) => {
+      if (typeof rubric === 'string') {
+        return {
+          id: `rubric-${index + 1}`,
+          expected_outcome: rubric,
+          weight: 1.0,
+          required: true,
+        };
+      }
+
+      // Support both expected_outcome and description (backward compatibility)
+      const expectedOutcome =
+        asString(rubric.expected_outcome) ?? asString(rubric.description) ?? '';
+
+      // Parse score_ranges if present
+      const rawScoreRanges = rubric.score_ranges;
+      const scoreRanges =
+        Array.isArray(rawScoreRanges) && rawScoreRanges.length > 0
+          ? rawScoreRanges
+              .filter((r): r is JsonObject => isJsonObject(r))
+              .map((range) => ({
+                score_range: Array.isArray(range.score_range)
+                  ? (range.score_range as unknown as readonly [number, number])
+                  : ([0, 10] as const),
+                expected_outcome:
+                  asString(range.expected_outcome) ?? asString(range.description) ?? '',
+              }))
+              .filter((r) => r.expected_outcome.length > 0)
+          : undefined;
+
+      const baseRubric = {
+        id: asString(rubric.id) ?? `rubric-${index + 1}`,
+        weight: typeof rubric.weight === 'number' ? rubric.weight : 1.0,
+      };
+
+      // For score_ranges rubrics, expected_outcome at rubric level is optional
+      if (scoreRanges && scoreRanges.length > 0) {
+        return {
+          ...baseRubric,
+          ...(expectedOutcome.length > 0 ? { expected_outcome: expectedOutcome } : {}),
+          ...(typeof rubric.required === 'boolean' ? { required: rubric.required } : {}),
+          ...(typeof rubric.required_min_score === 'number'
+            ? { required_min_score: rubric.required_min_score }
+            : {}),
+          score_ranges: scoreRanges,
+        };
+      }
+
+      // Checklist rubric: expected_outcome is required
+      return {
+        ...baseRubric,
+        expected_outcome: expectedOutcome,
+        required: typeof rubric.required === 'boolean' ? rubric.required : true,
+        ...(typeof rubric.required_min_score === 'number'
+          ? { required_min_score: rubric.required_min_score }
+          : {}),
+      };
+    })
+    // Filter: must have expected_outcome OR score_ranges
+    .filter(
+      (r) =>
+        (r.expected_outcome && r.expected_outcome.length > 0) ||
+        ('score_ranges' in r && r.score_ranges),
+    );
+
+  if (rubricItems.length === 0) {
+    return undefined;
+  }
+
+  return {
+    name: 'rubric',
+    type: 'llm_judge',
+    rubrics: rubricItems,
+  };
+}

--- a/packages/core/src/evaluation/loaders/jsonl-parser.ts
+++ b/packages/core/src/evaluation/loaders/jsonl-parser.ts
@@ -6,7 +6,7 @@ import { parse as parseYaml } from 'yaml';
 import type { EvalCase, JsonObject, JsonValue, TestMessage } from '../types.js';
 import { isJsonObject, isTestMessage } from '../types.js';
 import { loadConfig } from './config-loader.js';
-import { coerceEvaluator, parseEvaluators } from './evaluator-parser.js';
+import { coerceEvaluator, parseEvaluators, parseInlineRubrics } from './evaluator-parser.js';
 import { buildSearchRoots, fileExists, resolveToAbsolutePath } from './file-resolver.js';
 import { processExpectedMessages, processMessages } from './message-processor.js';
 import { resolveExpectedMessages, resolveInputMessages } from './shorthand-expansion.js';
@@ -264,78 +264,8 @@ export async function loadEvalCasesFromJsonl(
     // Handle inline rubrics field (syntactic sugar)
     const inlineRubrics = evalcase.rubrics;
     if (inlineRubrics !== undefined && Array.isArray(inlineRubrics)) {
-      const rubricItems = inlineRubrics
-        .filter((r): r is JsonObject | string => isJsonObject(r) || typeof r === 'string')
-        .map((rubric, index) => {
-          if (typeof rubric === 'string') {
-            return {
-              id: `rubric-${index + 1}`,
-              expected_outcome: rubric,
-              weight: 1.0,
-              required: true,
-            };
-          }
-          // Support both expected_outcome and description (backward compatibility)
-          const expectedOutcome =
-            asString(rubric.expected_outcome) ?? asString(rubric.description) ?? '';
-
-          // Parse score_ranges if present
-          const rawScoreRanges = rubric.score_ranges;
-          const scoreRanges =
-            Array.isArray(rawScoreRanges) && rawScoreRanges.length > 0
-              ? rawScoreRanges
-                  .filter((r): r is JsonObject => isJsonObject(r))
-                  .map((range) => ({
-                    score_range: Array.isArray(range.score_range)
-                      ? (range.score_range as unknown as readonly [number, number])
-                      : ([0, 10] as const),
-                    expected_outcome:
-                      asString(range.expected_outcome) ?? asString(range.description) ?? '',
-                  }))
-                  .filter((r) => r.expected_outcome.length > 0)
-              : undefined;
-
-          const baseRubric = {
-            id: asString(rubric.id) ?? `rubric-${index + 1}`,
-            weight: typeof rubric.weight === 'number' ? rubric.weight : 1.0,
-          };
-
-          // For score_ranges rubrics, expected_outcome at rubric level is optional
-          if (scoreRanges && scoreRanges.length > 0) {
-            return {
-              ...baseRubric,
-              ...(expectedOutcome.length > 0 ? { expected_outcome: expectedOutcome } : {}),
-              ...(typeof rubric.required === 'boolean' ? { required: rubric.required } : {}),
-              ...(typeof rubric.required_min_score === 'number'
-                ? { required_min_score: rubric.required_min_score }
-                : {}),
-              score_ranges: scoreRanges,
-            };
-          }
-
-          // Checklist rubric: expected_outcome is required
-          return {
-            ...baseRubric,
-            expected_outcome: expectedOutcome,
-            required: typeof rubric.required === 'boolean' ? rubric.required : true,
-            ...(typeof rubric.required_min_score === 'number'
-              ? { required_min_score: rubric.required_min_score }
-              : {}),
-          };
-        })
-        // Filter: must have expected_outcome OR score_ranges
-        .filter(
-          (r) =>
-            (r.expected_outcome && r.expected_outcome.length > 0) ||
-            ('score_ranges' in r && r.score_ranges),
-        );
-
-      if (rubricItems.length > 0) {
-        const rubricEvaluator: import('../types.js').LlmJudgeEvaluatorConfig = {
-          name: 'rubric',
-          type: 'llm_judge',
-          rubrics: rubricItems,
-        };
+      const rubricEvaluator = parseInlineRubrics(inlineRubrics);
+      if (rubricEvaluator) {
         // Prepend rubric evaluator to existing evaluators
         evaluators = evaluators ? [rubricEvaluator, ...evaluators] : [rubricEvaluator];
       }

--- a/packages/core/src/evaluation/yaml-parser.ts
+++ b/packages/core/src/evaluation/yaml-parser.ts
@@ -4,7 +4,11 @@ import micromatch from 'micromatch';
 import { parse } from 'yaml';
 
 import { extractTargetFromSuite, loadConfig } from './loaders/config-loader.js';
-import { coerceEvaluator, parseEvaluators } from './loaders/evaluator-parser.js';
+import {
+  coerceEvaluator,
+  parseEvaluators,
+  parseInlineRubrics,
+} from './loaders/evaluator-parser.js';
 import { buildSearchRoots, resolveToAbsolutePath } from './loaders/file-resolver.js';
 import { detectFormat, loadEvalCasesFromJsonl } from './loaders/jsonl-parser.js';
 import { processExpectedMessages, processMessages } from './loaders/message-processor.js';
@@ -220,78 +224,8 @@ export async function loadEvalCases(
     // Handle inline rubrics field (syntactic sugar)
     const inlineRubrics = evalcase.rubrics;
     if (inlineRubrics !== undefined && Array.isArray(inlineRubrics)) {
-      const rubricItems = inlineRubrics
-        .filter((r): r is JsonObject | string => isJsonObject(r) || typeof r === 'string')
-        .map((rubric, index) => {
-          if (typeof rubric === 'string') {
-            return {
-              id: `rubric-${index + 1}`,
-              expected_outcome: rubric,
-              weight: 1.0,
-              required: true,
-            };
-          }
-          // Support both expected_outcome and description (backward compatibility)
-          const expectedOutcome =
-            asString(rubric.expected_outcome) ?? asString(rubric.description) ?? '';
-
-          // Parse score_ranges if present
-          const rawScoreRanges = rubric.score_ranges;
-          const scoreRanges =
-            Array.isArray(rawScoreRanges) && rawScoreRanges.length > 0
-              ? rawScoreRanges
-                  .filter((r): r is JsonObject => isJsonObject(r))
-                  .map((range) => ({
-                    score_range: Array.isArray(range.score_range)
-                      ? (range.score_range as unknown as readonly [number, number])
-                      : ([0, 10] as const),
-                    expected_outcome:
-                      asString(range.expected_outcome) ?? asString(range.description) ?? '',
-                  }))
-                  .filter((r) => r.expected_outcome.length > 0)
-              : undefined;
-
-          const baseRubric = {
-            id: asString(rubric.id) ?? `rubric-${index + 1}`,
-            weight: typeof rubric.weight === 'number' ? rubric.weight : 1.0,
-          };
-
-          // For score_ranges rubrics, expected_outcome at rubric level is optional
-          if (scoreRanges && scoreRanges.length > 0) {
-            return {
-              ...baseRubric,
-              ...(expectedOutcome.length > 0 ? { expected_outcome: expectedOutcome } : {}),
-              ...(typeof rubric.required === 'boolean' ? { required: rubric.required } : {}),
-              ...(typeof rubric.required_min_score === 'number'
-                ? { required_min_score: rubric.required_min_score }
-                : {}),
-              score_ranges: scoreRanges,
-            };
-          }
-
-          // Checklist rubric: expected_outcome is required
-          return {
-            ...baseRubric,
-            expected_outcome: expectedOutcome,
-            required: typeof rubric.required === 'boolean' ? rubric.required : true,
-            ...(typeof rubric.required_min_score === 'number'
-              ? { required_min_score: rubric.required_min_score }
-              : {}),
-          };
-        })
-        // Filter: must have expected_outcome OR score_ranges
-        .filter(
-          (r) =>
-            (r.expected_outcome && r.expected_outcome.length > 0) ||
-            ('score_ranges' in r && r.score_ranges),
-        );
-
-      if (rubricItems.length > 0) {
-        const rubricEvaluator: import('./types.js').LlmJudgeEvaluatorConfig = {
-          name: 'rubric',
-          type: 'llm_judge',
-          rubrics: rubricItems,
-        };
+      const rubricEvaluator = parseInlineRubrics(inlineRubrics);
+      if (rubricEvaluator) {
         // Prepend rubric evaluator to existing evaluators
         evaluators = evaluators ? [rubricEvaluator, ...evaluators] : [rubricEvaluator];
       }


### PR DESCRIPTION
## Summary
- Extract inline rubrics parsing logic to shared `parseInlineRubrics()` function in `evaluator-parser.ts`
- Update `yaml-parser.ts` and `jsonl-parser.ts` to use the shared function
- Eliminates ~50 lines of duplicated code

## Before
Both `yaml-parser.ts` and `jsonl-parser.ts` had identical ~50-line blocks for parsing inline rubrics with support for:
- String shorthand
- Object form with expected_outcome, weight, required
- score_ranges and required_min_score

## After
Single `parseInlineRubrics()` function that both parsers call.

## Test plan
- [x] Build passes
- [x] Typecheck passes
- [x] Lint passes
- [x] All 352 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)