### PR TITLE
feat(core): rename cases to tests in eval schema and codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ description: Math problem solving evaluation
 execution:
   target: default
 
-cases:
+tests:
   - id: addition
     criteria: Correctly calculates 15 + 27 = 42
 
@@ -133,7 +133,7 @@ agentv run evals/my-eval.yaml
 # Override target
 agentv run --target azure_base evals/**/*.yaml
 
-# Run specific eval case
+# Run specific test
 agentv run --eval-id case-123 evals/my-eval.yaml
 
 # Dry-run with mock provider
@@ -253,10 +253,10 @@ Your judge prompt file defines criteria and scoring guidelines.
 
 ### Rubric-Based Evaluation
 
-Define structured criteria directly in your eval case:
+Define structured criteria directly in your test:
 
 ```yaml
-cases:
+tests:
   - id: quicksort-explain
     criteria: Explain how quicksort works
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -27,7 +27,7 @@ description: Math problem solving evaluation
 execution:
   target: default
 
-cases:
+tests:
   - id: addition
     criteria: Correctly calculates 15 + 27 = 42
 
@@ -133,7 +133,7 @@ agentv run evals/my-eval.yaml
 # Override target
 agentv run --target azure_base evals/**/*.yaml
 
-# Run specific eval case
+# Run specific test
 agentv run --eval-id case-123 evals/my-eval.yaml
 
 # Dry-run with mock provider
@@ -253,10 +253,10 @@ Your judge prompt file defines criteria and scoring guidelines.
 
 ### Rubric-Based Evaluation
 
-Define structured criteria directly in your eval case:
+Define structured criteria directly in your test:
 
 ```yaml
-cases:
+tests:
   - id: quicksort-explain
     criteria: Explain how quicksort works
 

--- a/apps/cli/src/commands/eval/commands/prompt/input.ts
+++ b/apps/cli/src/commands/eval/commands/prompt/input.ts
@@ -1,12 +1,12 @@
 import type { JsonObject, TestMessage } from '@agentv/core';
