### PR TITLE
feat(core): add external dataset loading with file:// references (#226)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -65,6 +65,7 @@
         "@mariozechner/pi-agent-core": "^0.50.9",
         "@mariozechner/pi-ai": "^0.50.9",
         "ai": "^5.0.106",
+        "fast-glob": "^3.3.3",
         "json5": "^2.2.3",
         "micromatch": "^4.0.8",
         "yaml": "^2.6.0",

--- a/examples/features/external-datasets/README.md
+++ b/examples/features/external-datasets/README.md
@@ -1,0 +1,52 @@
+# External Datasets Example
+
+Demonstrates loading test cases from external files using `file://` references.
+
+## What This Shows
+
+- Loading tests from external YAML files (`file://cases/accuracy.yaml`)
+- Loading tests from external JSONL files (`file://cases/regression.jsonl`)
+- Mixing inline test definitions with external file references
+- Glob patterns for loading multiple files (`file://cases/**/*.yaml`)
+
+## Running
+
+```bash
+# From repository root
+bun agentv run examples/features/external-datasets/evals/dataset.yaml
+```
+
+## Key Files
+
+- `evals/dataset.yaml` — Main eval with inline tests and `file://` references
+- `evals/cases/accuracy.yaml` — YAML array of test cases
+- `evals/cases/regression.jsonl` — JSONL test data (one test per line)
+
+## Supported Formats
+
+### YAML (.yaml, .yml)
+External YAML files must contain an array of test objects:
+```yaml
+- id: test-1
+  criteria: "Expected outcome"
+  input: "User input"
+- id: test-2
+  criteria: "Another outcome"
+  input: "Another input"
+```
+
+### JSONL (.jsonl)
+One JSON test object per line:
+```jsonl
+{"id": "test-1", "criteria": "Expected outcome", "input": "User input"}
+{"id": "test-2", "criteria": "Another outcome", "input": "Another input"}
+```
+
+## Glob Patterns
+
+Use glob patterns to load from multiple files:
+```yaml
+tests:
+  - file://cases/**/*.yaml    # All YAML files recursively
+  - file://cases/*.jsonl      # All JSONL files in cases/
+```

--- a/examples/features/external-datasets/evals/cases/accuracy.yaml
+++ b/examples/features/external-datasets/evals/cases/accuracy.yaml
@@ -1,0 +1,7 @@
+- id: accuracy-basic-math
+  criteria: "The agent should correctly answer the math question"
+  input: "What is 15 + 27?"
+
+- id: accuracy-capital
+  criteria: "The agent should correctly identify the capital city"
+  input: "What is the capital of France?"

--- a/examples/features/external-datasets/evals/cases/regression.jsonl
+++ b/examples/features/external-datasets/evals/cases/regression.jsonl
@@ -1,0 +1,2 @@
+{"id": "regression-greeting", "criteria": "The agent should respond with a greeting", "input": "Hi there!"}
+{"id": "regression-farewell", "criteria": "The agent should respond with a farewell", "input": "Goodbye!"}

--- a/examples/features/external-datasets/evals/dataset.yaml
+++ b/examples/features/external-datasets/evals/dataset.yaml
@@ -1,0 +1,12 @@
+name: external-datasets-demo
+version: "1.0"
+
+target: default
+
+tests:
+  - id: inline-test
+    criteria: "The agent should greet the user politely"
+    input: "Hello, how are you?"
+
+  - file://cases/accuracy.yaml
+  - file://cases/regression.jsonl

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,8 +45,9 @@
     "@mariozechner/pi-agent-core": "^0.50.9",
     "@mariozechner/pi-ai": "^0.50.9",
     "ai": "^5.0.106",
-    "micromatch": "^4.0.8",
+    "fast-glob": "^3.3.3",
     "json5": "^2.2.3",
+    "micromatch": "^4.0.8",
     "yaml": "^2.6.0",
     "zod": "^3.23.8"
   },

