### PR TITLE
fix(core): use fileURLToPath for Windows-compatible path resolution

### DIFF
--- a/packages/core/src/evaluation/loaders/file-resolver.ts
+++ b/packages/core/src/evaluation/loaders/file-resolver.ts
@@ -1,6 +1,7 @@
 import { constants } from 'node:fs';
 import { access } from 'node:fs/promises';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 /**
  * Check if a file exists on disk.
@@ -19,11 +20,11 @@ export async function fileExists(absolutePath: string): Promise<boolean> {
  */
 export function resolveToAbsolutePath(candidate: URL | string): string {
   if (candidate instanceof URL) {
-    return new URL(candidate).pathname;
+    return candidate.protocol === 'file:' ? fileURLToPath(candidate) : candidate.pathname;
   }
   if (typeof candidate === 'string') {
-    if (candidate.startsWith('file://')) {
-      return new URL(candidate).pathname;
+    if (candidate.startsWith('file:')) {
+      return fileURLToPath(candidate);
     }
     return path.resolve(candidate);
   }


### PR DESCRIPTION
## Summary
- Replace manual `file://` URL slicing (`resolved.slice(7)`) with Node's `fileURLToPath()` in the copilot-sdk provider's `resolvePlatformCliPath()`
- Fix the same `new URL(...).pathname` pattern in `file-resolver.ts` `resolveToAbsolutePath()` which also produces invalid paths on Windows (e.g., `/D:/...` instead of `D:\...`)

## Test plan
- [x] All 59 existing tests pass
- [x] Typecheck passes
- [x] Lint passes  
- [x] Copilot provider runs successfully on Windows (`bun agentv run examples/features/basic/evals/dataset.yaml --eval-id code-review-javascript --target copilot`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)