### PR TITLE
docs(examples): add tool-call F1 scoring example (#229)

### DIFF
--- a/examples/tool-evaluation-plugins/README.md
+++ b/examples/tool-evaluation-plugins/README.md
@@ -1,0 +1,66 @@
+# Tool-Call F1 Scoring
+
+Code judge plugins that compute **F1 scores** over tool calls, comparing expected tools against actual agent behavior.
+
+## Judges
+
+### `judges/tool-call-f1.ts` — Name-only F1
+
+Computes precision, recall, and F1 by comparing expected tool names against actual tool calls from `outputMessages`.
+
+- **True positive**: expected tool was called
+- **False negative**: expected tool was NOT called
+- **False positive**: unexpected tool was called
+
+```yaml
+evaluators:
+  - name: tool-f1
+    type: code_judge
+    script: ["bun", "run", "../judges/tool-call-f1.ts"]
+    expected_tools: ["search", "fetch"]
+```
+
+### `judges/tool-args-f1.ts` — Name + argument F1
+
+Extends the name-only judge by also validating tool arguments. A call is a hit only if both the name matches AND the required arguments are present (subset match).
+
+```yaml
+evaluators:
+  - name: tool-args-f1
+    type: code_judge
+    script: ["bun", "run", "../judges/tool-args-f1.ts"]
+    expected_tools:
+      - tool: search
+        args: { query: "weather tokyo" }
+      - tool: fetch
+```
+
+## Running
+
+```bash
+cd examples/tool-evaluation-plugins
+bun agentv run evals/dataset.yaml --target <your-target>
+```
+
+## Output
+
+Each judge returns:
+
+```json
+{
+  "score": 0.667,
+  "hits": ["Expected tool 'search' was called"],
+  "misses": ["Expected tool 'fetch' was NOT called"],
+  "reasoning": "precision=1.000 recall=0.500 F1=0.667 | expected=2 actual=1 TP=1 FP=0 FN=1",
+  "details": { "precision": 1, "recall": 0.5, "f1": 0.667, "tp": 1, "fp": 0, "fn": 1 }
+}
+```
+
+## When to Use
+
+| Need | Solution |
+|------|----------|
+| Exact tool sequence | Built-in `tool_trajectory` with `mode: in_order` |
+| Minimum tool counts | Built-in `tool_trajectory` with `minimums` |
+| Set-based F1 scoring | **This plugin** (`tool-call-f1.ts`) |
+| F1 with argument validation | **This plugin** (`tool-args-f1.ts`) |

--- a/examples/tool-evaluation-plugins/evals/dataset.yaml
+++ b/examples/tool-evaluation-plugins/evals/dataset.yaml
@@ -1,0 +1,83 @@
+# Tool-Call F1 Scoring Example
+#
+# Demonstrates using code_judge plugins to compute F1 scores over tool calls.
+# The judges compare expected tools (from evaluator config) against actual
+# tool calls in the agent's output messages.
+#
+# Run:
+#   cd examples/tool-evaluation-plugins
+#   bun agentv run evals/dataset.yaml --target <your-target>
+#
+# Or dry-run (mock responses — useful for testing harness flow only):
+#   bun agentv run evals/dataset.yaml --dry-run
+
+description: Tool-call F1 scoring examples
+
+tests:
+  # ==========================================
+  # Example 1: Basic tool-call F1
+  # Checks whether the right tool names were called
+  # ==========================================
+  - id: weather-lookup-f1
+    criteria: |-
+      Agent should search for weather data and fetch the forecast.
+
+    input:
+      - role: user
+        content: What is the weather in Tokyo? Fetch the detailed forecast.
+
+    execution:
+      evaluators:
+        - name: tool-f1
+          type: code_judge
+          script: ["bun", "run", "../judges/tool-call-f1.ts"]
+          expected_tools: ["search", "fetch"]
+
+  # ==========================================
+  # Example 2: Tool-call + argument F1
+  # Also validates that arguments match expected values
+  # ==========================================
+  - id: weather-lookup-args-f1
+    criteria: |-
+      Agent should search for "weather tokyo" and fetch the forecast API.
+
+    input:
+      - role: user
+        content: What is the weather in Tokyo? Fetch the detailed forecast.
+
+    execution:
+      evaluators:
+        - name: tool-args-f1
+          type: code_judge
+          script: ["bun", "run", "../judges/tool-args-f1.ts"]
+          expected_tools:
+            - tool: search
+              args: { query: "weather tokyo" }
+            - tool: fetch
+
+  # ==========================================
+  # Example 3: Combined with built-in tool_trajectory
+  # Uses F1 for scoring alongside deterministic checks
+  # ==========================================
+  - id: data-analysis-combined
+    criteria: |-
+      Agent should search for data, validate it, and process results.
+
+    input:
+      - role: user
+        content: Analyze the quarterly sales data and generate a summary report.
+
+    execution:
+      evaluators:
+        # Built-in: verify tool sequence
+        - name: trajectory-check
+          type: tool_trajectory
+          mode: any_order
+          minimums:
+            search: 1
+
+        # Plugin: F1 score over expected tools
+        - name: tool-f1
+          type: code_judge
+          script: ["bun", "run", "../judges/tool-call-f1.ts"]
+          expected_tools: ["search", "validate", "process"]

--- a/examples/tool-evaluation-plugins/judges/tool-args-f1.ts
+++ b/examples/tool-evaluation-plugins/judges/tool-args-f1.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env bun
+/**
+ * Tool-Call + Arguments F1 Scoring Judge
+ *
+ * Extends tool-call-f1.ts by also validating tool arguments.
+ * A tool call is a "hit" only if both the tool name matches AND the
+ * required arguments are present with expected values.
+ *
+ * Configuration (via evaluator config in YAML):
+ *   expected_tools:
+ *     - tool: "search"
+ *       args: { query: "weather tokyo" }    # required args (subset match)
+ *     - tool: "fetch"                       # no args check — name-only match
+ *
+ * Usage in eval YAML:
+ *   evaluators:
+ *     - name: tool-args-f1
+ *       type: code_judge
+ *       script: ["bun", "run", "../judges/tool-args-f1.ts"]
+ *       expected_tools:
+ *         - tool: search
+ *           args: { query: "weather" }
+ *         - tool: fetch
+ */
+import { type CodeJudgeInput, defineCodeJudge } from '@agentv/eval';
+
+interface ExpectedTool {
+  tool: string;
+  args?: Record<string, unknown>;
+}
+
+interface ActualCall {
+  tool: string;
+  input: Record<string, unknown>;
+}
+
+function extractActualCalls(input: CodeJudgeInput): ActualCall[] {
+  const calls: ActualCall[] = [];
+  for (const msg of input.outputMessages ?? []) {
+    if (msg.role === 'assistant' && msg.toolCalls) {
+      for (const call of msg.toolCalls) {
+        calls.push({
+          tool: call.tool,
+          input: (call.input as Record<string, unknown>) ?? {},
+        });
+      }
+    }
+  }
+  return calls;
+}
+
+/** Check if actual args contain all expected key-value pairs (subset match). */
+function argsMatch(expected: Record<string, unknown>, actual: Record<string, unknown>): boolean {
+  for (const [key, value] of Object.entries(expected)) {
+    const actualVal = actual[key];
+    if (typeof value === 'string' && typeof actualVal === 'string') {
+      if (!actualVal.toLowerCase().includes(value.toLowerCase())) return false;
+    } else if (JSON.stringify(actualVal) !== JSON.stringify(value)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export default defineCodeJudge(({ outputMessages, config, ...rest }) => {
+  const rawExpected = config?.expected_tools;
+  if (!rawExpected || !Array.isArray(rawExpected) || rawExpected.length === 0) {
+    return {
+      score: 0,
+      misses: ['No expected_tools configured — provide an array of {tool, args?} objects'],
+      reasoning: 'Cannot compute F1 without expected_tools.',
+    };
+  }
+
+  const expectedTools: ExpectedTool[] = rawExpected.map((e: unknown) =>
+    typeof e === 'string' ? { tool: e } : (e as ExpectedTool),
+  );
+
+  const input: CodeJudgeInput = { outputMessages, config, ...rest };
+  const actualCalls = extractActualCalls(input);
+
+  // Greedy matching: for each expected tool, find first unmatched actual call
+  const usedActual = new Set<number>();
+  const hits: string[] = [];
+  const fn: string[] = [];
+
+  for (const expected of expectedTools) {
+    let matched = false;
+    for (let i = 0; i < actualCalls.length; i++) {
+      if (usedActual.has(i)) continue;
+      const actual = actualCalls[i];
+      if (actual.tool !== expected.tool) continue;
+      if (expected.args && !argsMatch(expected.args, actual.input)) continue;
+      usedActual.add(i);
+      matched = true;
+      const detail = expected.args
+        ? `'${expected.tool}' called with matching args`
+        : `'${expected.tool}' called`;
+      hits.push(detail);
+      break;
+    }
+    if (!matched) {
+      const detail = expected.args
+        ? `'${expected.tool}' not called with args ${JSON.stringify(expected.args)}`
+        : `'${expected.tool}' not called`;
+      fn.push(detail);
+    }
+  }
+
+  // Unmatched actual calls are false positives
+  const fpTools: string[] = [];
+  for (let i = 0; i < actualCalls.length; i++) {
+    if (!usedActual.has(i)) {
+      fpTools.push(`Unexpected call to '${actualCalls[i].tool}'`);
+    }
+  }
+
+  const tp = hits.length;
+  const fpCount = fpTools.length;
+  const fnCount = fn.length;
+
+  const precision = tp + fpCount > 0 ? tp / (tp + fpCount) : 0;
+  const recall = tp + fnCount > 0 ? tp / (tp + fnCount) : 0;
+  const f1 = precision + recall > 0 ? (2 * precision * recall) / (precision + recall) : 0;
+
+  return {
+    score: Math.round(f1 * 1000) / 1000,
+    hits,
+    misses: [...fn, ...fpTools],
+    reasoning: `precision=${precision.toFixed(3)} recall=${recall.toFixed(3)} F1=${f1.toFixed(3)} | TP=${tp} FP=${fpCount} FN=${fnCount}`,
+    details: { precision, recall, f1, tp, fp: fpCount, fn: fnCount },
+  };
+});

--- a/examples/tool-evaluation-plugins/judges/tool-call-f1.ts
+++ b/examples/tool-evaluation-plugins/judges/tool-call-f1.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env bun
+/**
+ * Tool-Call F1 Scoring Judge
+ *
+ * Computes precision, recall, and F1 score by comparing expected tool calls
+ * against actual tool calls from the agent's output messages.
+ *
+ * Configuration (via evaluator config in YAML):
+ *   expected_tools: string[]  — list of tool names the agent should call
+ *
+ * Why this is a plugin (not built-in):
+ * - F1 scoring over tool names is a composed metric (set comparison)
+ * - Different projects may weight precision vs recall differently
+ * - Easy to extend with argument matching (see tool-args-f1.ts)
+ *
+ * Usage in eval YAML:
+ *   evaluators:
+ *     - name: tool-f1
+ *       type: code_judge
+ *       script: ["bun", "run", "../judges/tool-call-f1.ts"]
+ *       expected_tools: ["search", "fetch"]
+ */
+import { type CodeJudgeInput, defineCodeJudge } from '@agentv/eval';
+
+function extractActualTools(input: CodeJudgeInput): string[] {
+  const tools: string[] = [];
+  for (const msg of input.outputMessages ?? []) {
+    if (msg.role === 'assistant' && msg.toolCalls) {
+      for (const call of msg.toolCalls) {
+        tools.push(call.tool);
+      }
+    }
+  }
+  return tools;
+}
+
+export default defineCodeJudge(({ outputMessages, config, ...rest }) => {
+  const expectedTools: string[] = (config?.expected_tools as string[]) ?? [];
+
+  if (expectedTools.length === 0) {
+    return {
+      score: 0,
+      misses: ['No expected_tools configured — set expected_tools in evaluator config'],
+      reasoning: 'Cannot compute F1 without expected_tools.',
+    };
+  }
+
+  const input: CodeJudgeInput = { outputMessages, config, ...rest };
+  const actualTools = extractActualTools(input);
+  const actualSet = new Set(actualTools);
+
+  // True positives: expected tools that were called
+  const tp = expectedTools.filter((t) => actualSet.has(t));
+  // False negatives: expected tools that were NOT called
+  const fn = expectedTools.filter((t) => !actualSet.has(t));
+  // False positives: called tools that were NOT expected
+  const expectedSet = new Set(expectedTools);
+  const fp = actualTools.filter((t) => !expectedSet.has(t));
+  // Deduplicate FP list for reporting (but count all for precision)
+  const fpUnique = [...new Set(fp)];
+
+  const precision = tp.length + fp.length > 0 ? tp.length / (tp.length + fp.length) : 0;
+  const recall = tp.length + fn.length > 0 ? tp.length / (tp.length + fn.length) : 0;
+  const f1 = precision + recall > 0 ? (2 * precision * recall) / (precision + recall) : 0;
+
+  const hits: string[] = tp.map((t) => `Expected tool '${t}' was called`);
+  const misses: string[] = [
+    ...fn.map((t) => `Expected tool '${t}' was NOT called`),
+    ...fpUnique.map((t) => `Unexpected tool '${t}' was called`),
+  ];
+
+  return {
+    score: Math.round(f1 * 1000) / 1000,
+    hits,
+    misses,
+    reasoning: `precision=${precision.toFixed(3)} recall=${recall.toFixed(3)} F1=${f1.toFixed(3)} | expected=${expectedTools.length} actual=${actualTools.length} TP=${tp.length} FP=${fp.length} FN=${fn.length}`,
+    details: { precision, recall, f1, tp: tp.length, fp: fp.length, fn: fn.length },
+  };
+});


### PR DESCRIPTION
Adds tool-call F1 code judge with name-only and argument-matching variants. 3 example test cases.

Closes #229
Orchestration tracked in agentevals-research#1