### PR TITLE
docs(examples): add deterministic evaluator examples (#223)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -47,6 +47,7 @@ Focused demonstrations of specific AgentV capabilities. Each example includes it
 - [document-extraction](features/document-extraction/) - Document data extraction
 - [local-cli](features/local-cli/) - Local CLI targets
 - [compare](features/compare/) - Baseline comparison
+- [deterministic-evaluators](features/deterministic-evaluators/) - Deterministic assertions (contains, regex, JSON validation)
 
 ---
 

--- a/examples/features/deterministic-evaluators/README.md
+++ b/examples/features/deterministic-evaluators/README.md
@@ -1,0 +1,71 @@
+# Deterministic Evaluators
+
+Demonstrates how a single, parameterised `code_judge` script can replace a family of built-in assertion evaluators (contains, regex, JSON validation, etc.).
+
+## Why a Code Judge?
+
+AgentV's design philosophy keeps the core minimal. Instead of adding `contains`, `regex`, `is-json` as built-in evaluator types, you write a small code judge and drive it with YAML `config`:
+
+```yaml
+evaluators:
+  - name: has-keyword
+    type: code_judge
+    script: ["bun", "run", "../judges/assertions.ts"]
+    config:
+      type: contains
+      value: "hello"
+```
+
+## Supported Assertion Types
+
+| `type` | `value` | Description |
+|---|---|---|
+| `contains` | substring | Case-sensitive substring match |
+| `icontains` | substring | Case-insensitive substring match |
+| `equals` | string | Exact string equality |
+| `regex` | pattern | Regular expression test |
+| `starts-with` | prefix | String prefix match |
+| `is-json` | *(unused)* | Validates that the response is parseable JSON |
+
+Set `negated: true` in config to invert any assertion.
+
+## Files
+
+- `judges/assertions.ts` — Parameterised code judge using `defineCodeJudge` from `@agentv/eval`
+- `evals/dataset.yaml` — Example tests covering every assertion type
+
+## Setup
+
+From the repository root:
+
+```bash
+bun install
+bun run build
+```
+
+## Run
+
+```bash
+# From examples/features
+bun agentv run deterministic-evaluators/evals/dataset.yaml --target <your-target>
+```
+
+## Standalone Test
+
+Pipe a JSON payload directly to the judge:
+
+```bash
+cd examples/features/deterministic-evaluators
+cat <<'EOF' | bun run judges/assertions.ts
+{
+  "question": "Say hello",
+  "criteria": "Response contains hello",
+  "expected_messages": [],
+  "candidate_answer": "Hello world!",
+  "guideline_files": [],
+  "input_files": [],
+  "input_messages": [],
+  "config": { "type": "icontains", "value": "hello" }
+}
+EOF
+```

--- a/examples/features/deterministic-evaluators/evals/dataset.yaml
+++ b/examples/features/deterministic-evaluators/evals/dataset.yaml
@@ -1,0 +1,130 @@
+# Deterministic Evaluator Examples
+# Shows how a single parameterised code judge handles common assertion types.
+
+description: Deterministic assertions — contains, regex, JSON validation, and more
+
+tests:
+  # --- contains ---
+  - id: contains-basic
+    criteria: Response mentions the word "hello"
+    input: "Say hello to the user."
+    expected_output: "Hello there! How can I help you today?"
+
+    execution:
+      evaluators:
+        - name: contains-check
+          type: code_judge
+          script: ["bun", "run", "../judges/assertions.ts"]
+          config:
+            type: contains
+            value: "Hello"
+
+  # --- icontains (case-insensitive) ---
+  - id: icontains-basic
+    criteria: Response mentions "hello" regardless of case
+    input: "Greet the user."
+    expected_output: "HELLO! Nice to meet you."
+
+    execution:
+      evaluators:
+        - name: icontains-check
+          type: code_judge
+          script: ["bun", "run", "../judges/assertions.ts"]
+          config:
+            type: icontains
+            value: "hello"
+
+  # --- equals ---
+  - id: equals-exact
+    criteria: Response is exactly the expected string
+    input: "What is 2+2?"
+    expected_output: "4"
+
+    execution:
+      evaluators:
+        - name: equals-check
+          type: code_judge
+          script: ["bun", "run", "../judges/assertions.ts"]
+          config:
+            type: equals
+            value: "4"
+
+  # --- regex ---
+  - id: regex-email
+    criteria: Response contains a valid email address
+    input: "Provide your contact email."
+    expected_output: "You can reach me at support@example.com."
+
+    execution:
+      evaluators:
+        - name: regex-check
+          type: code_judge
+          script: ["bun", "run", "../judges/assertions.ts"]
+          config:
+            type: regex
+            value: "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"
+
+  # --- starts-with ---
+  - id: starts-with-prefix
+    criteria: Response begins with a greeting
+    input: "Start your reply with 'Dear User'."
+    expected_output: "Dear User, thank you for contacting us."
+
+    execution:
+      evaluators:
+        - name: starts-with-check
+          type: code_judge
+          script: ["bun", "run", "../judges/assertions.ts"]
+          config:
+            type: starts-with
+            value: "Dear User"
+
+  # --- is-json ---
+  - id: is-json-valid
+    criteria: Response is valid JSON
+    input: "Return a JSON object with a status field."
+    expected_output: '{"status": "ok", "code": 200}'
+
+    execution:
+      evaluators:
+        - name: json-check
+          type: code_judge
+          script: ["bun", "run", "../judges/assertions.ts"]
+          config:
+            type: is-json
+
+  # --- negation ---
+  - id: negated-contains
+    criteria: Response must NOT contain the word "error"
+    input: "Report the system status."
+    expected_output: "All systems operational."
+
+    execution:
+      evaluators:
+        - name: no-error-check
+          type: code_judge
+          script: ["bun", "run", "../judges/assertions.ts"]
+          config:
+            type: contains
+            value: "error"
+            negated: true
+
+  # --- combining multiple assertions on one test ---
+  - id: multi-assertion
+    criteria: Response is valid JSON that contains a "result" key
+    input: "Return a JSON object with a result key."
+    expected_output: '{"result": 42}'
+
+    execution:
+      evaluators:
+        - name: json-format
+          type: code_judge
+          script: ["bun", "run", "../judges/assertions.ts"]
+          config:
+            type: is-json
+        - name: has-result-key
+          type: code_judge
+          script: ["bun", "run", "../judges/assertions.ts"]
+          config:
+            type: contains
+            value: '"result"'

--- a/examples/features/deterministic-evaluators/judges/assertions.ts
+++ b/examples/features/deterministic-evaluators/judges/assertions.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env bun
+/**
+ * Parameterized assertion judge.
+ *
+ * A single code judge that handles common deterministic checks
+ * (contains, regex, JSON validation, etc.) driven by YAML config.
+ *
+ * Config fields (passed via evaluator `config` in YAML):
+ *   type    – assertion kind: contains | icontains | equals | regex | starts-with | is-json
+ *   value   – expected substring, pattern, or prefix (not used for is-json)
+ *   negated – when true, inverts the assertion (default: false)
+ */
+import { defineCodeJudge } from '@agentv/eval';
+
+type AssertionType = 'contains' | 'icontains' | 'equals' | 'regex' | 'starts-with' | 'is-json';
+
+function runAssertion(type: AssertionType, candidate: string, value?: string): boolean {
+  switch (type) {
+    case 'contains':
+      return value != null && candidate.includes(value);
+    case 'icontains':
+      return value != null && candidate.toLowerCase().includes(value.toLowerCase());
+    case 'equals':
+      return candidate === value;
+    case 'regex':
+      return value != null && new RegExp(value).test(candidate);
+    case 'starts-with':
+      return value != null && candidate.startsWith(value);
+    case 'is-json':
+      try {
+        JSON.parse(candidate);
+        return true;
+      } catch {
+        return false;
+      }
+  }
+}
+
+export default defineCodeJudge(({ candidateAnswer, criteria, config }) => {
+  const type = (config?.type as AssertionType) ?? 'contains';
+  const value = config?.value as string | undefined;
+  const negated = (config?.negated as boolean) ?? false;
+
+  const rawPass = runAssertion(type, candidateAnswer, value);
+  const pass = negated ? !rawPass : rawPass;
+
+  const label = negated ? `NOT ${type}` : type;
+  const detail = value != null ? `${label}(${JSON.stringify(value)})` : label;
+
+  return {
+    score: pass ? 1 : 0,
+    hits: pass ? [`PASS: ${detail}`] : [],
+    misses: pass ? [] : [`FAIL: ${detail}`],
+    reasoning: `Assertion "${detail}" against candidate — ${pass ? 'passed' : 'failed'}. Criteria: ${criteria}`,
+  };
+});

--- a/examples/features/deterministic-evaluators/package.json
+++ b/examples/features/deterministic-evaluators/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "agentv-example-deterministic-evaluators",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@agentv/eval": "file:../../../packages/eval"
+  }
+}


### PR DESCRIPTION
Adds parameterized assertion judge (contains, icontains, equals, regex, starts-with, is-json) with negation support. 8 example test cases.

Closes #223
Orchestration tracked in agentevals-research#1