### PR TITLE
feat(codex): replace CLI subprocess with @openai/codex-sdk provider (#236)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -29,10 +29,11 @@
   },
   "dependencies": {
     "@agentv/core": "workspace:*",
-    "@inquirer/prompts": "^8.2.1",
     "@github/copilot-sdk": "^0.1.25",
+    "@inquirer/prompts": "^8.2.1",
     "@mariozechner/pi-agent-core": "^0.50.9",
     "@mariozechner/pi-ai": "^0.50.9",
+    "@openai/codex-sdk": "^0.104.0",
     "cmd-ts": "^0.14.3",
     "dotenv": "^16.4.5",
     "fast-glob": "^3.3.3",

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
     '@mariozechner/pi-agent-core',
     '@mariozechner/pi-ai',
     '@github/copilot-sdk',
+    '@openai/codex-sdk',
   ],
   // Provide a real require() for bundled CJS modules (e.g. debug) that need Node.js builtins like tty
   banner: {

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "@inquirer/prompts": "^8.2.1",
         "@mariozechner/pi-agent-core": "^0.50.9",
         "@mariozechner/pi-ai": "^0.50.9",
+        "@openai/codex-sdk": "^0.104.0",
         "cmd-ts": "^0.14.3",
         "dotenv": "^16.4.5",
         "fast-glob": "^3.3.3",
@@ -64,6 +65,7 @@
         "@github/copilot-sdk": "^0.1.25",
         "@mariozechner/pi-agent-core": "^0.50.9",
         "@mariozechner/pi-ai": "^0.50.9",
+        "@openai/codex-sdk": "^0.104.0",
         "ai": "^5.0.106",
         "fast-glob": "^3.3.3",
         "json5": "^2.2.3",
@@ -438,6 +440,22 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@openai/codex": ["@openai/codex@0.104.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.104.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.104.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.104.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.104.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.104.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.104.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-pPa2VGHozwjPsPOYAEXcH7nNt1QH7AZR8zV8jYx6BFi1LJlmJkan2rvIS4MYbPdi2O6cd5kWfPCAHE0fEV2ifA=="],
+
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.104.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Y+lifRKAgNSBcaIM5UXXYnGWAJrPORPXABZBCxxiwwB8/XzZRDwp3K+X5i7dT0GfKScGFXuul6sJ2sVSPL4w4A=="],
+
+    "@openai/codex-darwin-x64": ["@openai/codex@0.104.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-TwQ9zj0XbSrtCxFWKnnSQfmWmKhNMx1rSpSaSrLNSFVohxRwOWUZ2GBciO6jCLEiJvswR6nTMy1mA0n7MyVJiw=="],
+
+    "@openai/codex-linux-arm64": ["@openai/codex@0.104.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-3oBBjMaCnhGfijsklOzVqG0LH/IFWoDnRJkvFl1utMI+GJECUr37uL/KsSFTuC2kIjham6U57dAK6xQnQxqxPQ=="],
+
+    "@openai/codex-linux-x64": ["@openai/codex@0.104.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-vhYaWsEwZmxZbeu5u9/k3VO1F4aTMYaTCebRgdzux7bfeDw2nms1SAcP+AkfCStqVSz26yaPGbwcUMqaknW4gQ=="],
+
+    "@openai/codex-sdk": ["@openai/codex-sdk@0.104.0", "", { "dependencies": { "@openai/codex": "0.104.0" } }, "sha512-eXnGqFUh4BRASRK4f8IyLHQG7b4DUjfM7GaasLUNggneUEUVmBgEP24mTo6Qu53oIuA1t+j1QxdCQbxAlWZKPA=="],
+
+    "@openai/codex-win32-arm64": ["@openai/codex@0.104.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-2ypuM6yWcjAtq7DmEgFBsmtw7rWLcoy6Cxaq+Hn8dZfEdijASyc59AzyWhWLKYLuOxcprFn/oQitElrpPD9JOA=="],
+
+    "@openai/codex-win32-x64": ["@openai/codex@0.104.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-awyNLtfbTbj+2JzgsAIm+KFrxeAmxe/Fuqw/ZwBj8ljtO7SQWTT3kxDbf7iuA7E7IErGlQw/plgFgq/LJdsacg=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,6 +44,7 @@
     "@github/copilot-sdk": "^0.1.25",
     "@mariozechner/pi-agent-core": "^0.50.9",
     "@mariozechner/pi-ai": "^0.50.9",
+    "@openai/codex-sdk": "^0.104.0",
     "ai": "^5.0.106",
     "fast-glob": "^3.3.3",
     "json5": "^2.2.3",

--- a/packages/core/src/evaluation/providers/codex-cli.ts
+++ b/packages/core/src/evaluation/providers/codex-cli.ts
@@ -1,0 +1,843 @@
+import { exec as execCallback, spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { constants, createWriteStream } from 'node:fs';
+import type { WriteStream } from 'node:fs';
+import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { recordCodexLogEntry } from './codex-log-tracker.js';
+import { buildPromptDocument, normalizeInputFiles } from './preread.js';
+import type { CodexResolvedConfig } from './targets.js';
+import type { Provider, ProviderRequest, ProviderResponse } from './types.js';
+
+const execAsync = promisify(execCallback);
+const WORKSPACE_PREFIX = 'agentv-codex-';
+const PROMPT_FILENAME = 'prompt.md';
+const JSONL_TYPE_ITEM_COMPLETED = 'item.completed';
+
+/**
+ * Default system prompt for Codex CLI evaluations.
+ * Ensures the agent returns code in its response rather than just writing files.
+ */
+const DEFAULT_SYSTEM_PROMPT = `**IMPORTANT**: Follow these instructions for your response:
+- Do NOT create any additional output files in the workspace.
+- All intended file outputs/changes MUST be written in your response.
+- For each intended file, include the relative path and unified git diff following the convention \`diff --git ...\`.
+This is required for evaluation scoring.`;
+
+interface CodexRunOptions {
+  readonly executable: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly prompt: string;
+  readonly timeoutMs?: number;
+  readonly env: NodeJS.ProcessEnv;
+  readonly signal?: AbortSignal;
+  readonly onStdoutChunk?: (chunk: string) => void;
+  readonly onStderrChunk?: (chunk: string) => void;
+}
+
+interface CodexRunResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+  readonly timedOut?: boolean;
+}
+
+type CodexRunner = (options: CodexRunOptions) => Promise<CodexRunResult>;
+
+export class CodexCliProvider implements Provider {
+  readonly id: string;
+  readonly kind = 'codex' as const;
+  readonly targetName: string;
+  readonly supportsBatch = false;
+
+  private readonly config: CodexResolvedConfig;
+  private readonly runCodex: CodexRunner;
+  private environmentCheck?: Promise<void>;
+  private resolvedExecutable?: string;
+
+  constructor(
+    targetName: string,
+    config: CodexResolvedConfig,
+    runner: CodexRunner = defaultCodexRunner,
+  ) {
+    this.id = `codex:${targetName}`;
+    this.targetName = targetName;
+    this.config = config;
+    this.runCodex = runner;
+  }
+
+  async invoke(request: ProviderRequest): Promise<ProviderResponse> {
+    if (request.signal?.aborted) {
+      throw new Error('Codex provider request was aborted before execution');
+    }
+
+    await this.ensureEnvironmentReady();
+
+    const inputFiles = normalizeInputFiles(request.inputFiles);
+
+    const workspaceRoot = await this.createWorkspace();
+    const logger = await this.createStreamLogger(request).catch(() => undefined);
+    try {
+      const basePrompt = buildPromptDocument(request, inputFiles);
+      // Skip forced diff prompt when AgentV captures file changes
+      const systemPrompt =
+        this.config.systemPrompt ??
+        (request.captureFileChanges ? undefined : DEFAULT_SYSTEM_PROMPT);
+      const promptContent = systemPrompt ? `${systemPrompt}\n\n${basePrompt}` : basePrompt;
+      const promptFile = path.join(workspaceRoot, PROMPT_FILENAME);
+      await writeFile(promptFile, promptContent, 'utf8');
+
+      const args = this.buildCodexArgs();
+      const cwd = this.resolveCwd(workspaceRoot, request.cwd);
+
+      const result = await this.executeCodex(args, cwd, promptContent, request.signal, logger);
+
+      if (result.timedOut) {
+        throw new Error(
+          `Codex CLI timed out${formatTimeoutSuffix(this.config.timeoutMs ?? undefined)}`,
+        );
+      }
+
+      if (result.exitCode !== 0) {
+        const detail = pickDetail(result.stderr, result.stdout);
+        const prefix = `Codex CLI exited with code ${result.exitCode}`;
+        throw new Error(detail ? `${prefix}: ${detail}` : prefix);
+      }
+
+      const parsed = parseCodexJson(result.stdout);
+      const assistantText = extractAssistantText(parsed);
+
+      return {
+        raw: {
+          response: parsed,
+          stdout: result.stdout,
+          stderr: result.stderr,
+          exitCode: result.exitCode,
+          args,
+          executable: this.resolvedExecutable ?? this.config.executable,
+          promptFile,
+          workspace: workspaceRoot,
+          inputFiles,
+          logFile: logger?.filePath,
+        },
+        outputMessages: [{ role: 'assistant' as const, content: assistantText }],
+      };
+    } finally {
+      await logger?.close();
+      await this.cleanupWorkspace(workspaceRoot);
+    }
+  }
+
+  private async ensureEnvironmentReady(): Promise<void> {
+    if (!this.environmentCheck) {
+      this.environmentCheck = this.validateEnvironment();
+    }
+    await this.environmentCheck;
+  }
+
+  private async validateEnvironment(): Promise<void> {
+    this.resolvedExecutable = await locateExecutable(this.config.executable);
+  }
+
+  private resolveCwd(workspaceRoot: string, cwdOverride?: string): string {
+    // Request cwd override takes precedence (e.g., from workspace_template)
+    if (cwdOverride) {
+      return path.resolve(cwdOverride);
+    }
+    if (!this.config.cwd) {
+      return workspaceRoot;
+    }
+    return path.resolve(this.config.cwd);
+  }
+
+  private buildCodexArgs(): string[] {
+    // Global flags must come before 'exec' subcommand
+    const args = [
+      '--ask-for-approval',
+      'never',
+      'exec',
+      '--json',
+      '--color',
+      'never',
+      '--skip-git-repo-check',
+    ];
+    if (this.config.args && this.config.args.length > 0) {
+      args.push(...this.config.args);
+    }
+    args.push('-');
+    return args;
+  }
+
+  private async executeCodex(
+    args: readonly string[],
+    cwd: string,
+    promptContent: string,
+    signal: AbortSignal | undefined,
+    logger: CodexStreamLogger | undefined,
+  ): Promise<CodexRunResult> {
+    try {
+      return await this.runCodex({
+        executable: this.resolvedExecutable ?? this.config.executable,
+        args,
+        cwd,
+        prompt: promptContent,
+        timeoutMs: this.config.timeoutMs,
+        env: process.env,
+        signal,
+        onStdoutChunk: logger ? (chunk) => logger.handleStdoutChunk(chunk) : undefined,
+        onStderrChunk: logger ? (chunk) => logger.handleStderrChunk(chunk) : undefined,
+      });
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code === 'ENOENT') {
+        throw new Error(
+          `Codex executable '${this.config.executable}' was not found. Update the target settings.executable or add it to PATH.`,
+        );
+      }
+      throw error;
+    }
+  }
+
+  private async createWorkspace(): Promise<string> {
+    return await mkdtemp(path.join(tmpdir(), WORKSPACE_PREFIX));
+  }
+
+  private async cleanupWorkspace(workspaceRoot: string): Promise<void> {
+    try {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup
+    }
+  }
+
+  private resolveLogDirectory(): string | undefined {
+    const disabled = isCodexLogStreamingDisabled();
+    if (disabled) {
+      return undefined;
+    }
+    if (this.config.logDir) {
+      return path.resolve(this.config.logDir);
+    }
+    return path.join(process.cwd(), '.agentv', 'logs', 'codex');
+  }
+
+  private async createStreamLogger(
+    request: ProviderRequest,
+  ): Promise<CodexStreamLogger | undefined> {
+    const logDir = this.resolveLogDirectory();
+    if (!logDir) {
+      return undefined;
+    }
+    try {
+      await mkdir(logDir, { recursive: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`Skipping Codex stream logging (could not create ${logDir}): ${message}`);
+      return undefined;
+    }
+
+    const filePath = path.join(logDir, buildLogFilename(request, this.targetName));
+
+    try {
+      const logger = await CodexStreamLogger.create({
+        filePath,
+        targetName: this.targetName,
+        evalCaseId: request.evalCaseId,
+        attempt: request.attempt,
+        format: this.config.logFormat ?? 'summary',
+      });
+      recordCodexLogEntry({
+        filePath,
+        targetName: this.targetName,
+        evalCaseId: request.evalCaseId,
+        attempt: request.attempt,
+      });
+      return logger;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`Skipping Codex stream logging for ${filePath}: ${message}`);
+      return undefined;
+    }
+  }
+}
+
+class CodexStreamLogger {
+  readonly filePath: string;
+  private readonly stream: WriteStream;
+  private readonly startedAt = Date.now();
+  private stdoutBuffer = '';
+  private stderrBuffer = '';
+  private readonly format: 'summary' | 'json';
+
+  private constructor(filePath: string, format: 'summary' | 'json') {
+    this.filePath = filePath;
+    this.format = format;
+    this.stream = createWriteStream(filePath, { flags: 'a' });
+  }
+
+  static async create(options: {
+    readonly filePath: string;
+    readonly targetName: string;
+    readonly evalCaseId?: string;
+    readonly attempt?: number;
+    readonly format: 'summary' | 'json';
+  }): Promise<CodexStreamLogger> {
+    const logger = new CodexStreamLogger(options.filePath, options.format);
+    const header = [
+      '# Codex CLI stream log',
+      `# target: ${options.targetName}`,
+      options.evalCaseId ? `# eval: ${options.evalCaseId}` : undefined,
+      options.attempt !== undefined ? `# attempt: ${options.attempt + 1}` : undefined,
+      `# started: ${new Date().toISOString()}`,
+      '',
+    ].filter((line): line is string => Boolean(line));
+    logger.writeLines(header);
+    return logger;
+  }
+
+  handleStdoutChunk(chunk: string): void {
+    this.stdoutBuffer += chunk;
+    this.flushBuffer('stdout');
+  }
+
+  handleStderrChunk(chunk: string): void {
+    this.stderrBuffer += chunk;
+    this.flushBuffer('stderr');
+  }
+
+  async close(): Promise<void> {
+    this.flushBuffer('stdout');
+    this.flushBuffer('stderr');
+    this.flushRemainder();
+    await new Promise<void>((resolve, reject) => {
+      this.stream.once('error', reject);
+      this.stream.end(() => resolve());
+    });
+  }
+
+  private writeLines(lines: readonly string[]): void {
+    for (const line of lines) {
+      this.stream.write(`${line}\n`);
+    }
+  }
+
+  private flushBuffer(source: 'stdout' | 'stderr'): void {
+    const buffer = source === 'stdout' ? this.stdoutBuffer : this.stderrBuffer;
+    const lines = buffer.split(/\r?\n/);
+    const remainder = lines.pop() ?? '';
+    if (source === 'stdout') {
+      this.stdoutBuffer = remainder;
+    } else {
+      this.stderrBuffer = remainder;
+    }
+    for (const line of lines) {
+      const formatted = this.formatLine(line, source);
+      if (formatted) {
+        this.stream.write(formatted);
+        this.stream.write('\n');
+      }
+    }
+  }
+
+  private formatLine(rawLine: string, source: 'stdout' | 'stderr'): string | undefined {
+    const trimmed = rawLine.trim();
+    if (trimmed.length === 0) {
+      return undefined;
+    }
+    const message =
+      this.format === 'json' ? formatCodexJsonLog(trimmed) : formatCodexLogMessage(trimmed, source);
+    return `[+${formatElapsed(this.startedAt)}] [${source}] ${message}`;
+  }
+
+  private flushRemainder(): void {
+    const stdoutRemainder = this.stdoutBuffer.trim();
+    if (stdoutRemainder.length > 0) {
+      const formatted = this.formatLine(stdoutRemainder, 'stdout');
+      if (formatted) {
+        this.stream.write(formatted);
+        this.stream.write('\n');
+      }
+    }
+    const stderrRemainder = this.stderrBuffer.trim();
+    if (stderrRemainder.length > 0) {
+      const formatted = this.formatLine(stderrRemainder, 'stderr');
+      if (formatted) {
+        this.stream.write(formatted);
+        this.stream.write('\n');
+      }
+    }
+    this.stdoutBuffer = '';
+    this.stderrBuffer = '';
+  }
+}
+
+function isCodexLogStreamingDisabled(): boolean {
+  const envValue = process.env.AGENTV_CODEX_STREAM_LOGS;
+  if (!envValue) {
+    return false;
+  }
+  const normalized = envValue.trim().toLowerCase();
+  return normalized === 'false' || normalized === '0' || normalized === 'off';
+}
+
+function buildLogFilename(request: ProviderRequest, targetName: string): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const evalId = sanitizeForFilename(request.evalCaseId ?? 'codex');
+  const attemptSuffix = request.attempt !== undefined ? `_attempt-${request.attempt + 1}` : '';
+  const target = sanitizeForFilename(targetName);
+  return `${timestamp}_${target}_${evalId}${attemptSuffix}_${randomUUID().slice(0, 8)}.log`;
+}
+
+function sanitizeForFilename(value: string): string {
+  const sanitized = value.replace(/[^A-Za-z0-9._-]+/g, '_');
+  return sanitized.length > 0 ? sanitized : 'codex';
+}
+
+function formatElapsed(startedAt: number): string {
+  const elapsedSeconds = Math.floor((Date.now() - startedAt) / 1000);
+  const hours = Math.floor(elapsedSeconds / 3600);
+  const minutes = Math.floor((elapsedSeconds % 3600) / 60);
+  const seconds = elapsedSeconds % 60;
+  if (hours > 0) {
+    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+  }
+  return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+}
+
+function formatCodexLogMessage(rawLine: string, source: 'stdout' | 'stderr'): string {
+  const parsed = tryParseJsonValue(rawLine);
+  if (parsed) {
+    const summary = summarizeCodexEvent(parsed);
+    if (summary) {
+      return summary;
+    }
+  }
+  if (source === 'stderr') {
+    return `stderr: ${rawLine}`;
+  }
+  return rawLine;
+}
+
+function formatCodexJsonLog(rawLine: string): string {
+  const parsed = tryParseJsonValue(rawLine);
+  if (!parsed) {
+    return rawLine;
+  }
+  try {
+    return JSON.stringify(parsed, null, 2);
+  } catch {
+    return rawLine;
+  }
+}
+
+function summarizeCodexEvent(event: unknown): string | undefined {
+  if (!event || typeof event !== 'object') {
+    return undefined;
+  }
+  const record = event as Record<string, unknown>;
+  const type = typeof record.type === 'string' ? record.type : undefined;
+  let message =
+    extractFromEvent(event) ??
+    extractFromItem(record.item) ??
+    flattenContent(record.output ?? record.content);
+  if (!message && type === JSONL_TYPE_ITEM_COMPLETED) {
+    const item = record.item;
+    if (item && typeof item === 'object') {
+      const candidate = flattenContent(
+        (item as Record<string, unknown>).text ??
+          (item as Record<string, unknown>).content ??
+          (item as Record<string, unknown>).output,
+      );
+      if (candidate) {
+        message = candidate;
+      }
+    }
+  }
+  if (!message) {
+    const itemType =
+      typeof (record.item as Record<string, unknown> | undefined)?.type === 'string'
+        ? (record.item as Record<string, unknown>).type
+        : undefined;
+    if (type && itemType) {
+      return `${type}:${itemType}`;
+    }
+    if (type) {
+      return type;
+    }
+  }
+  if (type && message) {
+    return `${type}: ${message}`;
+  }
+  if (message) {
+    return message;
+  }
+  return type;
+}
+
+function tryParseJsonValue(rawLine: string): unknown | undefined {
+  try {
+    return JSON.parse(rawLine);
+  } catch {
+    return undefined;
+  }
+}
+
+async function locateExecutable(candidate: string): Promise<string> {
+  const includesPathSeparator = candidate.includes('/') || candidate.includes('\\');
+  if (includesPathSeparator) {
+    const resolved = path.isAbsolute(candidate) ? candidate : path.resolve(candidate);
+    const executablePath = await ensureWindowsExecutableVariant(resolved);
+    await access(executablePath, constants.F_OK);
+    return executablePath;
+  }
+
+  const locator = process.platform === 'win32' ? 'where' : 'which';
+  try {
+    const { stdout } = await execAsync(`${locator} ${candidate}`);
+    const lines = stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+    const preferred = selectExecutableCandidate(lines);
+    if (preferred) {
+      const executablePath = await ensureWindowsExecutableVariant(preferred);
+      await access(executablePath, constants.F_OK);
+      return executablePath;
+    }
+  } catch {
+    // ignore and fall back to error below
+  }
+
+  throw new Error(`Codex executable '${candidate}' was not found on PATH`);
+}
+
+function selectExecutableCandidate(candidates: readonly string[]): string | undefined {
+  if (candidates.length === 0) {
+    return undefined;
+  }
+  if (process.platform !== 'win32') {
+    return candidates[0];
+  }
+  const extensions = getWindowsExecutableExtensions();
+  for (const ext of extensions) {
+    const match = candidates.find((candidate) => candidate.toLowerCase().endsWith(ext));
+    if (match) {
+      return match;
+    }
+  }
+  return candidates[0];
+}
+
+async function ensureWindowsExecutableVariant(candidate: string): Promise<string> {
+  if (process.platform !== 'win32') {
+    return candidate;
+  }
+  if (hasExecutableExtension(candidate)) {
+    return candidate;
+  }
+
+  const extensions = getWindowsExecutableExtensions();
+  for (const ext of extensions) {
+    const withExtension = `${candidate}${ext}`;
+    try {
+      await access(withExtension, constants.F_OK);
+      return withExtension;
+    } catch {
+      // keep searching
+    }
+  }
+  return candidate;
+}
+
+function hasExecutableExtension(candidate: string): boolean {
+  const lower = candidate.toLowerCase();
+  return getWindowsExecutableExtensions().some((ext) => lower.endsWith(ext));
+}
+
+const DEFAULT_WINDOWS_EXTENSIONS = ['.com', '.exe', '.bat', '.cmd', '.ps1'] as const;
+
+function getWindowsExecutableExtensions(): readonly string[] {
+  if (process.platform !== 'win32') {
+    return [];
+  }
+  const fromEnv = process.env.PATHEXT?.split(';')
+    .map((ext) => ext.trim().toLowerCase())
+    .filter((ext) => ext.length > 0);
+  return fromEnv && fromEnv.length > 0 ? fromEnv : DEFAULT_WINDOWS_EXTENSIONS;
+}
+
+function parseCodexJson(output: string): unknown {
+  const trimmed = output.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Codex CLI produced no output in --json mode');
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const lineObjects = parseJsonLines(trimmed);
+    if (lineObjects) {
+      return lineObjects;
+    }
+    const lastBrace = trimmed.lastIndexOf('{');
+    if (lastBrace >= 0) {
+      const candidate = trimmed.slice(lastBrace);
+      try {
+        return JSON.parse(candidate);
+      } catch {
+        // fallthrough
+      }
+    }
+    const preview = trimmed.slice(0, 200);
+    throw new Error(`Codex CLI emitted invalid JSON: ${preview}${trimmed.length > 200 ? '…' : ''}`);
+  }
+}
+
+function extractAssistantText(parsed: unknown): string {
+  if (Array.isArray(parsed)) {
+    const text = extractFromEventStream(parsed);
+    if (text) {
+      return text;
+    }
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('Codex CLI JSON response did not include an assistant message');
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const eventText = extractFromEvent(record);
+  if (eventText) {
+    return eventText;
+  }
+
+  const messages = Array.isArray(record.messages) ? record.messages : undefined;
+  if (messages) {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const entry = messages[index];
+      if (!entry || typeof entry !== 'object') {
+        continue;
+      }
+      const role = (entry as Record<string, unknown>).role;
+      if (role !== 'assistant') {
+        continue;
+      }
+      const content = (entry as Record<string, unknown>).content;
+      const flattened = flattenContent(content);
+      if (flattened) {
+        return flattened;
+      }
+    }
+  }
+
+  const response = record.response;
+  if (response && typeof response === 'object') {
+    const content = (response as Record<string, unknown>).content;
+    const flattened = flattenContent(content);
+    if (flattened) {
+      return flattened;
+    }
+  }
+
+  const output = record.output;
+  const flattenedOutput = flattenContent(output);
+  if (flattenedOutput) {
+    return flattenedOutput;
+  }
+
+  throw new Error('Codex CLI JSON response did not include an assistant message');
+}
+
+function extractFromEventStream(events: readonly unknown[]): string | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const candidate = events[index];
+    const text = extractFromEvent(candidate);
+    if (text) {
+      return text;
+    }
+  }
+  return undefined;
+}
+
+function extractFromEvent(event: unknown): string | undefined {
+  if (!event || typeof event !== 'object') {
+    return undefined;
+  }
+  const record = event as Record<string, unknown>;
+  const type = typeof record.type === 'string' ? record.type : undefined;
+  if (type === JSONL_TYPE_ITEM_COMPLETED) {
+    const item = record.item;
+    const text = extractFromItem(item);
+    if (text) {
+      return text;
+    }
+  }
+  const output = record.output ?? record.content;
+  const flattened = flattenContent(output);
+  if (flattened) {
+    return flattened;
+  }
+  return undefined;
+}
+
+function extractFromItem(item: unknown): string | undefined {
+  if (!item || typeof item !== 'object') {
+    return undefined;
+  }
+  const record = item as Record<string, unknown>;
+  const itemType = typeof record.type === 'string' ? record.type : undefined;
+  if (itemType === 'agent_message' || itemType === 'response' || itemType === 'output') {
+    const text = flattenContent(record.text ?? record.content ?? record.output);
+    if (text) {
+      return text;
+    }
+  }
+  return undefined;
+}
+
+function flattenContent(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    const parts = value
+      .map((segment) => {
+        if (typeof segment === 'string') {
+          return segment;
+        }
+        if (segment && typeof segment === 'object' && 'text' in segment) {
+          const text = (segment as Record<string, unknown>).text;
+          return typeof text === 'string' ? text : undefined;
+        }
+        return undefined;
+      })
+      .filter((part): part is string => typeof part === 'string' && part.length > 0);
+    return parts.length > 0 ? parts.join(' \n') : undefined;
+  }
+  if (value && typeof value === 'object' && 'text' in value) {
+    const text = (value as Record<string, unknown>).text;
+    return typeof text === 'string' ? text : undefined;
+  }
+  return undefined;
+}
+
+function parseJsonLines(output: string): unknown[] | undefined {
+  const lines = output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (lines.length <= 1) {
+    return undefined;
+  }
+  const parsed: unknown[] = [];
+  for (const line of lines) {
+    try {
+      parsed.push(JSON.parse(line));
+    } catch {
+      return undefined;
+    }
+  }
+  return parsed;
+}
+
+function pickDetail(stderr: string, stdout: string): string | undefined {
+  const errorText = stderr.trim();
+  if (errorText.length > 0) {
+    return errorText;
+  }
+  const stdoutText = stdout.trim();
+  return stdoutText.length > 0 ? stdoutText : undefined;
+}
+
+function formatTimeoutSuffix(timeoutMs: number | undefined): string {
+  if (!timeoutMs || timeoutMs <= 0) {
+    return '';
+  }
+  const seconds = Math.ceil(timeoutMs / 1000);
+  return ` after ${seconds}s`;
+}
+
+async function defaultCodexRunner(options: CodexRunOptions): Promise<CodexRunResult> {
+  return await new Promise<CodexRunResult>((resolve, reject) => {
+    const child = spawn(options.executable, options.args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      shell: shouldShellExecute(options.executable),
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+
+    const onAbort = (): void => {
+      child.kill('SIGTERM');
+    };
+
+    if (options.signal) {
+      if (options.signal.aborted) {
+        onAbort();
+      } else {
+        options.signal.addEventListener('abort', onAbort, { once: true });
+      }
+    }
+
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    if (options.timeoutMs && options.timeoutMs > 0) {
+      timeoutHandle = setTimeout(() => {
+        timedOut = true;
+        child.kill('SIGTERM');
+      }, options.timeoutMs);
+      timeoutHandle.unref?.();
+    }
+
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+      options.onStdoutChunk?.(chunk);
+    });
+
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+      options.onStderrChunk?.(chunk);
+    });
+
+    child.stdin.end(options.prompt);
+
+    const cleanup = (): void => {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+      if (options.signal) {
+        options.signal.removeEventListener('abort', onAbort);
+      }
+    };
+
+    child.on('error', (error) => {
+      cleanup();
+      reject(error);
+    });
+
+    child.on('close', (code) => {
+      cleanup();
+      resolve({
+        stdout,
+        stderr,
+        exitCode: typeof code === 'number' ? code : -1,
+        timedOut,
+      });
+    });
+  });
+}
+
+function shouldShellExecute(executable: string): boolean {
+  if (process.platform !== 'win32') {
+    return false;
+  }
+  const lower = executable.toLowerCase();
+  return lower.endsWith('.cmd') || lower.endsWith('.bat') || lower.endsWith('.ps1');
+}

