### PR TITLE
feat(core): add built-in execution_metrics evaluator (#103)

### DIFF
--- a/examples/features/execution-metrics/evals/dataset.yaml
+++ b/examples/features/execution-metrics/evals/dataset.yaml
@@ -1,21 +1,21 @@
-# Execution Metrics Demo
-# Demonstrates how to use execution metrics in evaluation
+# Execution Metrics Evaluator Demo
+# Demonstrates the built-in execution_metrics evaluator for declarative threshold-based checks.
 #
-# Execution metrics capture runtime information from provider invocations:
-# - tokenUsage: { input, output, cached? } - token consumption
-# - costUsd: API cost in USD
-# - durationMs: execution time in milliseconds
+# The execution_metrics evaluator allows you to set limits on:
+# - max_tool_calls: Maximum number of tool invocations
+# - max_llm_calls: Maximum number of LLM calls (assistant messages)
+# - max_tokens: Maximum total tokens (input + output)
+# - max_cost_usd: Maximum cost in USD
+# - max_duration_ms: Maximum execution duration in milliseconds
+# - target_exploration_ratio: Target ratio of read-only tool calls (with tolerance)
 #
-# These metrics are available in:
-# 1. TraceSummary (included in evaluation results)
-# 2. Code judge stdin (for custom metric-based evaluation)
+# Only specified thresholds are checked; omitted ones are ignored.
+# Score is proportional: hits / (hits + misses)
 #
-# Setup:
-#   1. Add to examples/features/.env:
-#      EXECUTION_METRICS_DIR=/absolute/path/to/examples/features/evals/execution-metrics
-#   2. Run: cd examples/features && npx agentv eval evals/execution-metrics/execution-metrics-demo.yaml
+# Run with:
+#   bun agentv eval examples/features/execution-metrics/evals/dataset.yaml --dry-run
 
-description: Demonstrates execution metrics collection and evaluation
+description: Demonstrates the built-in execution_metrics evaluator
 
 # Mock agent that returns realistic execution metrics
 execution:
@@ -23,14 +23,13 @@ execution:
 
 evalcases:
   # ==========================================
-  # Example 1: Basic metrics collection
-  # Metrics are automatically included in results when available
+  # Example 1: Simple threshold check - PASS
+  # Check that an efficient agent stays within limits
   # ==========================================
-  - id: metrics-collection
+  - id: simple-thresholds-pass
 
     expected_outcome: |-
-      Agent responds to a simple query. Execution metrics are captured
-      automatically and included in the evaluation result.
+      Agent responds efficiently within all specified limits.
 
     input:
       - role: user
@@ -38,20 +37,20 @@ evalcases:
 
     execution:
       evaluators:
-        # Verify that execution metrics are present in trace_summary
-        - name: metrics-present
-          type: code_judge
-          script: ["bun", "run", "../scripts/check-metrics-present.ts"]
+        - name: efficiency-check
+          type: execution_metrics
+          max_tool_calls: 10
+          max_tokens: 2000
+          max_duration_ms: 10000
 
   # ==========================================
-  # Example 2: Metric-aware code judge
-  # Use custom thresholds to evaluate efficiency
+  # Example 2: Multiple thresholds - PASS
+  # Comprehensive check with all threshold types
   # ==========================================
-  - id: efficiency-evaluation
+  - id: comprehensive-thresholds
 
     expected_outcome: |-
-      Agent efficiently answers a simple question without excessive
-      token usage or tool calls.
+      Agent performs a task within all efficiency constraints.
 
     input:
       - role: user
@@ -59,20 +58,23 @@ evalcases:
 
     execution:
       evaluators:
-        # Custom code judge that evaluates efficiency metrics
-        - name: efficiency-check
-          type: code_judge
-          script: ["bun", "run", "../scripts/check-efficiency.ts"]
+        - name: full-efficiency-check
+          type: execution_metrics
+          max_tool_calls: 15
+          max_llm_calls: 5
+          max_tokens: 3000
+          max_cost_usd: 0.1
+          max_duration_ms: 30000
 
   # ==========================================
-  # Example 3: Research task with higher metrics
-  # Demonstrates metrics for more complex operations
+  # Example 3: Research task with tool trajectory + metrics
+  # Combines multiple evaluator types
   # ==========================================
-  - id: research-metrics
+  - id: research-with-metrics
 
     expected_outcome: |-
-      Agent performs research and uses tools. Metrics reflect
-      higher token usage and multiple tool calls.
+      Agent performs research and uses tools efficiently.
+      Metrics reflect reasonable token usage and tool calls.
 
     input:
       - role: user
@@ -87,28 +89,75 @@ evalcases:
           minimums:
             search: 1
 
-        # Check efficiency metrics
+        # Check execution efficiency
         - name: metrics-check
-          type: code_judge
-          script: ["bun", "run", "../scripts/check-efficiency.ts"]
+          type: execution_metrics
+          max_tool_calls: 20
+          max_tokens: 5000
 
   # ==========================================
-  # Example 4: Inefficient agent detection
-  # Demonstrates failing efficiency checks
+  # Example 4: Exploration ratio check
+  # Validates the balance between read-only and write operations
   # ==========================================
-  - id: inefficient-detection
+  - id: exploration-ratio-check
 
     expected_outcome: |-
-      Agent uses excessive resources. Efficiency check should fail
-      due to too many tool calls and high token usage.
+      Agent maintains a good balance of exploration (reading) vs
+      action (writing/editing) tool calls.
 
     input:
       - role: user
-        content: Do something inefficient and wasteful.
+        content: Read the documentation and make small improvements.
 
     execution:
       evaluators:
-        # This should fail - agent uses too many tools
-        - name: efficiency-check
+        - name: exploration-balance
+          type: execution_metrics
+          target_exploration_ratio: 0.6  # 60% should be read-only tools
+          exploration_tolerance: 0.2      # Allow +/- 20% variance
+
+  # ==========================================
+  # Example 5: Strict cost budget
+  # Useful for cost-sensitive applications
+  # ==========================================
+  - id: cost-budget-check
+
+    expected_outcome: |-
+      Agent completes the task within the specified cost budget.
+
+    input:
+      - role: user
+        content: Generate a brief summary.
+
+    execution:
+      evaluators:
+        - name: cost-check
+          type: execution_metrics
+          max_cost_usd: 0.05
+          weight: 2.0  # Double weight for cost compliance
+
+  # ==========================================
+  # Example 6: Combining with code_judge
+  # Use execution_metrics for thresholds, code_judge for custom logic
+  # ==========================================
+  - id: hybrid-evaluation
+
+    expected_outcome: |-
+      Agent passes both declarative thresholds and custom evaluation.
+
+    input:
+      - role: user
+        content: Process the data efficiently.
+
+    execution:
+      evaluators:
+        # Declarative threshold checks
+        - name: metric-thresholds
+          type: execution_metrics
+          max_tool_calls: 10
+          max_duration_ms: 5000
+
+        # Custom evaluation logic (for more complex checks)
+        - name: custom-check
           type: code_judge
-          script: ["bun", "run", "../scripts/check-efficiency.ts"]
+          script: ["bun", "run", "../scripts/check-metrics-present.ts"]

--- a/packages/core/src/evaluation/evaluators/execution-metrics.ts
+++ b/packages/core/src/evaluation/evaluators/execution-metrics.ts
@@ -1,0 +1,249 @@
+import { explorationRatio } from '../trace.js';
+import type { ExecutionMetricsEvaluatorConfig } from '../types.js';
+import { scoreToVerdict } from './scoring.js';
+import type { EvaluationContext, EvaluationScore, Evaluator } from './types.js';
+
+export interface ExecutionMetricsEvaluatorOptions {
+  readonly config: ExecutionMetricsEvaluatorConfig;
+}
+
+/**
+ * Evaluator that checks execution metrics against configured thresholds.
+ * Supports multiple threshold types: tool calls, LLM calls, tokens, cost, duration,
+ * and exploration ratio. Only specified thresholds are checked.
+ *
+ * Score is proportional: hits.length / (hits.length + misses.length)
+ */
+export class ExecutionMetricsEvaluator implements Evaluator {
+  readonly kind = 'execution_metrics';
+
+  private readonly config: ExecutionMetricsEvaluatorConfig;
+
+  constructor(options: ExecutionMetricsEvaluatorOptions) {
+    this.config = options.config;
+  }
+
+  evaluate(context: EvaluationContext): EvaluationScore {
+    const { traceSummary } = context;
+    const {
+      max_tool_calls,
+      max_llm_calls,
+      max_tokens,
+      max_cost_usd,
+      max_duration_ms,
+      target_exploration_ratio,
+      exploration_tolerance = 0.2,
+    } = this.config;
+
+    // If no trace summary, we can't evaluate
+    if (!traceSummary) {
+      return {
+        score: 0,
+        verdict: 'fail',
+        hits: [],
+        misses: ['No trace summary available'],
+        expectedAspectCount: 1,
+        reasoning: 'Execution metrics not available - no trace summary provided',
+        evaluatorRawRequest: {
+          type: 'execution_metrics',
+          config: this.extractConfiguredThresholds(),
+          actual: null,
+        },
+      };
+    }
+
+    const hits: string[] = [];
+    const misses: string[] = [];
+    const actualMetrics: Record<string, number | undefined> = {};
+
+    // Check max_tool_calls
+    if (max_tool_calls !== undefined) {
+      const toolCalls = traceSummary.eventCount;
+      actualMetrics.tool_calls = toolCalls;
+
+      if (toolCalls <= max_tool_calls) {
+        hits.push(`Tool calls ${toolCalls} <= ${max_tool_calls} max`);
+      } else {
+        misses.push(`Tool calls ${toolCalls} > ${max_tool_calls} max`);
+      }
+    }
+
+    // Check max_llm_calls
+    if (max_llm_calls !== undefined) {
+      const llmCalls = traceSummary.llmCallCount;
+
+      if (llmCalls === undefined) {
+        misses.push('LLM call count data not available');
+      } else {
+        actualMetrics.llm_calls = llmCalls;
+
+        if (llmCalls <= max_llm_calls) {
+          hits.push(`LLM calls ${llmCalls} <= ${max_llm_calls} max`);
+        } else {
+          misses.push(`LLM calls ${llmCalls} > ${max_llm_calls} max`);
+        }
+      }
+    }
+
+    // Check max_tokens
+    if (max_tokens !== undefined) {
+      const tokenUsage = traceSummary.tokenUsage;
+
+      if (!tokenUsage) {
+        misses.push('Token usage data not available');
+      } else {
+        const totalTokens = tokenUsage.input + tokenUsage.output;
+        actualMetrics.tokens = totalTokens;
+
+        if (totalTokens <= max_tokens) {
+          hits.push(`Total tokens ${totalTokens} <= ${max_tokens} max`);
+        } else {
+          misses.push(`Total tokens ${totalTokens} > ${max_tokens} max`);
+        }
+      }
+    }
+
+    // Check max_cost_usd
+    if (max_cost_usd !== undefined) {
+      const costUsd = traceSummary.costUsd;
+
+      if (costUsd === undefined) {
+        misses.push('Cost data not available');
+      } else {
+        actualMetrics.cost_usd = costUsd;
+
+        const formatCost = (n: number) => `$${n.toFixed(4)}`;
+        if (costUsd <= max_cost_usd) {
+          hits.push(`Cost ${formatCost(costUsd)} <= ${formatCost(max_cost_usd)} max`);
+        } else {
+          misses.push(`Cost ${formatCost(costUsd)} > ${formatCost(max_cost_usd)} max`);
+        }
+      }
+    }
+
+    // Check max_duration_ms
+    if (max_duration_ms !== undefined) {
+      const durationMs = traceSummary.durationMs;
+
+      if (durationMs === undefined) {
+        misses.push('Duration data not available');
+      } else {
+        actualMetrics.duration_ms = durationMs;
+
+        if (durationMs <= max_duration_ms) {
+          hits.push(`Duration ${durationMs}ms <= ${max_duration_ms}ms max`);
+        } else {
+          misses.push(`Duration ${durationMs}ms > ${max_duration_ms}ms max`);
+        }
+      }
+    }
+
+    // Check target_exploration_ratio
+    if (target_exploration_ratio !== undefined) {
+      const ratio = explorationRatio(traceSummary);
+
+      if (ratio === undefined) {
+        misses.push('Exploration ratio not available (no tool calls)');
+      } else {
+        actualMetrics.exploration_ratio = ratio;
+
+        const diff = Math.abs(ratio - target_exploration_ratio);
+        if (diff <= exploration_tolerance) {
+          hits.push(
+            `Exploration ratio ${ratio.toFixed(2)} within tolerance of target ${target_exploration_ratio}`,
+          );
+        } else {
+          misses.push(
+            `Exploration ratio ${ratio.toFixed(2)} outside tolerance of target ${target_exploration_ratio} (diff: ${diff.toFixed(2)}, tolerance: ${exploration_tolerance})`,
+          );
+        }
+      }
+    }
+
+    // Calculate score as proportion of hits
+    const totalChecks = hits.length + misses.length;
+    const score = totalChecks > 0 ? hits.length / totalChecks : 0;
+
+    // Build reasoning
+    const reasoningParts: string[] = [];
+    if (actualMetrics.tool_calls !== undefined) {
+      reasoningParts.push(`tool_calls=${actualMetrics.tool_calls}`);
+    }
+    if (actualMetrics.llm_calls !== undefined) {
+      reasoningParts.push(`llm_calls=${actualMetrics.llm_calls}`);
+    }
+    if (actualMetrics.tokens !== undefined) {
+      reasoningParts.push(`tokens=${actualMetrics.tokens}`);
+    }
+    if (actualMetrics.cost_usd !== undefined) {
+      reasoningParts.push(`cost=$${actualMetrics.cost_usd.toFixed(4)}`);
+    }
+    if (actualMetrics.duration_ms !== undefined) {
+      reasoningParts.push(`duration=${actualMetrics.duration_ms}ms`);
+    }
+    if (actualMetrics.exploration_ratio !== undefined) {
+      reasoningParts.push(`exploration_ratio=${actualMetrics.exploration_ratio.toFixed(2)}`);
+    }
+
+    const reasoning =
+      reasoningParts.length > 0
+        ? `execution_metrics ${reasoningParts.join(', ')}`
+        : 'No metrics evaluated';
+
+    return {
+      score,
+      verdict: scoreToVerdict(score),
+      hits,
+      misses,
+      expectedAspectCount: totalChecks || 1,
+      reasoning,
+      evaluatorRawRequest: {
+        type: 'execution_metrics',
+        config: this.extractConfiguredThresholds(),
+        actual: this.filterDefinedMetrics(actualMetrics),
+      },
+    };
+  }
+
+  private extractConfiguredThresholds(): Record<string, number> {
+    const thresholds: Record<string, number> = {};
+
+    if (this.config.max_tool_calls !== undefined) {
+      thresholds.max_tool_calls = this.config.max_tool_calls;
+    }
+    if (this.config.max_llm_calls !== undefined) {
+      thresholds.max_llm_calls = this.config.max_llm_calls;
+    }
+    if (this.config.max_tokens !== undefined) {
+      thresholds.max_tokens = this.config.max_tokens;
+    }
+    if (this.config.max_cost_usd !== undefined) {
+      thresholds.max_cost_usd = this.config.max_cost_usd;
+    }
+    if (this.config.max_duration_ms !== undefined) {
+      thresholds.max_duration_ms = this.config.max_duration_ms;
+    }
+    if (this.config.target_exploration_ratio !== undefined) {
+      thresholds.target_exploration_ratio = this.config.target_exploration_ratio;
+      thresholds.exploration_tolerance = this.config.exploration_tolerance ?? 0.2;
+    }
+
+    return thresholds;
+  }
+
+  private filterDefinedMetrics(
+    metrics: Record<string, number | undefined>,
+  ): Record<string, number> | null {
+    const defined: Record<string, number> = {};
+    let hasAny = false;
+
+    for (const [key, value] of Object.entries(metrics)) {
+      if (value !== undefined) {
+        defined[key] = value;
+        hasAny = true;
+      }
+    }
+
+    return hasAny ? defined : null;
+  }
+}

--- a/packages/core/src/evaluation/evaluators/index.ts
+++ b/packages/core/src/evaluation/evaluators/index.ts
@@ -29,6 +29,9 @@ export type { CompositeEvaluatorOptions } from './composite.js';
 export { CostEvaluator } from './cost.js';
 export type { CostEvaluatorOptions } from './cost.js';
 
+export { ExecutionMetricsEvaluator } from './execution-metrics.js';
+export type { ExecutionMetricsEvaluatorOptions } from './execution-metrics.js';
+
 export { FieldAccuracyEvaluator } from './field-accuracy.js';
 export type { FieldAccuracyEvaluatorOptions } from './field-accuracy.js';
 

--- a/packages/core/src/evaluation/types.ts
+++ b/packages/core/src/evaluation/types.ts
@@ -157,6 +157,7 @@ const EVALUATOR_KIND_VALUES = [
   'latency',
   'cost',
   'token_usage',
+  'execution_metrics',
 ] as const;
 
 export type EvaluatorKind = (typeof EVALUATOR_KIND_VALUES)[number];
@@ -364,6 +365,31 @@ export type TokenUsageEvaluatorConfig = {
   readonly weight?: number;
 };
 
+/**
+ * Configuration for the execution_metrics evaluator.
+ * Provides declarative threshold-based checks on execution metrics.
+ * Only specified thresholds are checked; omitted ones are ignored.
+ */
+export type ExecutionMetricsEvaluatorConfig = {
+  readonly name: string;
+  readonly type: 'execution_metrics';
+  /** Maximum allowed number of tool calls */
+  readonly max_tool_calls?: number;
+  /** Maximum allowed number of LLM calls (assistant messages) */
+  readonly max_llm_calls?: number;
+  /** Maximum allowed total tokens (input + output) */
+  readonly max_tokens?: number;
+  /** Maximum allowed cost in USD */
+  readonly max_cost_usd?: number;
+  /** Maximum allowed duration in milliseconds */
+  readonly max_duration_ms?: number;
+  /** Target exploration ratio (0-1, proportion of read-only tool calls) */
+  readonly target_exploration_ratio?: number;
+  /** Tolerance for exploration ratio check (default: 0.2) */
+  readonly exploration_tolerance?: number;
+  readonly weight?: number;
+};
+
 export type EvaluatorConfig =
   | CodeEvaluatorConfig
   | LlmJudgeEvaluatorConfig
@@ -372,7 +398,8 @@ export type EvaluatorConfig =
   | FieldAccuracyEvaluatorConfig
   | LatencyEvaluatorConfig
   | CostEvaluatorConfig
-  | TokenUsageEvaluatorConfig;
+  | TokenUsageEvaluatorConfig
+  | ExecutionMetricsEvaluatorConfig;
 
 /**
  * Eval case definition sourced from AgentV specs.

--- a/packages/core/test/evaluation/evaluators/execution-metrics.test.ts
+++ b/packages/core/test/evaluation/evaluators/execution-metrics.test.ts
@@ -1,0 +1,597 @@
+import { describe, expect, it } from 'bun:test';
+
+import { ExecutionMetricsEvaluator } from '../../../src/evaluation/evaluators/execution-metrics.js';
+import type { ResolvedTarget } from '../../../src/evaluation/providers/targets.js';
+import type { TraceSummary } from '../../../src/evaluation/trace.js';
+import type { EvalCase, ExecutionMetricsEvaluatorConfig } from '../../../src/evaluation/types.js';
+
+const baseTestCase: EvalCase = {
+  id: 'metrics-test',
+  dataset: 'test',
+  question: 'Test question',
+  input_messages: [{ role: 'user', content: 'Test' }],
+  input_segments: [{ type: 'text', value: 'Test' }],
+  expected_messages: [],
+  reference_answer: '',
+  guideline_paths: [],
+  file_paths: [],
+  expected_outcome: 'Test outcome',
+};
+
+const baseTarget: ResolvedTarget = {
+  kind: 'mock',
+  name: 'mock',
+  config: { response: '{}' },
+};
+
+const baseMockProvider = {
+  id: 'mock',
+  kind: 'mock' as const,
+  targetName: 'mock',
+  invoke: async () => ({ outputMessages: [{ role: 'assistant' as const, content: 'test' }] }),
+};
+
+function createContext(traceSummary?: TraceSummary) {
+  return {
+    evalCase: baseTestCase,
+    candidate: 'Test answer',
+    target: baseTarget,
+    provider: baseMockProvider,
+    attempt: 0,
+    promptInputs: { question: '', guidelines: '' },
+    now: new Date(),
+    traceSummary,
+  };
+}
+
+describe('ExecutionMetricsEvaluator', () => {
+  describe('max_tool_calls', () => {
+    it('passes when tool calls are within limit', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        max_tool_calls: 10,
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 5,
+          toolNames: ['Read', 'Edit'],
+          toolCallsByName: { Read: 3, Edit: 2 },
+          errorCount: 0,
+        }),
+      );
+
+      expect(result.score).toBe(1);
+      expect(result.verdict).toBe('pass');
+      expect(result.hits).toContain('Tool calls 5 <= 10 max');
+      expect(result.misses).toHaveLength(0);
+    });
+
+    it('fails when tool calls exceed limit', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        max_tool_calls: 5,
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 10,
+          toolNames: ['Read', 'Edit'],
+          toolCallsByName: { Read: 6, Edit: 4 },
+          errorCount: 0,
+        }),
+      );
+
+      expect(result.score).toBe(0);
+      expect(result.verdict).toBe('fail');
+      expect(result.hits).toHaveLength(0);
+      expect(result.misses).toContain('Tool calls 10 > 5 max');
+    });
+  });
+
+  describe('max_llm_calls', () => {
+    it('passes when LLM calls are within limit', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        max_llm_calls: 5,
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 3,
+          toolNames: ['Read'],
+          toolCallsByName: { Read: 3 },
+          errorCount: 0,
+          llmCallCount: 3,
+        }),
+      );
+
+      expect(result.score).toBe(1);
+      expect(result.verdict).toBe('pass');
+      expect(result.hits).toContain('LLM calls 3 <= 5 max');
+    });
+
+    it('fails when LLM calls exceed limit', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        max_llm_calls: 2,
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 3,
+          toolNames: ['Read'],
+          toolCallsByName: { Read: 3 },
+          errorCount: 0,
+          llmCallCount: 5,
+        }),
+      );
+
+      expect(result.score).toBe(0);
+      expect(result.verdict).toBe('fail');
+      expect(result.misses).toContain('LLM calls 5 > 2 max');
+    });
+  });
+
+  describe('max_tokens', () => {
+    it('passes when token usage is within limit', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        max_tokens: 2000,
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 3,
+          toolNames: ['Read'],
+          toolCallsByName: { Read: 3 },
+          errorCount: 0,
+          tokenUsage: { input: 800, output: 400 },
+        }),
+      );
+
+      expect(result.score).toBe(1);
+      expect(result.verdict).toBe('pass');
+      expect(result.hits).toContain('Total tokens 1200 <= 2000 max');
+    });
+
+    it('fails when token usage exceeds limit', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        max_tokens: 1000,
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 3,
+          toolNames: ['Read'],
+          toolCallsByName: { Read: 3 },
+          errorCount: 0,
+          tokenUsage: { input: 800, output: 400 },
+        }),
+      );
+
+      expect(result.score).toBe(0);
+      expect(result.verdict).toBe('fail');
+      expect(result.misses).toContain('Total tokens 1200 > 1000 max');
+    });
+  });
+
+  describe('max_cost_usd', () => {
+    it('passes when cost is within budget', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        max_cost_usd: 0.1,
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 3,
+          toolNames: ['Read'],
+          toolCallsByName: { Read: 3 },
+          errorCount: 0,
+          costUsd: 0.05,
+        }),
+      );
+
+      expect(result.score).toBe(1);
+      expect(result.verdict).toBe('pass');
+      expect(result.hits).toContain('Cost $0.0500 <= $0.1000 max');
+    });
+
+    it('fails when cost exceeds budget', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        max_cost_usd: 0.05,
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 3,
+          toolNames: ['Read'],
+          toolCallsByName: { Read: 3 },
+          errorCount: 0,
+          costUsd: 0.1,
+        }),
+      );
+
+      expect(result.score).toBe(0);
+      expect(result.verdict).toBe('fail');
+      expect(result.misses).toContain('Cost $0.1000 > $0.0500 max');
+    });
+  });
+
+  describe('max_duration_ms', () => {
+    it('passes when duration is within limit', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        max_duration_ms: 5000,
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 3,
+          toolNames: ['Read'],
+          toolCallsByName: { Read: 3 },
+          errorCount: 0,
+          durationMs: 3000,
+        }),
+      );
+
+      expect(result.score).toBe(1);
+      expect(result.verdict).toBe('pass');
+      expect(result.hits).toContain('Duration 3000ms <= 5000ms max');
+    });
+
+    it('fails when duration exceeds limit', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        max_duration_ms: 2000,
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 3,
+          toolNames: ['Read'],
+          toolCallsByName: { Read: 3 },
+          errorCount: 0,
+          durationMs: 5000,
+        }),
+      );
+
+      expect(result.score).toBe(0);
+      expect(result.verdict).toBe('fail');
+      expect(result.misses).toContain('Duration 5000ms > 2000ms max');
+    });
+  });
+
+  describe('target_exploration_ratio', () => {
+    it('passes when exploration ratio is within tolerance of target', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        target_exploration_ratio: 0.6,
+        exploration_tolerance: 0.2,
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 10,
+          toolNames: ['Read', 'Edit'],
+          toolCallsByName: { Read: 7, Edit: 3 }, // 70% exploration
+          errorCount: 0,
+        }),
+      );
+
+      expect(result.score).toBe(1);
+      expect(result.verdict).toBe('pass');
+      expect(result.hits[0]).toMatch(/Exploration ratio 0\.7.* within tolerance/);
+    });
+
+    it('fails when exploration ratio is outside tolerance', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        target_exploration_ratio: 0.8,
+        exploration_tolerance: 0.1,
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 10,
+          toolNames: ['Read', 'Edit'],
+          toolCallsByName: { Read: 5, Edit: 5 }, // 50% exploration
+          errorCount: 0,
+        }),
+      );
+
+      expect(result.score).toBe(0);
+      expect(result.verdict).toBe('fail');
+      expect(result.misses[0]).toMatch(/Exploration ratio 0\.5.* outside tolerance/);
+    });
+
+    it('uses default tolerance of 0.2 when not specified', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        target_exploration_ratio: 0.5,
+        // No exploration_tolerance specified, should default to 0.2
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 10,
+          toolNames: ['Read', 'Edit'],
+          toolCallsByName: { Read: 6, Edit: 4 }, // 60% exploration - within 0.2 of target 0.5
+          errorCount: 0,
+        }),
+      );
+
+      expect(result.score).toBe(1);
+      expect(result.verdict).toBe('pass');
+    });
+  });
+
+  describe('combined thresholds', () => {
+    it('passes when all specified thresholds are within limits', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        max_tool_calls: 10,
+        max_llm_calls: 5,
+        max_tokens: 2000,
+        max_cost_usd: 0.1,
+        max_duration_ms: 5000,
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 5,
+          toolNames: ['Read', 'Edit'],
+          toolCallsByName: { Read: 3, Edit: 2 },
+          errorCount: 0,
+          llmCallCount: 3,
+          tokenUsage: { input: 500, output: 300 },
+          costUsd: 0.05,
+          durationMs: 3000,
+        }),
+      );
+
+      expect(result.score).toBe(1);
+      expect(result.verdict).toBe('pass');
+      expect(result.hits).toHaveLength(5);
+      expect(result.misses).toHaveLength(0);
+    });
+
+    it('calculates proportional score based on hits and misses', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        max_tool_calls: 10,
+        max_llm_calls: 2, // Will fail
+        max_tokens: 2000,
+        max_cost_usd: 0.01, // Will fail
+        max_duration_ms: 5000,
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 5,
+          toolNames: ['Read', 'Edit'],
+          toolCallsByName: { Read: 3, Edit: 2 },
+          errorCount: 0,
+          llmCallCount: 5, // Exceeds max_llm_calls
+          tokenUsage: { input: 500, output: 300 },
+          costUsd: 0.05, // Exceeds max_cost_usd
+          durationMs: 3000,
+        }),
+      );
+
+      // 3 hits (tool_calls, tokens, duration), 2 misses (llm_calls, cost)
+      expect(result.score).toBeCloseTo(0.6); // 3 / 5
+      expect(result.verdict).toBe('borderline');
+      expect(result.hits).toHaveLength(3);
+      expect(result.misses).toHaveLength(2);
+    });
+  });
+
+  describe('omitted thresholds', () => {
+    it('only checks specified thresholds', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        max_tool_calls: 10,
+        // Other thresholds not specified
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 5,
+          toolNames: ['Read', 'Edit'],
+          toolCallsByName: { Read: 3, Edit: 2 },
+          errorCount: 0,
+          // Even though llmCallCount is high, it's not being checked
+          llmCallCount: 100,
+          tokenUsage: { input: 10000, output: 10000 },
+          costUsd: 1.0,
+          durationMs: 100000,
+        }),
+      );
+
+      expect(result.score).toBe(1);
+      expect(result.verdict).toBe('pass');
+      expect(result.hits).toHaveLength(1);
+      expect(result.hits).toContain('Tool calls 5 <= 10 max');
+    });
+  });
+
+  describe('missing data handling', () => {
+    it('fails when no traceSummary is available', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        max_tool_calls: 10,
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(createContext(undefined));
+
+      expect(result.score).toBe(0);
+      expect(result.verdict).toBe('fail');
+      expect(result.misses).toContain('No trace summary available');
+    });
+
+    it('fails threshold check when required metric is missing', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        max_cost_usd: 0.1, // Checking cost
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 5,
+          toolNames: ['Read'],
+          toolCallsByName: { Read: 5 },
+          errorCount: 0,
+          // costUsd is not provided
+        }),
+      );
+
+      expect(result.score).toBe(0);
+      expect(result.verdict).toBe('fail');
+      expect(result.misses).toContain('Cost data not available');
+    });
+
+    it('fails when tokenUsage is missing for max_tokens check', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        max_tokens: 1000,
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 5,
+          toolNames: ['Read'],
+          toolCallsByName: { Read: 5 },
+          errorCount: 0,
+          // tokenUsage is not provided
+        }),
+      );
+
+      expect(result.score).toBe(0);
+      expect(result.verdict).toBe('fail');
+      expect(result.misses).toContain('Token usage data not available');
+    });
+
+    it('fails when durationMs is missing for max_duration_ms check', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        max_duration_ms: 5000,
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 5,
+          toolNames: ['Read'],
+          toolCallsByName: { Read: 5 },
+          errorCount: 0,
+          // durationMs is not provided
+        }),
+      );
+
+      expect(result.score).toBe(0);
+      expect(result.verdict).toBe('fail');
+      expect(result.misses).toContain('Duration data not available');
+    });
+
+    it('fails when llmCallCount is missing for max_llm_calls check', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        max_llm_calls: 5,
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 5,
+          toolNames: ['Read'],
+          toolCallsByName: { Read: 5 },
+          errorCount: 0,
+          // llmCallCount is not provided
+        }),
+      );
+
+      expect(result.score).toBe(0);
+      expect(result.verdict).toBe('fail');
+      expect(result.misses).toContain('LLM call count data not available');
+    });
+  });
+
+  describe('evaluatorRawRequest', () => {
+    it('includes all config values and actual metrics in rawRequest', () => {
+      const config: ExecutionMetricsEvaluatorConfig = {
+        name: 'test-metrics',
+        type: 'execution_metrics',
+        max_tool_calls: 10,
+        max_tokens: 2000,
+        weight: 2.0,
+      };
+
+      const evaluator = new ExecutionMetricsEvaluator({ config });
+      const result = evaluator.evaluate(
+        createContext({
+          eventCount: 5,
+          toolNames: ['Read'],
+          toolCallsByName: { Read: 5 },
+          errorCount: 0,
+          tokenUsage: { input: 500, output: 300 },
+        }),
+      );
+
+      expect(result.evaluatorRawRequest).toEqual({
+        type: 'execution_metrics',
+        config: {
+          max_tool_calls: 10,
+          max_tokens: 2000,
+        },
+        actual: {
+          tool_calls: 5,
+          tokens: 800,
+        },
+      });
+    });
+  });
+});

--- a/packages/core/test/evaluation/loaders/evaluator-parser.test.ts
+++ b/packages/core/test/evaluation/loaders/evaluator-parser.test.ts
@@ -592,3 +592,190 @@ describe('parseEvaluators - token_usage', () => {
     });
   });
 });
+
+describe('parseEvaluators - execution_metrics', () => {
+  it('parses execution_metrics evaluator with all thresholds', async () => {
+    const rawEvalCase = {
+      evaluators: [
+        {
+          name: 'efficiency-check',
+          type: 'execution_metrics',
+          max_tool_calls: 10,
+          max_llm_calls: 5,
+          max_tokens: 2000,
+          max_cost_usd: 0.1,
+          max_duration_ms: 5000,
+          target_exploration_ratio: 0.6,
+          exploration_tolerance: 0.15,
+          weight: 2.0,
+        },
+      ],
+    };
+
+    const evaluators = await parseEvaluators(rawEvalCase, undefined, [process.cwd()], 'test-case');
+
+    expect(evaluators).toHaveLength(1);
+    expect(evaluators?.[0]).toEqual({
+      name: 'efficiency-check',
+      type: 'execution_metrics',
+      max_tool_calls: 10,
+      max_llm_calls: 5,
+      max_tokens: 2000,
+      max_cost_usd: 0.1,
+      max_duration_ms: 5000,
+      target_exploration_ratio: 0.6,
+      exploration_tolerance: 0.15,
+      weight: 2.0,
+    });
+  });
+
+  it('parses execution_metrics with only max_tool_calls', async () => {
+    const rawEvalCase = {
+      evaluators: [
+        {
+          name: 'tool-limit',
+          type: 'execution_metrics',
+          max_tool_calls: 15,
+        },
+      ],
+    };
+
+    const evaluators = await parseEvaluators(rawEvalCase, undefined, [process.cwd()], 'test-case');
+
+    expect(evaluators).toHaveLength(1);
+    expect(evaluators?.[0]).toEqual({
+      name: 'tool-limit',
+      type: 'execution_metrics',
+      max_tool_calls: 15,
+    });
+  });
+
+  it('parses execution_metrics with camelCase aliases', async () => {
+    const rawEvalCase = {
+      evaluators: [
+        {
+          name: 'camel-case',
+          type: 'execution_metrics',
+          maxToolCalls: 10,
+          maxLlmCalls: 5,
+          maxTokens: 2000,
+          maxCostUsd: 0.1,
+          maxDurationMs: 5000,
+        },
+      ],
+    };
+
+    const evaluators = await parseEvaluators(rawEvalCase, undefined, [process.cwd()], 'test-case');
+
+    expect(evaluators).toHaveLength(1);
+    expect(evaluators?.[0]).toEqual({
+      name: 'camel-case',
+      type: 'execution_metrics',
+      max_tool_calls: 10,
+      max_llm_calls: 5,
+      max_tokens: 2000,
+      max_cost_usd: 0.1,
+      max_duration_ms: 5000,
+    });
+  });
+
+  it('skips execution_metrics with no thresholds specified', async () => {
+    const rawEvalCase = {
+      evaluators: [
+        {
+          name: 'no-thresholds',
+          type: 'execution_metrics',
+        },
+      ],
+    };
+
+    const evaluators = await parseEvaluators(rawEvalCase, undefined, [process.cwd()], 'test-case');
+
+    expect(evaluators).toBeUndefined();
+  });
+
+  it('skips execution_metrics when only exploration_tolerance is set (no threshold)', async () => {
+    const rawEvalCase = {
+      evaluators: [
+        {
+          name: 'only-tolerance',
+          type: 'execution_metrics',
+          exploration_tolerance: 0.2,
+        },
+      ],
+    };
+
+    const evaluators = await parseEvaluators(rawEvalCase, undefined, [process.cwd()], 'test-case');
+
+    expect(evaluators).toBeUndefined();
+  });
+
+  it('skips execution_metrics with invalid threshold value (negative)', async () => {
+    const rawEvalCase = {
+      evaluators: [
+        {
+          name: 'negative-threshold',
+          type: 'execution_metrics',
+          max_tool_calls: -5,
+        },
+      ],
+    };
+
+    const evaluators = await parseEvaluators(rawEvalCase, undefined, [process.cwd()], 'test-case');
+
+    expect(evaluators).toBeUndefined();
+  });
+
+  it('skips execution_metrics with invalid threshold value (non-number)', async () => {
+    const rawEvalCase = {
+      evaluators: [
+        {
+          name: 'string-threshold',
+          type: 'execution_metrics',
+          max_tool_calls: 'ten',
+        },
+      ],
+    };
+
+    const evaluators = await parseEvaluators(rawEvalCase, undefined, [process.cwd()], 'test-case');
+
+    expect(evaluators).toBeUndefined();
+  });
+
+  it('skips execution_metrics with Infinity threshold value', async () => {
+    const rawEvalCase = {
+      evaluators: [
+        {
+          name: 'infinity-threshold',
+          type: 'execution_metrics',
+          max_tokens: Number.POSITIVE_INFINITY,
+        },
+      ],
+    };
+
+    const evaluators = await parseEvaluators(rawEvalCase, undefined, [process.cwd()], 'test-case');
+
+    expect(evaluators).toBeUndefined();
+  });
+
+  it('parses execution_metrics with target_exploration_ratio', async () => {
+    const rawEvalCase = {
+      evaluators: [
+        {
+          name: 'exploration-check',
+          type: 'execution_metrics',
+          target_exploration_ratio: 0.7,
+        },
+      ],
+    };
+
+    const evaluators = await parseEvaluators(rawEvalCase, undefined, [process.cwd()], 'test-case');
+
+    expect(evaluators).toHaveLength(1);
+    expect(evaluators?.[0]).toEqual({
+      name: 'exploration-check',
+      type: 'execution_metrics',
+      target_exploration_ratio: 0.7,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a declarative `execution_metrics` evaluator type for threshold-based checks on execution metrics.

### Features
- **Threshold types**: `max_tool_calls`, `max_llm_calls`, `max_tokens`, `max_cost_usd`, `max_duration_ms`, `target_exploration_ratio`
- **Proportional scoring**: `hits / (hits + misses)`
- **Graceful handling**: Missing data is treated as a miss with clear messaging
- **Flexible config**: Only specified thresholds are checked; omitted ones are ignored

### Example usage
```yaml
evaluators:
  - name: efficiency-check
    type: execution_metrics
    max_tool_calls: 10
    max_llm_calls: 5
    max_tokens: 5000
    max_cost_usd: 0.05
    max_duration_ms: 30000
```

### Files changed
- `packages/core/src/evaluation/evaluators/execution-metrics.ts` - New evaluator
- `packages/core/src/evaluation/types.ts` - Config type
- `packages/core/src/evaluation/loaders/evaluator-parser.ts` - Parser support
- `packages/core/src/evaluation/orchestrator.ts` - Integration
- `examples/features/execution-metrics/` - Example eval file

### Test plan
- [x] 22 unit tests for evaluator
- [x] Parser tests for YAML config
- [x] E2E test with `--dry-run`
- [x] Full test suite passes (526 tests)

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)