--- a/packages/core/src/evaluation/loaders/case-file-loader.ts
+++ b/packages/core/src/evaluation/loaders/case-file-loader.ts
@@ -1,0 +1,178 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import fg from 'fast-glob';
+import { parse as parseYaml } from 'yaml';
+
+import type { JsonObject, JsonValue } from '../types.js';
+import { isJsonObject } from '../types.js';
+
+const ANSI_YELLOW = '\u001b[33m';
+const ANSI_RESET = '\u001b[0m';
+
+const FILE_PROTOCOL = 'file://';
+
+/**
+ * Check if a value in the tests array is a file:// reference string.
+ */
+export function isFileReference(value: JsonValue): value is string {
+  return typeof value === 'string' && value.startsWith(FILE_PROTOCOL);
+}
+
+/**
+ * Extract the path portion from a file:// reference.
+ */
+function extractFilePath(ref: string): string {
+  return ref.slice(FILE_PROTOCOL.length);
+}
+
+/**
+ * Check if a path contains glob pattern characters.
+ */
+function isGlobPattern(filePath: string): boolean {
+  return filePath.includes('*') || filePath.includes('?') || filePath.includes('{');
+}
+
+/**
+ * Parse test objects from a YAML file.
+ * Expects the file to contain an array of test objects.
+ */
+function parseYamlCases(content: string, filePath: string): JsonObject[] {
+  const parsed = parseYaml(content) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      `External test file must contain a YAML array, got ${typeof parsed}: ${filePath}`,
+    );
+  }
+  const results: JsonObject[] = [];
+  for (const item of parsed) {
+    if (!isJsonObject(item)) {
+      throw new Error(`External test file contains non-object entry: ${filePath}`);
+    }
+    results.push(item);
+  }
+  return results;
+}
+
+/**
+ * Parse test objects from a JSONL file.
+ * Each non-empty line must be a valid JSON object.
+ */
+function parseJsonlCases(content: string, filePath: string): JsonObject[] {
+  const lines = content.split('\n');
+  const results: JsonObject[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (line === '') continue;
+
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (!isJsonObject(parsed)) {
+        throw new Error('Expected JSON object');
+      }
+      results.push(parsed);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Malformed JSONL at line ${i + 1}: ${message}\n  File: ${filePath}`);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Load test objects from a single external file (YAML or JSONL).
+ */
+async function loadCasesFromFile(filePath: string): Promise<JsonObject[]> {
+  const ext = path.extname(filePath).toLowerCase();
+  let content: string;
+
+  try {
+    content = await readFile(filePath, 'utf8');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Cannot read external test file: ${filePath}\n  ${message}`);
+  }
+
+  if (content.trim() === '') {
+    console.warn(
+      `${ANSI_YELLOW}Warning: External test file is empty, skipping: ${filePath}${ANSI_RESET}`,
+    );
+    return [];
+  }
+
+  if (ext === '.yaml' || ext === '.yml') {
+    return parseYamlCases(content, filePath);
+  }
+  if (ext === '.jsonl') {
+    return parseJsonlCases(content, filePath);
+  }
+
+  throw new Error(
+    `Unsupported external test file format '${ext}': ${filePath}. Supported: .yaml, .yml, .jsonl`,
+  );
+}
+
+/**
+ * Resolve a file:// reference to test objects.
+ * Handles both direct file paths and glob patterns.
+ * Paths are resolved relative to the eval file directory.
+ */
+export async function resolveFileReference(
+  ref: string,
+  evalFileDir: string,
+): Promise<JsonObject[]> {
+  const rawPath = extractFilePath(ref);
+  const absolutePattern = path.resolve(evalFileDir, rawPath);
+
+  if (isGlobPattern(rawPath)) {
+    // Glob pattern: resolve matching files
+    const matches = await fg(absolutePattern, {
+      onlyFiles: true,
+      absolute: true,
+    });
+
+    if (matches.length === 0) {
+      console.warn(
+        `${ANSI_YELLOW}Warning: Glob pattern matched no files: ${ref} (resolved to ${absolutePattern})${ANSI_RESET}`,
+      );
+      return [];
+    }
+
+    // Sort for deterministic order
+    matches.sort();
+
+    const allCases: JsonObject[] = [];
+    for (const match of matches) {
+      const cases = await loadCasesFromFile(match);
+      allCases.push(...cases);
+    }
+    return allCases;
+  }
+
+  // Direct file path
+  return loadCasesFromFile(absolutePattern);
+}
+
+/**
+ * Process a tests array, expanding any file:// references into inline test objects.
+ * Returns a flat array of JsonValue where all file:// strings are replaced
+ * with the test objects loaded from the referenced files.
+ */
+export async function expandFileReferences(
+  tests: readonly JsonValue[],
+  evalFileDir: string,
+): Promise<JsonValue[]> {
+  const expanded: JsonValue[] = [];
+
+  for (const entry of tests) {
+    if (isFileReference(entry)) {
+      const cases = await resolveFileReference(entry, evalFileDir);
+      expanded.push(...cases);
+    } else {
+      expanded.push(entry);
+    }
+  }
+
+  return expanded;
+}

