### PR TITLE
feat(core): pass workspacePath to code judges for functional grading

### DIFF
--- a/.claude/skills/agentv-eval-builder/SKILL.md
+++ b/.claude/skills/agentv-eval-builder/SKILL.md
@@ -65,7 +65,9 @@ Configure via `execution.evaluators` array. Multiple evaluators produce a weight
   target: {}              # optional: enable LLM target proxy (max_calls: 50)
 ```
 Contract: stdin JSON -> stdout JSON `{score, hits, misses, reasoning}`
-See `references/custom-evaluators.md` for templates.
+Input includes: `question`, `expected_outcome`, `candidate_answer`, `reference_answer`, `output_messages`, `trace_summary`, `file_changes`, `workspace_path`, `config`
+When `workspace_template` is configured, `workspace_path` is the absolute path to the workspace dir (also available as `AGENTV_WORKSPACE_PATH` env var). Use this for functional grading (e.g., running `npm test` in the workspace).
+See docs at https://agentv.dev/evaluators/code-judges/
 
 ### llm_judge
 ```yaml

--- a/apps/web/src/content/docs/evaluators/code-judges.mdx
+++ b/apps/web/src/content/docs/evaluators/code-judges.mdx
@@ -192,6 +192,7 @@ Beyond the basic `question`, `expected_outcome`, `candidate_answer`, and `refere
 | `output_messages` | `Message[]` | Actual agent execution trace with tool calls |
 | `trace_summary` | `TraceSummary` | Lightweight execution metrics |
 | `file_changes` | `string \| null` | Unified diff of workspace file changes (when `workspace_template` is configured) |
+| `workspace_path` | `string \| null` | Absolute path to the workspace directory (when `workspace_template` is configured) |
 
 ### trace_summary structure
 
@@ -224,6 +225,75 @@ Beyond the basic `question`, `expected_outcome`, `candidate_answer`, and `refere
 | `end_time` | `string` | ISO timestamp of last event |
 
 Use `expected_messages` for retrieval context in RAG evals (tool calls with outputs) and `output_messages` for the actual agent execution trace from live runs.
+
+## Workspace Access
+
+When `workspace_template` is configured on a target, code judges receive the workspace path in two ways:
+
+1. **JSON payload**: `workspace_path` field in the stdin input
+2. **Environment variable**: `AGENTV_WORKSPACE_PATH`
+
+This enables **functional grading** — running commands like `npm test`, `pytest`, or `cargo test` directly in the agent's workspace.
+
+### Example: Deploy-and-Test Pattern
+
+```typescript
+#!/usr/bin/env bun
+import { readFileSync } from "fs";
+import { execFileSync } from "child_process";
+
+const input = JSON.parse(readFileSync("/dev/stdin", "utf-8"));
+const cwd = input.workspace_path;
+
+const hits: string[] = [];
+const misses: string[] = [];
+
+// Stage 1: Install dependencies
+try {
+  execFileSync("npm", ["install"], { cwd, stdio: "pipe" });
+  hits.push("npm install passed");
+} catch { misses.push("npm install failed"); }
+
+// Stage 2: Typecheck
+try {
+  execFileSync("npx", ["tsc", "--noEmit"], { cwd, stdio: "pipe" });
+  hits.push("typecheck passed");
+} catch { misses.push("typecheck failed"); }
+
+// Stage 3: Run tests
+try {
+  execFileSync("npm", ["test"], { cwd, stdio: "pipe" });
+  hits.push("tests passed");
+} catch { misses.push("tests failed"); }
+
+const total = hits.length + misses.length;
+console.log(JSON.stringify({
+  score: total > 0 ? hits.length / total : 0,
+  hits,
+  misses,
+}));
+```
+
+```yaml
+# targets.yaml
+targets:
+  - name: my_agent
+    provider: cli
+    command_template: "my-agent --task {INPUT_FILE} --output {OUTPUT_FILE}"
+    workspace_template: ./workspace-template
+
+# dataset.yaml
+evalcases:
+  - id: implement-feature
+    expected_outcome: Agent implements the feature correctly
+    input: "Implement the TODO functions in src/index.ts"
+    evaluators:
+      - name: functional-check
+        type: code_judge
+        script: bun scripts/functional-check.ts
+```
+
+See `examples/features/functional-grading/` for a complete working example.
 
 ## Testing Locally
 

