### PR TITLE
fix(core): allow file-based workspace templates for vscode providers

### DIFF
--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
+import { stat } from 'node:fs/promises';
 import path from 'node:path';
 import micromatch from 'micromatch';
 import pLimit from 'p-limit';
@@ -628,20 +629,26 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
   const workspaceTemplate = getWorkspaceTemplate(target);
   let workspacePath: string | undefined;
 
-  // Create temp workspace if template is configured and we have evalRunId
+  // Create temp workspace if template is a directory and we have evalRunId.
+  // File-based templates (e.g. .code-workspace) are passed through to the provider as-is.
   if (workspaceTemplate && evalRunId) {
-    try {
-      workspacePath = await createTempWorkspace(workspaceTemplate, evalRunId, evalCase.id);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      return buildErrorResult(
-        evalCase,
-        target.name,
-        nowFn(),
-        new Error(`Failed to create workspace: ${message}`),
-        promptInputs,
-        provider,
-      );
+    const templateIsDir = await stat(path.resolve(workspaceTemplate))
+      .then((s) => s.isDirectory())
+      .catch(() => false);
+    if (templateIsDir) {
+      try {
+        workspacePath = await createTempWorkspace(workspaceTemplate, evalRunId, evalCase.id);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return buildErrorResult(
+          evalCase,
+          target.name,
+          nowFn(),
+          new Error(`Failed to create workspace: ${message}`),
+          promptInputs,
+          provider,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- The orchestrator's `createTempWorkspace()` (introduced in #180) required `workspace_template` to be a directory, but vscode providers use `.code-workspace` files as templates
- Skip temp workspace creation when the template is a file (not a directory), letting the provider handle it directly
- Fixes regression where all vscode targets with `.code-workspace` templates failed with `TemplateNotDirectoryError`

## Test plan
- [x] All 59 tests pass
- [x] Typecheck and lint pass
- [x] E2E: `vscode_ediprod` target now launches VS Code instead of failing with "Workspace template is not a directory"
- [x] Directory-based templates (default/azure provider) continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)