### PR TITLE
docs: add execution_metrics evaluator and --trace flag documentation

### DIFF
--- a/.claude/skills/agentv-eval-builder/SKILL.md
+++ b/.claude/skills/agentv-eval-builder/SKILL.md
@@ -147,6 +147,21 @@ Compares `output_messages` fields against `expected_messages` fields.
   max_total_tokens: 4000
 ```
 
+### execution_metrics
+```yaml
+- name: efficiency
+  type: execution_metrics
+  max_tool_calls: 10        # Maximum tool invocations
+  max_llm_calls: 5          # Maximum LLM calls (assistant messages)
+  max_tokens: 5000          # Maximum total tokens (input + output)
+  max_cost_usd: 0.05        # Maximum cost in USD
+  max_duration_ms: 30000    # Maximum execution duration
+  target_exploration_ratio: 0.6   # Target ratio of read-only tool calls
+  exploration_tolerance: 0.2      # Tolerance for ratio check (default: 0.2)
+```
+Declarative threshold-based checks on execution metrics. Only specified thresholds are checked.
+Score is proportional: `hits / (hits + misses)`. Missing data counts as a miss.
+
 ### rubric (inline)
 ```yaml
 rubrics:
@@ -163,6 +178,9 @@ See `references/rubric-evaluator.md` for score-range mode and scoring formula.
 ```bash
 # Run evaluation
 bun agentv eval <file.yaml> [--eval-id <id>] [--target <name>] [--dry-run]
+
+# Run with trace persistence (writes to .agentv/traces/)
+bun agentv eval <file.yaml> --trace
 
 # Validate eval file
 bun agentv validate <file.yaml>

--- a/.claude/skills/agentv-eval-builder/references/custom-evaluators.md
+++ b/.claude/skills/agentv-eval-builder/references/custom-evaluators.md
@@ -20,9 +20,12 @@
     "tool_names": ["fetch"],
     "tool_calls_by_name": {"fetch": 1},
     "error_count": 0,
+    "llm_call_count": 2,
     "token_usage": {"input": 1000, "output": 500},
     "cost_usd": 0.0015,
-    "duration_ms": 3500
+    "duration_ms": 3500,
+    "start_time": "2026-02-13T10:00:00.000Z",
+    "end_time": "2026-02-13T10:00:03.500Z"
   }
 }
 ```

--- a/apps/web/src/content/docs/evaluation/running-evals.mdx
+++ b/apps/web/src/content/docs/evaluation/running-evals.mdx
@@ -49,6 +49,21 @@ Dry-run returns mock responses that don't match evaluator output schemas. Use it
 agentv eval evals/my-eval.yaml --out results/baseline.jsonl
 ```
 
+### Trace Persistence
+
+Persist full execution traces (tool calls, timing, spans) to disk for debugging and analysis:
+
+```bash
+agentv eval evals/my-eval.yaml --trace
+```
+
+Traces are written to `.agentv/traces/<timestamp>/<eval-file>.trace.jsonl` as JSONL records containing:
+- `evalId` - The eval case identifier
+- `startTime` / `endTime` - Execution boundaries
+- `durationMs` - Total execution duration
+- `spans` - Array of tool invocations with timing and input/output
+- `tokenUsage` / `costUsd` - Resource consumption
+
 ### Workspace Cleanup
 
 When using `workspace_template`, temporary workspaces are created for each eval case. By default, workspaces are cleaned up on success and preserved on failure for debugging.

--- a/apps/web/src/content/docs/evaluators/code-judges.mdx
+++ b/apps/web/src/content/docs/evaluators/code-judges.mdx
@@ -200,11 +200,27 @@ Beyond the basic `question`, `expected_outcome`, `candidate_answer`, and `refere
   "tool_names": ["fetch", "search"],
   "tool_calls_by_name": { "search": 2, "fetch": 1 },
   "error_count": 0,
+  "llm_call_count": 2,
   "token_usage": { "input": 1000, "output": 500 },
   "cost_usd": 0.0015,