--- a/examples/features/functional-grading/.agentv/targets.yaml
+++ b/examples/features/functional-grading/.agentv/targets.yaml
@@ -1,0 +1,12 @@
+targets:
+  # Mock agent that implements the stub functions in src/index.ts.
+  # Each eval case gets a fresh copy of workspace-template/ as its CWD.
+  - name: mock_agent
+    provider: cli
+    command_template: >-
+      bash -c '
+      printf "export function add(a: number, b: number): number {\n  return a + b;\n}\n\nexport function multiply(a: number, b: number): number {\n  return a * b;\n}\n\nexport function fibonacci(n: number): number {\n  if (n <= 1) return n;\n  let a = 0, b = 1;\n  for (let i = 2; i <= n; i++) {\n    const tmp = a + b;\n    a = b;\n    b = tmp;\n  }\n  return b;\n}\n" > src/index.ts &&
+      echo "Implemented add, multiply, and fibonacci functions." > {OUTPUT_FILE}
+      '
+    workspace_template: ../workspace-template
+    timeout_seconds: 30

--- a/examples/features/functional-grading/evals/dataset.yaml
+++ b/examples/features/functional-grading/evals/dataset.yaml
@@ -1,0 +1,30 @@
+# Functional grading example
+# Demonstrates using workspace_path to run commands in the agent's workspace.
+#
+# The workspace-template/ contains a TypeScript project with stubs and pre-written tests.
+# The mock agent implements the functions, then the code judge:
+# 1. Installs dependencies (npm install)
+# 2. Runs typecheck (tsc --noEmit)
+# 3. Compiles (tsc)
+# 4. Runs tests (npm test)
+#
+# This pattern works for any language/framework: Python + pytest, Rust + cargo test, etc.
+
+description: Functional grading with workspace_path — deploy-and-test pattern
+
+execution:
+  target: mock_agent
+
+evalcases:
+  - id: implement-math-functions
+    expected_outcome: >-
+      Agent implements add, multiply, and fibonacci functions
+      that pass all pre-written tests
+    input: >-
+      Implement the add, multiply, and fibonacci functions in src/index.ts.
+      The function signatures are already defined — replace the throw statements
+      with working implementations.
+    evaluators:
+      - name: functional-check
+        type: code_judge
+        script: ["bun", "run", "../scripts/functional-check.ts"]

