### PR TITLE
feat(cli): add JSON and JUnit XML output formats (#232)

### DIFF
--- a/apps/cli/src/commands/eval/commands/run.ts
+++ b/apps/cli/src/commands/eval/commands/run.ts
@@ -1,4 +1,14 @@
-import { command, flag, number, option, optional, restPositionals, string } from 'cmd-ts';
+import {
+  array,
+  command,
+  flag,
+  multioption,
+  number,
+  option,
+  optional,
+  restPositionals,
+  string,
+} from 'cmd-ts';
 
 import { runEvalCommand } from '../run-eval.js';
 import { resolveEvalPaths } from '../shared.js';
@@ -39,6 +49,13 @@ export const evalRunCommand = command({
       type: optional(string),
       long: 'out',
       description: 'Write results to the specified path',
+    }),
+    output: multioption({
+      type: array(string),
+      long: 'output',
+      short: 'o',
+      description:
+        'Output file path(s). Format inferred from extension: .jsonl, .json, .xml, .yaml',
     }),
     outputFormat: option({
       type: string,
@@ -118,6 +135,7 @@ export const evalRunCommand = command({
       filter: args.testId,
       workers: args.workers,
       out: args.out,
+      output: args.output,
       outputFormat: args.outputFormat,
       dryRun: args.dryRun,
       dryRunDelay: args.dryRunDelay,

--- a/apps/cli/src/commands/eval/json-writer.ts
+++ b/apps/cli/src/commands/eval/json-writer.ts
@@ -1,0 +1,52 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { EvaluationResult } from '@agentv/core';
+
+import { toSnakeCaseDeep } from '../../utils/case-conversion.js';
+
+export class JsonWriter {
+  private readonly filePath: string;
+  private readonly results: EvaluationResult[] = [];
+  private closed = false;
+
+  private constructor(filePath: string) {
+    this.filePath = filePath;
+  }
+
+  static async open(filePath: string): Promise<JsonWriter> {
+    await mkdir(path.dirname(filePath), { recursive: true });
+    return new JsonWriter(filePath);
+  }
+
+  async append(result: EvaluationResult): Promise<void> {
+    if (this.closed) {
+      throw new Error('Cannot write to closed JSON writer');
+    }
+    this.results.push(result);
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+
+    const passed = this.results.filter((r) => r.score >= 0.5).length;
+    const failed = this.results.length - passed;
+    const total = this.results.length;
+
+    const output = {
+      stats: {
+        total,
+        passed,
+        failed,
+        passRate: total > 0 ? passed / total : 0,
+      },
+      results: this.results,
+    };
+
+    const snakeCaseOutput = toSnakeCaseDeep(output);
+    await writeFile(this.filePath, `${JSON.stringify(snakeCaseOutput, null, 2)}\n`, 'utf8');
+  }
+}

--- a/apps/cli/src/commands/eval/junit-writer.ts
+++ b/apps/cli/src/commands/eval/junit-writer.ts
@@ -1,0 +1,94 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { EvaluationResult } from '@agentv/core';
+
+export function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export class JunitWriter {
+  private readonly filePath: string;
+  private readonly results: EvaluationResult[] = [];
+  private closed = false;
+
+  private constructor(filePath: string) {
+    this.filePath = filePath;
+  }
+
+  static async open(filePath: string): Promise<JunitWriter> {
+    await mkdir(path.dirname(filePath), { recursive: true });
+    return new JunitWriter(filePath);
+  }
+
+  async append(result: EvaluationResult): Promise<void> {
+    if (this.closed) {
+      throw new Error('Cannot write to closed JUnit writer');
+    }
+    this.results.push(result);
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+
+    const grouped = new Map<string, EvaluationResult[]>();
+    for (const result of this.results) {
+      const suite = result.dataset ?? 'default';
+      const existing = grouped.get(suite);
+      if (existing) {
+        existing.push(result);
+      } else {
+        grouped.set(suite, [result]);
+      }
+    }
+
+    const suiteXmls: string[] = [];
+    for (const [suiteName, results] of grouped) {
+      const failures = results.filter((r) => r.score < 0.5).length;
+      const errors = results.filter((r) => r.error !== undefined).length;
+
+      const testCases = results.map((r) => {
+        const time = r.traceSummary?.durationMs
+          ? (r.traceSummary.durationMs / 1000).toFixed(3)
+          : '0.000';
+
+        let inner = '';
+        if (r.error) {
+          inner = `\n      <error message="${escapeXml(r.error)}">${escapeXml(r.error)}</error>\n    `;
+        } else if (r.score < 0.5) {
+          const message = `score=${r.score.toFixed(3)}`;
+          const detail = [
+            `Score: ${r.score.toFixed(3)}`,
+            r.reasoning ? `Reasoning: ${r.reasoning}` : '',
+            r.misses.length > 0 ? `Misses: ${r.misses.join(', ')}` : '',
+          ]
+            .filter(Boolean)
+            .join('\n');
+          inner = `\n      <failure message="${escapeXml(message)}">${escapeXml(detail)}</failure>\n    `;
+        }
+
+        return `    <testcase name="${escapeXml(r.testId)}" classname="${escapeXml(suiteName)}" time="${time}">${inner}</testcase>`;
+      });
+
+      suiteXmls.push(
+        `  <testsuite name="${escapeXml(suiteName)}" tests="${results.length}" failures="${failures}" errors="${errors}">\n${testCases.join('\n')}\n  </testsuite>`,
+      );
+    }
+
+    const totalTests = this.results.length;
+    const totalFailures = this.results.filter((r) => r.score < 0.5).length;
+    const totalErrors = this.results.filter((r) => r.error !== undefined).length;
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<testsuites tests="${totalTests}" failures="${totalFailures}" errors="${totalErrors}">\n${suiteXmls.join('\n')}\n</testsuites>\n`;
+
+    await writeFile(this.filePath, xml, 'utf8');
+  }
+}

--- a/apps/cli/src/commands/eval/output-writer.ts
+++ b/apps/cli/src/commands/eval/output-writer.ts
@@ -1,6 +1,10 @@
+import path from 'node:path';
+
 import type { EvaluationResult } from '@agentv/core';
 
+import { JsonWriter } from './json-writer.js';
 import { JsonlWriter } from './jsonl-writer.js';
+import { JunitWriter } from './junit-writer.js';
 import { YamlWriter } from './yaml-writer.js';
 
 export type OutputFormat = 'jsonl' | 'yaml';
@@ -37,4 +41,37 @@ export function getDefaultExtension(format: OutputFormat): string {
       throw new Error(`Unsupported output format: ${exhaustiveCheck}`);
     }
   }
+}
+
+const SUPPORTED_EXTENSIONS = new Set(['.jsonl', '.json', '.xml', '.yaml', '.yml']);
+
+export function createWriterFromPath(filePath: string): Promise<OutputWriter> {
+  const ext = path.extname(filePath).toLowerCase();
+  switch (ext) {
+    case '.jsonl':
+      return JsonlWriter.open(filePath);
+    case '.json':
+      return JsonWriter.open(filePath);
+    case '.xml':
+      return JunitWriter.open(filePath);
+    case '.yaml':
+    case '.yml':
+      return YamlWriter.open(filePath);
+    default:
+      throw new Error(
+        `Unsupported output file extension "${ext}". Supported: ${[...SUPPORTED_EXTENSIONS].join(', ')}`,
+      );
+  }
+}
+
+export async function createMultiWriter(filePaths: readonly string[]): Promise<OutputWriter> {
+  const writers = await Promise.all(filePaths.map((fp) => createWriterFromPath(fp)));
+  return {
+    async append(result: EvaluationResult): Promise<void> {
+      await Promise.all(writers.map((w) => w.append(result)));
+    },
+    async close(): Promise<void> {
+      await Promise.all(writers.map((w) => w.close()));
+    },
+  };
 }

--- a/apps/cli/test/commands/eval/output-writers.test.ts
+++ b/apps/cli/test/commands/eval/output-writers.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { readFile, rm } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { EvaluationResult } from '@agentv/core';
+
+import { JsonWriter } from '../../../src/commands/eval/json-writer.js';
+import { JunitWriter, escapeXml } from '../../../src/commands/eval/junit-writer.js';
+import {
+  createMultiWriter,
+  createWriterFromPath,
+} from '../../../src/commands/eval/output-writer.js';
+
+function makeResult(overrides: Partial<EvaluationResult> = {}): EvaluationResult {
+  return {
+    timestamp: '2024-01-01T00:00:00Z',
+    testId: 'test-1',
+    score: 1.0,
+    hits: ['criterion-1'],
+    misses: [],
+    candidateAnswer: 'answer',
+    target: 'default',
+    ...overrides,
+  };
+}
+
+describe('JsonWriter', () => {
+  const testDir = path.join(import.meta.dir, '.test-json-output');
+  let testFilePath: string;
+
+  beforeEach(() => {
+    testFilePath = path.join(testDir, `results-${Date.now()}.json`);
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  it('should write aggregate JSON with stats and results', async () => {
+    const writer = await JsonWriter.open(testFilePath);
+
+    await writer.append(makeResult({ testId: 'pass-1', score: 0.9 }));
+    await writer.append(makeResult({ testId: 'pass-2', score: 0.7 }));
+    await writer.append(makeResult({ testId: 'fail-1', score: 0.3 }));
+    await writer.close();
+
+    const content = JSON.parse(await readFile(testFilePath, 'utf8'));
+    expect(content.stats.total).toBe(3);
+    expect(content.stats.passed).toBe(2);
+    expect(content.stats.failed).toBe(1);
+    expect(content.stats.pass_rate).toBeCloseTo(2 / 3);
+    expect(content.results).toHaveLength(3);
+    expect(content.results[0].test_id).toBe('pass-1');
+  });
+
+  it('should handle empty results', async () => {
+    const writer = await JsonWriter.open(testFilePath);
+    await writer.close();
+
+    const content = JSON.parse(await readFile(testFilePath, 'utf8'));
+    expect(content.stats.total).toBe(0);
+    expect(content.stats.passed).toBe(0);
+    expect(content.stats.failed).toBe(0);
+    expect(content.stats.pass_rate).toBe(0);
+    expect(content.results).toHaveLength(0);
+  });
+
+  it('should throw when writing to closed writer', async () => {
+    const writer = await JsonWriter.open(testFilePath);
+    await writer.close();
+
+    await expect(writer.append(makeResult())).rejects.toThrow('Cannot write to closed JSON writer');
+  });
+
+  it('should be idempotent on close', async () => {
+    const writer = await JsonWriter.open(testFilePath);
+    await writer.append(makeResult());
+    await writer.close();
+    await writer.close(); // Should not throw
+  });
+
+  it('should convert keys to snake_case', async () => {
+    const writer = await JsonWriter.open(testFilePath);
+    await writer.append(makeResult({ candidateAnswer: 'my answer', testId: 'snake-case-test' }));
+    await writer.close();
+
+    const content = JSON.parse(await readFile(testFilePath, 'utf8'));
+    expect(content.results[0].candidate_answer).toBe('my answer');
+    expect(content.results[0].test_id).toBe('snake-case-test');
+  });
+});
+
+describe('JunitWriter', () => {
+  const testDir = path.join(import.meta.dir, '.test-junit-output');
+  let testFilePath: string;
+
+  beforeEach(() => {
+    testFilePath = path.join(testDir, `results-${Date.now()}.xml`);
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  it('should write valid JUnit XML structure', async () => {
+    const writer = await JunitWriter.open(testFilePath);
+
+    await writer.append(makeResult({ testId: 'pass-1', score: 0.9 }));
+    await writer.append(makeResult({ testId: 'fail-1', score: 0.3, reasoning: 'Too low' }));
+    await writer.close();
+
+    const xml = await readFile(testFilePath, 'utf8');
+    expect(xml).toStartWith('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain('<testsuites tests="2" failures="1" errors="0">');
+    expect(xml).toContain('<testcase name="pass-1"');
+    expect(xml).toContain('<testcase name="fail-1"');
+    expect(xml).toContain('<failure');
+    expect(xml).toContain('score=0.300');
+    expect(xml).toContain('Too low');
+  });
+
+  it('should group results by dataset as testsuites', async () => {
+    const writer = await JunitWriter.open(testFilePath);
+
+    await writer.append(makeResult({ testId: 'a-1', dataset: 'suite-a', score: 1.0 }));
+    await writer.append(makeResult({ testId: 'a-2', dataset: 'suite-a', score: 0.8 }));
+    await writer.append(makeResult({ testId: 'b-1', dataset: 'suite-b', score: 0.5 }));
+    await writer.close();
+
+    const xml = await readFile(testFilePath, 'utf8');
+    expect(xml).toContain('testsuite name="suite-a" tests="2"');
+    expect(xml).toContain('testsuite name="suite-b" tests="1"');
+  });
+
+  it('should use default suite name when no dataset', async () => {
+    const writer = await JunitWriter.open(testFilePath);
+    await writer.append(makeResult({ testId: 'test-1', score: 1.0 }));
+    await writer.close();
+
+    const xml = await readFile(testFilePath, 'utf8');
+    expect(xml).toContain('testsuite name="default"');
+  });
+
+  it('should handle errors as <error> elements', async () => {
+    const writer = await JunitWriter.open(testFilePath);
+    await writer.append(makeResult({ testId: 'err-1', score: 0, error: 'Timeout exceeded' }));
+    await writer.close();
+
+    const xml = await readFile(testFilePath, 'utf8');
+    expect(xml).toContain('<error message="Timeout exceeded"');
+    expect(xml).toContain('errors="1"');
+  });
+
+  it('should throw when writing to closed writer', async () => {
+    const writer = await JunitWriter.open(testFilePath);
+    await writer.close();
+
+    await expect(writer.append(makeResult())).rejects.toThrow(
+      'Cannot write to closed JUnit writer',
+    );
+  });
+});
+
+describe('escapeXml', () => {
+  it('should escape ampersands', () => {
+    expect(escapeXml('a & b')).toBe('a &amp; b');
+  });
+
+  it('should escape angle brackets', () => {
+    expect(escapeXml('<tag>')).toBe('&lt;tag&gt;');
+  });
+
+  it('should escape quotes', () => {
+    expect(escapeXml('say "hello"')).toBe('say &quot;hello&quot;');
+  });
+
+  it('should escape apostrophes', () => {
+    expect(escapeXml("it's")).toBe('it&apos;s');
+  });
+
+  it('should handle all entities combined', () => {
+    expect(escapeXml('<a & "b" \'c\'>')).toBe('&lt;a &amp; &quot;b&quot; &apos;c&apos;&gt;');
+  });
+
+  it('should return empty string unchanged', () => {
+    expect(escapeXml('')).toBe('');
+  });
+
+  it('should return plain text unchanged', () => {
+    expect(escapeXml('hello world')).toBe('hello world');
+  });
+});
+
+describe('createWriterFromPath', () => {
+  const testDir = path.join(import.meta.dir, '.test-writer-dispatch');
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  it('should create JsonlWriter for .jsonl extension', async () => {
+    const writer = await createWriterFromPath(path.join(testDir, 'out.jsonl'));
+    expect(writer).toBeDefined();
+    await writer.close();
+  });
+
+  it('should create JsonWriter for .json extension', async () => {
+    const writer = await createWriterFromPath(path.join(testDir, 'out.json'));
+    expect(writer).toBeDefined();
+    await writer.close();
+  });
+
+  it('should create JunitWriter for .xml extension', async () => {
+    const writer = await createWriterFromPath(path.join(testDir, 'out.xml'));
+    expect(writer).toBeDefined();
+    await writer.close();
+  });
+
+  it('should create YamlWriter for .yaml extension', async () => {
+    const writer = await createWriterFromPath(path.join(testDir, 'out.yaml'));
+    expect(writer).toBeDefined();
+    await writer.close();
+  });
+
+  it('should throw for unsupported extension', () => {
+    expect(() => createWriterFromPath(path.join(testDir, 'out.csv'))).toThrow(
+      'Unsupported output file extension ".csv"',
+    );
+  });
+});
+
+describe('createMultiWriter', () => {
+  const testDir = path.join(import.meta.dir, '.test-multi-writer');
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  it('should write to multiple output files simultaneously', async () => {
+    const jsonlPath = path.join(testDir, 'results.jsonl');
+    const jsonPath = path.join(testDir, 'results.json');
+    const xmlPath = path.join(testDir, 'results.xml');
+
+    const writer = await createMultiWriter([jsonlPath, jsonPath, xmlPath]);
+
+    await writer.append(makeResult({ testId: 'multi-1', score: 0.9 }));
+    await writer.append(makeResult({ testId: 'multi-2', score: 0.3 }));
+    await writer.close();
+
+    // Verify JSONL
+    const jsonlContent = await readFile(jsonlPath, 'utf8');
+    const jsonlLines = jsonlContent.trim().split('\n');
+    expect(jsonlLines).toHaveLength(2);
+    expect(JSON.parse(jsonlLines[0]).test_id).toBe('multi-1');
+
+    // Verify JSON
+    const jsonContent = JSON.parse(await readFile(jsonPath, 'utf8'));
+    expect(jsonContent.stats.total).toBe(2);
+    expect(jsonContent.stats.passed).toBe(1);
+    expect(jsonContent.stats.failed).toBe(1);
+    expect(jsonContent.results).toHaveLength(2);
+
+    // Verify XML
+    const xmlContent = await readFile(xmlPath, 'utf8');
+    expect(xmlContent).toContain('<testsuites tests="2" failures="1"');
+    expect(xmlContent).toContain('<testcase name="multi-1"');
+    expect(xmlContent).toContain('<testcase name="multi-2"');
+  });
+});


### PR DESCRIPTION
## Summary

Add `-o` / `--output` flag supporting multiple output formats inferred from file extension.

## Formats

- `.jsonl` — existing default, unchanged
- `.json` — single object with `{ stats: { total, passed, failed, pass_rate }, results }`
- `.xml` — JUnit XML compatible with GitHub Actions / Jenkins / GitLab CI

## Usage

```bash
agentv run --target my-agent evals/ -o results.jsonl -o results.json -o results.xml
```

## Changes

- `json-writer.ts` — JSON output with aggregate stats
- `junit-writer.ts` — JUnit XML with proper entity escaping, grouped by dataset
- `output-writer.ts` — Extension-based dispatch + multi-writer fan-out
- `run.ts` / `run-eval.ts` — CLI flag and wiring
- 23 new tests

Closes #232

Orchestration tracked in agentevals-research#1