### PR TITLE
feat(core): rename evalcases to eval_cases (#200)

### DIFF
--- a/.claude/skills/agentv-eval-builder/SKILL.md
+++ b/.claude/skills/agentv-eval-builder/SKILL.md
@@ -14,7 +14,7 @@ description: Example eval
 execution:
   target: default
 
-evalcases:
+eval_cases:
   - id: greeting
     expected_outcome: Friendly greeting
     input: "Say hello"
@@ -26,7 +26,7 @@ evalcases:
 
 ## Eval File Structure
 
-**Required:** `evalcases` (array)
+**Required:** `eval_cases` (array)
 **Optional:** `description`, `execution`, `dataset`
 
 **Eval case fields:**

--- a/.claude/skills/agentv-eval-builder/references/eval-schema.json
+++ b/.claude/skills/agentv-eval-builder/references/eval-schema.json
@@ -60,7 +60,7 @@
       },
       "additionalProperties": true
     },
-    "evalcases": {
+    "eval_cases": {
       "type": "array",
       "description": "Array of evaluation cases",
       "minItems": 1,
@@ -273,6 +273,6 @@
       }
     }
   },
-  "required": ["evalcases"],
+  "required": ["eval_cases"],
   "additionalProperties": false
 }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ description: Math problem solving evaluation
 execution:
   target: default
 
-evalcases:
+eval_cases:
   - id: addition
     expected_outcome: Correctly calculates 15 + 27 = 42
 
@@ -256,7 +256,7 @@ Your judge prompt file defines criteria and scoring guidelines.
 Define structured criteria directly in your eval case:
 
 ```yaml
-evalcases:
+eval_cases:
   - id: quicksort-explain
     expected_outcome: Explain how quicksort works
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -27,7 +27,7 @@ description: Math problem solving evaluation
 execution:
   target: default
 
-evalcases:
+eval_cases:
   - id: addition
     expected_outcome: Correctly calculates 15 + 27 = 42
 
@@ -256,7 +256,7 @@ Your judge prompt file defines criteria and scoring guidelines.
 Define structured criteria directly in your eval case:
 
 ```yaml
-evalcases:
+eval_cases:
   - id: quicksort-explain
     expected_outcome: Explain how quicksort works
 

