### PR TITLE
feat(core): add threshold aggregation mode to composite evaluator (#235)

### DIFF
--- a/examples/features/threshold-evaluator/evals/dataset.yaml
+++ b/examples/features/threshold-evaluator/evals/dataset.yaml
@@ -1,0 +1,35 @@
+dataset: threshold-evaluator-example
+
+# Demonstrates the threshold aggregator: pass if N% of child evaluators pass.
+# Borderline verdicts count as passing (lenient).
+
+execution:
+  target: default
+
+tests:
+  - id: flexible-gate
+    input:
+      - role: user
+        content: "Summarize the benefits of renewable energy."
+    expected_output:
+      - role: assistant
+        content: |
+          Renewable energy reduces greenhouse gas emissions, lowers long-term energy costs, and decreases dependence on finite fossil fuels.
+    criteria: |
+      The response should be accurate, concise, and cover key benefits of renewable energy.
+    execution:
+      evaluators:
+        - name: flexible_gate
+          type: composite
+          aggregator:
+            type: threshold
+            threshold: 0.5
+          evaluators:
+            - name: quality_check
+              type: llm_judge
+            - name: latency_check
+              type: latency
+              threshold: 5000
+            - name: cost_check
+              type: cost
+              budget: 0.10

--- a/packages/core/src/evaluation/loaders/evaluator-parser.ts
+++ b/packages/core/src/evaluation/loaders/evaluator-parser.ts
@@ -167,7 +167,8 @@ export async function parseEvaluators(
       if (
         aggregatorType !== 'weighted_average' &&
         aggregatorType !== 'code_judge' &&
-        aggregatorType !== 'llm_judge'
+        aggregatorType !== 'llm_judge' &&
+        aggregatorType !== 'threshold'
       ) {
         logWarning(
           `Skipping composite evaluator '${name}' in '${evalId}': invalid aggregator type '${aggregatorType}'`,
@@ -245,6 +246,18 @@ export async function parseEvaluators(
           type: 'code_judge',
           path: aggregatorPath,
           cwd: searchRoots[0],
+        };
+      } else if (aggregatorType === 'threshold') {
+        const thresholdValue = rawAggregator.threshold;
+        if (typeof thresholdValue !== 'number' || thresholdValue < 0 || thresholdValue > 1) {
+          logWarning(
+            `Skipping composite evaluator '${name}' in '${evalId}': threshold must be a number between 0.0 and 1.0`,
+          );
+          continue;
+        }
+        aggregator = {
+          type: 'threshold',
+          threshold: thresholdValue,
         };
       } else {
         // llm_judge aggregator

--- a/packages/core/src/evaluation/types.ts
+++ b/packages/core/src/evaluation/types.ts
@@ -299,7 +299,8 @@ export type CompositeAggregatorConfig =
       readonly prompt?: string;
       readonly promptPath?: string;
       readonly model?: string;
-    };
+    }
+  | { readonly type: 'threshold'; readonly threshold: number };
 
 export type CompositeEvaluatorConfig = {
   readonly name: string;

--- a/packages/core/test/evaluation/evaluators/composite-threshold.test.ts
+++ b/packages/core/test/evaluation/evaluators/composite-threshold.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, it } from 'bun:test';
+
+import { CompositeEvaluator } from '../../../src/evaluation/evaluators/composite.js';
+import type {
+  EvaluationContext,
+  EvaluationScore,
+  Evaluator,
+  EvaluatorFactory,
+} from '../../../src/evaluation/evaluators/types.js';
+import type { ResolvedTarget } from '../../../src/evaluation/providers/targets.js';
+import type { EvalTest, EvaluatorConfig } from '../../../src/evaluation/types.js';
+
+const baseTestCase: EvalTest = {
+  id: 'threshold-test',
+  dataset: 'test',
+  question: 'Test question',
+  input_messages: [{ role: 'user', content: 'Test' }],
+  input_segments: [{ type: 'text', value: 'Test' }],
+  expected_messages: [],
+  reference_answer: '',
+  guideline_paths: [],
+  file_paths: [],
+  criteria: 'Test outcome',
+};
+
+const baseTarget: ResolvedTarget = {
+  kind: 'mock',
+  name: 'mock',
+  config: { response: '{}' },
+};
+
+const baseMockProvider = {
+  id: 'mock',
+  kind: 'mock' as const,
+  targetName: 'mock',
+  invoke: async () => ({ outputMessages: [{ role: 'assistant' as const, content: 'test' }] }),
+};
+
+function createContext(): EvaluationContext {
+  return {
+    evalCase: baseTestCase,
+    candidate: 'Test answer',
+    target: baseTarget,
+    provider: baseMockProvider,
+    attempt: 0,
+    promptInputs: { question: '', guidelines: '' },
+    now: new Date(),
+  };
+}
+
+function makeResult(verdict: 'pass' | 'fail' | 'borderline', score: number): EvaluationScore {
+  return {
+    score,
+    verdict,
+    hits: verdict === 'pass' ? ['passed'] : [],
+    misses: verdict === 'fail' ? ['failed'] : [],
+    expectedAspectCount: 1,
+    reasoning: `verdict: ${verdict}`,
+  };
+}
+
+function createMockFactory(results: Record<string, EvaluationScore>): EvaluatorFactory {
+  return {
+    create(config: EvaluatorConfig): Evaluator {
+      return {
+        kind: config.type,
+        evaluate: () => results[config.name],
+      };
+    },
+  };
+}
+
+describe('CompositeEvaluator threshold aggregation', () => {
+  it('all children pass, threshold 0.5 → pass, score = 1.0', async () => {
+    const factory = createMockFactory({
+      a: makeResult('pass', 1.0),
+      b: makeResult('pass', 0.9),
+      c: makeResult('pass', 0.85),
+      d: makeResult('pass', 0.8),
+    });
+
+    const evaluator = new CompositeEvaluator({
+      config: {
+        name: 'gate',
+        type: 'composite',
+        evaluators: [
+          { name: 'a', type: 'latency', threshold: 5000 },
+          { name: 'b', type: 'latency', threshold: 5000 },
+          { name: 'c', type: 'latency', threshold: 5000 },
+          { name: 'd', type: 'latency', threshold: 5000 },
+        ],
+        aggregator: { type: 'threshold', threshold: 0.5 },
+      },
+      evaluatorFactory: factory,
+    });
+
+    const result = await evaluator.evaluate(createContext());
+    expect(result.score).toBe(1.0);
+    expect(result.verdict).toBe('pass');
+    expect(result.evaluatorResults).toHaveLength(4);
+  });
+
+  it('2/4 pass, threshold 0.5 → pass, score = 0.5', async () => {
+    const factory = createMockFactory({
+      a: makeResult('pass', 1.0),
+      b: makeResult('pass', 0.9),
+      c: makeResult('fail', 0.3),
+      d: makeResult('fail', 0.1),
+    });
+
+    const evaluator = new CompositeEvaluator({
+      config: {
+        name: 'gate',
+        type: 'composite',
+        evaluators: [
+          { name: 'a', type: 'latency', threshold: 5000 },
+          { name: 'b', type: 'latency', threshold: 5000 },
+          { name: 'c', type: 'latency', threshold: 5000 },
+          { name: 'd', type: 'latency', threshold: 5000 },
+        ],
+        aggregator: { type: 'threshold', threshold: 0.5 },
+      },
+      evaluatorFactory: factory,
+    });
+
+    const result = await evaluator.evaluate(createContext());
+    expect(result.score).toBe(0.5);
+    expect(result.verdict).toBe('pass');
+  });
+
+  it('1/4 pass, threshold 0.5 → fail, score = 0.25', async () => {
+    const factory = createMockFactory({
+      a: makeResult('pass', 1.0),
+      b: makeResult('fail', 0.3),
+      c: makeResult('fail', 0.2),
+      d: makeResult('fail', 0.1),
+    });
+
+    const evaluator = new CompositeEvaluator({
+      config: {
+        name: 'gate',
+        type: 'composite',
+        evaluators: [
+          { name: 'a', type: 'latency', threshold: 5000 },
+          { name: 'b', type: 'latency', threshold: 5000 },
+          { name: 'c', type: 'latency', threshold: 5000 },
+          { name: 'd', type: 'latency', threshold: 5000 },
+        ],
+        aggregator: { type: 'threshold', threshold: 0.5 },
+      },
+      evaluatorFactory: factory,
+    });
+
+    const result = await evaluator.evaluate(createContext());
+    expect(result.score).toBe(0.25);
+    expect(result.verdict).toBe('fail');
+  });
+
+  it('borderline child counts as passing (lenient)', async () => {
+    const factory = createMockFactory({
+      a: makeResult('pass', 1.0),
+      b: makeResult('borderline', 0.7),
+      c: makeResult('fail', 0.3),
+      d: makeResult('fail', 0.1),
+    });
+
+    const evaluator = new CompositeEvaluator({
+      config: {
+        name: 'gate',
+        type: 'composite',
+        evaluators: [
+          { name: 'a', type: 'latency', threshold: 5000 },
+          { name: 'b', type: 'latency', threshold: 5000 },
+          { name: 'c', type: 'latency', threshold: 5000 },
+          { name: 'd', type: 'latency', threshold: 5000 },
+        ],
+        aggregator: { type: 'threshold', threshold: 0.5 },
+      },
+      evaluatorFactory: factory,
+    });
+
+    const result = await evaluator.evaluate(createContext());
+    expect(result.score).toBe(0.5);
+    expect(result.verdict).toBe('pass');
+  });
+
+  it('warning includes borderline count when borderline contributes to pass', async () => {
+    const factory = createMockFactory({
+      a: makeResult('pass', 1.0),
+      b: makeResult('borderline', 0.7),
+      c: makeResult('fail', 0.3),
+      d: makeResult('fail', 0.1),
+    });
+
+    const evaluator = new CompositeEvaluator({
+      config: {
+        name: 'gate',
+        type: 'composite',
+        evaluators: [
+          { name: 'a', type: 'latency', threshold: 5000 },
+          { name: 'b', type: 'latency', threshold: 5000 },
+          { name: 'c', type: 'latency', threshold: 5000 },
+          { name: 'd', type: 'latency', threshold: 5000 },
+        ],
+        aggregator: { type: 'threshold', threshold: 0.5 },
+      },
+      evaluatorFactory: factory,
+    });
+
+    const result = await evaluator.evaluate(createContext());
+    expect(result.reasoning).toContain('borderline');
+    expect(result.reasoning).toContain('1 borderline evaluator(s) counted as passing');
+  });
+
+  it('no warning when borderline present but result fails', async () => {
+    const factory = createMockFactory({
+      a: makeResult('borderline', 0.7),
+      b: makeResult('fail', 0.3),
+      c: makeResult('fail', 0.2),
+      d: makeResult('fail', 0.1),
+    });
+
+    const evaluator = new CompositeEvaluator({
+      config: {
+        name: 'gate',
+        type: 'composite',
+        evaluators: [
+          { name: 'a', type: 'latency', threshold: 5000 },
+          { name: 'b', type: 'latency', threshold: 5000 },
+          { name: 'c', type: 'latency', threshold: 5000 },
+          { name: 'd', type: 'latency', threshold: 5000 },
+        ],
+        aggregator: { type: 'threshold', threshold: 0.5 },
+      },
+      evaluatorFactory: factory,
+    });
+
+    const result = await evaluator.evaluate(createContext());
+    expect(result.verdict).toBe('fail');
+    expect(result.reasoning).not.toContain('Warning');
+  });
+
+  it('no children pass, threshold 0.0 → pass (0 >= 0)', async () => {
+    const factory = createMockFactory({
+      a: makeResult('fail', 0.3),
+      b: makeResult('fail', 0.1),
+    });
+
+    const evaluator = new CompositeEvaluator({
+      config: {
+        name: 'gate',
+        type: 'composite',
+        evaluators: [
+          { name: 'a', type: 'latency', threshold: 5000 },
+          { name: 'b', type: 'latency', threshold: 5000 },
+        ],
+        aggregator: { type: 'threshold', threshold: 0.0 },
+      },
+      evaluatorFactory: factory,
+    });
+
+    const result = await evaluator.evaluate(createContext());
+    expect(result.score).toBe(0);
+    expect(result.verdict).toBe('pass');
+  });
+
+  it('3/4 pass, threshold 1.0 → fail', async () => {
+    const factory = createMockFactory({
+      a: makeResult('pass', 1.0),
+      b: makeResult('pass', 0.9),
+      c: makeResult('pass', 0.85),
+      d: makeResult('fail', 0.3),
+    });
+
+    const evaluator = new CompositeEvaluator({
+      config: {
+        name: 'gate',
+        type: 'composite',
+        evaluators: [
+          { name: 'a', type: 'latency', threshold: 5000 },
+          { name: 'b', type: 'latency', threshold: 5000 },
+          { name: 'c', type: 'latency', threshold: 5000 },
+          { name: 'd', type: 'latency', threshold: 5000 },
+        ],
+        aggregator: { type: 'threshold', threshold: 1.0 },
+      },
+      evaluatorFactory: factory,
+    });
+
+    const result = await evaluator.evaluate(createContext());
+    expect(result.score).toBe(0.75);
+    expect(result.verdict).toBe('fail');
+  });
+
+  it('evaluatorResults array included in output', async () => {
+    const factory = createMockFactory({
+      a: makeResult('pass', 1.0),
+      b: makeResult('fail', 0.3),
+    });
+
+    const evaluator = new CompositeEvaluator({
+      config: {
+        name: 'gate',
+        type: 'composite',
+        evaluators: [
+          { name: 'a', type: 'latency', threshold: 5000 },
+          { name: 'b', type: 'latency', threshold: 5000 },
+        ],
+        aggregator: { type: 'threshold', threshold: 0.5 },
+      },
+      evaluatorFactory: factory,
+    });
+
+    const result = await evaluator.evaluate(createContext());
+    expect(result.evaluatorResults).toBeDefined();
+    expect(result.evaluatorResults).toHaveLength(2);
+    const results = result.evaluatorResults as NonNullable<typeof result.evaluatorResults>;
+    expect(results[0].name).toBe('a');
+    expect(results[1].name).toBe('b');
+    expect(result.evaluatorRawRequest).toEqual({
+      aggregator: 'threshold',
+      threshold: 0.5,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add `threshold` aggregation mode to the composite evaluator. Score = proportion of child evaluators that pass. Pass = score >= threshold.

## Design

- **Lenient**: `borderline` verdicts count as passing
- When borderline contributes to a pass, reasoning includes a warning
- Zod validation: threshold must be 0.0–1.0

## Changes

- `composite.ts`: Add `runThreshold()` method
- `evaluator-parser.ts`: Parse threshold aggregator config
- `types.ts`: Add threshold to `CompositeAggregatorConfig` union
- 9 new tests covering all edge cases
- Example YAML in `examples/features/threshold-evaluator/`

Closes #235

Orchestration tracked in agentevals-research#1