-  "duration_ms": 3500
+  "duration_ms": 3500,
+  "start_time": "2026-02-13T10:00:00.000Z",
+  "end_time": "2026-02-13T10:00:03.500Z"
 }
 ```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `event_count` | `number` | Total tool invocations |
+| `tool_names` | `string[]` | Unique tool names used |
+| `tool_calls_by_name` | `Record<string, number>` | Count per tool |
+| `error_count` | `number` | Failed tool calls |
+| `llm_call_count` | `number` | Number of LLM calls (assistant messages) |
+| `token_usage` | `{input, output}` | Token consumption |
+| `cost_usd` | `number` | Estimated cost |
+| `duration_ms` | `number` | Total execution duration |
+| `start_time` | `string` | ISO timestamp of first event |
+| `end_time` | `string` | ISO timestamp of last event |
 
 Use `expected_messages` for retrieval context in RAG evals (tool calls with outputs) and `output_messages` for the actual agent execution trace from live runs.
 

--- a/apps/web/src/content/docs/evaluators/execution-metrics.mdx
+++ b/apps/web/src/content/docs/evaluators/execution-metrics.mdx
@@ -1,0 +1,139 @@
+---
+title: Execution Metrics
+description: Threshold-based checks on execution metrics
+sidebar:
+  order: 5
+---
+
+AgentV provides built-in evaluators for checking execution metrics against thresholds. These are useful for enforcing efficiency constraints without writing custom code.
+
+## execution_metrics
+
+The `execution_metrics` evaluator provides declarative threshold-based checks on multiple metrics in a single evaluator.
+
+```yaml
+evaluators:
+  - name: efficiency
+    type: execution_metrics
+    max_tool_calls: 10        # Maximum tool invocations
+    max_llm_calls: 5          # Maximum LLM calls (assistant messages)
+    max_tokens: 5000          # Maximum total tokens (input + output)
+    max_cost_usd: 0.05        # Maximum cost in USD
+    max_duration_ms: 30000    # Maximum execution duration in ms
+    target_exploration_ratio: 0.6   # Target ratio of read-only tool calls
+    exploration_tolerance: 0.2      # Tolerance for ratio check (default: 0.2)
+```
+
+### Behavior
+
+- **Only specified thresholds are checked** — omit fields you don't care about
+- **Score is proportional**: `hits / (hits + misses)`
+- **Missing data counts as a miss** — if you check `max_tokens` but no token data is available, it fails
+- **All thresholds are "max" constraints** — values must be ≤ the specified threshold
+
+### Threshold Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `max_tool_calls` | number | Maximum number of tool invocations |
+| `max_llm_calls` | number | Maximum LLM calls (counts assistant messages) |
+| `max_tokens` | number | Maximum total tokens (input + output combined) |
+| `max_cost_usd` | number | Maximum cost in USD |
+| `max_duration_ms` | number | Maximum execution duration in milliseconds |
+| `target_exploration_ratio` | number | Target ratio of read-only tool calls (0-1) |
+| `exploration_tolerance` | number | Tolerance around target ratio (default: 0.2) |
+
+### Example: Comprehensive Efficiency Check
+
+```yaml
+evalcases:
+  - id: efficient-research
+    expected_outcome: Agent researches and summarizes efficiently
+    input: Research the topic and provide a summary
+    execution:
+      evaluators:
+        - name: efficiency
+          type: execution_metrics
+          max_tool_calls: 15
+          max_llm_calls: 5
+          max_tokens: 8000
+          max_cost_usd: 0.10
+          max_duration_ms: 60000
+```
+
+### Example: Exploration Balance
+
+Check that an agent maintains a good balance between reading (exploration) and writing (action):
+
+```yaml
+evaluators:
+  - name: exploration-balance
+    type: execution_metrics
+    target_exploration_ratio: 0.6  # 60% should be read-only tools
+    exploration_tolerance: 0.2     # Allow ±20% variance
+```
+
+## Single-Metric Evaluators
+
+For simple single-threshold checks, AgentV also provides dedicated evaluators:
+
+### latency
+
+```yaml
+- name: speed
+  type: latency
+  max_ms: 5000
+```
+
+Fails if execution duration exceeds the threshold.
+
+### cost
+
+```yaml
+- name: budget
+  type: cost
+  max_usd: 0.10
+```
+
+Fails if execution cost exceeds the threshold.
+
+### token_usage
+
+```yaml
+- name: tokens
+  type: token_usage
+  max_total_tokens: 4000
+```
+
+Fails if total token usage exceeds the threshold.
+
+## When to Use Each
+
+| Scenario | Recommended Evaluator |
+|----------|----------------------|
+| Check multiple metrics at once | `execution_metrics` |
+| Simple single-threshold check | `latency`, `cost`, or `token_usage` |
+| Complex custom formulas | `code_judge` with custom script |
+
+## Combining with Other Evaluators
+
+Execution metrics work well alongside semantic evaluators:
+
+```yaml
+evalcases:
+  - id: code-generation
+    expected_outcome: Generates correct, efficient code
+    input: Write a sorting algorithm
+    execution:
+      evaluators:
+        # Semantic quality
+        - name: quality
+          type: llm_judge
+          prompt: ./prompts/code-quality.md
+
+        # Efficiency constraints
+        - name: efficiency
+          type: execution_metrics
+          max_tool_calls: 10
+          max_duration_ms: 30000
+```


### PR DESCRIPTION
## Summary

Updates documentation for the trace & execution metrics features added in #183.

### Changes

**Skill files (`.claude/skills/agentv-eval-builder/`):**
- Added `execution_metrics` evaluator section with all threshold options
- Added `--trace` flag to CLI commands
- Updated `trace_summary` schema with new fields (`llmCallCount`, `startTime`, `endTime`)

**Docs site (`apps/web/src/content/docs/`):**
- Created new `evaluators/execution-metrics.mdx` page with comprehensive documentation
- Updated `evaluation/running-evals.mdx` with `--trace` flag documentation
- Updated `evaluators/code-judges.mdx` with trace_summary field descriptions

### Related Issues

Closes documentation gap for #103, #172, #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)