### PR TITLE
feat(cli): add --trace flag for persisting execution traces (#172)

### DIFF
--- a/apps/cli/src/commands/eval/index.ts
+++ b/apps/cli/src/commands/eval/index.ts
@@ -110,6 +110,10 @@ export const evalCommand = command({
       long: 'cleanup-workspaces',
       description: 'Always cleanup temporary workspaces, even on failure',
     }),
+    trace: flag({
+      long: 'trace',
+      description: 'Persist full execution traces to .agentv/traces/ as JSONL',
+    }),
   },
   handler: async (args) => {
     const resolvedPaths = await resolveEvalPaths(args.evalPaths, process.cwd());
@@ -130,6 +134,7 @@ export const evalCommand = command({
       verbose: args.verbose,
       keepWorkspaces: args.keepWorkspaces,
       cleanupWorkspaces: args.cleanupWorkspaces,
+      trace: args.trace,
     };
     await runEvalCommand({ testFiles: resolvedPaths, rawOptions });
   },

--- a/apps/cli/src/commands/eval/trace-writer.ts
+++ b/apps/cli/src/commands/eval/trace-writer.ts
@@ -1,0 +1,158 @@
+import { createWriteStream } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { finished } from 'node:stream/promises';
+import type { OutputMessage, ProviderTokenUsage } from '@agentv/core';
+import { Mutex } from 'async-mutex';
+
+import { toSnakeCaseDeep } from '../../utils/case-conversion.js';
+
+/**
+ * A span within a trace representing a tool invocation.
+ */
+export interface TraceSpan {
+  /** Span type (currently only 'tool') */
+  readonly type: 'tool';
+  /** Tool name */
+  readonly name: string;
+  /** ISO 8601 timestamp when the span started */
+  readonly startTime?: string;
+  /** ISO 8601 timestamp when the span ended */
+  readonly endTime?: string;
+  /** Duration of the span in milliseconds */
+  readonly durationMs?: number;
+  /** Tool input arguments */
+  readonly input?: unknown;
+  /** Tool output result */
+  readonly output?: unknown;
+}
+
+/**
+ * A trace record representing a single eval case execution.
+ */
+export interface TraceRecord {
+  /** Eval case identifier */
+  readonly evalId: string;
+  /** ISO 8601 timestamp when execution started */
+  readonly startTime?: string;
+  /** ISO 8601 timestamp when execution ended */
+  readonly endTime?: string;
+  /** Total execution duration in milliseconds */
+  readonly durationMs?: number;
+  /** List of spans (tool invocations) in the trace */
+  readonly spans: readonly TraceSpan[];
+  /** Token usage metrics */
+  readonly tokenUsage?: ProviderTokenUsage;
+  /** Total cost in USD */
+  readonly costUsd?: number;
+}
+
+/**
+ * Extracts trace spans from output messages.
+ * Converts tool calls from the agent execution into TraceSpan objects.
+ */
+export function extractTraceSpans(outputMessages: readonly OutputMessage[]): readonly TraceSpan[] {
+  const spans: TraceSpan[] = [];
+
+  for (const message of outputMessages) {
+    if (message.toolCalls && message.toolCalls.length > 0) {
+      for (const toolCall of message.toolCalls) {
+        spans.push({
+          type: 'tool',
+          name: toolCall.tool,
+          startTime: toolCall.startTime,
+          endTime: toolCall.endTime,
+          durationMs: toolCall.durationMs,
+          input: toolCall.input,
+          output: toolCall.output,
+        });
+      }
+    }
+  }
+
+  return spans;
+}
+
+/**
+ * Builds a TraceRecord from an EvaluationResult's outputMessages.
+ */
+export function buildTraceRecord(
+  evalId: string,
+  outputMessages: readonly OutputMessage[],
+  options?: {
+    readonly tokenUsage?: ProviderTokenUsage;
+    readonly costUsd?: number;
+    readonly startTime?: string;
+    readonly endTime?: string;
+    readonly durationMs?: number;
+  },
+): TraceRecord {
+  const spans = extractTraceSpans(outputMessages);
+
+  return {
+    evalId,
+    startTime: options?.startTime,
+    endTime: options?.endTime,
+    durationMs: options?.durationMs,
+    spans,
+    tokenUsage: options?.tokenUsage,
+    costUsd: options?.costUsd,
+  };
+}
+
+/**
+ * Writer for trace JSONL files.
+ * Persists full execution traces for debugging and analysis.
+ */
+export class TraceWriter {
+  private readonly stream: ReturnType<typeof createWriteStream>;
+  private readonly mutex = new Mutex();
+  private closed = false;
+
+  private constructor(stream: ReturnType<typeof createWriteStream>) {
+    this.stream = stream;
+  }
+
+  /**
+   * Opens a new TraceWriter for the given file path.
+   * Creates the directory structure if it doesn't exist.
+   */
+  static async open(filePath: string): Promise<TraceWriter> {
+    await mkdir(path.dirname(filePath), { recursive: true });
+    const stream = createWriteStream(filePath, { flags: 'w', encoding: 'utf8' });
+    return new TraceWriter(stream);
+  }
+
+  /**
+   * Appends a trace record to the file.
+   * Thread-safe via mutex for concurrent writes.
+   */
+  async append(record: TraceRecord): Promise<void> {
+    await this.mutex.runExclusive(async () => {
+      if (this.closed) {
+        throw new Error('Cannot write to closed trace writer');
+      }
+      // Convert camelCase keys to snake_case for Python ecosystem compatibility
+      const snakeCaseRecord = toSnakeCaseDeep(record);
+      const line = `${JSON.stringify(snakeCaseRecord)}\n`;
+      if (!this.stream.write(line)) {
+        await new Promise<void>((resolve, reject) => {
+          this.stream.once('drain', resolve);
+          this.stream.once('error', reject);
+        });
+      }
+    });
+  }
+
+  /**
+   * Closes the writer and finalises the stream.
+   */
+  async close(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    this.stream.end();
+    await finished(this.stream);
+  }
+}

--- a/apps/cli/test/commands/eval/trace-writer.test.ts
+++ b/apps/cli/test/commands/eval/trace-writer.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { readFile, rm, stat } from 'node:fs/promises';
+import path from 'node:path';
+import type { OutputMessage } from '@agentv/core';
+import {
+  TraceWriter,
+  buildTraceRecord,
+  extractTraceSpans,
+} from '../../../src/commands/eval/trace-writer.js';
+
+describe('TraceWriter', () => {
+  const testDir = path.join(import.meta.dir, '.test-traces');
+  let testFilePath: string;
+
+  beforeEach(() => {
+    testFilePath = path.join(testDir, `trace-${Date.now()}.jsonl`);
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe('open', () => {
+    it('should create directory and file', async () => {
+      const writer = await TraceWriter.open(testFilePath);
+
+      // Verify directory was created
+      const dirStat = await stat(path.dirname(testFilePath));
+      expect(dirStat.isDirectory()).toBe(true);
+
+      await writer.close();
+    });
+
+    it('should create nested directories', async () => {
+      const nestedPath = path.join(testDir, 'nested', 'deep', 'trace.jsonl');
+      const writer = await TraceWriter.open(nestedPath);
+
+      const dirStat = await stat(path.dirname(nestedPath));
+      expect(dirStat.isDirectory()).toBe(true);
+
+      await writer.close();
+    });
+  });
+
+  describe('append', () => {
+    it('should write a single trace record as JSONL', async () => {
+      const writer = await TraceWriter.open(testFilePath);
+
+      const record = {
+        evalId: 'test-1',
+        startTime: '2024-01-01T00:00:00Z',
+        endTime: '2024-01-01T00:01:00Z',
+        durationMs: 60000,
+        spans: [
+          {
+            type: 'tool' as const,
+            name: 'read_file',
+            startTime: '2024-01-01T00:00:10Z',
+            durationMs: 100,
+            input: { path: '/test/file.txt' },
+            output: { content: 'test content' },
+          },
+        ],
+        tokenUsage: { input: 100, output: 50 },
+        costUsd: 0.01,
+      };
+
+      await writer.append(record);
+      await writer.close();
+
+      const content = await readFile(testFilePath, 'utf8');
+      const lines = content.trim().split('\n');
+      expect(lines).toHaveLength(1);
+
+      const parsed = JSON.parse(lines[0]);
+      expect(parsed.eval_id).toBe('test-1');
+      expect(parsed.start_time).toBe('2024-01-01T00:00:00Z');
+      expect(parsed.duration_ms).toBe(60000);
+      expect(parsed.spans).toHaveLength(1);
+      expect(parsed.spans[0].type).toBe('tool');
+      expect(parsed.spans[0].name).toBe('read_file');
+      expect(parsed.token_usage.input).toBe(100);
+      expect(parsed.cost_usd).toBe(0.01);
+    });
+
+    it('should write multiple trace records', async () => {
+      const writer = await TraceWriter.open(testFilePath);
+
+      await writer.append({ evalId: 'test-1', spans: [] });
+      await writer.append({ evalId: 'test-2', spans: [] });
+      await writer.append({ evalId: 'test-3', spans: [] });
+
+      await writer.close();
+
+      const content = await readFile(testFilePath, 'utf8');
+      const lines = content.trim().split('\n');
+      expect(lines).toHaveLength(3);
+
+      expect(JSON.parse(lines[0]).eval_id).toBe('test-1');
+      expect(JSON.parse(lines[1]).eval_id).toBe('test-2');
+      expect(JSON.parse(lines[2]).eval_id).toBe('test-3');
+    });
+
+    it('should throw when writing to closed writer', async () => {
+      const writer = await TraceWriter.open(testFilePath);
+      await writer.close();
+
+      await expect(writer.append({ evalId: 'test', spans: [] })).rejects.toThrow(
+        'Cannot write to closed trace writer',
+      );
+    });
+  });
+
+  describe('close', () => {
+    it('should be idempotent', async () => {
+      const writer = await TraceWriter.open(testFilePath);
+
+      await writer.close();
+      await writer.close(); // Should not throw
+      await writer.close(); // Should not throw
+    });
+  });
+
+  describe('concurrent writes', () => {
+    it('should handle concurrent writes safely', async () => {
+      const writer = await TraceWriter.open(testFilePath);
+
+      // Write 100 records concurrently
+      const writePromises = Array.from({ length: 100 }, (_, i) =>
+        writer.append({ evalId: `test-${i}`, spans: [] }),
+      );
+
+      await Promise.all(writePromises);
+      await writer.close();
+
+      const content = await readFile(testFilePath, 'utf8');
+      const lines = content.trim().split('\n');
+      expect(lines).toHaveLength(100);
+
+      // Verify all records are valid JSON
+      for (const line of lines) {
+        const parsed = JSON.parse(line);
+        expect(parsed.eval_id).toMatch(/^test-\d+$/);
+      }
+    });
+  });
+});
+
+describe('extractTraceSpans', () => {
+  it('should extract tool calls from output messages', () => {
+    const messages: OutputMessage[] = [
+      {
+        role: 'assistant',
+        content: 'Let me help you',
+        toolCalls: [
+          {
+            tool: 'read_file',
+            input: { path: '/test/file.txt' },
+            output: { content: 'file content' },
+            startTime: '2024-01-01T00:00:00Z',
+            endTime: '2024-01-01T00:00:01Z',
+            durationMs: 1000,
+          },
+          {
+            tool: 'write_file',
+            input: { path: '/test/output.txt', content: 'new content' },
+            output: { success: true },
+            durationMs: 500,
+          },
+        ],
+      },
+    ];
+
+    const spans = extractTraceSpans(messages);
+
+    expect(spans).toHaveLength(2);
+    expect(spans[0].type).toBe('tool');
+    expect(spans[0].name).toBe('read_file');
+    expect(spans[0].startTime).toBe('2024-01-01T00:00:00Z');
+    expect(spans[0].durationMs).toBe(1000);
+    expect(spans[0].input).toEqual({ path: '/test/file.txt' });
+    expect(spans[0].output).toEqual({ content: 'file content' });
+
+    expect(spans[1].name).toBe('write_file');
+    expect(spans[1].durationMs).toBe(500);
+  });
+
+  it('should handle messages without tool calls', () => {
+    const messages: OutputMessage[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+    ];
+
+    const spans = extractTraceSpans(messages);
+    expect(spans).toHaveLength(0);
+  });
+
+  it('should handle multiple messages with tool calls', () => {
+    const messages: OutputMessage[] = [
+      {
+        role: 'assistant',
+        toolCalls: [{ tool: 'tool1', input: {} }],
+      },
+      {
+        role: 'assistant',
+        toolCalls: [
+          { tool: 'tool2', input: {} },
+          { tool: 'tool3', input: {} },
+        ],
+      },
+    ];
+
+    const spans = extractTraceSpans(messages);
+    expect(spans).toHaveLength(3);
+    expect(spans.map((s) => s.name)).toEqual(['tool1', 'tool2', 'tool3']);
+  });
+
+  it('should handle empty messages array', () => {
+    const spans = extractTraceSpans([]);
+    expect(spans).toHaveLength(0);
+  });
+});
+
+describe('buildTraceRecord', () => {
+  it('should build a complete trace record', () => {
+    const messages: OutputMessage[] = [
+      {
+        role: 'assistant',
+        toolCalls: [{ tool: 'read_file', input: { path: '/test' } }],
+      },
+    ];
+
+    const record = buildTraceRecord('eval-123', messages, {
+      startTime: '2024-01-01T00:00:00Z',
+      endTime: '2024-01-01T00:01:00Z',
+      durationMs: 60000,
+      tokenUsage: { input: 100, output: 50 },
+      costUsd: 0.01,
+    });
+
+    expect(record.evalId).toBe('eval-123');
+    expect(record.startTime).toBe('2024-01-01T00:00:00Z');
+    expect(record.endTime).toBe('2024-01-01T00:01:00Z');
+    expect(record.durationMs).toBe(60000);
+    expect(record.spans).toHaveLength(1);
+    expect(record.spans[0].name).toBe('read_file');
+    expect(record.tokenUsage).toEqual({ input: 100, output: 50 });
+    expect(record.costUsd).toBe(0.01);
+  });
+
+  it('should build a minimal trace record', () => {
+    const record = buildTraceRecord('eval-456', []);
+
+    expect(record.evalId).toBe('eval-456');
+    expect(record.spans).toHaveLength(0);
+    expect(record.startTime).toBeUndefined();
+    expect(record.tokenUsage).toBeUndefined();
+    expect(record.costUsd).toBeUndefined();
+  });
+});

--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -884,6 +884,7 @@ async function evaluateCandidate(options: {
     evaluatorProviderRequest: evaluatorResults ? undefined : score.evaluatorRawRequest,
     evaluatorResults: evaluatorResults,
     traceSummary: traceSummary,
+    outputMessages: outputMessages,
   };
 }
 

--- a/packages/core/src/evaluation/providers/index.ts
+++ b/packages/core/src/evaluation/providers/index.ts
@@ -13,12 +13,14 @@ import { VSCodeProvider } from './vscode-provider.js';
 
 export type {
   EnvLookup,
+  OutputMessage,
   Provider,
   ProviderKind,
   ProviderRequest,
   ProviderResponse,
   ProviderTokenUsage,
   TargetDefinition,
+  ToolCall,
 } from './types.js';
 
 export type {

--- a/packages/core/src/evaluation/types.ts
+++ b/packages/core/src/evaluation/types.ts
@@ -417,6 +417,8 @@ export interface EvaluationResult {
   readonly traceSummary?: TraceSummary;
   /** Path to the temporary workspace directory (included on failure for debugging) */
   readonly workspacePath?: string;
+  /** Full output messages from agent execution (only included when --trace flag is set) */
+  readonly outputMessages?: readonly import('./providers/types.js').OutputMessage[];
 }
 
 export type EvaluationVerdict = 'pass' | 'fail' | 'borderline';


### PR DESCRIPTION
## Summary
- Add `--trace` CLI flag that persists full execution traces to `.agentv/traces/<timestamp>/<eval-file>.trace.jsonl`
- Create `TraceWriter` class with mutex-protected concurrent writes for thread-safe trace logging
- Add `outputMessages` field to `EvaluationResult` and orchestrator for passing trace data through the pipeline

## Changes
- `packages/core/src/evaluation/types.ts`: Add `outputMessages` field to `EvaluationResult` interface
- `packages/core/src/evaluation/orchestrator.ts`: Include `outputMessages` in evaluation results
- `packages/core/src/evaluation/providers/index.ts`: Export `OutputMessage` and `ToolCall` types
- `apps/cli/src/commands/eval/index.ts`: Add `--trace` flag to eval command
- `apps/cli/src/commands/eval/run-eval.ts`: Handle trace writing and strip outputMessages from results JSONL
- `apps/cli/src/commands/eval/trace-writer.ts`: New TraceWriter class with TraceRecord/TraceSpan types
- `apps/cli/test/commands/eval/trace-writer.test.ts`: Tests for TraceWriter (creation, append, close, concurrent writes)

## Test plan
- [x] Unit tests for TraceWriter pass (13 tests)
- [x] All existing tests continue to pass
- [x] Build and typecheck pass
- [x] Lint passes

Closes #172 (Task 3)

Generated with [Claude Code](https://claude.com/claude-code)