--- a/examples/features/functional-grading/scripts/functional-check.ts
+++ b/examples/features/functional-grading/scripts/functional-check.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env bun
+/**
+ * Multi-stage functional grading judge.
+ *
+ * Uses workspace_path to run commands in the agent's workspace:
+ * 1. Install dependencies (npm install)
+ * 2. Typecheck (npx tsc --noEmit)
+ * 3. Run tests (npm test)
+ *
+ * Each stage contributes to the overall score.
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const input = JSON.parse(readFileSync('/dev/stdin', 'utf-8'));
+const workspacePath: string | null = input.workspace_path;
+
+if (!workspacePath) {
+  console.log(
+    JSON.stringify({
+      score: 0,
+      hits: [],
+      misses: ['workspace_path not provided — cannot run functional checks'],
+      reasoning: 'Code judge requires workspace_path to execute commands in the workspace',
+    }),
+  );
+  process.exit(0);
+}
+
+const hits: string[] = [];
+const misses: string[] = [];
+
+function runStage(name: string, command: string, args: string[]): boolean {
+  try {
+    execFileSync(command, args, { cwd: workspacePath as string, stdio: 'pipe', timeout: 60_000 });
+    hits.push(`${name} passed`);
+    return true;
+  } catch (err: unknown) {
+    const stderr =
+      err && typeof err === 'object' && 'stderr' in err
+        ? String((err as { stderr: unknown }).stderr).slice(-500)
+        : String(err).slice(-500);
+    misses.push(`${name} failed: ${stderr.trim()}`);
+    return false;
+  }
+}
+
+// Stage 1: Install dependencies
+runStage('npm install', 'npm', ['install', '--ignore-scripts']);
+
+// Stage 2: Typecheck
+runStage('typecheck', 'npx', ['tsc', '--noEmit']);
+
+// Stage 3: Compile
+const compiled = runStage('compile', 'npx', ['tsc']);
+
+// Stage 4: Run tests (only if compile succeeded)
+if (compiled) {
+  runStage('tests', 'node', ['test/index.test.js']);
+}
+
+const total = hits.length + misses.length;
+const score = total > 0 ? hits.length / total : 0;
+
+console.log(
+  JSON.stringify({
+    score,
+    hits,
+    misses,
+    reasoning: `Passed ${hits.length}/${total} stages`,
+  }),
+);

--- a/examples/features/functional-grading/workspace-template/package.json
+++ b/examples/features/functional-grading/workspace-template/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "workspace-template",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "node test/index.test.js"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/features/functional-grading/workspace-template/src/index.ts
+++ b/examples/features/functional-grading/workspace-template/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Implement the following functions:
+ *
+ * 1. add(a, b) - returns the sum of a and b
+ * 2. multiply(a, b) - returns the product of a and b
+ * 3. fibonacci(n) - returns the nth Fibonacci number (0-indexed)
+ */
+
+// TODO: implement add
+export function add(a: number, b: number): number {
+  throw new Error('Not implemented');
+}
+
+// TODO: implement multiply
+export function multiply(a: number, b: number): number {
+  throw new Error('Not implemented');
+}
+
+// TODO: implement fibonacci
+export function fibonacci(n: number): number {
+  throw new Error('Not implemented');
+}

--- a/examples/features/functional-grading/workspace-template/test/index.test.js
+++ b/examples/features/functional-grading/workspace-template/test/index.test.js
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+
+// Tests run against compiled output
+const { add, multiply, fibonacci } = await import('../dist/index.js');
+
+// add tests
+assert.strictEqual(add(2, 3), 5, 'add(2, 3) should be 5');
+assert.strictEqual(add(-1, -2), -3, 'add(-1, -2) should be -3');
+assert.strictEqual(add(0, 5), 5, 'add(0, 5) should be 5');
+
+// multiply tests
+assert.strictEqual(multiply(3, 4), 12, 'multiply(3, 4) should be 12');
+assert.strictEqual(multiply(5, 0), 0, 'multiply(5, 0) should be 0');
+assert.strictEqual(multiply(-2, 3), -6, 'multiply(-2, 3) should be -6');
+
+// fibonacci tests
+assert.strictEqual(fibonacci(0), 0, 'fibonacci(0) should be 0');
+assert.strictEqual(fibonacci(1), 1, 'fibonacci(1) should be 1');
+assert.strictEqual(fibonacci(6), 8, 'fibonacci(6) should be 8');
+assert.strictEqual(fibonacci(10), 55, 'fibonacci(10) should be 55');
+
+console.log('All tests passed');

--- a/examples/features/functional-grading/workspace-template/tsconfig.json
+++ b/examples/features/functional-grading/workspace-template/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "outDir": "dist",
+    "strict": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/core/src/evaluation/evaluators/types.ts
+++ b/packages/core/src/evaluation/evaluators/types.ts
@@ -37,6 +37,8 @@ export interface EvaluationContext {
   readonly availableTargets?: readonly string[];
   /** Unified diff of file changes from workspace (when workspace_template is configured) */
   readonly fileChanges?: string;
+  /** Absolute path to the workspace directory (when workspace_template is configured) */
+  readonly workspacePath?: string;
 }
 
 export interface EvaluationScore {

--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -783,6 +783,7 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
       targetResolver,
       availableTargets,
       fileChanges,
+      workspacePath,
     });
 
     const finalResult = providerError ? { ...result, error: providerError } : result;
