### PR TITLE
docs: document evaluator template variable derivation

### DIFF
--- a/.claude/skills/agentv-eval-builder/references/eval-schema.json
+++ b/.claude/skills/agentv-eval-builder/references/eval-schema.json
@@ -156,7 +156,7 @@
           },
           "expected_messages": {
             "type": "array",
-            "description": "Expected response messages",
+            "description": "Expected response messages. Canonical form — use this or expected_output (alias). The content of the last entry is derived as the template variable 'reference_answer' for evaluator prompts.",
             "minItems": 1,
             "items": {
               "type": "object",
@@ -198,7 +198,7 @@
             }
           },
           "expected_output": {
-            "description": "Alias for expected_messages with shorthand support. String expands to single assistant message, object wraps as assistant message content.",
+            "description": "Alias for expected_messages with shorthand support. String expands to single assistant message, object wraps as assistant message content. Resolves to expected_messages internally — the content of the last resolved entry becomes the template variable 'reference_answer'.",
             "oneOf": [
               {
                 "type": "string",


### PR DESCRIPTION
Clarify the three-layer data flow: authoring fields (expected_output/ expected_messages) → resolved fields → derived template variables (reference_answer, candidate_answer). This prevents confusion with peer framework naming (e.g., DeepEval's expected_output/actual_output).