--- a/packages/core/test/evaluation/loaders/case-file-loader.test.ts
+++ b/packages/core/test/evaluation/loaders/case-file-loader.test.ts
@@ -1,0 +1,286 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  expandFileReferences,
+  isFileReference,
+  resolveFileReference,
+} from '../../../src/evaluation/loaders/case-file-loader.js';
+import { loadTests } from '../../../src/evaluation/yaml-parser.js';
+
+describe('isFileReference', () => {
+  it('returns true for file:// strings', () => {
+    expect(isFileReference('file://cases/test.yaml')).toBe(true);
+    expect(isFileReference('file://test.jsonl')).toBe(true);
+    expect(isFileReference('file://path/**/*.yaml')).toBe(true);
+  });
+
+  it('returns false for non-file:// values', () => {
+    expect(isFileReference('hello')).toBe(false);
+    expect(isFileReference('')).toBe(false);
+    expect(isFileReference(42)).toBe(false);
+    expect(isFileReference(null)).toBe(false);
+    expect(isFileReference({ id: 'test' })).toBe(false);
+  });
+});
+
+describe('resolveFileReference', () => {
+  let tempDir: string;
+
+  beforeAll(async () => {
+    tempDir = path.join(os.tmpdir(), `agentv-case-file-loader-${Date.now()}`);
+    await mkdir(path.join(tempDir, 'cases'), { recursive: true });
+  });
+
+  afterAll(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('loads test objects from a YAML file', async () => {
+    await writeFile(
+      path.join(tempDir, 'cases', 'tests.yaml'),
+      `- id: yaml-test-1
+  criteria: "Test goal 1"
+  input: "Hello"
+- id: yaml-test-2
+  criteria: "Test goal 2"
+  input: "World"
+`,
+    );
+
+    const cases = await resolveFileReference('file://cases/tests.yaml', tempDir);
+
+    expect(cases).toHaveLength(2);
+    expect(cases[0].id).toBe('yaml-test-1');
+    expect(cases[0].criteria).toBe('Test goal 1');
+    expect(cases[1].id).toBe('yaml-test-2');
+    expect(cases[1].criteria).toBe('Test goal 2');
+  });
+
+  it('loads test objects from a JSONL file', async () => {
+    await writeFile(
+      path.join(tempDir, 'cases', 'tests.jsonl'),
+      [
+        '{"id": "jsonl-1", "criteria": "Goal 1", "input": "Query 1"}',
+        '{"id": "jsonl-2", "criteria": "Goal 2", "input": "Query 2"}',
+      ].join('\n'),
+    );
+
+    const cases = await resolveFileReference('file://cases/tests.jsonl', tempDir);
+
+    expect(cases).toHaveLength(2);
+    expect(cases[0].id).toBe('jsonl-1');
+    expect(cases[1].id).toBe('jsonl-2');
+  });
+
+  it('resolves glob patterns to multiple files', async () => {
+    await mkdir(path.join(tempDir, 'glob-cases'), { recursive: true });
+    await writeFile(
+      path.join(tempDir, 'glob-cases', 'a.yaml'),
+      '- id: glob-a\n  criteria: "Goal A"\n  input: "A"\n',
+    );
+    await writeFile(
+      path.join(tempDir, 'glob-cases', 'b.yaml'),
+      '- id: glob-b\n  criteria: "Goal B"\n  input: "B"\n',
+    );
+
+    const cases = await resolveFileReference('file://glob-cases/*.yaml', tempDir);
+
+    expect(cases).toHaveLength(2);
+    const ids = cases.map((c) => c.id);
+    expect(ids).toContain('glob-a');
+    expect(ids).toContain('glob-b');
+  });
+
+  it('throws clear error for missing file', async () => {
+    await expect(resolveFileReference('file://nonexistent/file.yaml', tempDir)).rejects.toThrow(
+      /Cannot read external test file/,
+    );
+  });
+
+  it('throws clear error for malformed JSONL', async () => {
+    await writeFile(path.join(tempDir, 'cases', 'bad.jsonl'), '{"id": "ok"}\n{bad json}\n');
+
+    await expect(resolveFileReference('file://cases/bad.jsonl', tempDir)).rejects.toThrow(
+      /Malformed JSONL at line 2/,
+    );
+  });
+
+  it('warns and returns empty for glob matching nothing', async () => {
+    const cases = await resolveFileReference('file://no-match/**/*.yaml', tempDir);
+    expect(cases).toHaveLength(0);
+  });
+
+  it('warns and returns empty for empty file', async () => {
+    await writeFile(path.join(tempDir, 'cases', 'empty.yaml'), '');
+
+    const cases = await resolveFileReference('file://cases/empty.yaml', tempDir);
+    expect(cases).toHaveLength(0);
+  });
+});
+
+describe('expandFileReferences', () => {
+  let tempDir: string;
+
+  beforeAll(async () => {
+    tempDir = path.join(os.tmpdir(), `agentv-expand-refs-${Date.now()}`);
+    await mkdir(path.join(tempDir, 'cases'), { recursive: true });
+
+    await writeFile(
+      path.join(tempDir, 'cases', 'extra.yaml'),
+      '- id: external-1\n  criteria: "External goal"\n  input: "External input"\n',
+    );
+  });
+
+  afterAll(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('mixes inline test objects and file:// references', async () => {
+    const tests = [
+      { id: 'inline-1', criteria: 'Inline goal', input: 'Inline input' },
+      'file://cases/extra.yaml',
+      { id: 'inline-2', criteria: 'Inline goal 2', input: 'Inline input 2' },
+    ];
+
+    const expanded = await expandFileReferences(tests, tempDir);
+
+    expect(expanded).toHaveLength(3);
+    expect((expanded[0] as { id: string }).id).toBe('inline-1');
+    expect((expanded[1] as { id: string }).id).toBe('external-1');
+    expect((expanded[2] as { id: string }).id).toBe('inline-2');
+  });
+});
+
+describe('loadTests with file:// references', () => {
+  let tempDir: string;
+
+  beforeAll(async () => {
+    tempDir = path.join(os.tmpdir(), `agentv-file-ref-integration-${Date.now()}`);
+    await mkdir(path.join(tempDir, 'cases'), { recursive: true });
+  });
+
+  afterAll(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('loads mixed inline and file:// tests from YAML', async () => {
+    // Create external YAML test file
+    await writeFile(
+      path.join(tempDir, 'cases', 'accuracy.yaml'),
+      `- id: accuracy-1
+  criteria: "Accurate response"
+  input: "What is 2+2?"
+`,
+    );
+
+    // Create external JSONL test file
+    await writeFile(
+      path.join(tempDir, 'cases', 'regression.jsonl'),
+      '{"id": "regression-1", "criteria": "No regression", "input": "Test query"}\n',
+    );
+
+    // Create main eval file with file:// references
+    await writeFile(
+      path.join(tempDir, 'dataset.yaml'),
+      `name: test-suite
+tests:
+  - id: inline-test
+    criteria: "Inline goal"
+    input: "Hello"
+  - file://cases/accuracy.yaml
+  - file://cases/regression.jsonl
+`,
+    );
+
+    const tests = await loadTests(path.join(tempDir, 'dataset.yaml'), tempDir);
+
+    expect(tests).toHaveLength(3);
+    expect(tests[0].id).toBe('inline-test');
+    expect(tests[1].id).toBe('accuracy-1');
+    expect(tests[2].id).toBe('regression-1');
+  });
+
+  it('loads tests from glob patterns', async () => {
+    const subDir = path.join(tempDir, 'glob-suite');
+    await mkdir(path.join(subDir, 'cases'), { recursive: true });
+
+    await writeFile(
+      path.join(subDir, 'cases', 'set-a.yaml'),
+      '- id: glob-a\n  criteria: "Goal A"\n  input: "Input A"\n',
+    );
+    await writeFile(
+      path.join(subDir, 'cases', 'set-b.yaml'),
+      '- id: glob-b\n  criteria: "Goal B"\n  input: "Input B"\n',
+    );
+
+    await writeFile(
+      path.join(subDir, 'suite.yaml'),
+      `tests:
+  - file://cases/*.yaml
+`,
+    );
+
+    const tests = await loadTests(path.join(subDir, 'suite.yaml'), subDir);
+
+    expect(tests).toHaveLength(2);
+    const ids = tests.map((t) => t.id);
+    expect(ids).toContain('glob-a');
+    expect(ids).toContain('glob-b');
+  });
+
+  it('resolves paths relative to eval file directory', async () => {
+    const nested = path.join(tempDir, 'nested', 'evals');
+    await mkdir(path.join(nested, 'data'), { recursive: true });
+
+    await writeFile(
+      path.join(nested, 'data', 'cases.yaml'),
+      '- id: nested-case\n  criteria: "Nested goal"\n  input: "Nested input"\n',
+    );
+
+    await writeFile(
+      path.join(nested, 'suite.yaml'),
+      `tests:
+  - file://data/cases.yaml
+`,
+    );
+
+    const tests = await loadTests(path.join(nested, 'suite.yaml'), tempDir);
+
+    expect(tests).toHaveLength(1);
+    expect(tests[0].id).toBe('nested-case');
+  });
+
+  it('throws for missing file:// reference', async () => {
+    await writeFile(
+      path.join(tempDir, 'missing-ref.yaml'),
+      `tests:
+  - file://nonexistent.yaml
+`,
+    );
+
+    await expect(loadTests(path.join(tempDir, 'missing-ref.yaml'), tempDir)).rejects.toThrow(
+      /Cannot read external test file/,
+    );
+  });
+
+  it('throws for malformed JSONL in file:// reference', async () => {
+    await writeFile(
+      path.join(tempDir, 'cases', 'malformed.jsonl'),
+      '{"id": "ok"}\n{invalid json here}\n',
+    );
+
+    await writeFile(
+      path.join(tempDir, 'malformed-ref.yaml'),
+      `tests:
+  - file://cases/malformed.jsonl
+`,
+    );
+
+    await expect(loadTests(path.join(tempDir, 'malformed-ref.yaml'), tempDir)).rejects.toThrow(
+      /Malformed JSONL at line 2/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Support `file://` references in the `tests` array for loading test definitions from external YAML and JSONL files.

## Features

- `file://path/to/tests.yaml` — load YAML array of test definitions
- `file://path/to/tests.jsonl` — load one-test-per-line JSONL
- `file://cases/**/*.yaml` — glob patterns for multi-file discovery
- Mixed inline + file:// entries in the same `tests` array
- Paths resolve relative to eval file directory
- Clear error messages for missing/malformed files

## Changes

- New: `case-file-loader.ts` — file reference parsing, loading, glob expansion
- Modified: `yaml-parser.ts` — integrates file reference expansion
- Added `fast-glob` dependency to core
- 15 new tests
- Example in `examples/features/external-datasets/`

Closes #226

Orchestration tracked in agentevals-research#1