### PR TITLE
fix(cli): bundle cmd-ts to resolve ESM/CJS compatibility error

### DIFF
--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   platform: 'node',
   tsconfig: './tsconfig.build.json',
   // Bundle @agentv/core but keep micromatch and pi-agent packages external (they have dynamic requires)
-  noExternal: [/^@agentv\//],
+  noExternal: [/^@agentv\//, 'cmd-ts'],
   external: ['micromatch', '@mariozechner/pi-agent', '@mariozechner/pi-ai'],
   // Copy template files after build
   onSuccess: async () => {


### PR DESCRIPTION
## Summary
- Adds `cmd-ts` to tsup's `noExternal` array so it gets bundled into the CLI output instead of remaining an external runtime dependency
- `cmd-ts` has no `"exports"` field, so Node.js resolves to its CJS entry point which calls `require("chalk")`. Since chalk v5+ is ESM-only, this causes a runtime crash on Windows (and any Node.js environment)
- Bundling cmd-ts ensures tsup uses the ESM source via the `"module"` field, eliminating the CJS→ESM conflict

## Test plan
- [x] `bun run build` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` — all 369 tests pass
- [x] Bundle size increase is negligible (5.1 MB → 5.3 MB)
- [ ] Verify on Windows with Node.js: `npm install -g agentv && agentv --help`

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)