@@ -841,6 +842,7 @@ async function evaluateCandidate(options: {
   readonly targetResolver?: (name: string) => Provider | undefined;
   readonly availableTargets?: readonly string[];
   readonly fileChanges?: string;
+  readonly workspacePath?: string;
 }): Promise<EvaluationResult> {
   const {
     evalCase,
@@ -858,6 +860,7 @@ async function evaluateCandidate(options: {
     targetResolver,
     availableTargets,
     fileChanges,
+    workspacePath,
   } = options;
 
   const gradeTimestamp = nowFn();
@@ -877,6 +880,7 @@ async function evaluateCandidate(options: {
     targetResolver,
     availableTargets,
     fileChanges,
+    workspacePath,
   });
 
   const completedAt = nowFn();
@@ -939,6 +943,7 @@ async function runEvaluatorsForCase(options: {
   readonly targetResolver?: (name: string) => Provider | undefined;
   readonly availableTargets?: readonly string[];
   readonly fileChanges?: string;
+  readonly workspacePath?: string;
 }): Promise<{ score: EvaluationScore; evaluatorResults?: EvaluatorResult[] }> {
   const {
     evalCase,
@@ -956,6 +961,7 @@ async function runEvaluatorsForCase(options: {
     targetResolver,
     availableTargets,
     fileChanges,
+    workspacePath,
   } = options;
 
   if (evalCase.evaluators && evalCase.evaluators.length > 0) {
@@ -976,6 +982,7 @@ async function runEvaluatorsForCase(options: {
       targetResolver,
       availableTargets,
       fileChanges,
+      workspacePath,
     });
   }
 
@@ -999,6 +1006,7 @@ async function runEvaluatorsForCase(options: {
     targetResolver,
     availableTargets,
     fileChanges,
+    workspacePath,
   });
 
   return { score };
@@ -1023,6 +1031,7 @@ async function runEvaluatorList(options: {
   readonly targetResolver?: (name: string) => Provider | undefined;
   readonly availableTargets?: readonly string[];
   readonly fileChanges?: string;
+  readonly workspacePath?: string;
 }): Promise<{ score: EvaluationScore; evaluatorResults: EvaluatorResult[] }> {
   const {
     evalCase,
@@ -1041,6 +1050,7 @@ async function runEvaluatorList(options: {
     targetResolver,
     availableTargets,
     fileChanges,
+    workspacePath,
   } = options;
 
   const scored: Array<{
@@ -1069,6 +1079,7 @@ async function runEvaluatorList(options: {
           traceSummary,
           agentTimeoutMs,
           fileChanges,
+          workspacePath,
         });
         const weight = evaluator.weight ?? 1.0;
         scored.push({ score, name: evaluator.name, type: evaluator.type, weight });
@@ -1107,6 +1118,7 @@ async function runEvaluatorList(options: {
           targetResolver,
           availableTargets,
           fileChanges,
+          workspacePath,
         });
         const weight = evaluator.weight ?? 1.0;
         scored.push({ score, name: evaluator.name, type: 'code_judge', weight });
@@ -1197,6 +1209,7 @@ async function runEvaluatorList(options: {
           targetResolver,
           availableTargets,
           fileChanges,
+          workspacePath,
         });
         const weight = evaluator.weight ?? 1.0;
         scored.push({ score, name: evaluator.name, type: evaluator.type, weight });
@@ -1229,6 +1242,7 @@ async function runEvaluatorList(options: {
           outputMessages,
           traceSummary,
           fileChanges,
+          workspacePath,
         });
         const weight = evaluator.weight ?? 1.0;
         scored.push({ score, name: evaluator.name, type: evaluator.type, weight });
@@ -1259,6 +1273,7 @@ async function runEvaluatorList(options: {
           outputMessages,
           traceSummary,
           fileChanges,
+          workspacePath,
         });
         const weight = evaluator.weight ?? 1.0;
         scored.push({ score, name: evaluator.name, type: evaluator.type, weight });
@@ -1289,6 +1304,7 @@ async function runEvaluatorList(options: {
           outputMessages,
           traceSummary,
           fileChanges,
+          workspacePath,
         });
         const weight = evaluator.weight ?? 1.0;
         scored.push({ score, name: evaluator.name, type: evaluator.type, weight });
@@ -1319,6 +1335,7 @@ async function runEvaluatorList(options: {
           outputMessages,
           traceSummary,
           fileChanges,
+          workspacePath,
         });
         const weight = evaluator.weight ?? 1.0;
         scored.push({ score, name: evaluator.name, type: evaluator.type, weight });
@@ -1349,6 +1366,7 @@ async function runEvaluatorList(options: {
           outputMessages,
           traceSummary,
           fileChanges,
+          workspacePath,
         });
         const weight = evaluator.weight ?? 1.0;
         scored.push({ score, name: evaluator.name, type: evaluator.type, weight });
@@ -1379,6 +1397,7 @@ async function runEvaluatorList(options: {
           outputMessages,
           traceSummary,
           fileChanges,
+          workspacePath,
         });
         const weight = evaluator.weight ?? 1.0;
         scored.push({ score, name: evaluator.name, type: evaluator.type, weight });
@@ -1470,6 +1489,7 @@ async function runLlmJudgeEvaluator(options: {
   readonly traceSummary?: TraceSummary;
   readonly agentTimeoutMs?: number;
   readonly fileChanges?: string;
+  readonly workspacePath?: string;
 }): Promise<EvaluationScore> {
   const {
     config,
@@ -1486,6 +1506,7 @@ async function runLlmJudgeEvaluator(options: {
     traceSummary,
     agentTimeoutMs,
     fileChanges,
+    workspacePath,
   } = options;
   const customPrompt = await resolveCustomPrompt(
     config,
@@ -1496,6 +1517,7 @@ async function runLlmJudgeEvaluator(options: {
       traceSummary,
       config: config.config,
       fileChanges,
+      workspacePath,
     },
     agentTimeoutMs,
   );
@@ -1512,6 +1534,7 @@ async function runLlmJudgeEvaluator(options: {
     evaluatorTemplateOverride: customPrompt,
     evaluator: config,
     fileChanges,
+    workspacePath,
   });
 }
 
@@ -1522,6 +1545,7 @@ interface ResolveCustomPromptContext {
   readonly traceSummary?: TraceSummary;
   readonly config?: Record<string, unknown>;
   readonly fileChanges?: string;
+  readonly workspacePath?: string;
 }
 
 async function resolveCustomPrompt(
@@ -1591,6 +1615,7 @@ async function executePromptTemplate(
     inputMessages: context.evalCase.input_messages,
     traceSummary: context.traceSummary ?? null,
     fileChanges: context.fileChanges ?? null,
+    workspacePath: context.workspacePath ?? null,
     config: config ?? context.config ?? null,
   };
 

--- a/packages/core/test/evaluation/evaluators.test.ts
+++ b/packages/core/test/evaluation/evaluators.test.ts
@@ -549,6 +549,32 @@ describe('CodeEvaluator', () => {
     expect(result.details?.f1).toBeCloseTo(0.769);
   });
 
+  it('passes workspace_path to code judge via payload and env var', async () => {
+    const judgeProvider = new StubProvider(textResponse('{}'));
+
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const script = ['node', join(__dirname, '../fixtures/test-judge-workspace.cjs')];
+
+    const evaluator = new CodeEvaluator({ script });
+
+    const result = await evaluator.evaluate({
+      evalCase: baseTestCase,
+      candidate: 'Test candidate',
+      target: baseTarget,
+      provider: judgeProvider,
+      attempt: 0,
+      promptInputs: { question: '', guidelines: '' },
+      now: new Date(),
+      workspacePath: '/tmp/test-workspace',
+    });
+
+    expect(result.score).toBe(1);
+    expect(result.verdict).toBe('pass');
+    expect(result.hits).toContain('workspace_path present in payload');
+    expect(result.hits).toContain('AGENTV_WORKSPACE_PATH env var set');
+    expect(result.hits).toContain('payload and env var match');
+  });
+
   it('omits details when not returned by code judge', async () => {
     const judgeProvider = new StubProvider(textResponse('{}'));
 

--- a/packages/core/test/fixtures/test-judge-workspace.cjs
+++ b/packages/core/test/fixtures/test-judge-workspace.cjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+
+const input = JSON.parse(fs.readFileSync(0, 'utf8'));
+
+const hits = [];
+const misses = [];
+
+// Check workspace_path in JSON payload
+if (typeof input.workspace_path === 'string' && input.workspace_path.length > 0) {
+  hits.push('workspace_path present in payload');
+} else {
+  misses.push('workspace_path missing from payload');
+}
+
+// Check AGENTV_WORKSPACE_PATH env var
+const envPath = process.env.AGENTV_WORKSPACE_PATH;
+if (typeof envPath === 'string' && envPath.length > 0) {
+  hits.push('AGENTV_WORKSPACE_PATH env var set');
+} else {
+  misses.push('AGENTV_WORKSPACE_PATH env var missing');
+}
+
+// Check that both match when present
+if (input.workspace_path && envPath && input.workspace_path === envPath) {
+  hits.push('payload and env var match');
+} else if (input.workspace_path && envPath) {
+  misses.push('payload and env var do not match');
+}
+
+const score = misses.length === 0 ? 1.0 : hits.length / (hits.length + misses.length);
+
+console.log(JSON.stringify({ score, hits, misses }));

--- a/packages/eval/src/schemas.ts
+++ b/packages/eval/src/schemas.ts
@@ -71,6 +71,8 @@ export const CodeJudgeInputSchema = z.object({
   inputFiles: z.array(z.string()),
   inputMessages: z.array(MessageSchema),
   traceSummary: TraceSummarySchema.nullable().optional(),
+  fileChanges: z.string().nullable().optional(),
+  workspacePath: z.string().nullable().optional(),
   config: z.record(z.unknown()).nullable().optional(),
 });
 


### PR DESCRIPTION
## Summary
- Thread `workspacePath` from the orchestrator through the entire evaluation chain to code judges
- Code judges receive workspace path via JSON payload (`workspace_path`) and env var (`AGENTV_WORKSPACE_PATH`)
- Enables the **deploy-and-test pattern**: code judges can run `npm test`, `pytest`, `cargo test`, etc. in the agent's workspace

## Changes
- **`packages/core/src/evaluation/evaluators/types.ts`** — Added `workspacePath` to `EvaluationContext`
- **`packages/core/src/evaluation/evaluators/code-evaluator.ts`** — Added `workspacePath` to payload + `AGENTV_WORKSPACE_PATH` env var
- **`packages/core/src/evaluation/orchestrator.ts`** — Threaded `workspacePath` through `evaluateCandidate`, `runEvaluatorsForCase`, `runEvaluatorList`, `runLlmJudgeEvaluator`, `ResolveCustomPromptContext`, and `executePromptTemplate`
- **`packages/eval/src/schemas.ts`** — Added `fileChanges` and `workspacePath` to `CodeJudgeInputSchema`
- **`packages/core/test/`** — New test fixture and test case verifying both payload and env var
- **`examples/features/functional-grading/`** — Complete working example: mock agent + workspace template + multi-stage code judge (install → typecheck → compile → test)
- **Docs** — Updated `code-judges.mdx` with "Workspace Access" section and updated eval builder skill

## Test plan
- [x] `bun run typecheck` — passes
- [x] `bun run lint` — passes
- [x] `bun run test` — all 490 tests pass (including new workspace_path test)
- [x] `bun agentv eval examples/features/functional-grading/evals/dataset.yaml` — score 1.0, all 4 stages pass (install, typecheck, compile, tests)
- [x] Results JSONL confirms `evaluator_results[].type = "code_judge"` and workspace_path flows through

🤖 Generated with [Claude Code](https://claude.com/claude-code)