### PR TITLE
feat(core): default evaluators merged across tests (#225)

### DIFF
--- a/apps/web/src/content/docs/evaluation/eval-cases.mdx
+++ b/apps/web/src/content/docs/evaluation/eval-cases.mdx
@@ -85,6 +85,32 @@ tests:
           prompt: ./judges/depth.md
 ```
 
+Per-case evaluators are **merged** with root-level `execution.evaluators` — test-specific evaluators run first, then root-level defaults are appended. To opt out of root-level evaluators for a specific test, set `skip_defaults: true`:
+
+```yaml
+execution:
+  evaluators:
+    - name: latency_check
+      type: latency
+      threshold: 5000
+
+tests:
+  - id: normal-case
+    criteria: Returns correct answer
+    input: What is 2+2?
+    # Gets latency_check from root-level evaluators
+
+  - id: special-case
+    criteria: Handles edge case
+    input: Handle this edge case
+    execution:
+      skip_defaults: true
+      evaluators:
+        - name: custom_eval
+          type: llm_judge
+      # Does NOT get latency_check
+```
+
 ## Per-Case Workspace Config
 
 Override the suite-level workspace config for individual tests. Test-level fields replace suite-level fields:

--- a/apps/web/src/content/docs/evaluation/eval-files.mdx
+++ b/apps/web/src/content/docs/evaluation/eval-files.mdx
@@ -33,7 +33,7 @@ tests:
 |-------|-------------|
 | `description` | Human-readable description of the evaluation |
 | `dataset` | Optional dataset identifier |
-| `execution` | Default execution config (target, evaluators) |
+| `execution` | Default execution config (target, evaluators). Root-level evaluators are appended to every test's evaluators unless the test sets `skip_defaults: true` |
 | `workspace` | Suite-level workspace config (setup/teardown scripts, template) |
 | `tests` | Array of individual tests |
 

--- a/examples/features/default-evaluators/evals/dataset.yaml
+++ b/examples/features/default-evaluators/evals/dataset.yaml
@@ -1,0 +1,39 @@
+# Default Evaluators Example
+# Demonstrates root-level execution.evaluators that apply to all tests
+
+dataset: default-evaluators-example
+
+execution:
+  target: default
+  evaluators:
+    - name: latency_check
+      type: latency
+      threshold: 5000
+
+tests:
+  - id: greeting
+    criteria: The assistant responds with a friendly greeting
+    input: "Hello!"
+    expected_output: "Hello! How can I help you today?"
+    # Gets latency_check from root-level evaluators
+
+  - id: with-custom-eval
+    criteria: The assistant provides a helpful response about refunds
+    input: "I want a refund"
+    expected_output: "I'd be happy to help you with a refund. Could you provide your order number?"
+    execution:
+      evaluators:
+        - name: helpfulness
+          type: llm_judge
+      # Also gets latency_check from root-level evaluators
+
+  - id: skip-defaults
+    criteria: The assistant handles urgent requests appropriately
+    input: "URGENT: System is down"
+    expected_output: "I understand this is urgent. Let me escalate this immediately."
+    execution:
+      skip_defaults: true
+      evaluators:
+        - name: urgency_check
+          type: llm_judge
+      # Does NOT get latency_check — skip_defaults opts out

--- a/skills/agentv-eval-builder/references/eval-schema.json
+++ b/skills/agentv-eval-builder/references/eval-schema.json
@@ -22,7 +22,7 @@
         },
         "evaluators": {
           "type": "array",
-          "description": "Default evaluators for all tests (code-based and LLM judges)",
+          "description": "Default evaluators appended to every test's evaluators (unless skip_defaults is set per test)",
           "items": {
             "type": "object",
             "properties": {
@@ -235,9 +235,13 @@
                 "type": "string",
                 "description": "Override target for this specific test"
               },
+              "skip_defaults": {
+                "type": "boolean",
+                "description": "When true, root-level execution.evaluators are not appended to this test's evaluators"
+              },
               "evaluators": {
                 "type": "array",
-                "description": "Multiple evaluators (code-based and LLM judges)",
+                "description": "Per-test evaluators (root-level evaluators are appended unless skip_defaults is true)",
                 "items": {
                   "type": "object",
                   "properties": {


### PR DESCRIPTION
## Summary

Add root-level `execution.evaluators` that are automatically appended to all tests. Per-test `execution.skip_defaults: true` opts out.

## Design

Follows the existing pattern where root `execution.target` and `execution.trials` already serve as file-level defaults. Not a new `defaults` block.

## Merge Behavior

- Root evaluators are **appended** to per-test evaluators (test-specific run first)
- `skip_defaults: true` opts out per-test
- No root evaluators → no-op (backward compatible)

## Changes

- `evaluator-parser.ts`: Refactored to merge evaluators, extracted `parseEvaluatorList`
- 7 new tests for merge behavior, skip_defaults, backward compat
- Example in `examples/features/default-evaluators/`
- Schema and docs updated

Closes #225

Orchestration tracked in agentevals-research#1