### PR TITLE
feat(core): add error handling and timeouts to VS Code provider

### DIFF
--- a/.agentv/targets.yaml
+++ b/.agentv/targets.yaml
@@ -24,6 +24,11 @@ targets:
     api_key: ${{ GOOGLE_GENERATIVE_AI_API_KEY }}
     model: ${{ GEMINI_MODEL_NAME }}
 
+  - name: vscode
+    provider: vscode
+    executable: ${{ VSCODE_CMD }}
+    judge_target: judge
+
   - name: judge
     provider: gemini
     model: gemini-3-flash-preview

--- a/examples/features/.agentv/targets.yaml
+++ b/examples/features/.agentv/targets.yaml
@@ -12,6 +12,7 @@ targets:
 
   - name: vscode
     provider: vscode
+    executable: ${{ VSCODE_CMD }}
     judge_target: azure_base
 
   - name: codex

--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -528,6 +528,7 @@ export interface VSCodeResolvedConfig {
   readonly dryRun: boolean;
   readonly subagentRoot?: string;
   readonly workspaceTemplate?: string;
+  readonly timeoutMs?: number;
 }
 
 /**
@@ -1393,6 +1394,7 @@ function resolveVSCodeConfig(
   const waitSource = target.wait;
   const dryRunSource = target.dry_run ?? target.dryRun;
   const subagentRootSource = target.subagent_root ?? target.subagentRoot;
+  const timeoutSource = target.timeout_seconds ?? target.timeoutSeconds;
 
   const defaultCommand = insiders ? 'code-insiders' : 'code';
   const executable =
@@ -1400,6 +1402,8 @@ function resolveVSCodeConfig(
       allowLiteral: true,
       optionalEnv: true,
     }) ?? defaultCommand;
+
+  const timeoutMs = resolveTimeoutMs(timeoutSource, `${target.name} vscode timeout`);
 
   return {
     executable,
@@ -1410,6 +1414,7 @@ function resolveVSCodeConfig(
       optionalEnv: true,
     }),
     workspaceTemplate,
+    timeoutMs,
   };
 }
 

--- a/packages/core/src/evaluation/validation/targets-validator.ts
+++ b/packages/core/src/evaluation/validation/targets-validator.ts
@@ -125,6 +125,7 @@ const COPILOT_SETTINGS = new Set([
 
 const VSCODE_SETTINGS = new Set([
   ...COMMON_SETTINGS,
+  'executable',
   'workspace_template',
   'workspaceTemplate',
   'wait',
@@ -132,6 +133,8 @@ const VSCODE_SETTINGS = new Set([
   'dryRun',
   'subagent_root',
   'subagentRoot',
+  'timeout_seconds',
+  'timeoutSeconds',
 ]);
 
 const MOCK_SETTINGS = new Set([


### PR DESCRIPTION
## Summary
- **Executable validation**: Adds `ensureEnvironmentReady()` pattern (same as codex/copilot providers) that validates the VS Code executable exists before dispatching. Fails fast with a clear error message instead of hanging.
- **Configurable timeout**: Adds `timeout_seconds` / `timeoutSeconds` to VS Code target config. Response polling now has a deadline (default 10 min) instead of looping forever.
- **Spawn error handling**: Adds `spawnVsCode()` helper with `error` event listener and `raceSpawnError()` to detect immediate spawn failures (ENOENT, EACCES) within 200ms.
- **Workspace readiness**: `launchVsCodeWithChat` and `launchVsCodeWithBatchChat` now return `false` (fail) when `ensureWorkspaceFocused` times out, instead of logging a warning and continuing.

## Files changed
- `packages/core/src/evaluation/providers/targets.ts` — `timeoutMs` on `VSCodeResolvedConfig`, resolved in `resolveVSCodeConfig()`
- `packages/core/src/evaluation/validation/targets-validator.ts` — `timeout_seconds`, `timeoutSeconds`, `executable` added to `VSCODE_SETTINGS`
- `packages/core/src/evaluation/providers/vscode/dispatch/responseWaiter.ts` — `timeoutMs` parameter with deadline check
- `packages/core/src/evaluation/providers/vscode/dispatch/agentDispatch.ts` — `timeoutMs` on `DispatchOptions`, threaded to waiters
- `packages/core/src/evaluation/providers/vscode-provider.ts` — `locateVSCodeExecutable()`, `ensureEnvironmentReady()`, `timeoutMs` passthrough
- `packages/core/src/evaluation/providers/vscode/dispatch/vscodeProcess.ts` — `spawnVsCode()`, `raceSpawnError()`, fail on workspace timeout

## Test plan
- [x] `bun run build` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run test` — all 516 tests pass
- [ ] Manual: set `executable: "/nonexistent/path"` → eval fails fast with clear error
- [ ] Manual: run eval with `timeout_seconds: 10` → times out after 10s if VS Code doesn't respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)