--- a/apps/cli/src/commands/generate/rubrics.ts
+++ b/apps/cli/src/commands/generate/rubrics.ts
@@ -30,7 +30,8 @@ interface RawEvalCase {
 }
 
 interface RawTestSuite {
-  readonly evalcases?: readonly unknown[];
+  readonly eval_cases?: readonly unknown[];
+  readonly evalcases?: readonly unknown[]; // deprecated alias
   readonly target?: string;
   readonly execution?: {
     readonly target?: string;
@@ -77,10 +78,10 @@ export async function generateRubricsCommand(options: GenerateRubricsOptions): P
   }
 
   const suite = parsed as RawTestSuite;
-  const evalcases = suite.evalcases;
+  const evalcases = suite.eval_cases ?? suite.evalcases;
 
   if (!Array.isArray(evalcases)) {
-    throw new Error(`No evalcases found in ${file}`);
+    throw new Error(`No eval_cases found in ${file}`);
   }
 
   // Resolve target using the same logic as eval command
@@ -106,10 +107,10 @@ export async function generateRubricsCommand(options: GenerateRubricsOptions): P
   let updatedCount = 0;
   let skippedCount = 0;
 
-  // Get the evalcases node from the document for modification
-  const evalcasesNode = doc.getIn(['evalcases']);
+  // Get the eval_cases node from the document for modification (with deprecated evalcases fallback)
+  const evalcasesNode = doc.getIn(['eval_cases']) ?? doc.getIn(['evalcases']);
   if (!evalcasesNode || !isSeq(evalcasesNode)) {
-    throw new Error('evalcases must be a sequence');
+    throw new Error('eval_cases must be a sequence');
   }
 
   // Process each eval case

--- a/apps/cli/test/eval.integration.test.ts
+++ b/apps/cli/test/eval.integration.test.ts
@@ -50,7 +50,7 @@ targets:
   const testFileContent = `description: CLI integration test
 target: file-target
 
-evalcases:
+eval_cases:
   - id: case-alpha
     outcome: System responds with alpha
     input_messages:

--- a/apps/cli/test/generate-rubrics.integration.test.ts
+++ b/apps/cli/test/generate-rubrics.integration.test.ts
@@ -54,7 +54,7 @@ targets:
 execution:
   target: default
 
-evalcases:`;
+eval_cases:`;
 
   if (withComments) {
     testFileContent += '\n  # This is a test comment\n  # TODO: update this test case';
@@ -176,7 +176,7 @@ describe('generate rubrics integration', () => {
 
     // Check that structure is maintained (basic indentation check)
     const lines = updatedContent.split('\n');
-    const evalcasesLine = lines.findIndex((line) => line.includes('evalcases:'));
+    const evalcasesLine = lines.findIndex((line) => line.includes('eval_cases:'));
     const rubricsLine = lines.findIndex((line) => line.includes('rubrics:'));
 
     // rubrics should be indented more than evalcases

--- a/apps/web/src/content/docs/evaluation/batch-cli.mdx
+++ b/apps/web/src/content/docs/evaluation/batch-cli.mdx
@@ -30,7 +30,7 @@ description: Batch CLI demo using structured input
 execution:
   target: batch_cli
 
-evalcases:
+eval_cases:
   - id: case-001
     expected_outcome: |-
       Batch runner returns JSON with decision=CLEAR.

--- a/apps/web/src/content/docs/evaluation/eval-cases.mdx
+++ b/apps/web/src/content/docs/evaluation/eval-cases.mdx
@@ -10,7 +10,7 @@ Eval cases are individual test cases within an evaluation file. Each case define
 ## Basic Structure
 
 ```yaml
-evalcases:
+eval_cases:
   - id: addition
     expected_outcome: Correctly calculates 15 + 27 = 42
 
@@ -70,7 +70,7 @@ expected_output:
 Override the default target or evaluators for specific cases:
 
 ```yaml
-evalcases:
+eval_cases:
   - id: complex-case
     expected_outcome: Provides detailed explanation
     input: Explain quicksort algorithm
@@ -88,7 +88,7 @@ evalcases:
 Pass additional context to evaluators via the `sidecar` field:
 
 ```yaml
-evalcases:
+eval_cases:
   - id: code-gen
     expected_outcome: Generates valid Python
     sidecar:

--- a/apps/web/src/content/docs/evaluation/eval-files.mdx
+++ b/apps/web/src/content/docs/evaluation/eval-files.mdx
@@ -20,7 +20,7 @@ execution:
       type: llm_judge
       prompt: ./judges/correctness.md
 
-evalcases:
+eval_cases:
   - id: addition
     expected_outcome: Correctly calculates 15 + 27 = 42
     input: What is 15 + 27?
@@ -34,7 +34,7 @@ evalcases:
 | `description` | Human-readable description of the evaluation |
 | `dataset` | Optional dataset identifier |
 | `execution` | Default execution config (target, evaluators) |
-| `evalcases` | Array of individual test cases |
+| `eval_cases` | Array of individual test cases |
 
 ## JSONL Format
 

--- a/apps/web/src/content/docs/evaluation/examples.mdx
+++ b/apps/web/src/content/docs/evaluation/examples.mdx
@@ -16,7 +16,7 @@ description: Basic arithmetic evaluation
 execution:
   target: default
 
-evalcases:
+eval_cases:
   - id: simple-addition
     expected_outcome: Correctly calculates 2+2
 
@@ -34,7 +34,7 @@ description: Code review with guidelines
 execution:
   target: azure_base
 
-evalcases:
+eval_cases:
   - id: code-review-basic
     expected_outcome: Assistant provides helpful code analysis with security considerations
 
@@ -78,7 +78,7 @@ description: JSON generation with validation
 execution:
   target: default
 
-evalcases:
+eval_cases:
   - id: json-generation-with-validation
     expected_outcome: Generates valid JSON with required fields
 
@@ -113,7 +113,7 @@ description: Tool usage validation
 execution:
   target: mock_agent
 
-evalcases:
+eval_cases:
   # Validate minimum tool usage (order doesn't matter)
   - id: research-depth
     expected_outcome: Agent researches thoroughly
@@ -150,7 +150,7 @@ description: Static trace evaluation
 execution:
   target: static_trace
 
-evalcases:
+eval_cases:
   - id: validate-trace-file
     expected_outcome: Trace contains required steps
     input: Analyze trace
@@ -173,7 +173,7 @@ description: Multi-turn debugging session with clarifying questions
 execution:
   target: default
 
-evalcases:
+eval_cases:
   - id: debug-with-clarification
     expected_outcome: |-
       Assistant conducts a multi-turn debugging session, asking clarification
@@ -234,7 +234,7 @@ description: Batch CLI demo (AML screening)
 execution:
   target: batch_cli
 
-evalcases:
+eval_cases:
   - id: aml-001
     expected_outcome: |-
       Batch runner returns JSON with decision=CLEAR.

--- a/apps/web/src/content/docs/evaluation/rubrics.mdx
+++ b/apps/web/src/content/docs/evaluation/rubrics.mdx
@@ -12,7 +12,7 @@ Rubrics define structured evaluation criteria directly in your eval cases. They 
 The simplest form — each string becomes a required criterion:
 
 ```yaml
-evalcases:
+eval_cases:
   - id: quicksort-explain
     expected_outcome: Explain how quicksort works
     input: Explain quicksort algorithm
@@ -107,7 +107,7 @@ This analyzes each eval case's `expected_outcome` and creates structured rubric 
 Rubrics work alongside code and LLM judges:
 
 ```yaml
-evalcases:
+eval_cases:
   - id: code-quality
     expected_outcome: Generates correct, clean Python code
     input: Write a fibonacci function

--- a/apps/web/src/content/docs/evaluators/code-judges.mdx
+++ b/apps/web/src/content/docs/evaluators/code-judges.mdx
@@ -283,7 +283,7 @@ targets:
     workspace_template: ./workspace-template
 
 # dataset.yaml
-evalcases:
+eval_cases:
   - id: implement-feature
     expected_outcome: Agent implements the feature correctly
     input: "Implement the TODO functions in src/index.ts"

--- a/apps/web/src/content/docs/evaluators/composite.mdx
+++ b/apps/web/src/content/docs/evaluators/composite.mdx
@@ -107,7 +107,7 @@ Inside the prompt file, use the `{{EVALUATOR_RESULTS_JSON}}` variable to inject 
 Block outputs that fail safety even if quality is high. A code judge aggregator can enforce hard gates:
 
 ```yaml
-evalcases:
+eval_cases:
   - id: safety-gated-response
     expected_outcome: Safe and accurate response
 

--- a/apps/web/src/content/docs/evaluators/custom-evaluators.mdx
+++ b/apps/web/src/content/docs/evaluators/custom-evaluators.mdx
@@ -29,7 +29,7 @@ execution:
       type: llm_judge
       prompt: ./judges/correctness.md
 
-evalcases:
+eval_cases:
   - id: test-1
     # Uses the top-level evaluator
     ...
@@ -38,7 +38,7 @@ evalcases:
 ### Per-Case Override
 
 ```yaml
-evalcases:
+eval_cases:
   - id: test-1
     expected_outcome: Returns valid JSON
     input: Generate a JSON config
@@ -54,7 +54,7 @@ evalcases:
 Use multiple evaluators on the same case for comprehensive scoring:
 
 ```yaml
-evalcases:
+eval_cases:
   - id: code-generation
     expected_outcome: Generates correct Python code
     input: Write a sorting function

--- a/apps/web/src/content/docs/evaluators/execution-metrics.mdx
+++ b/apps/web/src/content/docs/evaluators/execution-metrics.mdx
@@ -46,7 +46,7 @@ evaluators:
 ### Example: Comprehensive Efficiency Check
 
 ```yaml
-evalcases:
+eval_cases:
   - id: efficient-research
     expected_outcome: Agent researches and summarizes efficiently
     input: Research the topic and provide a summary
@@ -120,7 +120,7 @@ Fails if total token usage exceeds the threshold.
 Execution metrics work well alongside semantic evaluators:
 
 ```yaml
-evalcases:
+eval_cases:
   - id: code-generation
     expected_outcome: Generates correct, efficient code
     input: Write a sorting algorithm

--- a/apps/web/src/content/docs/evaluators/structured-data.mdx
+++ b/apps/web/src/content/docs/evaluators/structured-data.mdx
@@ -17,7 +17,7 @@ Built-in evaluators for grading structured outputs and gating on execution metri
 Put the expected structured output in the evalcase `expected_output` (as an object or message array). Evaluators read expected values from there.
 
 ```yaml
-evalcases:
+eval_cases:
   - id: invoice-001
     expected_output:
       invoice_number: "INV-2025-001234"

--- a/apps/web/src/content/docs/evaluators/tool-trajectory.mdx
+++ b/apps/web/src/content/docs/evaluators/tool-trajectory.mdx
@@ -188,7 +188,7 @@ description: Validate research agent tool usage
 execution:
   target: codex_agent
 
-evalcases:
+eval_cases:
   - id: comprehensive-research
     expected_outcome: Agent thoroughly researches the topic
 
@@ -218,7 +218,7 @@ evalcases:
 ### Multi-Step Pipeline
 
 ```yaml
-evalcases:
+eval_cases:
   - id: data-pipeline
     expected_outcome: Process data through complete pipeline
 
@@ -239,7 +239,7 @@ evalcases:
 ### Pipeline with Latency Assertions
 
 ```yaml
-evalcases:
+eval_cases:
   - id: data-pipeline-perf
     expected_outcome: Process data within timing budgets
 

--- a/apps/web/src/content/docs/getting-started/quickstart.mdx
+++ b/apps/web/src/content/docs/getting-started/quickstart.mdx
@@ -36,7 +36,7 @@ description: Math problem solving evaluation
 execution:
   target: default
 
-evalcases:
+eval_cases:
   - id: addition
     expected_outcome: Correctly calculates 15 + 27 = 42
 

--- a/apps/web/src/content/docs/targets/configuration.mdx
+++ b/apps/web/src/content/docs/targets/configuration.mdx
@@ -66,7 +66,7 @@ Set the default target at the top level or override per case:
 execution:
   target: azure_base
 
-evalcases:
+eval_cases:
   - id: test-1
     # Uses azure_base
 

--- a/apps/web/src/content/docs/tools/generate.mdx
+++ b/apps/web/src/content/docs/tools/generate.mdx
@@ -29,7 +29,7 @@ This analyzes each eval case's `expected_outcome` field and creates structured r
 Before:
 
 ```yaml
-evalcases:
+eval_cases:
   - id: quicksort
     expected_outcome: Explains quicksort with time complexity and examples
     input: Explain quicksort
@@ -38,7 +38,7 @@ evalcases:
 After running `agentv generate rubrics`:
 
 ```yaml
-evalcases:
+eval_cases:
   - id: quicksort
     expected_outcome: Explains quicksort with time complexity and examples
     input: Explain quicksort

--- a/evals/architecture/dataset.yaml
+++ b/evals/architecture/dataset.yaml
@@ -3,7 +3,7 @@ description: Evaluates whether proposed changes follow AGENTS.md design principl
 execution:
   target: default
 
-evalcases:
+eval_cases:
   - id: violates-lightweight-core
     expected_outcome: |
       The proposed change violates the "Lightweight Core, Plugin Extensibility" principle.

--- a/examples/features/basic/evals/dataset.yaml
+++ b/examples/features/basic/evals/dataset.yaml
@@ -7,7 +7,7 @@ description: Example showing basic features, conversation threading, multiple ev
 execution:
   target: default
 
-evalcases:
+eval_cases:
   # ==========================================
   # Example 1: Basic V2 features with file references
   # Demonstrates: input, expected_output, file references, array content format

--- a/examples/features/batch-cli/evals/dataset.yaml
+++ b/examples/features/batch-cli/evals/dataset.yaml
@@ -11,7 +11,7 @@ description: Batch CLI demo (AML screening) using structured input_messages → 
 execution:
   target: batch_cli
 
-evalcases:
+eval_cases:
   - id: aml-001
     expected_outcome: |-
       Batch runner returns a JSON object with decision=CLEAR.

--- a/examples/features/batch-cli/scripts/build-csv-from-eval.ts
+++ b/examples/features/batch-cli/scripts/build-csv-from-eval.ts
@@ -50,7 +50,8 @@ export function extractRowsFromEvalYaml(yamlText: string): readonly EvalRow[] {
   const parsed = parse(yamlText) as unknown;
   if (!isObject(parsed)) return [];
 
-  const evalcases = (parsed as Record<string, unknown>).evalcases;
+  const evalcases =
+    (parsed as Record<string, unknown>).eval_cases ?? (parsed as Record<string, unknown>).evalcases;
   if (!Array.isArray(evalcases)) return [];
 
   const rows: EvalRow[] = [];
@@ -60,7 +61,7 @@ export function extractRowsFromEvalYaml(yamlText: string): readonly EvalRow[] {
     const id = typeof item.id === 'string' ? item.id : '';
     if (!id) continue;
     if (id.includes('not-exist')) {
-      // Skip placeholder evalcases that should not reach the CSV artifact.
+      // Skip placeholder eval_cases that should not reach the CSV artifact.
       continue;
     }
 
@@ -139,7 +140,7 @@ async function main(): Promise<void> {
 
   if (rows.length === 0) {
     throw new Error(
-      'No rows extracted. Ensure evalcases have a user input_message with object content.request/content.row',
+      'No rows extracted. Ensure eval_cases have a user input_message with object content.request/content.row',
     );
   }
 

--- a/examples/features/code-judge-sdk/evals/dataset.yaml
+++ b/examples/features/code-judge-sdk/evals/dataset.yaml
@@ -7,7 +7,7 @@ description: Demonstrates TypeScript helpers for code_judge payloads
 execution:
   target: local_cli
 
-evalcases:
+eval_cases:
   - id: code-judge-sdk-attachments
     expected_outcome: The CLI echoes the prompt and lists attachment names.
 

--- a/examples/features/code-judge-with-llm-calls/evals/contextual-precision.yaml
+++ b/examples/features/code-judge-with-llm-calls/evals/contextual-precision.yaml
@@ -19,7 +19,7 @@ execution:
       target:
         max_calls: 10
 
-evalcases:
+eval_cases:
   # Test case 1: Perfect ranking - relevant node first
   # Node 1: Relevant (TypeScript builds on JS)
   # Node 2: Irrelevant (Microsoft, 2012)

--- a/examples/features/code-judge-with-llm-calls/evals/contextual-recall.yaml
+++ b/examples/features/code-judge-with-llm-calls/evals/contextual-recall.yaml
@@ -22,7 +22,7 @@ execution:
       target:
         max_calls: 15
 
-evalcases:
+eval_cases:
   # Test case 1: Perfect recall - all statements supported by retrieval
   # Expected: "Python was created by Guido van Rossum and first released in 1991"
   # Statements: (1) Created by Guido van Rossum, (2) First released in 1991

--- a/examples/features/composite/evals/dataset.yaml
+++ b/examples/features/composite/evals/dataset.yaml
@@ -5,7 +5,7 @@ dataset: composite-evaluator-examples
 execution:
   target: default
 
-evalcases:
+eval_cases:
   # Example 1: Weighted Average Aggregation
   - id: weighted-average-example
     input:

--- a/examples/features/document-extraction/README.md
+++ b/examples/features/document-extraction/README.md
@@ -66,7 +66,7 @@ evaluators:
       - path: supplier.name
 ```
 
-**Key requirement**: All evalcases must use the **same evaluator** with the **same fields** to enable cross-document aggregation.
+**Key requirement**: All eval_cases must use the **same evaluator** with the **same fields** to enable cross-document aggregation.
 
 **Output**: Aggregate metrics table with fractional precision/recall:
 

--- a/examples/features/document-extraction/evals/dataset-confusion-metrics.yaml
+++ b/examples/features/document-extraction/evals/dataset-confusion-metrics.yaml
@@ -1,7 +1,7 @@
 # Confusion Metrics Dataset
 #
 # This dataset demonstrates aggregatable TP/TN/FP/FN metrics across multiple documents.
-# All evalcases use the SAME header_confusion evaluator with the SAME fields,
+# All eval_cases use the SAME header_confusion evaluator with the SAME fields,
 # enabling cross-document aggregation with fractional precision/recall.
 #
 # Use case: Measuring field-level extraction accuracy across a document corpus.
@@ -29,7 +29,7 @@ execution:
         - path: importer.name
         - path: gross_total
 
-evalcases:
+eval_cases:
   # ============================================
   # Case 1: Perfect extraction
   # Expected: All TP

--- a/examples/features/document-extraction/evals/dataset-field-accuracy.yaml
+++ b/examples/features/document-extraction/evals/dataset-field-accuracy.yaml
@@ -101,7 +101,7 @@ execution:
     #   type: cost
     #   budget: 0.10  # max allowed cost in USD per eval case
 
-evalcases:
+eval_cases:
   # ============================================
   # Test Case 1: CMA CGM Shipping Invoice
   # Perfect extraction scenario

--- a/examples/features/execution-metrics/evals/dataset.yaml
+++ b/examples/features/execution-metrics/evals/dataset.yaml
@@ -21,7 +21,7 @@ description: Demonstrates the built-in execution_metrics evaluator
 execution:
   target: mock_metrics_agent
 
-evalcases:
+eval_cases:
   # ==========================================
   # Example 1: Simple threshold check - PASS
   # Check that an efficient agent stays within limits

--- a/examples/features/file-changes/evals/dataset.yaml
+++ b/examples/features/file-changes/evals/dataset.yaml
@@ -14,7 +14,7 @@ description: Verify file_changes captures edits, creates, and deletes across mul
 execution:
   target: mock_agent
 
-evalcases:
+eval_cases:
   # Case 1: verify edits and creates
   - id: verify-edits-and-creates
     expected_outcome: >-

--- a/examples/features/functional-grading/evals/dataset.yaml
+++ b/examples/features/functional-grading/evals/dataset.yaml
@@ -15,7 +15,7 @@ description: Functional grading with workspace_path — deploy-and-test pattern
 execution:
   target: mock_agent
 
-evalcases:
+eval_cases:
   - id: implement-math-functions
     expected_outcome: >-
       Agent implements add, multiply, and fibonacci functions

--- a/examples/features/latency-assertions/evals/dataset.yaml
+++ b/examples/features/latency-assertions/evals/dataset.yaml
@@ -33,7 +33,7 @@
 
 description: Latency assertions for per-step performance validation
 
-evalcases:
+eval_cases:
   # ==========================================
   # Example 1: Simple latency assertion - PASS
   # Validates a single tool completes within time budget

--- a/examples/features/local-cli/evals/dataset.yaml
+++ b/examples/features/local-cli/evals/dataset.yaml
@@ -6,7 +6,7 @@ description: Minimal demo showing how to invoke a CLI target with file attachmen
 execution:
   target: local_cli
 
-evalcases:
+eval_cases:
   - id: cli-provider-echo
     expected_outcome: CLI echoes the prompt and mentions all attachment names
 

--- a/examples/features/prompt-template-sdk/evals/dataset.yaml
+++ b/examples/features/prompt-template-sdk/evals/dataset.yaml
@@ -8,7 +8,7 @@ description: Demonstrates TypeScript prompt templates for custom LLM judge promp
 execution:
   target: default
 
-evalcases:
+eval_cases:
   - id: prompt-template-basic
     expected_outcome: The CLI provides a clear answer about TypeScript benefits.
 

--- a/examples/features/rubric/evals/dataset.yaml
+++ b/examples/features/rubric/evals/dataset.yaml
@@ -6,7 +6,7 @@ description: Example showing rubric evaluator with inline rubrics and expected_o
 execution:
   target: default
 
-evalcases:
+eval_cases:
   # ==========================================
   # Example 1: Simple inline rubrics
   # Demonstrates: inline rubrics as strings, expected_outcome field

--- a/examples/features/tool-trajectory-advanced/evals/trace-file-demo.yaml
+++ b/examples/features/tool-trajectory-advanced/evals/trace-file-demo.yaml
@@ -15,7 +15,7 @@ description: Static trace file evaluation demo - Product Research Agent
 execution:
   target: static_trace
 
-evalcases:
+eval_cases:
   # =============================================================================
   # Example 1: In-Order Validation
   # Use case: Ensure tools are called in the expected sequence (allows gaps)

--- a/examples/features/tool-trajectory-simple/evals/dataset.yaml
+++ b/examples/features/tool-trajectory-simple/evals/dataset.yaml
@@ -28,7 +28,7 @@ description: Tool trajectory evaluator examples for agent execution validation
 execution:
   target: mock_agent
 
-evalcases:
+eval_cases:
   # ==========================================
   # Example 1: any_order mode - Validate minimum tool usage
   # Use case: Ensure agent uses required tools at least N times, regardless of order

--- a/examples/features/weighted-evaluators/evals/dataset.yaml
+++ b/examples/features/weighted-evaluators/evals/dataset.yaml
@@ -5,7 +5,7 @@ dataset: weighted-evaluators-examples
 execution:
   target: default
 
-evalcases:
+eval_cases:
   # Example 1: Different weights for multiple evaluators
   - id: weighted-multi-evaluator
     input:

--- a/examples/showcase/cw-incident-triage/evals/dataset.yaml
+++ b/examples/showcase/cw-incident-triage/evals/dataset.yaml
@@ -15,7 +15,7 @@ execution:
     - name: content_evaluator
       type: llm_judge
 
-evalcases:
+eval_cases:
   # ==========================================
   # Basic criticality rating classification with explicit reasoning
   # ==========================================

--- a/examples/showcase/export-screening/evals/dataset.yaml
+++ b/examples/showcase/export-screening/evals/dataset.yaml
@@ -24,7 +24,7 @@ execution:
       type: code_judge
       script: ["bun", "run", "validate_risk_output.ts"]
 
-evalcases:
+eval_cases:
   # ============================================
   # HIGH RISK CASES (Expert Assessment: High)
   # Based on CHPL (Common High Priority List) codes

--- a/examples/showcase/psychotherapy/evals/dataset-encouragement.yaml
+++ b/examples/showcase/psychotherapy/evals/dataset-encouragement.yaml
@@ -12,7 +12,7 @@ execution:
     - name: content_evaluator
       type: llm_judge
 
-evalcases:
+eval_cases:
   # ==============================================================================
   # TIER 1: STANDARD REFERENCE CASES (Explicit Resources)
   # ==============================================================================

--- a/examples/showcase/psychotherapy/evals/dataset-listening.yaml
+++ b/examples/showcase/psychotherapy/evals/dataset-listening.yaml
@@ -11,7 +11,7 @@ execution:
     - name: content_evaluator
       type: llm_judge
 
-evalcases:
+eval_cases:
   # ==============================================================================
   # TIER 1: BASIC BENCHMARKS (Explicit Text)
   # ==============================================================================

--- a/examples/showcase/psychotherapy/evals/dataset-routing.yaml
+++ b/examples/showcase/psychotherapy/evals/dataset-routing.yaml
@@ -10,7 +10,7 @@ execution:
     - name: content_evaluator
       type: llm_judge
 
-evalcases:
+eval_cases:
   # Case 1: Routing to Listening (Ah Yang)
   # Rationale: Client is venting grievance and describing a complex dynamic. Needs understanding first.
   - id: route-to-listening

--- a/examples/showcase/tool-evaluation-plugins/tool-eval-demo.yaml
+++ b/examples/showcase/tool-evaluation-plugins/tool-eval-demo.yaml
@@ -13,7 +13,7 @@ description: Showcase of tool evaluation plugin patterns
 execution:
   target: mock_agent
 
-evalcases:
+eval_cases:
   # ==========================================
   # Example 1: Tool Selection Evaluation
   # Use case: Verify agent chose appropriate tools for the task

--- a/packages/core/src/evaluation/validation/eval-validator.ts
+++ b/packages/core/src/evaluation/validation/eval-validator.ts
@@ -51,14 +51,22 @@ export async function validateEvalFile(filePath: string): Promise<ValidationResu
     };
   }
 
-  // Validate evalcases array
-  const evalcases = parsed.evalcases;
+  // Validate eval_cases array (with deprecated evalcases fallback)
+  const evalcases = parsed.eval_cases ?? parsed.evalcases;
+  if (parsed.evalcases !== undefined && parsed.eval_cases === undefined) {
+    errors.push({
+      severity: 'warning',
+      filePath: absolutePath,
+      location: 'evalcases',
+      message: "'evalcases' is deprecated, use 'eval_cases' instead",
+    });
+  }
   if (!Array.isArray(evalcases)) {
     errors.push({
       severity: 'error',
       filePath: absolutePath,
-      location: 'evalcases',
-      message: "Missing or invalid 'evalcases' field (must be an array)",
+      location: 'eval_cases',
+      message: "Missing or invalid 'eval_cases' field (must be an array)",
     });
     return {
       valid: errors.length === 0,
@@ -71,7 +79,7 @@ export async function validateEvalFile(filePath: string): Promise<ValidationResu
   // Validate each eval case
   for (let i = 0; i < evalcases.length; i++) {
     const evalCase = evalcases[i];
-    const location = `evalcases[${i}]`;
+    const location = `eval_cases[${i}]`;
 
     if (!isObject(evalCase)) {
       errors.push({
@@ -182,7 +190,7 @@ export async function validateEvalFile(filePath: string): Promise<ValidationResu
   }
 
   return {
-    valid: errors.length === 0,
+    valid: errors.filter((e) => e.severity === 'error').length === 0,
     filePath: absolutePath,
     fileType: 'eval',
     errors,

--- a/packages/core/src/evaluation/validation/file-reference-validator.ts
+++ b/packages/core/src/evaluation/validation/file-reference-validator.ts
@@ -50,7 +50,7 @@ export async function validateFileReferences(
     return errors;
   }
 
-  const evalcases = parsed.evalcases;
+  const evalcases = parsed.eval_cases ?? parsed.evalcases;
   if (!Array.isArray(evalcases)) {
     return errors;
   }
@@ -66,7 +66,7 @@ export async function validateFileReferences(
     if (Array.isArray(inputMessages)) {
       await validateMessagesFileRefs(
         inputMessages,
-        `evalcases[${i}].input_messages`,
+        `eval_cases[${i}].input_messages`,
         searchRoots,
         absolutePath,
         errors,
@@ -78,7 +78,7 @@ export async function validateFileReferences(
     if (Array.isArray(expectedMessages)) {
       await validateMessagesFileRefs(
         expectedMessages,
-        `evalcases[${i}].expected_messages`,
+        `eval_cases[${i}].expected_messages`,
         searchRoots,
         absolutePath,
         errors,

--- a/packages/core/src/evaluation/yaml-parser.ts
+++ b/packages/core/src/evaluation/yaml-parser.ts
@@ -32,7 +32,8 @@ type LoadOptions = {
 };
 
 type RawTestSuite = JsonObject & {
-  readonly evalcases?: JsonValue;
+  readonly eval_cases?: JsonValue;
+  readonly evalcases?: JsonValue; // deprecated alias
   readonly target?: JsonValue;
   readonly execution?: JsonValue;
   readonly dataset?: JsonValue;
@@ -52,6 +53,15 @@ type RawEvalCase = JsonObject & {
   readonly evaluators?: JsonValue;
   readonly rubrics?: JsonValue;
 };
+
+function resolveEvalCases(suite: RawTestSuite): JsonValue | undefined {
+  if (suite.eval_cases !== undefined) return suite.eval_cases;
+  if (suite.evalcases !== undefined) {
+    logWarning("'evalcases' is deprecated, use 'eval_cases' instead");
+    return suite.evalcases;
+  }
+  return undefined;
+}
 
 /**
  * Read metadata from a test suite file (like target name).
@@ -114,9 +124,9 @@ export async function loadEvalCases(
       ? datasetNameFromSuite
       : fallbackDataset;
 
-  const rawTestcases = suite.evalcases;
+  const rawTestcases = resolveEvalCases(suite);
   if (!Array.isArray(rawTestcases)) {
-    throw new Error(`Invalid test file format: ${evalFilePath} - missing 'evalcases' field`);
+    throw new Error(`Invalid test file format: ${evalFilePath} - missing 'eval_cases' field`);
   }
 
   const globalEvaluator = coerceEvaluator(suite.evaluator, 'global') ?? 'llm_judge';

--- a/packages/core/test/evaluation/loaders/jsonl-parser.test.ts
+++ b/packages/core/test/evaluation/loaders/jsonl-parser.test.ts
@@ -315,7 +315,7 @@ describe('loadEvalCases with format detection', () => {
     const yamlPath = path.join(tempDir, 'test.yaml');
     await writeFile(
       yamlPath,
-      `evalcases:
+      `eval_cases:
   - id: yaml-test
     expected_outcome: Goal
     input_messages:
@@ -334,7 +334,7 @@ describe('loadEvalCases with format detection', () => {
     const ymlPath = path.join(tempDir, 'test.yml');
     await writeFile(
       ymlPath,
-      `evalcases:
+      `eval_cases:
   - id: yml-test
     expected_outcome: Goal
     input_messages:
@@ -377,7 +377,7 @@ describe('JSONL and YAML produce equivalent EvalCases', () => {
     await writeFile(
       yamlPath,
       `dataset: my-dataset
-evalcases:
+eval_cases:
   - id: test-1
     expected_outcome: "The agent should respond with a helpful answer"
     input_messages:
@@ -519,7 +519,7 @@ describe('Input/expected_output aliases and shorthand', () => {
       const yamlPath = path.join(tempDir, 'input-shorthand.yaml');
       await writeFile(
         yamlPath,
-        `evalcases:
+        `eval_cases:
   - id: test-1
     expected_outcome: Goal
     input: "What is 2+2?"
@@ -538,7 +538,7 @@ describe('Input/expected_output aliases and shorthand', () => {
       const yamlPath = path.join(tempDir, 'input-array.yaml');
       await writeFile(
         yamlPath,
-        `evalcases:
+        `eval_cases:
   - id: test-1
     expected_outcome: Goal
     input:
@@ -561,7 +561,7 @@ describe('Input/expected_output aliases and shorthand', () => {
       const yamlPath = path.join(tempDir, 'expected-string.yaml');
       await writeFile(
         yamlPath,
-        `evalcases:
+        `eval_cases:
   - id: test-1
     expected_outcome: Goal
     input: Query
@@ -581,7 +581,7 @@ describe('Input/expected_output aliases and shorthand', () => {
       const yamlPath = path.join(tempDir, 'expected-object.yaml');
       await writeFile(
         yamlPath,
-        `evalcases:
+        `eval_cases:
   - id: test-1
     expected_outcome: Goal
     input: Query
@@ -604,7 +604,7 @@ describe('Input/expected_output aliases and shorthand', () => {
       const yamlPath = path.join(tempDir, 'canonical-precedence.yaml');
       await writeFile(
         yamlPath,
-        `evalcases:
+        `eval_cases:
   - id: test-1
     expected_outcome: Goal
     input_messages:
@@ -626,7 +626,7 @@ describe('Input/expected_output aliases and shorthand', () => {
       const yamlPath = path.join(tempDir, 'mixed.yaml');
       await writeFile(
         yamlPath,
-        `evalcases:
+        `eval_cases:
   - id: test-canonical
     expected_outcome: Goal
     input_messages:
@@ -658,7 +658,7 @@ describe('Input/expected_output aliases and shorthand', () => {
 
       await writeFile(
         yamlPath,
-        `evalcases:
+        `eval_cases:
   - id: test-1
     expected_outcome: Goal
     input: "What is 2+2?"

--- a/packages/core/test/evaluation/validation/eval-validator.test.ts
+++ b/packages/core/test/evaluation/validation/eval-validator.test.ts
@@ -21,7 +21,7 @@ describe('validateEvalFile', () => {
     const filePath = path.join(tempDir, 'input-alias.yaml');
     await writeFile(
       filePath,
-      `evalcases:
+      `eval_cases:
   - id: test-1
     expected_outcome: Goal
     input: "What is 2+2?"
@@ -38,7 +38,7 @@ describe('validateEvalFile', () => {
     const filePath = path.join(tempDir, 'input-array.yaml');
     await writeFile(
       filePath,
-      `evalcases:
+      `eval_cases:
   - id: test-1
     expected_outcome: Goal
     input:
@@ -59,7 +59,7 @@ describe('validateEvalFile', () => {
     const filePath = path.join(tempDir, 'output-string.yaml');
     await writeFile(
       filePath,
-      `evalcases:
+      `eval_cases:
   - id: test-1
     expected_outcome: Goal
     input: Query
@@ -77,7 +77,7 @@ describe('validateEvalFile', () => {
     const filePath = path.join(tempDir, 'output-object.yaml');
     await writeFile(
       filePath,
-      `evalcases:
+      `eval_cases:
   - id: test-1
     expected_outcome: Goal
     input: Query
@@ -97,7 +97,7 @@ describe('validateEvalFile', () => {
     const filePath = path.join(tempDir, 'missing-input.yaml');
     await writeFile(
       filePath,
-      `evalcases:
+      `eval_cases:
   - id: test-1
     expected_outcome: Goal
 `,
@@ -113,7 +113,7 @@ describe('validateEvalFile', () => {
     const filePath = path.join(tempDir, 'invalid-input.yaml');
     await writeFile(
       filePath,
-      `evalcases:
+      `eval_cases:
   - id: test-1
     expected_outcome: Goal
     input: 123
@@ -130,7 +130,7 @@ describe('validateEvalFile', () => {
     const filePath = path.join(tempDir, 'canonical-precedence.yaml');
     await writeFile(
       filePath,
-      `evalcases:
+      `eval_cases:
   - id: test-1
     expected_outcome: Goal
     input_messages:
@@ -144,5 +144,26 @@ describe('validateEvalFile', () => {
 
     expect(result.valid).toBe(true);
     expect(result.errors).toHaveLength(0);
+  });
+
+  it('accepts deprecated evalcases key with deprecation warning', async () => {
+    const filePath = path.join(tempDir, 'deprecated-evalcases.yaml');
+    await writeFile(
+      filePath,
+      `evalcases:
+  - id: test-1
+    expected_outcome: Goal
+    input: "What is 2+2?"
+`,
+    );
+
+    const result = await validateEvalFile(filePath);
+
+    expect(result.valid).toBe(true);
+    expect(
+      result.errors.some(
+        (e) => e.severity === 'warning' && e.message.includes("'evalcases' is deprecated"),
+      ),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Renames the YAML key `evalcases` to `eval_cases` to match the snake_case convention used throughout the schema (`expected_outcome`, `input_messages`, etc.)
- Supports `evalcases` as a deprecated alias with a warning in the YAML parser, eval validator, and file reference validator
- Updates all 25 example YAML files, 14 docs pages, 5 markdown/JSON references, and 4 test files

## Test plan
- [x] `bun run build` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] All 491 tests pass (including new backwards-compat test)
- [x] Pre-push hooks pass

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)