### PR TITLE
fix(core): add auth token support for private git repo file references

### DIFF
--- a/apps/web/src/content/docs/evaluation/eval-cases.mdx
+++ b/apps/web/src/content/docs/evaluation/eval-cases.mdx
@@ -108,7 +108,7 @@ Supported file path formats:
 | `https://gitlab.com/...` | GitLab blob URL (cloned and cached) |
 | `https://bitbucket.org/...` | Bitbucket src URL (cloned and cached) |
 
-Git URLs are cloned once and cached in `~/.agentv/cache/repos/`.
+Git URLs are cloned once and cached in `~/.agentv/cache/repos/`. For private repositories, authenticate with your git host first (e.g., `gh auth login` for GitHub).
 
 ## Sidecar Metadata
 


### PR DESCRIPTION
## Summary

- Set `GIT_TERMINAL_PROMPT=0` on all git operations to prevent hanging on auth prompts in non-interactive mode
- Detect auth errors and show actionable hint: `Authenticate with your git host first (e.g., gh auth login for GitHub)`
- Relies on user's existing git credentials (SSH keys, credential helpers, etc.) — no token reading

Closes #192

## Test plan

- [x] All existing git-cache-manager tests pass (19 tests)
- [x] Manual verification: `bun agentv eval examples/features/git-url-references/evals/dataset.yaml` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)