-import { loadEvalCaseById } from '@agentv/core';
+import { loadTestById } from '@agentv/core';
 import { command, option, positional, string } from 'cmd-ts';
 
 import { findRepoRoot } from '../../shared.js';
 
 export const evalPromptInputCommand = command({
   name: 'input',
-  description: 'Output task input JSON for a single eval case',
+  description: 'Output task input JSON for a single test',
   args: {
     evalPath: positional({
       type: string,
@@ -16,14 +16,14 @@ export const evalPromptInputCommand = command({
     evalId: option({
       type: string,
       long: 'eval-id',
-      description: 'Eval case ID',
+      description: 'Test ID',
     }),
   },
   handler: async (args) => {
     const cwd = process.cwd();
     const repoRoot = await findRepoRoot(cwd);
 
-    const evalCase = await loadEvalCaseById(args.evalPath, repoRoot, args.evalId);
+    const evalCase = await loadTestById(args.evalPath, repoRoot, args.evalId);
 
     // Build mapping from relative file names to resolved absolute paths.
     // input_segments has resolvedPath for non-guideline files;

--- a/apps/cli/src/commands/eval/commands/prompt/judge.ts
+++ b/apps/cli/src/commands/eval/commands/prompt/judge.ts
@@ -1,11 +1,11 @@
 import { readFile } from 'node:fs/promises';
 import {
-  type EvalCase,
+  type EvalTest,
   type EvaluatorConfig,
   assembleLlmJudgePrompt,
   buildPromptInputs,
   executeScript,
-  loadEvalCaseById,
+  loadTestById,
   toSnakeCaseDeep,
 } from '@agentv/core';
 import { command, option, positional, string } from 'cmd-ts';
@@ -27,7 +27,7 @@ interface EvaluatorOutput {
 
 export const evalPromptJudgeCommand = command({
   name: 'judge',
-  description: 'Run code judges and output LLM judge prompts for a single eval case',
+  description: 'Run code judges and output LLM judge prompts for a single test',
   args: {
     evalPath: positional({
       type: string,
@@ -37,7 +37,7 @@ export const evalPromptJudgeCommand = command({
     evalId: option({
       type: string,
       long: 'eval-id',
-      description: 'Eval case ID',
+      description: 'Test ID',
     }),
     answerFile: option({
       type: string,
@@ -49,7 +49,7 @@ export const evalPromptJudgeCommand = command({
     const cwd = process.cwd();
     const repoRoot = await findRepoRoot(cwd);
 
-    const evalCase = await loadEvalCaseById(args.evalPath, repoRoot, args.evalId);
+    const evalCase = await loadTestById(args.evalPath, repoRoot, args.evalId);
     const candidate = (await readFile(args.answerFile, 'utf8')).trim();
     const promptInputs = await buildPromptInputs(evalCase);
 
@@ -92,7 +92,7 @@ export const evalPromptJudgeCommand = command({
 
 async function processEvaluator(
   config: EvaluatorConfig,
-  evalCase: EvalCase,
+  evalCase: EvalTest,
   candidate: string,
   promptInputs: Awaited<ReturnType<typeof buildPromptInputs>>,
 ): Promise<EvaluatorOutput> {

--- a/apps/cli/src/commands/eval/commands/prompt/overview.ts
+++ b/apps/cli/src/commands/eval/commands/prompt/overview.ts
@@ -1,4 +1,4 @@
-import { type EvalCase, loadEvalCases } from '@agentv/core';
+import { type EvalTest, loadTests } from '@agentv/core';
 import { command, restPositionals, string } from 'cmd-ts';
 
 import { findRepoRoot, resolveEvalPaths } from '../../shared.js';
@@ -19,13 +19,13 @@ export const evalPromptOverviewCommand = command({
     const repoRoot = await findRepoRoot(cwd);
 
     // Collect all cases upfront for the summary
-    const fileEntries: Array<{ path: string; cases: readonly EvalCase[] }> = [];
+    const fileEntries: Array<{ path: string; tests: readonly EvalTest[] }> = [];
     for (const evalPath of resolvedPaths) {
-      const cases = await loadEvalCases(evalPath, repoRoot);
-      fileEntries.push({ path: evalPath, cases });
+      const tests = await loadTests(evalPath, repoRoot);
+      fileEntries.push({ path: evalPath, tests });
     }
 
-    const totalCases = fileEntries.reduce((sum, e) => sum + e.cases.length, 0);
+    const totalCases = fileEntries.reduce((sum, e) => sum + e.tests.length, 0);
 
     const lines: string[] = [
       '# AgentV Eval Orchestration',
@@ -57,11 +57,11 @@ export const evalPromptOverviewCommand = command({
       '',
     ];
 
-    for (const { path: evalPath, cases } of fileEntries) {
+    for (const { path: evalPath, tests } of fileEntries) {
       lines.push(`## ${evalPath}`);
       lines.push('');
 
-      for (const evalCase of cases) {
+      for (const evalCase of tests) {
         const evaluatorSummary = describeEvaluators(evalCase);
         lines.push(`### ${evalCase.id}`);
         lines.push(`Criteria: ${evalCase.criteria}`);
@@ -83,7 +83,7 @@ export const evalPromptOverviewCommand = command({
   },
 });
 
-function describeEvaluators(evalCase: EvalCase): string | undefined {
+function describeEvaluators(evalCase: EvalTest): string | undefined {
   const configs = evalCase.evaluators;
   if (!configs || configs.length === 0) return undefined;
   return configs.map((c) => `${c.name} (${c.type})`).join(', ');

--- a/apps/cli/src/commands/eval/commands/run.ts
+++ b/apps/cli/src/commands/eval/commands/run.ts
@@ -26,7 +26,7 @@ export const evalRunCommand = command({
     evalId: option({
       type: optional(string),
       long: 'eval-id',
-      description: 'Filter eval cases by ID pattern (glob supported, e.g., "summary-*")',
+      description: 'Filter tests by ID pattern (glob supported, e.g., "summary-*")',
     }),
     workers: option({
       type: number,

--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -4,14 +4,14 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import {
-  type EvalCase,
+  type EvalTest,
   type EvaluationCache,
   type EvaluationResult,
   type ProviderResponse,
   type TrialsConfig,
   runEvaluation as defaultRunEvaluation,
   ensureVSCodeSubagents,
-  loadEvalSuite,
+  loadTestSuite,
   subscribeToCodexLogEntries,
   subscribeToCopilotSdkLogEntries,
   subscribeToPiLogEntries,
@@ -219,7 +219,7 @@ async function prepareFileMetadata(params: {
   readonly options: NormalizedOptions;
 }): Promise<{
   readonly evalIds: readonly string[];
-  readonly evalCases: readonly EvalCase[];
+  readonly evalCases: readonly EvalTest[];
   readonly selection: TargetSelection;
   readonly inlineTargetLabel: string;
   readonly trialsConfig?: TrialsConfig;
@@ -251,15 +251,15 @@ async function prepareFileMetadata(params: {
     : selection.resolvedTarget.kind;
   const inlineTargetLabel = `${selection.targetName} [provider=${providerLabel}]`;
 
-  const suite = await loadEvalSuite(testFilePath, repoRoot, {
+  const suite = await loadTestSuite(testFilePath, repoRoot, {
     verbose: options.verbose,
     filter: options.filter,
   });
-  const filteredIds = suite.cases.map((value) => value.id);
+  const filteredIds = suite.tests.map((value) => value.id);
 
   return {
     evalIds: filteredIds,
-    evalCases: suite.cases,
+    evalCases: suite.tests,
     selection,
     inlineTargetLabel,
     trialsConfig: suite.trials,
@@ -300,7 +300,7 @@ async function runSingleEvalFile(params: {
   readonly displayIdTracker: { getOrAssign(evalKey: string): number };
   readonly selection: TargetSelection;
   readonly inlineTargetLabel: string;
-  readonly evalCases: readonly EvalCase[];
+  readonly evalCases: readonly EvalTest[];
   readonly trialsConfig?: TrialsConfig;
 }): Promise<{ results: EvaluationResult[] }> {
   const {
@@ -476,7 +476,7 @@ export async function runEvalCommand(input: RunEvalCommandInput): Promise<void> 
     string,
     {
       readonly evalIds: readonly string[];
-      readonly evalCases: readonly EvalCase[];
+      readonly evalCases: readonly EvalTest[];
       readonly selection: TargetSelection;
       readonly inlineTargetLabel: string;
       readonly trialsConfig?: TrialsConfig;
@@ -496,7 +496,7 @@ export async function runEvalCommand(input: RunEvalCommandInput): Promise<void> 
     0,
   );
   if (totalEvalCount === 0) {
-    throw new Error('No eval cases matched the provided filters.');
+    throw new Error('No tests matched the provided filters.');
   }
   const progressReporter = createProgressReporter(totalWorkers, { verbose: options.verbose });
   progressReporter.start();

--- a/apps/cli/src/commands/eval/statistics.ts
+++ b/apps/cli/src/commands/eval/statistics.ts
@@ -157,7 +157,7 @@ export function formatEvaluationSummary(summary: EvaluationSummary): string {
   lines.push('\n==================================================');
   lines.push('EVALUATION SUMMARY');
   lines.push('==================================================');
-  lines.push(`Total eval cases: ${summary.total}`);
+  lines.push(`Total tests: ${summary.total}`);
 
   if (summary.errorCount > 0) {
     lines.push(`Failed: ${summary.errorCount}`);
@@ -178,12 +178,12 @@ export function formatEvaluationSummary(summary: EvaluationSummary): string {
     lines.push(`  ${start.toFixed(1)}-${end.toFixed(1)}: ${bin.count}`);
   }
 
-  lines.push('\nTop performing eval cases:');
+  lines.push('\nTop performing tests:');
   summary.topResults.forEach((result, index) => {
     lines.push(`  ${index + 1}. ${result.evalId}: ${formatScore(result.score)}`);
   });
 
-  lines.push('\nLowest performing eval cases:');
+  lines.push('\nLowest performing tests:');
   summary.bottomResults.forEach((result, index) => {
     lines.push(`  ${index + 1}. ${result.evalId}: ${formatScore(result.score)}`);
   });

--- a/apps/cli/src/commands/generate/rubrics.ts
+++ b/apps/cli/src/commands/generate/rubrics.ts
@@ -30,7 +30,7 @@ interface RawEvalCase {
 }
 
 interface RawTestSuite {
-  readonly cases?: readonly unknown[];
+  readonly tests?: readonly unknown[];
   readonly target?: string;
   readonly execution?: {
     readonly target?: string;
@@ -77,10 +77,10 @@ export async function generateRubricsCommand(options: GenerateRubricsOptions): P
   }
 
   const suite = parsed as RawTestSuite;
-  const evalcases = suite.cases;
+  const evalcases = suite.tests;
 
   if (!Array.isArray(evalcases)) {
-    throw new Error(`No cases found in ${file}`);
+    throw new Error(`No tests found in ${file}`);
   }
 
   // Resolve target using the same logic as eval command
@@ -107,12 +107,12 @@ export async function generateRubricsCommand(options: GenerateRubricsOptions): P
   let skippedCount = 0;
 
   // Get the cases node from the document for modification
-  const evalcasesNode = doc.getIn(['cases']);
+  const evalcasesNode = doc.getIn(['tests']);
   if (!evalcasesNode || !isSeq(evalcasesNode)) {
-    throw new Error('cases must be a sequence');
+    throw new Error('tests must be a sequence');
   }
 
-  // Process each eval case
+  // Process each test
   for (let i = 0; i < evalcases.length; i++) {
     const rawCase = evalcases[i];
     if (!isJsonObject(rawCase)) {
@@ -154,7 +154,7 @@ export async function generateRubricsCommand(options: GenerateRubricsOptions): P
       provider,
     });
 
-    // Update the eval case with rubrics in the YAML document
+    // Update the test with rubrics in the YAML document
     const caseNode = (evalcasesNode as YAMLSeq).items[i];
     if (caseNode && isMap(caseNode)) {
       caseNode.set(
@@ -181,12 +181,12 @@ export async function generateRubricsCommand(options: GenerateRubricsOptions): P
   if (updatedCount > 0) {
     const output = doc.toString();
     await writeFile(absolutePath, output, 'utf8');
-    console.log(`\nUpdated ${updatedCount} eval case(s) with generated rubrics`);
+    console.log(`\nUpdated ${updatedCount} test(s) with generated rubrics`);
     if (skippedCount > 0) {
-      console.log(`Skipped ${skippedCount} eval case(s)`);
+      console.log(`Skipped ${skippedCount} test(s)`);
     }
   } else {
-    console.log('\nNo eval cases updated (all already have rubrics or missing criteria)');
+    console.log('\nNo tests updated (all already have rubrics or missing criteria)');
   }
 }
 

--- a/apps/cli/src/templates/.agentv/config.yaml
+++ b/apps/cli/src/templates/.agentv/config.yaml
@@ -12,4 +12,4 @@ guideline_patterns:
 # - Patterns use standard glob syntax (via micromatch library)
 # - Paths are normalized to forward slashes for cross-platform compatibility
 # - Only files matching these patterns are loaded as guidelines
-# - All other files referenced in eval cases are treated as regular file content
+# - All other files referenced in tests are treated as regular file content

--- a/apps/cli/test/eval.integration.test.ts
+++ b/apps/cli/test/eval.integration.test.ts
@@ -50,7 +50,7 @@ targets:
   const testFileContent = `description: CLI integration test
 target: file-target
 
-cases:
+tests:
   - id: case-alpha
     criteria: System responds with alpha
     input_messages:

--- a/apps/cli/test/generate-rubrics.integration.test.ts
+++ b/apps/cli/test/generate-rubrics.integration.test.ts
@@ -54,7 +54,7 @@ targets:
 execution:
   target: default
 
-cases:`;
+tests:`;
 
   if (withComments) {
     testFileContent += '\n  # This is a test comment\n  # TODO: update this test case';
@@ -134,7 +134,7 @@ describe('generate rubrics integration', () => {
 
     expect(stdout).toContain('Generating rubrics for:');
     expect(stdout).toContain('case-with-outcome');
-    expect(stdout).toMatch(/Updated \d+ eval case\(s\) with generated rubrics/);
+    expect(stdout).toMatch(/Updated \d+ test\(s\) with generated rubrics/);
 
     // Read the updated file
     const content = await readFile(fixture.testFilePath, 'utf8');
@@ -176,10 +176,10 @@ describe('generate rubrics integration', () => {
 
     // Check that structure is maintained (basic indentation check)
     const lines = updatedContent.split('\n');
-    const casesLine = lines.findIndex((line) => line.includes('cases:'));
+    const casesLine = lines.findIndex((line) => line.includes('tests:'));
     const rubricsLine = lines.findIndex((line) => line.includes('rubrics:'));
 
-    // rubrics should be indented more than cases
+    // rubrics should be indented more than tests
     if (casesLine >= 0 && rubricsLine >= 0) {
       const casesIndent = lines[casesLine].match(/^\s*/)?.[0].length ?? 0;
       const rubricsIndent = lines[rubricsLine].match(/^\s*/)?.[0].length ?? 0;

--- a/apps/web/src/components/Lander.astro
+++ b/apps/web/src/components/Lander.astro
@@ -58,7 +58,7 @@ import type { Props } from '@astrojs/starlight/props';
             <!-- Scene 1: agentv run -->
             <div class="av-scene av-scene-1">
               <div class="av-line av-line-cmd"><span class="av-prompt">$</span> <span class="av-typing">agentv run ./evals/math.yaml</span></div>
-              <div class="av-line av-line-out av-line-delay-1"><span class="av-dim">Running 3 eval cases...</span></div>
+              <div class="av-line av-line-out av-line-delay-1"><span class="av-dim">Running 3 tests...</span></div>
               <div class="av-line av-line-out av-line-delay-2"><span class="av-pass">PASS</span> addition <span class="av-dim">score: 1.0</span></div>
               <div class="av-line av-line-out av-line-delay-3"><span class="av-pass">PASS</span> multiplication <span class="av-dim">score: 1.0</span></div>
               <div class="av-line av-line-out av-line-delay-4"><span class="av-fail">FAIL</span> division <span class="av-dim">score: 0.4</span></div>
@@ -165,7 +165,7 @@ import type { Props } from '@astrojs/starlight/props';
 execution:
   target: default
 
-cases:
+tests:
   - id: addition
     criteria: Correctly calculates 15 + 27 = 42
     input: What is 15 + 27?`}</code></pre>

--- a/apps/web/src/content/docs/evaluation/batch-cli.mdx
+++ b/apps/web/src/content/docs/evaluation/batch-cli.mdx
@@ -1,27 +1,27 @@
 ---
 title: Batch CLI Evaluation
-description: Evaluate external tools that process all eval cases in a single invocation
+description: Evaluate external tools that process all tests in a single invocation
 sidebar:
   order: 5
 ---
 
-Batch CLI evaluation handles tools that process multiple inputs at once — bulk classifiers, screening engines, or any runner that reads all eval cases and outputs results in one pass.
+Batch CLI evaluation handles tools that process multiple inputs at once — bulk classifiers, screening engines, or any runner that reads all tests and outputs results in one pass.
 
 ## Overview
 
 Use batch CLI evaluation when:
 
 - An external tool processes multiple inputs in a single invocation (e.g., AML screening, bulk classification)
-- The runner reads the eval YAML directly to extract all eval cases
-- Output is JSONL with records keyed by eval case `id`
-- Each eval case has its own evaluator to validate its corresponding output record
+- The runner reads the eval YAML directly to extract all tests
+- Output is JSONL with records keyed by test `id`
+- Each test has its own evaluator to validate its corresponding output record
 
 ## Execution Flow
 
 1. **AgentV** invokes the batch runner once, passing `--eval <yaml-path>` and `--output <jsonl-path>`
-2. **Batch runner** reads the eval YAML, extracts all eval cases, processes them, and writes JSONL output keyed by `id`
-3. **AgentV** parses the JSONL and routes each record to its matching eval case by `id`
-4. **Per-case evaluators** validate the output for each eval case independently
+2. **Batch runner** reads the eval YAML, extracts all tests, processes them, and writes JSONL output keyed by `id`
+3. **AgentV** parses the JSONL and routes each record to its matching test by `id`
+4. **Per-test evaluators** validate the output for each test independently
 
 ## Eval File Structure
 
@@ -30,7 +30,7 @@ description: Batch CLI demo using structured input
 execution:
   target: batch_cli
 
-cases:
+tests:
   - id: case-001
     criteria: |-
       Batch runner returns JSON with decision=CLEAR.
@@ -92,7 +92,7 @@ cases:
 
 ## Batch Runner Contract
 
-The batch runner reads the eval YAML directly and processes all eval cases in one invocation.
+The batch runner reads the eval YAML directly and processes all tests in one invocation.
 
 ### Input
 
@@ -104,14 +104,14 @@ bun run batch-runner.ts --eval ./my-eval.yaml --output ./results.jsonl
 
 ### Output
 
-JSONL where each line is a JSON object with an `id` matching an eval case:
+JSONL where each line is a JSON object with an `id` matching a test:
 
 ```json
 {"id": "case-001", "text": "{\"decision\": \"CLEAR\", ...}"}
 {"id": "case-002", "text": "{\"decision\": \"REVIEW\", ...}"}
 ```
 
-The `id` field must match the eval case `id` for AgentV to route output to the correct evaluator.
+The `id` field must match the test `id` for AgentV to route output to the correct evaluator.
 
 ### Output with Tool Trajectory
 
@@ -144,7 +144,7 @@ AgentV extracts tool calls directly from `output_messages[].tool_calls[]` for `t
 
 ## Evaluator Implementation
 
-Each eval case has its own evaluator that validates the batch runner output. The evaluator receives the standard `code_judge` input via stdin.
+Each test has its own evaluator that validates the batch runner output. The evaluator receives the standard `code_judge` input via stdin.
 
 **Input (stdin):**
 ```json
@@ -256,13 +256,13 @@ Key settings:
 | Setting | Description |
 |---------|-------------|
 | `provider: cli` | Use the CLI provider |
-| `provider_batching: true` | Run once for all eval cases instead of per-case |
+| `provider_batching: true` | Run once for all tests instead of per-test |
 | `{EVAL_FILE}` | Placeholder replaced with the eval file path |
 | `{OUTPUT_FILE}` | Placeholder replaced with the JSONL output path |
 
 ## Best Practices
 
-1. **Use unique eval case IDs** -- the batch runner and AgentV use `id` to route outputs to the correct evaluator
+1. **Use unique test IDs** -- the batch runner and AgentV use `id` to route outputs to the correct evaluator
 2. **Structured input** -- put structured data in `user.content` for the runner to extract
 3. **Structured expected_output** -- define expected output as objects for easy comparison
 4. **Deterministic runners** -- batch runners should produce consistent output for reliable testing

--- a/apps/web/src/content/docs/evaluation/eval-cases.mdx
+++ b/apps/web/src/content/docs/evaluation/eval-cases.mdx
@@ -1,16 +1,16 @@
 ---
-title: Eval Cases
-description: Defining individual test cases
+title: Tests
+description: Defining individual tests
 sidebar:
   order: 2
 ---
 
-Eval cases are individual test cases within an evaluation file. Each case defines input messages, expected outcomes, and optional evaluator overrides.
+Tests are individual test entries within an evaluation file. Each test defines input messages, expected outcomes, and optional evaluator overrides.
 
 ## Basic Structure
 
 ```yaml
-cases:
+tests:
   - id: addition
     criteria: Correctly calculates 15 + 27 = 42
 
@@ -23,7 +23,7 @@ cases:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `id` | Yes | Unique identifier for the eval case |
+| `id` | Yes | Unique identifier for the test |
 | `criteria` | Yes | Description of what a correct response should contain |
 | `input` | Yes | Input sent to the target (string, object, or message array). Alias: `input_messages` |
 | `expected_output` | No | Expected response for comparison (string, object, or message array). Alias: `expected_messages` |
@@ -69,10 +69,10 @@ expected_output:
 
 ## Per-Case Execution Overrides
 
-Override the default target or evaluators for specific cases:
+Override the default target or evaluators for specific tests:
 
 ```yaml
-cases:
+tests:
   - id: complex-case
     criteria: Provides detailed explanation
     input: Explain quicksort algorithm
@@ -87,14 +87,14 @@ cases:
 
 ## Per-Case Workspace Config
 
-Override the suite-level workspace config for individual cases. Case-level fields replace suite-level fields:
+Override the suite-level workspace config for individual tests. Test-level fields replace suite-level fields:
 
 ```yaml
 workspace:
   setup:
     script: ["bun", "run", "default-setup.ts"]
 
-cases:
+tests:
   - id: case-1
     criteria: Should work
     input: Do something
@@ -115,7 +115,7 @@ See [Workspace Setup/Teardown](/targets/configuration/#workspace-setupteardown) 
 Pass arbitrary key-value pairs to setup/teardown scripts via the `metadata` field. This is useful for benchmark datasets where each case needs repo info, commit hashes, or other context:
 
 ```yaml
-cases:
+tests:
   - id: sympy-20590
     criteria: Bug should be fixed
     input: Fix the diophantine equation bug
@@ -134,7 +134,7 @@ The `metadata` field is included in the stdin JSON passed to setup and teardown 
 Pass additional context to evaluators via the `sidecar` field:
 
 ```yaml
-cases:
+tests:
   - id: code-gen
     criteria: Generates valid Python
     sidecar:

--- a/apps/web/src/content/docs/evaluation/eval-files.mdx
+++ b/apps/web/src/content/docs/evaluation/eval-files.mdx
@@ -9,7 +9,7 @@ Evaluation files define the test cases, targets, and evaluators for an evaluatio
 
 ## YAML Format
 
-The primary format. A single file contains metadata, execution config, and eval cases:
+The primary format. A single file contains metadata, execution config, and tests:
 
 ```yaml
 description: Math problem solving evaluation
@@ -20,7 +20,7 @@ execution:
       type: llm_judge
       prompt: ./judges/correctness.md
 
-cases:
+tests:
   - id: addition
     criteria: Correctly calculates 15 + 27 = 42
     input: What is 15 + 27?
@@ -35,11 +35,11 @@ cases:
 | `dataset` | Optional dataset identifier |
 | `execution` | Default execution config (target, evaluators) |
 | `workspace` | Suite-level workspace config (setup/teardown scripts, template) |
-| `cases` | Array of individual test cases |
+| `tests` | Array of individual tests |
 
 ## JSONL Format
 
-For large-scale evaluations, AgentV supports JSONL (JSON Lines) format. Each line is a single eval case:
+For large-scale evaluations, AgentV supports JSONL (JSON Lines) format. Each line is a single test:
 
 ```jsonl
 {"id": "test-1", "criteria": "Calculates correctly", "input": "What is 2+2?"}

--- a/apps/web/src/content/docs/evaluation/examples.mdx
+++ b/apps/web/src/content/docs/evaluation/examples.mdx
@@ -16,7 +16,7 @@ description: Basic arithmetic evaluation
 execution:
   target: default
 
-cases:
+tests:
   - id: simple-addition
     criteria: Correctly calculates 2+2
 
@@ -34,7 +34,7 @@ description: Code review with guidelines
 execution:
   target: azure_base
 
-cases:
+tests:
   - id: code-review-basic
     criteria: Assistant provides helpful code analysis with security considerations
 
@@ -71,14 +71,14 @@ cases:
 
 ## Multi-Evaluator
 
-Combine a code judge and an LLM judge on the same eval case:
+Combine a code judge and an LLM judge on the same test:
 
 ```yaml
 description: JSON generation with validation
 execution:
   target: default
 
-cases:
+tests:
   - id: json-generation-with-validation
     criteria: Generates valid JSON with required fields
 
@@ -113,7 +113,7 @@ description: Tool usage validation
 execution:
   target: mock_agent
 
-cases:
+tests:
   # Validate minimum tool usage (order doesn't matter)
   - id: research-depth
     criteria: Agent researches thoroughly
@@ -150,7 +150,7 @@ description: Static trace evaluation
 execution:
   target: static_trace
 
-cases:
+tests:
   - id: validate-trace-file
     criteria: Trace contains required steps
     input: Analyze trace
@@ -173,7 +173,7 @@ description: Multi-turn debugging session with clarifying questions
 execution:
   target: default
 
-cases:
+tests:
   - id: debug-with-clarification
     criteria: |-
       Assistant conducts a multi-turn debugging session, asking clarification
@@ -227,14 +227,14 @@ cases:
 
 ## Batch CLI
 
-Evaluate external batch runners that process all eval cases in one invocation:
+Evaluate external batch runners that process all tests in one invocation:
 
 ```yaml
 description: Batch CLI demo (AML screening)
 execution:
   target: batch_cli
 
-cases:
+tests:
   - id: aml-001
     criteria: |-
       Batch runner returns JSON with decision=CLEAR.
@@ -310,7 +310,7 @@ cases:
 - The batch runner reads the eval YAML via `--eval` flag and outputs JSONL keyed by `id`
 - Put structured data in `user.content` as objects for the runner to extract
 - Use `expected_output` with object fields for structured expected output
-- Each eval case has its own evaluator to validate its portion of the output
+- Each test has its own evaluator to validate its portion of the output
 
 ## File Path Conventions
 

--- a/apps/web/src/content/docs/evaluation/rubrics.mdx
+++ b/apps/web/src/content/docs/evaluation/rubrics.mdx
@@ -5,14 +5,14 @@ sidebar:
   order: 3
 ---
 
-Rubrics define structured evaluation criteria directly in your eval cases. They support binary checklist grading and score-range analytic grading.
+Rubrics define structured evaluation criteria directly in your tests. They support binary checklist grading and score-range analytic grading.
 
 ## Basic Usage
 
 The simplest form — each string becomes a required criterion:
 
 ```yaml
-cases:
+tests:
   - id: quicksort-explain
     criteria: Explain how quicksort works
     input: Explain quicksort algorithm
@@ -100,14 +100,14 @@ Generate rubrics from expected outcomes:
 agentv generate rubrics evals/my-eval.yaml
 ```
 
-This analyzes each eval case's `criteria` and creates structured rubric criteria.
+This analyzes each test's `criteria` and creates structured rubric criteria.
 
 ## Combining with Other Evaluators
 
 Rubrics work alongside code and LLM judges:
 
 ```yaml
-cases:
+tests:
   - id: code-quality
     criteria: Generates correct, clean Python code
     input: Write a fibonacci function

--- a/apps/web/src/content/docs/evaluation/running-evals.mdx
+++ b/apps/web/src/content/docs/evaluation/running-evals.mdx
@@ -23,9 +23,9 @@ Run against a different target than specified in the eval file:
 agentv run --target azure_base evals/**/*.yaml
 ```
 
-### Run Specific Eval Case
+### Run Specific Test
 
-Run a single eval case by ID:
+Run a single test by ID:
 
 ```bash
 agentv run --eval-id case-123 evals/my-eval.yaml
@@ -58,7 +58,7 @@ agentv run evals/my-eval.yaml --trace
 ```
 
 Traces are written to `.agentv/traces/<timestamp>/<eval-file>.trace.jsonl` as JSONL records containing:
-- `evalId` - The eval case identifier
+- `evalId` - The test identifier
 - `startTime` / `endTime` - Execution boundaries
 - `durationMs` - Total execution duration
 - `spans` - Array of tool invocations with timing and input/output
@@ -66,7 +66,7 @@ Traces are written to `.agentv/traces/<timestamp>/<eval-file>.trace.jsonl` as JS
 
 ### Workspace Cleanup
 
-When using `workspace_template` or the `workspace` config block, temporary workspaces are created for each eval case. By default, workspaces are cleaned up on success and preserved on failure for debugging.
+When using `workspace_template` or the `workspace` config block, temporary workspaces are created for each test. By default, workspaces are cleaned up on success and preserved on failure for debugging.
 
 ```bash
 # Always keep workspaces (for debugging)
@@ -96,7 +96,7 @@ Run evaluations without API keys by letting an external agent (e.g., Claude Code
 agentv prompt evals/my-eval.yaml
 ```
 
-Outputs a step-by-step orchestration prompt listing all eval cases and the commands to run for each.
+Outputs a step-by-step orchestration prompt listing all tests and the commands to run for each.
 
 ### Get Task Input
 

--- a/apps/web/src/content/docs/evaluators/code-judges.mdx
+++ b/apps/web/src/content/docs/evaluators/code-judges.mdx
@@ -283,7 +283,7 @@ targets:
     workspace_template: ./workspace-template
 
 # dataset.yaml
-cases:
+tests:
   - id: implement-feature
     criteria: Agent implements the feature correctly
     input: "Implement the TODO functions in src/index.ts"

--- a/apps/web/src/content/docs/evaluators/composite.mdx
+++ b/apps/web/src/content/docs/evaluators/composite.mdx
@@ -107,7 +107,7 @@ Inside the prompt file, use the `{{EVALUATOR_RESULTS_JSON}}` variable to inject 
 Block outputs that fail safety even if quality is high. A code judge aggregator can enforce hard gates:
 
 ```yaml
-cases:
+tests:
   - id: safety-gated-response
     criteria: Safe and accurate response
 

--- a/apps/web/src/content/docs/evaluators/custom-evaluators.mdx
+++ b/apps/web/src/content/docs/evaluators/custom-evaluators.mdx
@@ -13,13 +13,13 @@ AgentV supports multiple evaluator types that can be combined for comprehensive 
 |------|-------------|----------|
 | `code_judge` | Deterministic script (Python/TS/any) | Exact matching, format validation, programmatic checks |
 | `llm_judge` | LLM-based evaluation with custom prompt | Semantic evaluation, nuance, subjective quality |
-| Rubrics | Structured criteria in eval case | Multi-criterion grading with weights |
+| Rubrics | Structured criteria in test | Multi-criterion grading with weights |
 
 ## Referencing Evaluators
 
-Evaluators are configured at the execution level — either top-level (applies to all cases) or per-case:
+Evaluators are configured at the execution level — either top-level (applies to all tests) or per-test:
 
-### Top-Level (Default for All Cases)
+### Top-Level (Default for All Tests)
 
 ```yaml
 description: My evaluation
@@ -29,7 +29,7 @@ execution:
       type: llm_judge
       prompt: ./judges/correctness.md
 
-cases:
+tests:
   - id: test-1
     # Uses the top-level evaluator
     ...
@@ -38,7 +38,7 @@ cases:
 ### Per-Case Override
 
 ```yaml
-cases:
+tests:
   - id: test-1
     criteria: Returns valid JSON
     input: Generate a JSON config
@@ -54,7 +54,7 @@ cases:
 Use multiple evaluators on the same case for comprehensive scoring:
 
 ```yaml
-cases:
+tests:
   - id: code-generation
     criteria: Generates correct Python code
     input: Write a sorting function

--- a/apps/web/src/content/docs/evaluators/execution-metrics.mdx
+++ b/apps/web/src/content/docs/evaluators/execution-metrics.mdx
@@ -46,7 +46,7 @@ evaluators:
 ### Example: Comprehensive Efficiency Check
 
 ```yaml
-cases:
+tests:
   - id: efficient-research
     criteria: Agent researches and summarizes efficiently
     input: Research the topic and provide a summary
@@ -120,7 +120,7 @@ Fails if total token usage exceeds the threshold.
 Execution metrics work well alongside semantic evaluators:
 
 ```yaml
-cases:
+tests:
   - id: code-generation
     criteria: Generates correct, efficient code
     input: Write a sorting algorithm

--- a/apps/web/src/content/docs/evaluators/llm-judges.mdx
+++ b/apps/web/src/content/docs/evaluators/llm-judges.mdx
@@ -50,11 +50,11 @@ Score the response from 0.0 to 1.0 based on:
 | Variable | Source |
 |----------|--------|
 | `question` | First user message content |
-| `criteria` | Eval case `criteria` field |
+| `criteria` | Test `criteria` field |
 | `reference_answer` | Last expected message content |
 | `candidate_answer` | Last candidate response content |
-| `sidecar` | Eval case `sidecar` metadata |
-| `rubrics` | Eval case `rubrics` (if defined) |
+| `sidecar` | Test `sidecar` metadata |
+| `rubrics` | Test `rubrics` (if defined) |
 | `file_changes` | Unified diff of workspace file changes (when `workspace_template` is configured) |
 
 ### TypeScript Template
@@ -86,7 +86,7 @@ Evaluate and provide a score from 0 to 1.`;
 
 ## How It Works
 
-1. AgentV renders the prompt template with variables from the eval case
+1. AgentV renders the prompt template with variables from the test
 2. The rendered prompt is sent to the judge target (configured in targets.yaml)
 3. The LLM returns a structured evaluation with score, hits, misses, and reasoning
 4. Results are recorded in the output JSONL
@@ -117,7 +117,7 @@ TypeScript templates receive a context object with these fields:
 | `question` | `string` | First user message content |
 | `candidateAnswer` | `string` | Last entry in `output_messages` |
 | `referenceAnswer` | `string` | Last entry in `expected_messages` |
-| `criteria` | `string` | Eval case `criteria` field |
+| `criteria` | `string` | Test `criteria` field |
 | `expectedMessages` | `Message[]` | Full resolved expected messages |
 | `outputMessages` | `Message[]` | Full provider output messages |
 | `traceSummary` | `TraceSummary` | Execution metrics summary |
@@ -150,7 +150,7 @@ Derived strings injected into evaluator prompts:
 | Variable | Derivation |
 |----------|------------|
 | `question` | Content of the first `user` role entry in `input_messages` |
-| `criteria` | Passed through from the eval case field |
+| `criteria` | Passed through from the test field |
 | `reference_answer` | Content of the last entry in `expected_messages` |
 | `candidate_answer` | Content of the last entry in `output_messages` |
 | `input_messages` | Full resolved input array, JSON-serialized |

--- a/apps/web/src/content/docs/evaluators/structured-data.mdx
+++ b/apps/web/src/content/docs/evaluators/structured-data.mdx
@@ -17,7 +17,7 @@ Built-in evaluators for grading structured outputs and gating on execution metri
 Put the expected structured output in the evalcase `expected_output` (as an object or message array). Evaluators read expected values from there.
 
 ```yaml
-cases:
+tests:
   - id: invoice-001
     expected_output:
       invoice_number: "INV-2025-001234"

--- a/apps/web/src/content/docs/evaluators/tool-trajectory.mdx
+++ b/apps/web/src/content/docs/evaluators/tool-trajectory.mdx
@@ -188,7 +188,7 @@ description: Validate research agent tool usage
 execution:
   target: codex_agent
 
-cases:
+tests:
   - id: comprehensive-research
     criteria: Agent thoroughly researches the topic
 
@@ -218,7 +218,7 @@ cases:
 ### Multi-Step Pipeline
 
 ```yaml
-cases:
+tests:
   - id: data-pipeline
     criteria: Process data through complete pipeline
 
@@ -239,7 +239,7 @@ cases:
 ### Pipeline with Latency Assertions
 
 ```yaml
-cases:
+tests:
   - id: data-pipeline-perf
     criteria: Process data within timing budgets
 

--- a/apps/web/src/content/docs/getting-started/introduction.mdx
+++ b/apps/web/src/content/docs/getting-started/introduction.mdx
@@ -36,7 +36,7 @@ AgentV is a CLI-first AI agent evaluation framework. It evaluates your agents lo
 ### Key Components
 
 - **Eval files** — YAML or JSONL definitions of test cases
-- **Eval cases** — Individual test cases with input messages and expected outcomes
+- **Tests** — Individual test entries with input messages and expected outcomes
 - **Targets** — The agent or LLM provider being evaluated
 - **Evaluators** — Code judges (Python/TypeScript) or LLM judges that score responses
 - **Rubrics** — Structured criteria with weights for grading

--- a/apps/web/src/content/docs/getting-started/quickstart.mdx
+++ b/apps/web/src/content/docs/getting-started/quickstart.mdx
@@ -36,7 +36,7 @@ description: Math problem solving evaluation
 execution:
   target: default
 
-cases:
+tests:
   - id: addition
     criteria: Correctly calculates 15 + 27 = 42
 

--- a/apps/web/src/content/docs/targets/configuration.mdx
+++ b/apps/web/src/content/docs/targets/configuration.mdx
@@ -66,7 +66,7 @@ Set the default target at the top level or override per case:
 execution:
   target: azure_base
 
-cases:
+tests:
   - id: test-1
     # Uses azure_base
 
@@ -88,7 +88,7 @@ targets:
 
 ## Workspace Template
 
-For agent targets, `workspace_template` specifies a directory that gets copied to a temporary location before each eval case runs. This provides isolated, reproducible workspaces.
+For agent targets, `workspace_template` specifies a directory that gets copied to a temporary location before each test runs. This provides isolated, reproducible workspaces.
 
 ```yaml
 targets:
@@ -101,11 +101,11 @@ targets:
 When `workspace_template` is set:
 - The template directory is copied to `~/.agentv/workspaces/<eval-run-id>/<case-id>/`
 - The `.git` directory is skipped during copy
-- Each eval case gets its own isolated copy
+- Each test gets its own isolated copy
 
 ### Workspace Setup/Teardown
 
-Run scripts before and after each eval case using the `workspace` block. This can be defined at the suite level (applies to all cases) or per case (overrides suite-level).
+Run scripts before and after each test using the `workspace` block. This can be defined at the suite level (applies to all tests) or per test (overrides suite-level).
 
 ```yaml
 workspace:
@@ -136,7 +136,7 @@ Each script config accepts:
 **Lifecycle order:** template copy → setup script → git baseline → agent runs → file changes captured → teardown script → cleanup
 
 **Error handling:**
-- Setup failure aborts the eval case with an error result
+- Setup failure aborts the test with an error result
 - Teardown failure is non-fatal (warning only)
 
 **Script context:** Both scripts receive a JSON object on stdin with case context:
@@ -151,7 +151,7 @@ Each script config accepts:
 }
 ```
 
-**Suite vs per-case:** When both are defined, case-level fields replace suite-level fields. See [Per-Case Workspace Config](/evaluation/eval-cases/#per-case-workspace-config) for examples.
+**Suite vs per-test:** When both are defined, test-level fields replace suite-level fields. See [Per-Test Workspace Config](/evaluation/eval-cases/#per-case-workspace-config) for examples.
 
 ### Workspace Fingerprinting
 
@@ -171,7 +171,7 @@ Override with CLI flags:
 
 | Option | Use Case |
 |--------|----------|
-| `cwd` | Run in an existing directory (shared across cases) |
+| `cwd` | Run in an existing directory (shared across tests) |
 | `workspace_template` | Copy template to temp location (isolated per case) |
 
 These options are mutually exclusive. If neither is set, the eval file's directory is used as the working directory.

--- a/apps/web/src/content/docs/tools/compare.mdx
+++ b/apps/web/src/content/docs/tools/compare.mdx
@@ -143,5 +143,5 @@ echo "Candidate is equal or better than baseline."
 ## Tips
 
 - **Threshold selection** -- the default 0.1 means a 10% difference is required for a win or loss. Use stricter thresholds (0.05) for critical evaluations.
-- **Unmatched results** -- check `unmatched` counts in JSON output to identify eval cases that only exist in one file.
+- **Unmatched results** -- check `unmatched` counts in JSON output to identify tests that only exist in one file.
 - **Multiple comparisons** -- compare against multiple baselines by running the command multiple times.

--- a/apps/web/src/content/docs/tools/generate.mdx
+++ b/apps/web/src/content/docs/tools/generate.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 3
 ---
 
-The `generate` command creates structured evaluation criteria from your eval cases.
+The `generate` command creates structured evaluation criteria from your tests.
 
 ## Generate Rubrics
 
@@ -15,11 +15,11 @@ Auto-generate rubrics from expected outcomes:
 agentv generate rubrics evals/my-eval.yaml
 ```
 
-This analyzes each eval case's `criteria` field and creates structured rubric criteria with appropriate weights.
+This analyzes each test's `criteria` field and creates structured rubric criteria with appropriate weights.
 
 ## How It Works
 
-1. Reads each eval case's `criteria`
+1. Reads each test's `criteria`
 2. Uses an LLM to decompose the criteria into individual checkable rubric items
 3. Assigns weights based on importance
 4. Writes the rubrics back to the eval file
@@ -29,7 +29,7 @@ This analyzes each eval case's `criteria` field and creates structured rubric cr
 Before:
 
 ```yaml
-cases:
+tests:
   - id: quicksort
     criteria: Explains quicksort with time complexity and examples
     input: Explain quicksort
@@ -38,7 +38,7 @@ cases:
 After running `agentv generate rubrics`:
 
 ```yaml
-cases:
+tests:
   - id: quicksort
     criteria: Explains quicksort with time complexity and examples
     input: Explain quicksort

--- a/evals/README.md
+++ b/evals/README.md
@@ -7,7 +7,7 @@ This folder contains evaluations to ensure AgentV's `AGENTS.md` design principle
 ```
 evals/
 ├── targets.yaml              # Target definitions
-├── design-principles.yaml    # Eval cases
+├── design-principles.yaml    # Tests
 └── design-principles-judge.md # LLM judge prompt
 ```
 

--- a/evals/architecture/dataset.yaml
+++ b/evals/architecture/dataset.yaml
@@ -3,7 +3,7 @@ description: Evaluates whether proposed changes follow AGENTS.md design principl
 execution:
   target: default
 
-cases:
+tests:
   - id: violates-lightweight-core
     criteria: |
       The proposed change violates the "Lightweight Core, Plugin Extensibility" principle.

--- a/examples/features/.agentv/config.yaml
+++ b/examples/features/.agentv/config.yaml
@@ -21,4 +21,4 @@ eval_patterns:
 # - Patterns use standard glob syntax (via fast-glob)
 # - Matching is case-insensitive
 # - Only files matching these patterns are discovered in interactive mode
-# - All other files referenced in eval cases are treated as regular file content
+# - All other files referenced in tests are treated as regular file content

--- a/examples/features/agent-judge/.agentv/targets.yaml
+++ b/examples/features/agent-judge/.agentv/targets.yaml
@@ -1,6 +1,6 @@
 targets:
   # Mock agent that "creates tests" in the workspace.
-  # Each eval case gets a fresh copy of workspace-template/ as its CWD.
+  # Each test gets a fresh copy of workspace-template/ as its CWD.
   - name: mock_agent
     provider: cli
     command_template: >-

--- a/examples/features/agent-judge/evals/dataset.yaml
+++ b/examples/features/agent-judge/evals/dataset.yaml
@@ -11,7 +11,7 @@ description: Verify agent_judge evaluator can audit workspace file creation
 execution:
   target: mock_agent
 
-cases:
+tests:
   # Case 1: freeform agent_judge (no rubrics) — scores 0-1
   - id: verify-test-creation-freeform
     criteria: >-

--- a/examples/features/basic-jsonl/evals/dataset.yaml
+++ b/examples/features/basic-jsonl/evals/dataset.yaml
@@ -1,5 +1,5 @@
 # Sidecar metadata for dataset.jsonl
-# Provides default values for all eval cases
+# Provides default values for all tests
 
 description: JSONL version of the basic example - demonstrates file references, multi-turn, and per-case overrides
 dataset: basic-jsonl

--- a/examples/features/basic/evals/dataset.yaml
+++ b/examples/features/basic/evals/dataset.yaml
@@ -7,7 +7,7 @@ description: Example showing basic features, conversation threading, multiple ev
 execution:
   target: default
 
-cases:
+tests:
   # ==========================================
   # Example 1: Basic V2 features with file references
   # Demonstrates: input, expected_output, file references, array content format
@@ -63,14 +63,14 @@ cases:
   - id: code-gen-python-comprehensive
     # Baseline note: type hints are required; missing them typically drops score (~0.95).
     
-    # conversation_id represents the full conversation that may be split into multiple eval cases
-    # Most commonly, eval cases test the final response, but could also test intermediate turns
+    # conversation_id represents the full conversation that may be split into multiple tests
+    # Most commonly, tests validate the final response, but could also test intermediate turns
     conversation_id: python-code-generation
     
     criteria: AI generates correct Python function with proper error handling, type hints, and mentions SUPERSECRET_INSTRUCTION_MARKER_PYTHON
 
     execution:
-      # Override file-level target for this specific eval case
+      # Override file-level target for this specific test
       target: azure_base
       
       # Multiple evaluators - supports both code-based and LLM judges

--- a/examples/features/batch-cli/README.md
+++ b/examples/features/batch-cli/README.md
@@ -4,7 +4,7 @@ This example demonstrates an **external batch runner** pattern for a (synthetic)
 
 ## How it works
 
-1. **Ground truth**: `evals/dataset.yaml` contains eval cases with `input` (structured object content) and `expected_output` (e.g., `content.decision`).
+1. **Ground truth**: `evals/dataset.yaml` contains tests with `input` (structured object content) and `expected_output` (e.g., `content.decision`).
 
 2. **CSV conversion**: `batch-cli-runner.ts` imports functions from `build-csv-from-eval.ts` to convert `input` into CSV format. The CSV contains only inputs (customer data, transaction details) - no expected decisions.
 
@@ -14,13 +14,13 @@ This example demonstrates an **external batch runner** pattern for a (synthetic)
 
 ## Batch error handling (missing JSONL id)
 
-This example intentionally includes an eval case (`aml-004-not-exist`) that is **not written into the CSV input** by `scripts/build-csv-from-eval.ts`.
+This example intentionally includes a test (`aml-004-not-exist`) that is **not written into the CSV input** by `scripts/build-csv-from-eval.ts`.
 
 That means the batch runner never emits a JSONL record for that `eval_id`, and the CLI provider surfaces a provider-side error:
 
 - `error: "Batch output missing id 'aml-004-not-exist'"`
 
-AgentV then reports that eval case as failed (with `error` populated), while still evaluating the other items in the batch.
+AgentV then reports that test as failed (with `error` populated), while still evaluating the other items in the batch.
 
 ## Tool Trajectory via output_messages
 
@@ -49,8 +49,8 @@ The `tool_trajectory` evaluator extracts tool calls directly from `output_messag
 
 ## Files
 
-- `batch-cli-demo.yaml` — Ground truth: eval cases with inputs and expected outputs
-- `scripts/build-csv-from-eval.ts` — Utilities to convert YAML eval cases to CSV format (imported by batch-cli-runner.ts)
+- `batch-cli-demo.yaml` — Ground truth: tests with inputs and expected outputs
+- `scripts/build-csv-from-eval.ts` — Utilities to convert YAML tests to CSV format (imported by batch-cli-runner.ts)
 - `scripts/batch-cli-runner.ts` — Main batch runner: converts inputs to CSV, processes them, writes actual responses as JSONL
 - `.agentv/targets.yaml` — Defines the `batch_cli` CLI target with provider batching enabled
 

--- a/examples/features/batch-cli/evals/dataset.yaml
+++ b/examples/features/batch-cli/evals/dataset.yaml
@@ -1,7 +1,7 @@
 # Batch CLI provider demo (synthetic)
 #
 # Goal: demonstrate a realistic batch pattern for AML screening.
-# - Eval cases contain structured `input_messages` objects.
+# - Tests contain structured `input_messages` objects.
 # - A batch runner converts those objects into a CSV input file.
 # - The CLI provider runs the batch runner once, producing JSONL output.
 # - output_messages in JSONL are automatically converted to trace events for tool_trajectory evaluation.
@@ -11,7 +11,7 @@ description: Batch CLI demo (AML screening) using structured input_messages → 
 execution:
   target: batch_cli
 
-cases:
+tests:
   - id: aml-001
     criteria: |-
       Batch runner returns a JSON object with decision=CLEAR.

--- a/examples/features/code-judge-sdk/README.md
+++ b/examples/features/code-judge-sdk/README.md
@@ -4,7 +4,7 @@ Demonstrates how a TypeScript code_judge evaluator can use `defineCodeJudge` fro
 
 ## Files
 
-- `evals/dataset.yaml`: Example eval case that uses a code_judge evaluator.
+- `evals/dataset.yaml`: Example test that uses a code_judge evaluator.
 - `scripts/verify-attachments.ts`: Code judge script using `defineCodeJudge`.
 - `evals/example.txt`, `evals/python.instructions.md`: Attachment fixtures.
 

--- a/examples/features/code-judge-sdk/evals/dataset.yaml
+++ b/examples/features/code-judge-sdk/evals/dataset.yaml
@@ -7,7 +7,7 @@ description: Demonstrates TypeScript helpers for code_judge payloads
 execution:
   target: local_cli
 
-cases:
+tests:
   - id: code-judge-sdk-attachments
     criteria: The CLI echoes the prompt and lists attachment names.
 

--- a/examples/features/code-judge-with-llm-calls/evals/dataset-contextual-precision.yaml
+++ b/examples/features/code-judge-with-llm-calls/evals/dataset-contextual-precision.yaml
@@ -19,7 +19,7 @@ execution:
       target:
         max_calls: 10
 
-cases:
+tests:
   # Test case 1: Perfect ranking - relevant node first
   # Node 1: Relevant (TypeScript builds on JS)
   # Node 2: Irrelevant (Microsoft, 2012)

--- a/examples/features/code-judge-with-llm-calls/evals/dataset-contextual-recall.yaml
+++ b/examples/features/code-judge-with-llm-calls/evals/dataset-contextual-recall.yaml
@@ -22,7 +22,7 @@ execution:
       target:
         max_calls: 15
 
-cases:
+tests:
   # Test case 1: Perfect recall - all statements supported by retrieval
   # Expected: "Python was created by Guido van Rossum and first released in 1991"
   # Statements: (1) Created by Guido van Rossum, (2) First released in 1991

--- a/examples/features/composite/evals/dataset.yaml
+++ b/examples/features/composite/evals/dataset.yaml
@@ -5,7 +5,7 @@ dataset: composite-evaluator-examples
 execution:
   target: default
 
-cases:
+tests:
   # Example 1: Weighted Average Aggregation
   - id: weighted-average-example
     input:

--- a/examples/features/document-extraction/evals/dataset-confusion-metrics.yaml
+++ b/examples/features/document-extraction/evals/dataset-confusion-metrics.yaml
@@ -29,7 +29,7 @@ execution:
         - path: importer.name
         - path: gross_total
 
-cases:
+tests:
   # ============================================
   # Case 1: Perfect extraction
   # Expected: All TP

--- a/examples/features/document-extraction/evals/dataset-field-accuracy.yaml
+++ b/examples/features/document-extraction/evals/dataset-field-accuracy.yaml
@@ -99,9 +99,9 @@ execution:
     #   threshold: 2000  # max allowed duration in milliseconds
     # - name: cost_tracking
     #   type: cost
-    #   budget: 0.10  # max allowed cost in USD per eval case
+    #   budget: 0.10  # max allowed cost in USD per test
 
-cases:
+tests:
   # ============================================
   # Test Case 1: CMA CGM Shipping Invoice
   # Perfect extraction scenario

--- a/examples/features/execution-metrics/evals/dataset.yaml
+++ b/examples/features/execution-metrics/evals/dataset.yaml
@@ -21,7 +21,7 @@ description: Demonstrates the built-in execution_metrics evaluator
 execution:
   target: mock_metrics_agent
 
-cases:
+tests:
   # ==========================================
   # Example 1: Simple threshold check - PASS
   # Check that an efficient agent stays within limits

--- a/examples/features/file-changes/.agentv/targets.yaml
+++ b/examples/features/file-changes/.agentv/targets.yaml
@@ -1,6 +1,6 @@
 targets:
   # Mock agent that edits, creates, and deletes files in the workspace.
-  # Each eval case gets a fresh copy of workspace-template/ as its CWD.
+  # Each test gets a fresh copy of workspace-template/ as its CWD.
   - name: mock_agent
     provider: cli
     command_template: >-

--- a/examples/features/file-changes/evals/dataset.yaml
+++ b/examples/features/file-changes/evals/dataset.yaml
@@ -6,15 +6,15 @@
 # The mock agent: edits hello.txt + config.json, creates src/utils.ts + tests/main.test.ts,
 # and deletes obsolete.log.
 #
-# Two eval cases each get their own fresh workspace copy, proving the feature
+# Two tests each get their own fresh workspace copy, proving the feature
 # works independently across parallel eval runs.
 
-description: Verify file_changes captures edits, creates, and deletes across multiple eval cases
+description: Verify file_changes captures edits, creates, and deletes across multiple tests
 
 execution:
   target: mock_agent
 
-cases:
+tests:
   # Case 1: verify edits and creates
   - id: verify-edits-and-creates
     criteria: >-

--- a/examples/features/functional-grading/.agentv/targets.yaml
+++ b/examples/features/functional-grading/.agentv/targets.yaml
@@ -1,6 +1,6 @@
 targets:
   # Mock agent that implements the stub functions in src/index.ts.
-  # Each eval case gets a fresh copy of workspace-template/ as its CWD.
+  # Each test gets a fresh copy of workspace-template/ as its CWD.
   - name: mock_agent
     provider: cli
     command_template: >-

--- a/examples/features/functional-grading/evals/dataset.yaml
+++ b/examples/features/functional-grading/evals/dataset.yaml
@@ -15,7 +15,7 @@ description: Functional grading with workspace_path — deploy-and-test pattern
 execution:
   target: mock_agent
 
-cases:
+tests:
   - id: implement-math-functions
     criteria: >-
       Agent implements add, multiply, and fibonacci functions

--- a/examples/features/latency-assertions/evals/dataset.yaml
+++ b/examples/features/latency-assertions/evals/dataset.yaml
@@ -33,7 +33,7 @@
 
 description: Latency assertions for per-step performance validation
 
-cases:
+tests:
   # ==========================================
   # Example 1: Simple latency assertion - PASS
   # Validates a single tool completes within time budget

--- a/examples/features/local-cli/evals/dataset.yaml
+++ b/examples/features/local-cli/evals/dataset.yaml
@@ -6,7 +6,7 @@ description: Minimal demo showing how to invoke a CLI target with file attachmen
 execution:
   target: local_cli
 
-cases:
+tests:
   - id: cli-provider-echo
     criteria: CLI echoes the prompt and mentions all attachment names
 

--- a/examples/features/prompt-template-sdk/README.md
+++ b/examples/features/prompt-template-sdk/README.md
@@ -28,7 +28,7 @@ The template receives evaluation context via stdin (JSON) and outputs the prompt
 
 ## Available Context Fields
 
-- `question` - The eval case question
+- `question` - The test question
 - `candidateAnswer` - The agent's response being evaluated
 - `referenceAnswer` - Optional reference answer
 - `criteria` - Optional criteria / expected outcome
@@ -51,7 +51,7 @@ bun agentv run examples/features/prompt-template-sdk/evals/dataset.yaml --dry-ru
 ```
 prompt-template-sdk/
   evals/
-    dataset.yaml       # Eval cases using TypeScript prompt
+    dataset.yaml       # Tests using TypeScript prompt
   prompts/
     custom-evaluator.ts  # TypeScript prompt template
   README.md

--- a/examples/features/prompt-template-sdk/evals/dataset.yaml
+++ b/examples/features/prompt-template-sdk/evals/dataset.yaml
@@ -8,7 +8,7 @@ description: Demonstrates TypeScript prompt templates for custom LLM judge promp
 execution:
   target: default
 
-cases:
+tests:
   - id: prompt-template-basic
     criteria: The CLI provides a clear answer about TypeScript benefits.
 

--- a/examples/features/rubric/evals/dataset.yaml
+++ b/examples/features/rubric/evals/dataset.yaml
@@ -6,7 +6,7 @@ description: Example showing rubric evaluator with inline rubrics and criteria
 execution:
   target: default
 
-cases:
+tests:
   # ==========================================
   # Example 1: Simple inline rubrics
   # Demonstrates: inline rubrics as strings, criteria field

--- a/examples/features/tool-trajectory-advanced/evals/dataset-trace-file-demo.yaml
+++ b/examples/features/tool-trajectory-advanced/evals/dataset-trace-file-demo.yaml
@@ -15,7 +15,7 @@ description: Static trace file evaluation demo - Product Research Agent
 execution:
   target: static_trace
 
-cases:
+tests:
   # =============================================================================
   # Example 1: In-Order Validation
   # Use case: Ensure tools are called in the expected sequence (allows gaps)

--- a/examples/features/tool-trajectory-simple/evals/dataset.yaml
+++ b/examples/features/tool-trajectory-simple/evals/dataset.yaml
@@ -28,7 +28,7 @@ description: Tool trajectory evaluator examples for agent execution validation
 execution:
   target: mock_agent
 
-cases:
+tests:
   # ==========================================
   # Example 1: any_order mode - Validate minimum tool usage
   # Use case: Ensure agent uses required tools at least N times, regardless of order

--- a/examples/features/trials/evals/dataset.yaml
+++ b/examples/features/trials/evals/dataset.yaml
@@ -10,7 +10,7 @@ execution:
     strategy: pass_at_k
     cost_limit_usd: 1.00
 
-cases:
+tests:
   - id: math-basics
     criteria: Assistant correctly answers the math question and shows reasoning
 

--- a/examples/features/weighted-evaluators/evals/dataset.yaml
+++ b/examples/features/weighted-evaluators/evals/dataset.yaml
@@ -5,7 +5,7 @@ dataset: weighted-evaluators-examples
 execution:
   target: default
 
-cases:
+tests:
   # Example 1: Different weights for multiple evaluators
   - id: weighted-multi-evaluator
     input:

--- a/examples/showcase/.agentv/config.yaml
+++ b/examples/showcase/.agentv/config.yaml
@@ -21,4 +21,4 @@ guideline_patterns:
 # - Patterns use standard glob syntax (via micromatch library)
 # - Paths are normalized to forward slashes for cross-platform compatibility
 # - Only files matching these patterns are loaded as guidelines
-# - All other files referenced in eval cases are treated as regular file content
+# - All other files referenced in tests are treated as regular file content

--- a/examples/showcase/cw-incident-triage/evals/dataset.yaml
+++ b/examples/showcase/cw-incident-triage/evals/dataset.yaml
@@ -15,7 +15,7 @@ execution:
     - name: content_evaluator
       type: llm_judge
 
-cases:
+tests:
   # ==========================================
   # Basic criticality rating classification with explicit reasoning
   # ==========================================

--- a/examples/showcase/export-screening/README.md
+++ b/examples/showcase/export-screening/README.md
@@ -25,7 +25,7 @@ export-screening/
 ├── skills/
 │   └── export-risk-assessment.md       # Classification guidelines
 ├── evals/
-│   ├── dataset.yaml                    # Eval cases with expert assessments
+│   ├── dataset.yaml                    # Tests with expert assessments
 │   ├── validate_risk_output.ts         # JSON validator + accuracy checker
 │   └── ci_check.ts                     # CI/CD threshold checker
 └── .agentv/
@@ -62,7 +62,7 @@ flowchart LR
 
 ## How It Works
 
-### 1. Eval Cases (`dataset.yaml`)
+### 1. Tests (`dataset.yaml`)
 
 Each case contains:
 - **Input**: Shipment details (origin, destination, product, HS code)
@@ -90,7 +90,7 @@ The `ci_check.ts` script:
 
 ## Customization
 
-### Adding eval cases
+### Adding tests
 
 Add cases to `dataset.yaml` following the existing pattern:
 

--- a/examples/showcase/export-screening/evals/dataset.yaml
+++ b/examples/showcase/export-screening/evals/dataset.yaml
@@ -24,7 +24,7 @@ execution:
       type: code_judge
       script: ["bun", "run", "validate_risk_output.ts"]
 
-cases:
+tests:
   # ============================================
   # HIGH RISK CASES (Expert Assessment: High)
   # Based on CHPL (Common High Priority List) codes

--- a/examples/showcase/psychotherapy/evals/dataset-encouragement.yaml
+++ b/examples/showcase/psychotherapy/evals/dataset-encouragement.yaml
@@ -12,7 +12,7 @@ execution:
     - name: content_evaluator
       type: llm_judge
 
-cases:
+tests:
   # ==============================================================================
   # TIER 1: STANDARD REFERENCE CASES (Explicit Resources)
   # ==============================================================================

--- a/examples/showcase/psychotherapy/evals/dataset-listening.yaml
+++ b/examples/showcase/psychotherapy/evals/dataset-listening.yaml
@@ -11,7 +11,7 @@ execution:
     - name: content_evaluator
       type: llm_judge
 
-cases:
+tests:
   # ==============================================================================
   # TIER 1: BASIC BENCHMARKS (Explicit Text)
   # ==============================================================================

--- a/examples/showcase/psychotherapy/evals/dataset-routing.yaml
+++ b/examples/showcase/psychotherapy/evals/dataset-routing.yaml
@@ -10,7 +10,7 @@ execution:
     - name: content_evaluator
       type: llm_judge
 
-cases:
+tests:
   # Case 1: Routing to Listening (Ah Yang)
   # Rationale: Client is venting grievance and describing a complex dynamic. Needs understanding first.
   - id: route-to-listening

--- a/examples/showcase/tool-evaluation-plugins/tool-eval-demo.yaml
+++ b/examples/showcase/tool-evaluation-plugins/tool-eval-demo.yaml
@@ -13,7 +13,7 @@ description: Showcase of tool evaluation plugin patterns
 execution:
   target: mock_agent
 
-cases:
+tests:
   # ==========================================
   # Example 1: Tool Selection Evaluation
   # Use case: Verify agent chose appropriate tools for the task

--- a/packages/core/src/evaluation/evaluators/llm-judge-prompt.ts
+++ b/packages/core/src/evaluation/evaluators/llm-judge-prompt.ts
@@ -1,6 +1,6 @@
 import type { OutputMessage } from '../providers/types.js';
 import { TEMPLATE_VARIABLES } from '../template-variables.js';
-import type { EvalCase, LlmJudgeEvaluatorConfig, RubricItem } from '../types.js';
+import type { EvalTest, LlmJudgeEvaluatorConfig, RubricItem } from '../types.js';
 import type { PromptInputs } from '../yaml-parser.js';
 import {
   DEFAULT_EVALUATOR_TEMPLATE,
@@ -18,7 +18,7 @@ export interface LlmJudgePromptAssembly {
 }
 
 export function assembleLlmJudgePrompt(input: {
-  evalCase: EvalCase;
+  evalCase: EvalTest;
   candidate: string;
   promptInputs: PromptInputs;
   evaluatorConfig?: LlmJudgeEvaluatorConfig;
@@ -56,7 +56,7 @@ export function assembleLlmJudgePrompt(input: {
 }
 
 function assembleFreeform(
-  evalCase: EvalCase,
+  evalCase: EvalTest,
   candidate: string,
   promptInputs: PromptInputs,
   fileChanges?: string,
@@ -96,7 +96,7 @@ function assembleFreeform(
 }
 
 function assembleChecklist(
-  evalCase: EvalCase,
+  evalCase: EvalTest,
   candidate: string,
   promptInputs: PromptInputs,
   rubrics: readonly RubricItem[],
@@ -143,7 +143,7 @@ function assembleChecklist(
 }
 
 function assembleScoreRange(
-  evalCase: EvalCase,
+  evalCase: EvalTest,
   candidate: string,
   promptInputs: PromptInputs,
   rubrics: readonly RubricItem[],

--- a/packages/core/src/evaluation/evaluators/types.ts
+++ b/packages/core/src/evaluation/evaluators/types.ts
@@ -1,7 +1,7 @@
 import type { ResolvedTarget } from '../providers/targets.js';
 import type { ChatPrompt, OutputMessage, Provider } from '../providers/types.js';
 import type { TraceSummary } from '../trace.js';
-import type { EvalCase, EvaluationVerdict, EvaluatorConfig, JsonObject } from '../types.js';
+import type { EvalTest, EvaluationVerdict, EvaluatorConfig, JsonObject } from '../types.js';
 
 export type { EvaluationVerdict };
 
@@ -12,7 +12,7 @@ export type { EvaluationVerdict };
 export type TargetResolver = (targetName: string) => Provider | undefined;
 
 export interface EvaluationContext {
-  readonly evalCase: EvalCase;
+  readonly evalCase: EvalTest;
   readonly candidate: string;
   readonly target: ResolvedTarget;
   readonly provider: Provider;

--- a/packages/core/src/evaluation/formatting/prompt-builder.ts
+++ b/packages/core/src/evaluation/formatting/prompt-builder.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { isGuidelineFile } from '../loaders/config-loader.js';
 import { fileExists } from '../loaders/file-resolver.js';
 import type { ChatMessageRole, ChatPrompt } from '../providers/types.js';
-import type { EvalCase, JsonObject, TestMessage } from '../types.js';
+import type { EvalTest, JsonObject, TestMessage } from '../types.js';
 import { isJsonObject } from '../types.js';
 import {
   type FormattingMode,
@@ -33,7 +33,7 @@ export interface PromptInputs {
  * @param mode - Formatting mode: 'agent' for file references, 'lm' for embedded content (default: 'lm')
  */
 export async function buildPromptInputs(
-  testCase: EvalCase,
+  testCase: EvalTest,
   mode: FormattingMode = 'lm',
 ): Promise<PromptInputs> {
   const guidelineParts: Array<{ content: string; isFile: boolean; displayPath?: string }> = [];

--- a/packages/core/src/evaluation/types.ts
+++ b/packages/core/src/evaluation/types.ts
@@ -194,7 +194,7 @@ export type WorkspaceScriptConfig = {
 };
 
 /**
- * Workspace configuration for eval cases.
+ * Workspace configuration for eval tests.
  * Can be specified at suite level and overridden per-case.
  * Merge strategy: template/scripts replaced, env deep-merged.
  */
@@ -458,9 +458,9 @@ export type EvaluatorConfig =
   | AgentJudgeEvaluatorConfig;
 
 /**
- * Eval case definition sourced from AgentV specs.
+ * Eval test definition sourced from AgentV specs.
  */
-export interface EvalCase {
+export interface EvalTest {
   readonly id: string;
   readonly dataset?: string;
   readonly conversation_id?: string;
@@ -480,6 +480,9 @@ export interface EvalCase {
   /** Arbitrary metadata passed to workspace scripts via stdin */
   readonly metadata?: Record<string, unknown>;
 }
+
+/** @deprecated Use `EvalTest` instead */
+export type EvalCase = EvalTest;
 
 /**
  * Supported trial aggregation strategies.

--- a/packages/core/src/evaluation/validation/eval-validator.ts
+++ b/packages/core/src/evaluation/validation/eval-validator.ts
@@ -51,15 +51,15 @@ export async function validateEvalFile(filePath: string): Promise<ValidationResu
     };
   }
 
-  // Resolve cases with backward-compat aliases
-  let cases: JsonValue | undefined = parsed.cases;
+  // Resolve tests with backward-compat aliases
+  let cases: JsonValue | undefined = parsed.tests;
   if (cases === undefined && 'eval_cases' in parsed) {
     cases = parsed.eval_cases;
     errors.push({
       severity: 'warning',
       filePath: absolutePath,
       location: 'eval_cases',
-      message: "'eval_cases' is deprecated. Use 'cases' instead.",
+      message: "'eval_cases' is deprecated. Use 'tests' instead.",
     });
   }
   if (cases === undefined && 'evalcases' in parsed) {
@@ -68,15 +68,15 @@ export async function validateEvalFile(filePath: string): Promise<ValidationResu
       severity: 'warning',
       filePath: absolutePath,
       location: 'evalcases',
-      message: "'evalcases' is deprecated. Use 'cases' instead.",
+      message: "'evalcases' is deprecated. Use 'tests' instead.",
     });
   }
   if (!Array.isArray(cases)) {
     errors.push({
       severity: 'error',
       filePath: absolutePath,
-      location: 'cases',
-      message: "Missing or invalid 'cases' field (must be an array)",
+      location: 'tests',
+      message: "Missing or invalid 'tests' field (must be an array)",
     });
     return {
       valid: errors.length === 0,
@@ -89,7 +89,7 @@ export async function validateEvalFile(filePath: string): Promise<ValidationResu
   // Validate each eval case
   for (let i = 0; i < cases.length; i++) {
     const evalCase = cases[i];
-    const location = `cases[${i}]`;
+    const location = `tests[${i}]`;
 
     if (!isObject(evalCase)) {
       errors.push({

--- a/packages/core/src/evaluation/validation/file-reference-validator.ts
+++ b/packages/core/src/evaluation/validation/file-reference-validator.ts
@@ -50,7 +50,7 @@ export async function validateFileReferences(
     return errors;
   }
 
-  let cases: JsonValue | undefined = parsed.cases;
+  let cases: JsonValue | undefined = parsed.tests;
   if (cases === undefined && 'eval_cases' in parsed) {
     cases = parsed.eval_cases;
   }
@@ -72,7 +72,7 @@ export async function validateFileReferences(
     if (Array.isArray(inputMessages)) {
       await validateMessagesFileRefs(
         inputMessages,
-        `cases[${i}].input_messages`,
+        `tests[${i}].input_messages`,
         searchRoots,
         absolutePath,
         errors,
@@ -84,7 +84,7 @@ export async function validateFileReferences(
     if (Array.isArray(expectedMessages)) {
       await validateMessagesFileRefs(
         expectedMessages,
-        `cases[${i}].expected_messages`,
+        `tests[${i}].expected_messages`,
         searchRoots,
         absolutePath,
         errors,

--- a/packages/core/src/evaluation/workspace/script-executor.ts
+++ b/packages/core/src/evaluation/workspace/script-executor.ts
@@ -6,7 +6,9 @@ import type { WorkspaceScriptConfig } from '../types.js';
  */
 export interface ScriptExecutionContext {
   readonly workspacePath: string;
-  readonly evalCaseId: string;
+  readonly testId: string;
+  /** @deprecated Use `testId` instead */
+  readonly evalCaseId?: string;
   readonly evalRunId: string;
   readonly caseInput?: string;
   readonly caseMetadata?: Record<string, unknown>;
@@ -27,7 +29,7 @@ export async function executeWorkspaceSetup(
 ): Promise<string> {
   const stdin = JSON.stringify({
     workspace_path: context.workspacePath,
-    eval_case_id: context.evalCaseId,
+    eval_case_id: context.testId,
     eval_run_id: context.evalRunId,
     case_input: context.caseInput ?? null,
     case_metadata: context.caseMetadata ?? null,
@@ -65,7 +67,7 @@ export async function executeWorkspaceTeardown(
 ): Promise<string> {
   const stdin = JSON.stringify({
     workspace_path: context.workspacePath,
-    eval_case_id: context.evalCaseId,
+    eval_case_id: context.testId,
     eval_run_id: context.evalRunId,
     case_input: context.caseInput ?? null,
     case_metadata: context.caseMetadata ?? null,

--- a/packages/core/test/evaluation/evaluators.test.ts
+++ b/packages/core/test/evaluation/evaluators.test.ts
@@ -16,7 +16,7 @@ import type {
   ProviderRequest,
   ProviderResponse,
 } from '../../src/evaluation/providers/types.js';
-import type { EvalCase } from '../../src/evaluation/types.js';
+import type { EvalTest } from '../../src/evaluation/types.js';
 
 /** Helper to create a ProviderResponse with text wrapped in outputMessages */
 function textResponse(text: string): ProviderResponse {
@@ -51,7 +51,7 @@ class CapturingProvider implements Provider {
   }
 }
 
-const baseTestCase: EvalCase = {
+const baseTestCase: EvalTest = {
   id: 'case-1',
   dataset: 'test-dataset',
   question: 'Improve the logging implementation',
@@ -441,7 +441,7 @@ describe('CodeEvaluator', () => {
   it('passes required fields to code_judge scripts', async () => {
     const judgeProvider = new StubProvider(textResponse('{}'));
 
-    const evalCaseWithExpectedMessages: EvalCase = {
+    const evalCaseWithExpectedMessages: EvalTest = {
       ...baseTestCase,
       expected_messages: [{ role: 'assistant', content: { decision: 'ACCEPT' } }],
     };
@@ -602,7 +602,7 @@ describe('CodeEvaluator', () => {
 });
 
 describe('FieldAccuracyEvaluator', () => {
-  const baseTestCaseWithExpected: EvalCase = {
+  const baseTestCaseWithExpected: EvalTest = {
     ...baseTestCase,
     expected_messages: [
       {
@@ -860,7 +860,7 @@ describe('FieldAccuracyEvaluator', () => {
   });
 
   it('handles array index paths', () => {
-    const evalCaseWithArray: EvalCase = {
+    const evalCaseWithArray: EvalTest = {
       ...baseTestCase,
       expected_messages: [
         {

--- a/packages/core/test/evaluation/evaluators/execution-metrics.test.ts
+++ b/packages/core/test/evaluation/evaluators/execution-metrics.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, it } from 'bun:test';
 import { ExecutionMetricsEvaluator } from '../../../src/evaluation/evaluators/execution-metrics.js';
 import type { ResolvedTarget } from '../../../src/evaluation/providers/targets.js';
 import type { TraceSummary } from '../../../src/evaluation/trace.js';
-import type { EvalCase, ExecutionMetricsEvaluatorConfig } from '../../../src/evaluation/types.js';
+import type { EvalTest, ExecutionMetricsEvaluatorConfig } from '../../../src/evaluation/types.js';
 
-const baseTestCase: EvalCase = {
+const baseTestCase: EvalTest = {
   id: 'metrics-test',
   dataset: 'test',
   question: 'Test question',

--- a/packages/core/test/evaluation/evaluators_variables.test.ts
+++ b/packages/core/test/evaluation/evaluators_variables.test.ts
@@ -7,7 +7,7 @@ import type {
   ProviderRequest,
   ProviderResponse,
 } from '../../src/evaluation/providers/types.js';
-import type { EvalCase } from '../../src/evaluation/types.js';
+import type { EvalTest } from '../../src/evaluation/types.js';
 
 class CapturingProvider implements Provider {
   readonly id = 'capturing';
@@ -23,7 +23,7 @@ class CapturingProvider implements Provider {
   }
 }
 
-const baseTestCase: EvalCase = {
+const baseTestCase: EvalTest = {
   id: 'case-1',
   dataset: 'test-dataset',
   question: 'Original Question Text',

--- a/packages/core/test/evaluation/execution-metrics.test.ts
+++ b/packages/core/test/evaluation/execution-metrics.test.ts
@@ -11,7 +11,7 @@ import {
   mergeExecutionMetrics,
   tokensPerTool,
 } from '../../src/evaluation/trace.js';
-import type { EvalCase } from '../../src/evaluation/types.js';
+import type { EvalTest } from '../../src/evaluation/types.js';
 
 describe('Execution Metrics', () => {
   describe('explorationRatio', () => {
@@ -253,7 +253,7 @@ describe('Execution Metrics', () => {
 });
 
 describe('Code Judge Metrics Integration', () => {
-  const baseTestCase: EvalCase = {
+  const baseTestCase: EvalTest = {
     id: 'metrics-test',
     dataset: 'test',
     question: 'Test question',

--- a/packages/core/test/evaluation/loaders/config-loader.test.ts
+++ b/packages/core/test/evaluation/loaders/config-loader.test.ts
@@ -8,7 +8,7 @@ import type { JsonObject } from '../../../src/evaluation/types.js';
 
 describe('extractTrialsConfig', () => {
   it('returns undefined when no execution block', () => {
-    const suite: JsonObject = { cases: [] };
+    const suite: JsonObject = { tests: [] };
     expect(extractTrialsConfig(suite)).toBeUndefined();
   });
 
@@ -148,7 +148,7 @@ describe('extractTargetFromSuite', () => {
   });
 
   it('returns undefined when no target specified', () => {
-    const suite: JsonObject = { cases: [] };
+    const suite: JsonObject = { tests: [] };
     expect(extractTargetFromSuite(suite)).toBeUndefined();
   });
 });

--- a/packages/core/test/evaluation/loaders/jsonl-parser.test.ts
+++ b/packages/core/test/evaluation/loaders/jsonl-parser.test.ts
@@ -3,11 +3,8 @@ import { mkdir, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import {
-  detectFormat,
-  loadEvalCasesFromJsonl,
-} from '../../../src/evaluation/loaders/jsonl-parser.js';
-import { loadEvalCases } from '../../../src/evaluation/yaml-parser.js';
+import { detectFormat, loadTestsFromJsonl } from '../../../src/evaluation/loaders/jsonl-parser.js';
+import { loadTests } from '../../../src/evaluation/yaml-parser.js';
 
 describe('detectFormat', () => {
   it('returns jsonl for .jsonl extension', () => {
@@ -32,7 +29,7 @@ describe('detectFormat', () => {
   });
 });
 
-describe('loadEvalCasesFromJsonl', () => {
+describe('loadTestsFromJsonl', () => {
   let tempDir: string;
 
   beforeAll(async () => {
@@ -51,7 +48,7 @@ describe('loadEvalCasesFromJsonl', () => {
       '{"id": "test-1", "criteria": "Goal", "input_messages": [{"role": "user", "content": "Query"}]}\n',
     );
 
-    const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir);
+    const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
     expect(cases).toHaveLength(1);
     expect(cases[0].id).toBe('test-1');
@@ -72,7 +69,7 @@ describe('loadEvalCasesFromJsonl', () => {
       ].join('\n'),
     );
 
-    const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir);
+    const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
     expect(cases).toHaveLength(3);
     expect(cases[0].id).toBe('test-1');
@@ -97,7 +94,7 @@ describe('loadEvalCasesFromJsonl', () => {
       ].join('\n'),
     );
 
-    const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir);
+    const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
     expect(cases).toHaveLength(3);
     expect(cases[0].id).toBe('test-1');
@@ -116,7 +113,7 @@ describe('loadEvalCasesFromJsonl', () => {
       ].join('\n'),
     );
 
-    await expect(loadEvalCasesFromJsonl(jsonlPath, tempDir)).rejects.toThrow(/Line 3/);
+    await expect(loadTestsFromJsonl(jsonlPath, tempDir)).rejects.toThrow(/Line 3/);
   });
 
   it('skips cases with missing required fields', async () => {
@@ -132,7 +129,7 @@ describe('loadEvalCasesFromJsonl', () => {
       ].join('\n'),
     );
 
-    const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir);
+    const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
     expect(cases).toHaveLength(2);
     expect(cases[0].id).toBe('test-1');
@@ -152,7 +149,7 @@ describe('loadEvalCasesFromJsonl', () => {
       'description: Test dataset\ndataset: my-tests\nevaluator: llm_judge\n',
     );
 
-    const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir);
+    const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
     expect(cases).toHaveLength(1);
     expect(cases[0].dataset).toBe('my-tests');
@@ -166,7 +163,7 @@ describe('loadEvalCasesFromJsonl', () => {
       '{"id": "test-1", "criteria": "Goal", "input_messages": [{"role": "user", "content": "Query"}]}\n',
     );
 
-    const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir);
+    const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
     expect(cases).toHaveLength(1);
     expect(cases[0].dataset).toBe('my-dataset');
@@ -179,7 +176,7 @@ describe('loadEvalCasesFromJsonl', () => {
       '{"id": "test-1", "criteria": "Goal", "input_messages": [{"role": "user", "content": "Query"}], "evaluators": [{"name": "rubric-check", "type": "llm_judge", "rubrics": [{"id": "r1", "description": "Must be polite", "weight": 1.0, "required": true}]}]}\n',
     );
 
-    const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir);
+    const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
     expect(cases).toHaveLength(1);
     expect(cases[0].evaluators).toHaveLength(1);
@@ -193,7 +190,7 @@ describe('loadEvalCasesFromJsonl', () => {
       '{"id": "test-1", "criteria": "Goal", "input_messages": [{"role": "user", "content": "Query"}], "rubrics": ["Must be polite", "Must be helpful"]}\n',
     );
 
-    const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir);
+    const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
     expect(cases).toHaveLength(1);
     expect(cases[0].evaluators).toHaveLength(1);
@@ -213,7 +210,7 @@ describe('loadEvalCasesFromJsonl', () => {
       ].join('\n'),
     );
 
-    const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir, { filter: 'test-2' });
+    const cases = await loadTestsFromJsonl(jsonlPath, tempDir, { filter: 'test-2' });
 
     expect(cases).toHaveLength(1);
     expect(cases[0].id).toBe('test-2');
@@ -230,7 +227,7 @@ describe('loadEvalCasesFromJsonl', () => {
       ].join('\n'),
     );
 
-    const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir, { filter: 'summary-*' });
+    const cases = await loadTestsFromJsonl(jsonlPath, tempDir, { filter: 'summary-*' });
 
     expect(cases).toHaveLength(2);
     expect(cases.map((c) => c.id)).toEqual(['summary-basic', 'summary-advanced']);
@@ -243,7 +240,7 @@ describe('loadEvalCasesFromJsonl', () => {
       '{"id": "test-1", "conversation_id": "conv-123", "criteria": "Goal", "input_messages": [{"role": "user", "content": "Query"}]}\n',
     );
 
-    const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir);
+    const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
     expect(cases).toHaveLength(1);
     expect(cases[0].conversation_id).toBe('conv-123');
@@ -256,7 +253,7 @@ describe('loadEvalCasesFromJsonl', () => {
       '{"id": "test-1", "criteria": "Goal", "input_messages": [{"role": "user", "content": "Query"}], "expected_messages": [{"role": "assistant", "content": "Response"}]}\n',
     );
 
-    const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir);
+    const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
     expect(cases).toHaveLength(1);
     expect(cases[0].expected_messages).toHaveLength(1);
@@ -267,17 +264,17 @@ describe('loadEvalCasesFromJsonl', () => {
     const jsonlPath = path.join(tempDir, 'empty.jsonl');
     await writeFile(jsonlPath, '');
 
-    const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir);
+    const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
     expect(cases).toHaveLength(0);
   });
 });
 
-describe('loadEvalCases with format detection', () => {
+describe('loadTests with format detection', () => {
   let tempDir: string;
 
   beforeAll(async () => {
-    tempDir = path.join(os.tmpdir(), `agentv-test-loadEvalCases-${Date.now()}`);
+    tempDir = path.join(os.tmpdir(), `agentv-test-loadTests-${Date.now()}`);
     await mkdir(tempDir, { recursive: true });
   });
 
@@ -292,7 +289,7 @@ describe('loadEvalCases with format detection', () => {
       '{"id": "jsonl-test", "criteria": "Goal", "input_messages": [{"role": "user", "content": "Query"}]}\n',
     );
 
-    const cases = await loadEvalCases(jsonlPath, tempDir);
+    const cases = await loadTests(jsonlPath, tempDir);
 
     expect(cases).toHaveLength(1);
     expect(cases[0].id).toBe('jsonl-test');
@@ -302,7 +299,7 @@ describe('loadEvalCases with format detection', () => {
     const yamlPath = path.join(tempDir, 'test.yaml');
     await writeFile(
       yamlPath,
-      `cases:
+      `tests:
   - id: yaml-test
     criteria: Goal
     input_messages:
@@ -311,7 +308,7 @@ describe('loadEvalCases with format detection', () => {
 `,
     );
 
-    const cases = await loadEvalCases(yamlPath, tempDir);
+    const cases = await loadTests(yamlPath, tempDir);
 
     expect(cases).toHaveLength(1);
     expect(cases[0].id).toBe('yaml-test');
@@ -321,7 +318,7 @@ describe('loadEvalCases with format detection', () => {
     const ymlPath = path.join(tempDir, 'test.yml');
     await writeFile(
       ymlPath,
-      `cases:
+      `tests:
   - id: yml-test
     criteria: Goal
     input_messages:
@@ -330,21 +327,21 @@ describe('loadEvalCases with format detection', () => {
 `,
     );
 
-    const cases = await loadEvalCases(ymlPath, tempDir);
+    const cases = await loadTests(ymlPath, tempDir);
 
     expect(cases).toHaveLength(1);
     expect(cases[0].id).toBe('yml-test');
   });
 
-  it('throws for unsupported extensions via loadEvalCases', async () => {
+  it('throws for unsupported extensions via loadTests', async () => {
     const txtPath = path.join(tempDir, 'test.txt');
     await writeFile(txtPath, '{}');
 
-    await expect(loadEvalCases(txtPath, tempDir)).rejects.toThrow('Unsupported file format');
+    await expect(loadTests(txtPath, tempDir)).rejects.toThrow('Unsupported file format');
   });
 });
 
-describe('JSONL and YAML produce equivalent EvalCases', () => {
+describe('JSONL and YAML produce equivalent EvalTests', () => {
   let tempDir: string;
 
   beforeAll(async () => {
@@ -356,7 +353,7 @@ describe('JSONL and YAML produce equivalent EvalCases', () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  it('produces identical EvalCase structure from both formats', async () => {
+  it('produces identical EvalTest structure from both formats', async () => {
     // Create equivalent YAML and JSONL files
     const yamlPath = path.join(tempDir, 'equiv.yaml');
     const jsonlPath = path.join(tempDir, 'equiv.jsonl');
@@ -364,7 +361,7 @@ describe('JSONL and YAML produce equivalent EvalCases', () => {
     await writeFile(
       yamlPath,
       `dataset: my-dataset
-cases:
+tests:
   - id: test-1
     criteria: "The agent should respond with a helpful answer"
     input_messages:
@@ -383,8 +380,8 @@ cases:
       '{"id": "test-1", "criteria": "The agent should respond with a helpful answer", "input_messages": [{"role": "user", "content": "What is 2+2?"}]}\n',
     );
 
-    const yamlCases = await loadEvalCases(yamlPath, tempDir);
-    const jsonlCases = await loadEvalCases(jsonlPath2, tempDir);
+    const yamlCases = await loadTests(yamlPath, tempDir);
+    const jsonlCases = await loadTests(jsonlPath2, tempDir);
 
     expect(yamlCases).toHaveLength(1);
     expect(jsonlCases).toHaveLength(1);
@@ -416,7 +413,7 @@ describe('Input/expected_output aliases and shorthand', () => {
       const jsonlPath = path.join(tempDir, 'input-shorthand.jsonl');
       await writeFile(jsonlPath, '{"id": "test-1", "criteria": "Goal", "input": "What is 2+2?"}\n');
 
-      const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir);
+      const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
       expect(cases).toHaveLength(1);
       expect(cases[0].input_messages).toHaveLength(1);
@@ -431,7 +428,7 @@ describe('Input/expected_output aliases and shorthand', () => {
         '{"id": "test-1", "criteria": "Goal", "input": [{"role": "system", "content": "Be helpful"}, {"role": "user", "content": "Hello"}]}\n',
       );
 
-      const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir);
+      const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
       expect(cases).toHaveLength(1);
       expect(cases[0].input_messages).toHaveLength(2);
@@ -446,7 +443,7 @@ describe('Input/expected_output aliases and shorthand', () => {
         '{"id": "test-1", "criteria": "Goal", "input": "Query", "expected_output": "The answer is 4"}\n',
       );
 
-      const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir);
+      const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
       expect(cases).toHaveLength(1);
       expect(cases[0].expected_messages).toHaveLength(1);
@@ -462,7 +459,7 @@ describe('Input/expected_output aliases and shorthand', () => {
         '{"id": "test-1", "criteria": "Goal", "input": "Query", "expected_output": {"riskLevel": "High", "confidence": 0.95}}\n',
       );
 
-      const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir);
+      const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
       expect(cases).toHaveLength(1);
       expect(cases[0].expected_messages).toHaveLength(1);
@@ -478,7 +475,7 @@ describe('Input/expected_output aliases and shorthand', () => {
         '{"id": "test-1", "criteria": "Goal", "input_messages": [{"role": "user", "content": "Canonical"}], "input": "Should be ignored"}\n',
       );
 
-      const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir);
+      const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
       expect(cases).toHaveLength(1);
       expect(cases[0].input_messages[0].content).toBe('Canonical');
@@ -491,7 +488,7 @@ describe('Input/expected_output aliases and shorthand', () => {
         '{"id": "test-1", "criteria": "Goal", "input": "Query", "expected_messages": [{"role": "assistant", "content": "Canonical"}], "expected_output": "Should be ignored"}\n',
       );
 
-      const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir);
+      const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
       expect(cases).toHaveLength(1);
       expect(cases[0].expected_messages[0].content).toBe('Canonical');
@@ -503,14 +500,14 @@ describe('Input/expected_output aliases and shorthand', () => {
       const yamlPath = path.join(tempDir, 'input-shorthand.yaml');
       await writeFile(
         yamlPath,
-        `cases:
+        `tests:
   - id: test-1
     criteria: Goal
     input: "What is 2+2?"
 `,
       );
 
-      const cases = await loadEvalCases(yamlPath, tempDir);
+      const cases = await loadTests(yamlPath, tempDir);
 
       expect(cases).toHaveLength(1);
       expect(cases[0].input_messages).toHaveLength(1);
@@ -522,7 +519,7 @@ describe('Input/expected_output aliases and shorthand', () => {
       const yamlPath = path.join(tempDir, 'input-array.yaml');
       await writeFile(
         yamlPath,
-        `cases:
+        `tests:
   - id: test-1
     criteria: Goal
     input:
@@ -533,7 +530,7 @@ describe('Input/expected_output aliases and shorthand', () => {
 `,
       );
 
-      const cases = await loadEvalCases(yamlPath, tempDir);
+      const cases = await loadTests(yamlPath, tempDir);
 
       expect(cases).toHaveLength(1);
       expect(cases[0].input_messages).toHaveLength(2);
@@ -545,7 +542,7 @@ describe('Input/expected_output aliases and shorthand', () => {
       const yamlPath = path.join(tempDir, 'expected-string.yaml');
       await writeFile(
         yamlPath,
-        `cases:
+        `tests:
   - id: test-1
     criteria: Goal
     input: Query
@@ -553,7 +550,7 @@ describe('Input/expected_output aliases and shorthand', () => {
 `,
       );
 
-      const cases = await loadEvalCases(yamlPath, tempDir);
+      const cases = await loadTests(yamlPath, tempDir);
 
       expect(cases).toHaveLength(1);
       expect(cases[0].expected_messages).toHaveLength(1);
@@ -565,7 +562,7 @@ describe('Input/expected_output aliases and shorthand', () => {
       const yamlPath = path.join(tempDir, 'expected-object.yaml');
       await writeFile(
         yamlPath,
-        `cases:
+        `tests:
   - id: test-1
     criteria: Goal
     input: Query
@@ -575,7 +572,7 @@ describe('Input/expected_output aliases and shorthand', () => {
 `,
       );
 
-      const cases = await loadEvalCases(yamlPath, tempDir);
+      const cases = await loadTests(yamlPath, tempDir);
 
       expect(cases).toHaveLength(1);
       expect(cases[0].expected_messages).toHaveLength(1);
@@ -588,7 +585,7 @@ describe('Input/expected_output aliases and shorthand', () => {
       const yamlPath = path.join(tempDir, 'canonical-precedence.yaml');
       await writeFile(
         yamlPath,
-        `cases:
+        `tests:
   - id: test-1
     criteria: Goal
     input_messages:
@@ -598,7 +595,7 @@ describe('Input/expected_output aliases and shorthand', () => {
 `,
       );
 
-      const cases = await loadEvalCases(yamlPath, tempDir);
+      const cases = await loadTests(yamlPath, tempDir);
 
       expect(cases).toHaveLength(1);
       expect(cases[0].input_messages[0].content).toBe('Canonical');
@@ -610,7 +607,7 @@ describe('Input/expected_output aliases and shorthand', () => {
       const yamlPath = path.join(tempDir, 'mixed.yaml');
       await writeFile(
         yamlPath,
-        `cases:
+        `tests:
   - id: test-canonical
     criteria: Goal
     input_messages:
@@ -626,7 +623,7 @@ describe('Input/expected_output aliases and shorthand', () => {
 `,
       );
 
-      const cases = await loadEvalCases(yamlPath, tempDir);
+      const cases = await loadTests(yamlPath, tempDir);
 
       expect(cases).toHaveLength(2);
       expect(cases[0].id).toBe('test-canonical');
@@ -642,7 +639,7 @@ describe('Input/expected_output aliases and shorthand', () => {
 
       await writeFile(
         yamlPath,
-        `cases:
+        `tests:
   - id: test-1
     criteria: Goal
     input: "What is 2+2?"
@@ -656,8 +653,8 @@ describe('Input/expected_output aliases and shorthand', () => {
         '{"id": "test-1", "criteria": "Goal", "input": "What is 2+2?", "expected_output": {"answer": 4}}\n',
       );
 
-      const yamlCases = await loadEvalCases(yamlPath, tempDir);
-      const jsonlCases = await loadEvalCases(jsonlPath, tempDir);
+      const yamlCases = await loadTests(yamlPath, tempDir);
+      const jsonlCases = await loadTests(jsonlPath, tempDir);
 
       expect(yamlCases).toHaveLength(1);
       expect(jsonlCases).toHaveLength(1);
@@ -687,8 +684,8 @@ describe('Backward-compat aliases', () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  describe('eval_cases → cases alias (YAML)', () => {
-    it('supports eval_cases as deprecated alias for cases', async () => {
+  describe('eval_cases → tests alias (YAML)', () => {
+    it('supports eval_cases as deprecated alias for tests', async () => {
       const yamlPath = path.join(tempDir, 'eval-cases-alias.yaml');
       await writeFile(
         yamlPath,
@@ -701,14 +698,14 @@ describe('Backward-compat aliases', () => {
 `,
       );
 
-      const cases = await loadEvalCases(yamlPath, tempDir);
+      const cases = await loadTests(yamlPath, tempDir);
 
       expect(cases).toHaveLength(1);
       expect(cases[0].id).toBe('test-1');
       expect(cases[0].criteria).toBe('Goal');
     });
 
-    it('supports evalcases as deprecated alias for cases', async () => {
+    it('supports evalcases as deprecated alias for tests', async () => {
       const yamlPath = path.join(tempDir, 'evalcases-alias.yaml');
       await writeFile(
         yamlPath,
@@ -721,17 +718,17 @@ describe('Backward-compat aliases', () => {
 `,
       );
 
-      const cases = await loadEvalCases(yamlPath, tempDir);
+      const cases = await loadTests(yamlPath, tempDir);
 
       expect(cases).toHaveLength(1);
       expect(cases[0].id).toBe('test-1');
     });
 
-    it('cases takes precedence over eval_cases', async () => {
+    it('tests takes precedence over eval_cases', async () => {
       const yamlPath = path.join(tempDir, 'cases-precedence.yaml');
       await writeFile(
         yamlPath,
-        `cases:
+        `tests:
   - id: canonical
     criteria: Goal
     input_messages:
@@ -746,7 +743,7 @@ eval_cases:
 `,
       );
 
-      const cases = await loadEvalCases(yamlPath, tempDir);
+      const cases = await loadTests(yamlPath, tempDir);
 
       expect(cases).toHaveLength(1);
       expect(cases[0].id).toBe('canonical');
@@ -758,7 +755,7 @@ eval_cases:
       const yamlPath = path.join(tempDir, 'expected-outcome-alias.yaml');
       await writeFile(
         yamlPath,
-        `cases:
+        `tests:
   - id: test-1
     expected_outcome: Goal
     input_messages:
@@ -767,7 +764,7 @@ eval_cases:
 `,
       );
 
-      const cases = await loadEvalCases(yamlPath, tempDir);
+      const cases = await loadTests(yamlPath, tempDir);
 
       expect(cases).toHaveLength(1);
       expect(cases[0].id).toBe('test-1');
@@ -778,7 +775,7 @@ eval_cases:
       const yamlPath = path.join(tempDir, 'criteria-precedence.yaml');
       await writeFile(
         yamlPath,
-        `cases:
+        `tests:
   - id: test-1
     criteria: Canonical
     expected_outcome: Deprecated
@@ -788,7 +785,7 @@ eval_cases:
 `,
       );
 
-      const cases = await loadEvalCases(yamlPath, tempDir);
+      const cases = await loadTests(yamlPath, tempDir);
 
       expect(cases).toHaveLength(1);
       expect(cases[0].criteria).toBe('Canonical');
@@ -803,7 +800,7 @@ eval_cases:
         '{"id": "test-1", "expected_outcome": "Goal", "input_messages": [{"role": "user", "content": "Query"}]}\n',
       );
 
-      const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir);
+      const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
       expect(cases).toHaveLength(1);
       expect(cases[0].id).toBe('test-1');
@@ -817,7 +814,7 @@ eval_cases:
         '{"id": "test-1", "criteria": "Canonical", "expected_outcome": "Deprecated", "input_messages": [{"role": "user", "content": "Query"}]}\n',
       );
 
-      const cases = await loadEvalCasesFromJsonl(jsonlPath, tempDir);
+      const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
       expect(cases).toHaveLength(1);
       expect(cases[0].criteria).toBe('Canonical');

--- a/packages/core/test/evaluation/orchestrator.test.ts
+++ b/packages/core/test/evaluation/orchestrator.test.ts
@@ -17,7 +17,7 @@ import type {
   ProviderResponse,
   ToolCall,
 } from '../../src/evaluation/providers/types.js';
-import type { EvalCase, TrialsConfig } from '../../src/evaluation/types.js';
+import type { EvalTest, TrialsConfig } from '../../src/evaluation/types.js';
 
 class SequenceProvider implements Provider {
   readonly id: string;
@@ -110,7 +110,7 @@ class CapturingCliProvider implements Provider {
   }
 }
 
-const baseTestCase: EvalCase = {
+const baseTestCase: EvalTest = {
   id: 'case-1',
   dataset: 'test-dataset',
   question: 'Explain logging improvements',
@@ -311,7 +311,7 @@ describe('runTestCase', () => {
 
     const events: Array<{ evalId: string; status: string; error?: string }> = [];
 
-    const evalCases: EvalCase[] = [
+    const evalCases: EvalTest[] = [
       { ...baseTestCase, id: 'case-1' },
       { ...baseTestCase, id: 'case-2' },
     ];
@@ -568,7 +568,7 @@ class TraceProvider implements Provider {
 }
 
 describe('runEvalCase trace integration', () => {
-  const traceTestCase: EvalCase = {
+  const traceTestCase: EvalTest = {
     id: 'trace-case',
     dataset: 'trace-dataset',
     question: 'What is the weather?',
@@ -980,7 +980,7 @@ Reference: \${input.reference_answer ?? 'none'}\`);
       let receivedQuestion = '';
       const captureJudge = {
         kind: 'llm_judge' as const,
-        async evaluate(context: { evalCase: EvalCase; evaluatorTemplateOverride?: string }) {
+        async evaluate(context: { evalCase: EvalTest; evaluatorTemplateOverride?: string }) {
           // The evaluatorTemplateOverride should contain our custom prompt
           receivedQuestion = context.evaluatorTemplateOverride ?? '';
           return {
@@ -1402,7 +1402,7 @@ rl.on('close', () => {
       ],
     });
 
-    const evalCase: EvalCase = {
+    const evalCase: EvalTest = {
       ...baseTestCase,
       workspace: {
         template: templateDir,
@@ -1444,7 +1444,7 @@ rl.on('close', () => {
       ],
     });
 
-    const evalCase: EvalCase = {
+    const evalCase: EvalTest = {
       ...baseTestCase,
       workspace: {
         template: templateDir,
@@ -1501,7 +1501,7 @@ rl.on('close', () => {
       ],
     });
 
-    const evalCase: EvalCase = {
+    const evalCase: EvalTest = {
       ...baseTestCase,
       workspace: {
         template: templateDir,

--- a/packages/core/test/evaluation/tool-trajectory-evaluator.test.ts
+++ b/packages/core/test/evaluation/tool-trajectory-evaluator.test.ts
@@ -6,7 +6,7 @@ import type { ResolvedTarget } from '../../src/evaluation/providers/targets.js';
 import type { OutputMessage, Provider } from '../../src/evaluation/providers/types.js';
 import type { ToolTrajectoryEvaluatorConfig, TraceSummary } from '../../src/evaluation/trace.js';
 import { computeTraceSummary } from '../../src/evaluation/trace.js';
-import type { EvalCase } from '../../src/evaluation/types.js';
+import type { EvalTest } from '../../src/evaluation/types.js';
 
 // Minimal mock objects
 const mockTarget: ResolvedTarget = {
@@ -24,7 +24,7 @@ const mockProvider: Provider = {
   },
 };
 
-const mockEvalCase: EvalCase = {
+const mockEvalCase: EvalTest = {
   id: 'test-case',
   question: 'Test question',
   input_messages: [],

--- a/packages/core/test/evaluation/validation/eval-validator.test.ts
+++ b/packages/core/test/evaluation/validation/eval-validator.test.ts
@@ -21,7 +21,7 @@ describe('validateEvalFile', () => {
     const filePath = path.join(tempDir, 'input-alias.yaml');
     await writeFile(
       filePath,
-      `cases:
+      `tests:
   - id: test-1
     criteria: Goal
     input: "What is 2+2?"
@@ -38,7 +38,7 @@ describe('validateEvalFile', () => {
     const filePath = path.join(tempDir, 'input-array.yaml');
     await writeFile(
       filePath,
-      `cases:
+      `tests:
   - id: test-1
     criteria: Goal
     input:
@@ -59,7 +59,7 @@ describe('validateEvalFile', () => {
     const filePath = path.join(tempDir, 'output-string.yaml');
     await writeFile(
       filePath,
-      `cases:
+      `tests:
   - id: test-1
     criteria: Goal
     input: Query
@@ -77,7 +77,7 @@ describe('validateEvalFile', () => {
     const filePath = path.join(tempDir, 'output-object.yaml');
     await writeFile(
       filePath,
-      `cases:
+      `tests:
   - id: test-1
     criteria: Goal
     input: Query
@@ -97,7 +97,7 @@ describe('validateEvalFile', () => {
     const filePath = path.join(tempDir, 'missing-input.yaml');
     await writeFile(
       filePath,
-      `cases:
+      `tests:
   - id: test-1
     criteria: Goal
 `,
@@ -113,7 +113,7 @@ describe('validateEvalFile', () => {
     const filePath = path.join(tempDir, 'invalid-input.yaml');
     await writeFile(
       filePath,
-      `cases:
+      `tests:
   - id: test-1
     criteria: Goal
     input: 123
@@ -130,7 +130,7 @@ describe('validateEvalFile', () => {
     const filePath = path.join(tempDir, 'canonical-precedence.yaml');
     await writeFile(
       filePath,
-      `cases:
+      `tests:
   - id: test-1
     criteria: Goal
     input_messages:
@@ -147,7 +147,7 @@ describe('validateEvalFile', () => {
   });
 
   describe('backward-compat aliases', () => {
-    it('accepts eval_cases as deprecated alias for cases (with warning)', async () => {
+    it('accepts eval_cases as deprecated alias for tests (with warning)', async () => {
       const filePath = path.join(tempDir, 'eval-cases-alias.yaml');
       await writeFile(
         filePath,
@@ -167,7 +167,7 @@ describe('validateEvalFile', () => {
       expect(warnings.some((e) => e.message.includes("'eval_cases' is deprecated"))).toBe(true);
     });
 
-    it('accepts evalcases as deprecated alias for cases (with warning)', async () => {
+    it('accepts evalcases as deprecated alias for tests (with warning)', async () => {
       const filePath = path.join(tempDir, 'evalcases-alias.yaml');
       await writeFile(
         filePath,
@@ -191,7 +191,7 @@ describe('validateEvalFile', () => {
       const filePath = path.join(tempDir, 'expected-outcome-alias.yaml');
       await writeFile(
         filePath,
-        `cases:
+        `tests:
   - id: test-1
     expected_outcome: Goal
     input:

--- a/packages/core/test/evaluation/workspace-config-parsing.test.ts
+++ b/packages/core/test/evaluation/workspace-config-parsing.test.ts
@@ -3,7 +3,7 @@ import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { loadEvalCases } from '../../src/evaluation/yaml-parser.js';
+import { loadTests } from '../../src/evaluation/yaml-parser.js';
 
 describe('Workspace config parsing', () => {
   let testDir: string;
@@ -22,7 +22,7 @@ describe('Workspace config parsing', () => {
     await writeFile(
       evalFile,
       `
-cases:
+tests:
   - id: test-case-1
     input: "Do something"
     criteria: "Should do the thing"
@@ -36,7 +36,7 @@ cases:
 `,
     );
 
-    const cases = await loadEvalCases(evalFile, testDir);
+    const cases = await loadTests(evalFile, testDir);
     expect(cases).toHaveLength(1);
     expect(cases[0].workspace).toBeDefined();
     expect(cases[0].workspace?.setup).toEqual({
@@ -54,7 +54,7 @@ cases:
     await writeFile(
       evalFile,
       `
-cases:
+tests:
   - id: sympy-20590
     input: "Fix the bug"
     criteria: "Bug should be fixed"
@@ -64,7 +64,7 @@ cases:
 `,
     );
 
-    const cases = await loadEvalCases(evalFile, testDir);
+    const cases = await loadTests(evalFile, testDir);
     expect(cases).toHaveLength(1);
     expect(cases[0].metadata).toEqual({
       repo: 'sympy/sympy',
@@ -81,7 +81,7 @@ workspace:
   setup:
     script: ["bun", "run", "default-setup.ts"]
 
-cases:
+tests:
   - id: case-1
     input: "Do something"
     criteria: "Should work"
@@ -91,7 +91,7 @@ cases:
 `,
     );
 
-    const cases = await loadEvalCases(evalFile, testDir);
+    const cases = await loadTests(evalFile, testDir);
     expect(cases).toHaveLength(2);
     // Both cases should inherit suite-level workspace
     expect(cases[0].workspace?.setup).toEqual({
@@ -111,7 +111,7 @@ workspace:
   setup:
     script: ["bun", "run", "default-setup.ts"]
 
-cases:
+tests:
   - id: case-override
     input: "Do something"
     criteria: "Should work"
@@ -124,7 +124,7 @@ cases:
 `,
     );
 
-    const cases = await loadEvalCases(evalFile, testDir);
+    const cases = await loadTests(evalFile, testDir);
     expect(cases).toHaveLength(2);
 
     // case-override: setup replaced
@@ -147,7 +147,7 @@ cases:
     await writeFile(
       evalFile,
       `
-cases:
+tests:
   - id: test-cwd
     input: "Do something"
     criteria: "Should work"
@@ -158,7 +158,7 @@ cases:
 `,
     );
 
-    const cases = await loadEvalCases(evalFile, testDir);
+    const cases = await loadTests(evalFile, testDir);
     expect(cases).toHaveLength(1);
     expect(cases[0].workspace?.setup?.cwd).toBe(path.join(testDir, 'scripts'));
   });
@@ -171,14 +171,14 @@ cases:
 workspace:
   template: ./workspace-template
 
-cases:
+tests:
   - id: test-template
     input: "Do something"
     criteria: "Should work"
 `,
     );
 
-    const cases = await loadEvalCases(evalFile, testDir);
+    const cases = await loadTests(evalFile, testDir);
     expect(cases).toHaveLength(1);
     expect(cases[0].workspace?.template).toBe(path.join(testDir, 'workspace-template'));
   });
@@ -188,14 +188,14 @@ cases:
     await writeFile(
       evalFile,
       `
-cases:
+tests:
   - id: simple-case
     input: "Do something"
     criteria: "Should work"
 `,
     );
 
-    const cases = await loadEvalCases(evalFile, testDir);
+    const cases = await loadTests(evalFile, testDir);
     expect(cases).toHaveLength(1);
     expect(cases[0].workspace).toBeUndefined();
   });

--- a/packages/core/test/evaluation/workspace/script-executor.test.ts
+++ b/packages/core/test/evaluation/workspace/script-executor.test.ts
@@ -78,7 +78,7 @@ process.exit(1);
 
     const context: ScriptExecutionContext = {
       workspacePath: '/tmp/workspace',
-      evalCaseId: 'test-case-1',
+      testId: 'test-case-1',
       evalRunId: 'run-123',
     };
 
@@ -96,7 +96,7 @@ process.exit(1);
 
     const context: ScriptExecutionContext = {
       workspacePath: '/tmp/workspace',
-      evalCaseId: 'test-case-2',
+      testId: 'test-case-2',
       evalRunId: 'run-123',
     };
 
@@ -113,7 +113,7 @@ process.exit(1);
 
     const context: ScriptExecutionContext = {
       workspacePath: '/tmp/workspace',
-      evalCaseId: 'test-case-3',
+      testId: 'test-case-3',
       evalRunId: 'run-123',
     };
 
@@ -128,7 +128,7 @@ process.exit(1);
 
     const context: ScriptExecutionContext = {
       workspacePath: '/tmp/workspace',
-      evalCaseId: 'test-case-4',
+      testId: 'test-case-4',
       evalRunId: 'run-123',
     };
 
@@ -168,7 +168,7 @@ rl.on('close', () => {
 
     const context: ScriptExecutionContext = {
       workspacePath: '/home/test/workspace',
-      evalCaseId: 'my-case',
+      testId: 'my-case',
       evalRunId: 'my-run',
     };
 
@@ -210,7 +210,7 @@ rl.on('close', () => {
 
     const context: ScriptExecutionContext = {
       workspacePath: '/tmp/workspace',
-      evalCaseId: 'sympy-20590',
+      testId: 'sympy-20590',
       evalRunId: 'run-123',
       caseInput: 'Fix the bug in issue #20590...',
       caseMetadata: { repo: 'sympy/sympy', base_commit: '9aabb237' },
@@ -229,7 +229,7 @@ rl.on('close', () => {
 
     const context: ScriptExecutionContext = {
       workspacePath: '/tmp/workspace',
-      evalCaseId: 'test-case-5',
+      testId: 'test-case-5',
       evalRunId: 'run-123',
     };
 

--- a/skills/agentv-eval-builder/SKILL.md
+++ b/skills/agentv-eval-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentv-eval-builder
-description: Create and maintain AgentV YAML evaluation files for testing AI agent performance. Use this skill when creating new eval files, adding eval cases, or configuring evaluators.
+description: Create and maintain AgentV YAML evaluation files for testing AI agent performance. Use this skill when creating new eval files, adding tests, or configuring evaluators.
 ---
 
 # AgentV Eval Builder
@@ -14,7 +14,7 @@ description: Example eval
 execution:
   target: default
 
-cases:
+tests:
   - id: greeting
     criteria: Friendly greeting
     input: "Say hello"
@@ -26,10 +26,10 @@ cases:
 
 ## Eval File Structure
 
-**Required:** `cases` (array)
+**Required:** `tests` (array)
 **Optional:** `description`, `execution`, `dataset`, `workspace`
 
-**Eval case fields:**
+**Test fields:**
 
 | Field | Required | Description |
 |-------|----------|-------------|
@@ -52,11 +52,11 @@ cases:
 **Content types:** inline text, `{type: "file", value: "./path.md"}`
 **File paths:** relative from eval file dir, or absolute with `/` prefix from repo root
 
-**JSONL format:** One eval case per line as JSON. Optional `.yaml` sidecar for shared defaults. See `examples/features/basic-jsonl/`.
+**JSONL format:** One test per line as JSON. Optional `.yaml` sidecar for shared defaults. See `examples/features/basic-jsonl/`.
 
 ## Workspace Setup/Teardown
 
-Run scripts before/after each eval case. Define at suite level or override per case:
+Run scripts before/after each test. Define at suite level or override per case:
 
 ```yaml
 workspace:
@@ -67,7 +67,7 @@ workspace:
   teardown:
     script: ["bun", "run", "teardown.ts"]
 
-cases:
+tests:
   - id: case-1
     input: Fix the bug
     criteria: Bug is fixed

--- a/skills/agentv-eval-builder/references/custom-evaluators.md
+++ b/skills/agentv-eval-builder/references/custom-evaluators.md
@@ -103,12 +103,12 @@ export default defineCodeJudge(({ candidateAnswer, criteria }) => {
 
 ## Template Variables
 
-Derived from eval case fields (users never author these directly):
+Derived from test fields (users never author these directly):
 
 | Variable | Source |
 |----------|--------|
 | `question` | First user message in `input_messages` |
-| `criteria` | Eval case `criteria` field |
+| `criteria` | Test `criteria` field |
 | `reference_answer` | Last entry in `expected_messages` |
 | `candidate_answer` | Last entry in `output_messages` (runtime) |
 | `input_messages` | Full resolved input array (JSON) |

--- a/skills/agentv-eval-builder/references/eval-schema.json
+++ b/skills/agentv-eval-builder/references/eval-schema.json
@@ -10,19 +10,19 @@
     },
     "target": {
       "type": "string",
-      "description": "(Deprecated: use execution.target instead) Default target configuration name. Can be overridden per eval case."
+      "description": "(Deprecated: use execution.target instead) Default target configuration name. Can be overridden per test."
     },
     "execution": {
       "type": "object",
-      "description": "Default execution configuration for all eval cases (can be overridden per case)",
+      "description": "Default execution configuration for all tests (can be overridden per test)",
       "properties": {
         "target": {
           "type": "string",
-          "description": "Default target configuration name (e.g., default, azure_base, vscode_projectx). Can be overridden per eval case."
+          "description": "Default target configuration name (e.g., default, azure_base, vscode_projectx). Can be overridden per test."
         },
         "evaluators": {
           "type": "array",
-          "description": "Default evaluators for all eval cases (code-based and LLM judges)",
+          "description": "Default evaluators for all tests (code-based and LLM judges)",
           "items": {
             "type": "object",
             "properties": {
@@ -60,20 +60,20 @@
       },
       "additionalProperties": true
     },
-    "cases": {
+    "tests": {
       "type": "array",
-      "description": "Array of evaluation cases",
+      "description": "Array of evaluation tests",
       "minItems": 1,
       "items": {
         "type": "object",
         "properties": {
           "id": {
             "type": "string",
-            "description": "Unique identifier for the eval case"
+            "description": "Unique identifier for the test"
           },
           "conversation_id": {
             "type": "string",
-            "description": "Optional conversation identifier for threading multiple eval cases together"
+            "description": "Optional conversation identifier for threading multiple tests together"
           },
           "criteria": {
             "type": "string",
@@ -81,7 +81,7 @@
           },
           "note": {
             "type": "string",
-            "description": "Optional note or additional context for the eval case. Use this to document test-specific considerations, known limitations, or rationale for expected behavior."
+            "description": "Optional note or additional context for the test. Use this to document test-specific considerations, known limitations, or rationale for expected behavior."
           },
           "input_messages": {
             "type": "array",
@@ -233,7 +233,7 @@
             "properties": {
               "target": {
                 "type": "string",
-                "description": "Override target for this specific eval case"
+                "description": "Override target for this specific test"
               },
               "evaluators": {
                 "type": "array",
@@ -273,6 +273,6 @@
       }
     }
   },
-  "required": ["cases"],
+  "required": ["tests"],
   "additionalProperties": false
 }

--- a/skills/agentv-eval-orchestrator/SKILL.md
+++ b/skills/agentv-eval-orchestrator/SKILL.md
@@ -13,11 +13,11 @@ Run AgentV evaluations by acting as the LLM yourself — no API keys needed.
 agentv prompt <eval-file.yaml>
 ```
 
-This outputs a complete orchestration prompt with step-by-step instructions and all eval case IDs. Follow its instructions.
+This outputs a complete orchestration prompt with step-by-step instructions and all test IDs. Follow its instructions.
 
 ## Workflow
 
-For each eval case, run these three steps:
+For each test, run these three steps:
 
 ### 1. Get Task Input
 

--- a/skills/agentv-prompt-optimizer/SKILL.md
+++ b/skills/agentv-prompt-optimizer/SKILL.md
@@ -24,7 +24,7 @@ description: Iteratively optimize prompt files against AgentV evaluation dataset
 
 2.  **Optimization Loop** (Max 10 iterations)
     - **Execute (The Generator)**: Run `agentv run <eval-path>`.
-        - *Targeted Run*: If iterating on specific stubborn failures, use `--eval-id <case_id>` to run only the relevant eval cases.
+        - *Targeted Run*: If iterating on specific stubborn failures, use `--eval-id <case_id>` to run only the relevant tests.
     - **Analyze (The Reflector)**:
         - Locate the results file path from the console output (e.g., `.agentv/results/eval_...jsonl`).
         - **Orchestrate Subagent**: Use `runSubagent` to analyze the results.


### PR DESCRIPTION
## Summary
- Renames YAML schema key `cases` → `tests` across the entire codebase
- Renames TypeScript type `EvalCase` → `EvalTest` (with deprecated alias for backward compat)
- Renames exported functions: `loadEvalCases` → `loadTests`, `loadEvalSuite` → `loadTestSuite`, `loadEvalCaseById` → `loadTestById` (with deprecated aliases)
- Updates all 27 example YAML files, documentation, skills, and tests
- Keeps `evalcases`/`eval_cases` as deprecated aliases now pointing to `tests`

## Motivation
Aligns with the agentevals spec rename. `tests` is the dominant term across eval frameworks and has broader LLM weight coverage for zero-shot authoring.

Closes #238

## Test plan
- [x] `bun run build` passes
- [x] `bun run typecheck` passes  
- [x] `bun run lint` passes
- [x] 471 core tests + 59 CLI tests pass (530 total, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)