--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -457,6 +457,7 @@ export interface GeminiResolvedConfig {
 }
 
 export interface CodexResolvedConfig {
+  readonly model?: string;
   readonly executable: string;
   readonly args?: readonly string[];
   readonly cwd?: string;
@@ -918,6 +919,7 @@ function resolveCodexConfig(
   env: EnvLookup,
   evalFilePath?: string,
 ): CodexResolvedConfig {
+  const modelSource = target.model;
   const executableSource = target.executable ?? target.command ?? target.binary;
   const argsSource = target.args ?? target.arguments;
   const cwdSource = target.cwd;
@@ -932,6 +934,11 @@ function resolveCodexConfig(
     target.logOutputFormat ??
     env.AGENTV_CODEX_LOG_FORMAT;
   const systemPromptSource = target.system_prompt ?? target.systemPrompt;
+
+  const model = resolveOptionalString(modelSource, env, `${target.name} codex model`, {
+    allowLiteral: true,
+    optionalEnv: true,
+  });
 
   const executable =
     resolveOptionalString(executableSource, env, `${target.name} codex executable`, {
@@ -981,6 +988,7 @@ function resolveCodexConfig(
       : undefined;
 
   return {
+    model,
     executable,
     args,
     cwd,

--- a/packages/core/src/evaluation/validation/targets-validator.ts
+++ b/packages/core/src/evaluation/validation/targets-validator.ts
@@ -78,6 +78,7 @@ const GEMINI_SETTINGS = new Set([
 
 const CODEX_SETTINGS = new Set([
   ...COMMON_SETTINGS,
+  'model',
   'executable',
   'command',
   'binary',
@@ -94,6 +95,8 @@ const CODEX_SETTINGS = new Set([
   'logFormat',
   'log_output_format',
   'logOutputFormat',
+  'system_prompt',
+  'systemPrompt',
   'workspace_template',
   'workspaceTemplate',
 ]);

--- a/packages/core/test/evaluation/providers/codex-sdk.test.ts
+++ b/packages/core/test/evaluation/providers/codex-sdk.test.ts
@@ -1,0 +1,414 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  type CodexLogEntry,
+  consumeCodexLogEntries,
+} from '../../../src/evaluation/providers/codex-log-tracker.js';
+import type { ProviderRequest } from '../../../src/evaluation/providers/types.js';
+import { extractLastAssistantContent } from '../../../src/evaluation/providers/types.js';
+
+interface MockThread {
+  runStreamed: ReturnType<typeof mock>;
+}
+
+interface MockCodex {
+  startThread: ReturnType<typeof mock>;
+}
+
+function createMockThread(options?: {
+  events?: Array<Record<string, unknown>>;
+  error?: Error;
+}): MockThread {
+  const events = options?.events ?? [];
+
+  return {
+    runStreamed: mock(async () => {
+      if (options?.error) {
+        throw options.error;
+      }
+      return {
+        events: (async function* () {
+          for (const event of events) {
+            yield event;
+          }
+        })(),
+      };
+    }),
+  };
+}
+
+function createMockCodex(thread: MockThread): MockCodex {
+  return {
+    startThread: mock(() => thread),
+  };
+}
+
+function mockCodexSdk(codexInstance: MockCodex) {
+  return {
+    Codex: mock(function Codex() {
+      return codexInstance;
+    }),
+  };
+}
+
+describe('CodexProvider (SDK)', () => {
+  let fixturesRoot: string;
+
+  beforeEach(async () => {
+    fixturesRoot = path.join(tmpdir(), `codex-sdk-test-${Date.now()}`);
+    consumeCodexLogEntries();
+  });
+
+  afterEach(async () => {
+    await rm(fixturesRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('invokes SDK and extracts response text', async () => {
+    const thread = createMockThread({
+      events: [
+        {
+          type: 'item.completed',
+          item: { id: 'msg-1', type: 'agent_message', text: 'Hello from Codex SDK' },
+        },
+        {
+          type: 'turn.completed',
+          usage: { input_tokens: 10, output_tokens: 5, cached_input_tokens: 0 },
+        },
+      ],
+    });
+    const codexInstance = createMockCodex(thread);
+    const sdkMock = mockCodexSdk(codexInstance);
+
+    mock.module('@openai/codex-sdk', () => sdkMock);
+
+    const { CodexProvider } = await import('../../../src/evaluation/providers/codex.js');
+
+    const provider = new CodexProvider('test-target', { executable: 'codex' });
+
+    const request: ProviderRequest = {
+      question: 'Write hello world',
+    };
+
+    const response = await provider.invoke(request);
+    const content = extractLastAssistantContent(response.outputMessages);
+    expect(content).toBe('Hello from Codex SDK');
+    expect(thread.runStreamed).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes model config to Codex constructor', async () => {
+    const thread = createMockThread({
+      events: [
+        {
+          type: 'item.completed',
+          item: { id: 'msg-1', type: 'agent_message', text: 'response' },
+        },
+        {
+          type: 'turn.completed',
+          usage: { input_tokens: 10, output_tokens: 5, cached_input_tokens: 0 },
+        },
+      ],
+    });
+    const codexInstance = createMockCodex(thread);
+
+    const CodexMock = mock(function Codex() {
+      return codexInstance;
+    });
+    mock.module('@openai/codex-sdk', () => ({ Codex: CodexMock }));
+
+    const { CodexProvider } = await import('../../../src/evaluation/providers/codex.js');
+
+    const provider = new CodexProvider('test-target', {
+      executable: 'codex',
+      model: 'o4-mini',
+    });
+
+    await provider.invoke({ question: 'Test' });
+
+    const constructorArgs = CodexMock.mock.calls[0][0];
+    expect(constructorArgs.config.model).toBe('o4-mini');
+  });
+
+  it('passes workingDirectory to startThread', async () => {
+    const thread = createMockThread({
+      events: [
+        {
+          type: 'item.completed',
+          item: { id: 'msg-1', type: 'agent_message', text: 'response' },
+        },
+        {
+          type: 'turn.completed',
+          usage: { input_tokens: 10, output_tokens: 5, cached_input_tokens: 0 },
+        },
+      ],
+    });
+    const codexInstance = createMockCodex(thread);
+    const sdkMock = mockCodexSdk(codexInstance);
+
+    mock.module('@openai/codex-sdk', () => sdkMock);
+
+    const { CodexProvider } = await import('../../../src/evaluation/providers/codex.js');
+
+    const provider = new CodexProvider('test-target', {
+      executable: 'codex',
+      cwd: '/tmp/test-workspace',
+    });
+
+    await provider.invoke({ question: 'Test' });
+
+    const threadOptions = codexInstance.startThread.mock.calls[0][0];
+    expect(threadOptions.skipGitRepoCheck).toBe(true);
+    expect(threadOptions.workingDirectory).toBe('/tmp/test-workspace');
+  });
+
+  it('handles timeout', async () => {
+    const thread = createMockThread();
+    // Override runStreamed to be slow
+    thread.runStreamed = mock(
+      async () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve({
+                events: (async function* () {})(),
+              }),
+            5000,
+          ),
+        ),
+    );
+    const codexInstance = createMockCodex(thread);
+    const sdkMock = mockCodexSdk(codexInstance);
+
+    mock.module('@openai/codex-sdk', () => sdkMock);
+    const { CodexProvider } = await import('../../../src/evaluation/providers/codex.js');
+
+    const provider = new CodexProvider('test-target', {
+      executable: 'codex',
+      timeoutMs: 100,
+    });
+
+    await expect(provider.invoke({ question: 'Slow' })).rejects.toThrow(/timed out/i);
+  });
+
+  it('handles abort signal', async () => {
+    const thread = createMockThread({
+      events: [
+        {
+          type: 'item.completed',
+          item: { id: 'msg-1', type: 'agent_message', text: 'response' },
+        },
+        {
+          type: 'turn.completed',
+          usage: { input_tokens: 10, output_tokens: 5, cached_input_tokens: 0 },
+        },
+      ],
+    });
+    const codexInstance = createMockCodex(thread);
+    const sdkMock = mockCodexSdk(codexInstance);
+
+    mock.module('@openai/codex-sdk', () => sdkMock);
+    const { CodexProvider } = await import('../../../src/evaluation/providers/codex.js');
+
+    const provider = new CodexProvider('test-target', { executable: 'codex' });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(provider.invoke({ question: 'Abort', signal: controller.signal })).rejects.toThrow(
+      /aborted/i,
+    );
+  });
+
+  it('extracts token usage from turn.completed event', async () => {
+    const thread = createMockThread({
+      events: [
+        {
+          type: 'item.completed',
+          item: { id: 'msg-1', type: 'agent_message', text: 'response' },
+        },
+        {
+          type: 'turn.completed',
+          usage: { input_tokens: 100, output_tokens: 50, cached_input_tokens: 20 },
+        },
+      ],
+    });
+    const codexInstance = createMockCodex(thread);
+    const sdkMock = mockCodexSdk(codexInstance);
+
+    mock.module('@openai/codex-sdk', () => sdkMock);
+    const { CodexProvider } = await import('../../../src/evaluation/providers/codex.js');
+
+    const provider = new CodexProvider('test-target', { executable: 'codex' });
+
+    const response = await provider.invoke({ question: 'Tokens' });
+
+    expect(response.tokenUsage).toBeDefined();
+    expect(response.tokenUsage?.input).toBe(100);
+    expect(response.tokenUsage?.output).toBe(50);
+    expect(response.tokenUsage?.cached).toBe(20);
+  });
+
+  it('extracts command execution tool calls from events', async () => {
+    const thread = createMockThread({
+      events: [
+        {
+          type: 'item.completed',
+          item: {
+            id: 'cmd-1',
+            type: 'command_execution',
+            command: 'ls -la',
+            aggregated_output: 'file1.ts\nfile2.ts',
+            exit_code: 0,
+            status: 'completed',
+          },
+        },
+        {
+          type: 'item.completed',
+          item: { id: 'msg-1', type: 'agent_message', text: 'Done listing files' },
+        },
+        {
+          type: 'turn.completed',
+          usage: { input_tokens: 10, output_tokens: 5, cached_input_tokens: 0 },
+        },
+      ],
+    });
+    const codexInstance = createMockCodex(thread);
+    const sdkMock = mockCodexSdk(codexInstance);
+
+    mock.module('@openai/codex-sdk', () => sdkMock);
+    const { CodexProvider } = await import('../../../src/evaluation/providers/codex.js');
+
+    const provider = new CodexProvider('test-target', { executable: 'codex' });
+
+    const response = await provider.invoke({ question: 'List files' });
+
+    expect(response.outputMessages).toBeDefined();
+    expect(response.outputMessages?.length).toBe(1);
+    const msg = response.outputMessages?.[0];
+    expect(msg?.toolCalls).toBeDefined();
+    expect(msg?.toolCalls?.length).toBe(1);
+    expect(msg?.toolCalls?.[0]?.tool).toBe('command_execution');
+    expect(msg?.toolCalls?.[0]?.input).toBe('ls -la');
+    expect(msg?.toolCalls?.[0]?.output).toBe('file1.ts\nfile2.ts');
+    expect(msg?.toolCalls?.[0]?.id).toBe('cmd-1');
+  });
+
+  it('extracts file change tool calls from events', async () => {
+    const thread = createMockThread({
+      events: [
+        {
+          type: 'item.completed',
+          item: {
+            id: 'fc-1',
+            type: 'file_change',
+            changes: [{ path: 'src/index.ts', kind: 'update' }],
+            status: 'completed',
+          },
+        },
+        {
+          type: 'item.completed',
+          item: { id: 'msg-1', type: 'agent_message', text: 'Updated file' },
+        },
+        {
+          type: 'turn.completed',
+          usage: { input_tokens: 10, output_tokens: 5, cached_input_tokens: 0 },
+        },
+      ],
+    });
+    const codexInstance = createMockCodex(thread);
+    const sdkMock = mockCodexSdk(codexInstance);
+
+    mock.module('@openai/codex-sdk', () => sdkMock);
+    const { CodexProvider } = await import('../../../src/evaluation/providers/codex.js');
+
+    const provider = new CodexProvider('test-target', { executable: 'codex' });
+
+    const response = await provider.invoke({ question: 'Update file' });
+
+    const msg = response.outputMessages?.[0];
+    expect(msg?.toolCalls?.length).toBe(1);
+    expect(msg?.toolCalls?.[0]?.tool).toBe('file_change');
+    expect(msg?.toolCalls?.[0]?.input).toEqual([{ path: 'src/index.ts', kind: 'update' }]);
+  });
+
+  it('includes timing information in response', async () => {
+    const thread = createMockThread({
+      events: [
+        {
+          type: 'item.completed',
+          item: { id: 'msg-1', type: 'agent_message', text: 'response' },
+        },
+        {
+          type: 'turn.completed',
+          usage: { input_tokens: 10, output_tokens: 5, cached_input_tokens: 0 },
+        },
+      ],
+    });
+    const codexInstance = createMockCodex(thread);
+    const sdkMock = mockCodexSdk(codexInstance);
+
+    mock.module('@openai/codex-sdk', () => sdkMock);
+    const { CodexProvider } = await import('../../../src/evaluation/providers/codex.js');
+
+    const provider = new CodexProvider('test-target', { executable: 'codex' });
+    const response = await provider.invoke({ question: 'Timing' });
+
+    expect(response.startTime).toBeDefined();
+    expect(response.endTime).toBeDefined();
+    expect(response.durationMs).toBeDefined();
+    expect(typeof response.durationMs).toBe('number');
+  });
+
+  it('handles turn.failed events', async () => {
+    const thread = createMockThread({
+      events: [
+        {
+          type: 'turn.failed',
+          error: { message: 'Model overloaded' },
+        },
+      ],
+    });
+    const codexInstance = createMockCodex(thread);
+    const sdkMock = mockCodexSdk(codexInstance);
+
+    mock.module('@openai/codex-sdk', () => sdkMock);
+    const { CodexProvider } = await import('../../../src/evaluation/providers/codex.js');
+
+    const provider = new CodexProvider('test-target', { executable: 'codex' });
+
+    await expect(provider.invoke({ question: 'Fail' })).rejects.toThrow(/turn failed/i);
+  });
+
+  it('creates fresh Codex instance per invocation', async () => {
+    const thread = createMockThread({
+      events: [
+        {
+          type: 'item.completed',
+          item: { id: 'msg-1', type: 'agent_message', text: 'response' },
+        },
+        {
+          type: 'turn.completed',
+          usage: { input_tokens: 10, output_tokens: 5, cached_input_tokens: 0 },
+        },
+      ],
+    });
+    const codexInstance = createMockCodex(thread);
+
+    const CodexMock = mock(function Codex() {
+      return codexInstance;
+    });
+    mock.module('@openai/codex-sdk', () => ({ Codex: CodexMock }));
+
+    const { CodexProvider } = await import('../../../src/evaluation/providers/codex.js');
+
+    const provider = new CodexProvider('test-target', { executable: 'codex' });
+
+    await provider.invoke({ question: 'First' });
+    await provider.invoke({ question: 'Second' });
+
+    // Each invocation creates a new Codex instance and thread
+    expect(CodexMock).toHaveBeenCalledTimes(2);
+    expect(codexInstance.startThread).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/test/evaluation/providers/codex.test.ts
+++ b/packages/core/test/evaluation/providers/codex.test.ts
@@ -3,12 +3,12 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
+import { CodexCliProvider } from '../../../src/evaluation/providers/codex-cli.js';
 import {
   type CodexLogEntry,
   consumeCodexLogEntries,
   subscribeToCodexLogEntries,
 } from '../../../src/evaluation/providers/codex-log-tracker.js';
-import { CodexProvider } from '../../../src/evaluation/providers/codex.js';
 import {
   type ProviderRequest,
   extractLastAssistantContent,
@@ -18,7 +18,7 @@ async function createTempDir(prefix: string): Promise<string> {
   return await mkdtemp(path.join(tmpdir(), prefix));
 }
 
-describe('CodexProvider', () => {
+describe('CodexCliProvider', () => {
   let fixturesRoot: string;
 
   beforeEach(async () => {
@@ -42,7 +42,7 @@ describe('CodexProvider', () => {
         exitCode: 0,
       }),
     );
-    const provider = new CodexProvider(
+    const provider = new CodexCliProvider(
       'codex-target',
       {
         executable: process.execPath,
@@ -105,7 +105,7 @@ describe('CodexProvider', () => {
       stderr: '',
       exitCode: 0,
     }));
-    const provider = new CodexProvider(
+    const provider = new CodexCliProvider(
       'codex-target',
       {
         executable: process.execPath,
@@ -136,7 +136,7 @@ describe('CodexProvider', () => {
       exitCode: 0,
     }));
 
-    const provider = new CodexProvider(
+    const provider = new CodexCliProvider(
       'codex-target',
       {
         executable: process.execPath,
@@ -172,7 +172,7 @@ describe('CodexProvider', () => {
       };
     });
 
-    const provider = new CodexProvider(
+    const provider = new CodexCliProvider(
       'codex-target',
       {
         executable: process.execPath,
@@ -217,7 +217,7 @@ describe('CodexProvider', () => {
       };
     });
 
-    const provider = new CodexProvider(
+    const provider = new CodexCliProvider(
       'codex-target',
       {
         executable: process.execPath,


### PR DESCRIPTION
## Summary

Replace the `codex` CLI subprocess provider with SDK-based implementation using `@openai/codex-sdk`. Follows copilot-sdk pattern from PR #211.

## Changes

- **Rewritten**: `codex.ts` → SDK-based `CodexSdkProvider` using `Codex.startThread().runStreamed()`
- **Preserved**: Old CLI provider as `codex-cli.ts` (`CodexCliProvider`) for fallback
- **New**: `codex-sdk.test.ts` — 11 tests with mocked SDK
- **Updated**: targets, validator, tsup externals, package deps

## Key Features
- Structured tool call extraction via streaming events
- Token usage and cost tracking from SDK metadata
- Ephemeral threads per eval case
- Existing `codex` configs continue working

Supersedes #99 (execution metrics now native via SDK)
Closes #236

Orchestration tracked in agentevals-research#1