### PR TITLE
docs(examples): add NLP metrics evaluator examples (#227)

### DIFF
--- a/examples/nlp-metrics/README.md
+++ b/examples/nlp-metrics/README.md
@@ -1,0 +1,39 @@
+# NLP Metrics Examples
+
+Demonstrates how to implement common NLP evaluation metrics as AgentV `code_judge` evaluators — no external dependencies required.
+
+## Judges
+
+| File | Metric | Use Case |
+|------|--------|----------|
+| `judges/rouge.ts` | ROUGE-1 / ROUGE-2 | Summarisation — measures n-gram recall and F1 |
+| `judges/bleu.ts` | BLEU | Translation — measures n-gram precision with brevity penalty |
+| `judges/similarity.ts` | Cosine + Jaccard | Paraphrasing — token-overlap similarity |
+| `judges/levenshtein.ts` | Levenshtein distance | Extraction — character-level edit distance |
+
+Each judge is a standalone TypeScript file that uses `defineCodeJudge` from `@agentv/eval`. Scores are normalised to the 0–1 range expected by AgentV.
+
+## Running
+
+```bash
+# From the repository root
+bun agentv run examples/nlp-metrics/evals/dataset.yaml
+```
+
+Run a single test:
+
+```bash
+bun agentv run examples/nlp-metrics/evals/dataset.yaml --test-id summarisation-rouge
+```
+
+## How It Works
+
+Each judge receives the candidate answer and reference text via the `defineCodeJudge` handler, computes the relevant metric from scratch, and returns a `CodeJudgeResult` with:
+
+- **score** — normalised 0–1 value
+- **hits / misses** — threshold checks for quick pass/fail
+- **details** — raw metric values for downstream analysis
+
+## Combining Metrics
+
+The `multi-metric-evaluation` test in `dataset.yaml` shows how to attach multiple evaluators to a single test case. AgentV runs each judge independently and reports all scores.

--- a/examples/nlp-metrics/evals/dataset.yaml
+++ b/examples/nlp-metrics/evals/dataset.yaml
@@ -1,0 +1,100 @@
+# NLP Metrics Evaluator Examples
+# Demonstrates ROUGE, BLEU, cosine similarity, and Levenshtein distance
+# as code_judge evaluators — no external dependencies required.
+
+description: NLP text-quality metrics using code_judge evaluators
+
+execution:
+  target: local_cli
+
+tests:
+  - id: summarisation-rouge
+    criteria: Summary captures key points from the original text.
+
+    input:
+      - role: user
+        content: Summarise the following article in one sentence.
+
+    expected_output:
+      - role: assistant
+        content: The quick brown fox jumps over the lazy dog near the river bank.
+
+    execution:
+      evaluators:
+        - name: rouge-score
+          type: code_judge
+          script: ["bun", "run", "../judges/rouge.ts"]
+
+  - id: translation-bleu
+    criteria: Translation preserves meaning and word choice of the reference.
+
+    input:
+      - role: user
+        content: Translate the following sentence to English.
+
+    expected_output:
+      - role: assistant
+        content: The cat sat on the mat and watched the birds in the garden.
+
+    execution:
+      evaluators:
+        - name: bleu-score
+          type: code_judge
+          script: ["bun", "run", "../judges/bleu.ts"]
+
+  - id: paraphrase-similarity
+    criteria: Paraphrase conveys the same meaning as the reference.
+
+    input:
+      - role: user
+        content: Paraphrase the following sentence.
+
+    expected_output:
+      - role: assistant
+        content: Machine learning models require large amounts of training data to perform well.
+
+    execution:
+      evaluators:
+        - name: cosine-similarity
+          type: code_judge
+          script: ["bun", "run", "../judges/similarity.ts"]
+
+  - id: extraction-levenshtein
+    criteria: Extracted text closely matches the expected value.
+
+    input:
+      - role: user
+        content: Extract the product name from this invoice.
+
+    expected_output:
+      - role: assistant
+        content: "Widget Pro 3000"
+
+    execution:
+      evaluators:
+        - name: edit-distance
+          type: code_judge
+          script: ["bun", "run", "../judges/levenshtein.ts"]
+
+  - id: multi-metric-evaluation
+    criteria: Response is evaluated by multiple NLP metrics simultaneously.
+
+    input:
+      - role: user
+        content: Rewrite the following paragraph more concisely.
+
+    expected_output:
+      - role: assistant
+        content: Artificial intelligence is transforming healthcare by enabling faster diagnosis and personalised treatment plans.
+
+    execution:
+      evaluators:
+        - name: rouge-score
+          type: code_judge
+          script: ["bun", "run", "../judges/rouge.ts"]
+        - name: cosine-similarity
+          type: code_judge
+          script: ["bun", "run", "../judges/similarity.ts"]
+        - name: edit-distance
+          type: code_judge
+          script: ["bun", "run", "../judges/levenshtein.ts"]

--- a/examples/nlp-metrics/judges/bleu.ts
+++ b/examples/nlp-metrics/judges/bleu.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env bun
+/**
+ * BLEU Code Judge
+ *
+ * Computes a BLEU-like score between candidate and reference text.
+ * BLEU (Bilingual Evaluation Understudy) measures n-gram precision with a
+ * brevity penalty, commonly used for translation evaluation.
+ */
+import { defineCodeJudge } from '@agentv/eval';
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s]/g, '')
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function ngramCounts(tokens: string[], n: number): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (let i = 0; i <= tokens.length - n; i++) {
+    const gram = tokens.slice(i, i + n).join(' ');
+    counts.set(gram, (counts.get(gram) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function clippedPrecision(candidate: string[], reference: string[], n: number): number {
+  const candGrams = ngramCounts(candidate, n);
+  const refGrams = ngramCounts(reference, n);
+
+  let clipped = 0;
+  let total = 0;
+
+  for (const [gram, count] of candGrams) {
+    const refCount = refGrams.get(gram) ?? 0;
+    clipped += Math.min(count, refCount);
+    total += count;
+  }
+
+  return total === 0 ? 0 : clipped / total;
+}
+
+function bleuScore(candidate: string, reference: string, maxN = 4): number {
+  const candTokens = tokenize(candidate);
+  const refTokens = tokenize(reference);
+
+  if (candTokens.length === 0) return 0;
+
+  // Brevity penalty
+  const bp =
+    candTokens.length >= refTokens.length ? 1 : Math.exp(1 - refTokens.length / candTokens.length);
+
+  const effectiveN = Math.min(maxN, candTokens.length);
+  let logSum = 0;
+  let count = 0;
+
+  for (let n = 1; n <= effectiveN; n++) {
+    const p = clippedPrecision(candTokens, refTokens, n);
+    if (p === 0) return 0; // If any n-gram precision is 0, BLEU is 0
+    logSum += Math.log(p);
+    count++;
+  }
+
+  return bp * Math.exp(logSum / count);
+}
+
+export default defineCodeJudge(({ candidateAnswer, referenceAnswer, expectedMessages }) => {
+  const reference =
+    referenceAnswer ??
+    (expectedMessages[0] && typeof expectedMessages[0].content === 'string'
+      ? expectedMessages[0].content
+      : '');
+
+  if (!reference) {
+    return { score: 0, misses: ['No reference text provided'], reasoning: 'Missing reference.' };
+  }
+
+  const score = bleuScore(candidateAnswer, reference);
+
+  const hits: string[] = [];
+  const misses: string[] = [];
+
+  if (score >= 0.3) hits.push(`BLEU ${score.toFixed(3)} >= 0.3`);
+  else misses.push(`BLEU ${score.toFixed(3)} < 0.3`);
+
+  return {
+    score,
+    hits,
+    misses,
+    reasoning: `BLEU score: ${score.toFixed(3)}`,
+    details: { bleu: score },
+  };
+});

--- a/examples/nlp-metrics/judges/levenshtein.ts
+++ b/examples/nlp-metrics/judges/levenshtein.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env bun
+/**
+ * Levenshtein Distance Code Judge
+ *
+ * Computes normalised edit distance between candidate and reference text.
+ * The score is 1 - (distance / maxLength), so identical strings score 1.0
+ * and completely different strings score close to 0.
+ */
+import { defineCodeJudge } from '@agentv/eval';
+
+function levenshteinDistance(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+
+  // Use two-row optimisation for memory efficiency
+  let prev: number[] = Array.from({ length: n + 1 }, (_, i) => i);
+  let curr: number[] = new Array<number>(n + 1).fill(0);
+
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      const del = (prev[j] ?? 0) + 1;
+      const ins = (curr[j - 1] ?? 0) + 1;
+      const sub = (prev[j - 1] ?? 0) + cost;
+      curr[j] = Math.min(del, ins, sub);
+    }
+    [prev, curr] = [curr, prev];
+  }
+
+  return prev[n] ?? 0;
+}
+
+export default defineCodeJudge(({ candidateAnswer, referenceAnswer, expectedMessages }) => {
+  const reference =
+    referenceAnswer ??
+    (expectedMessages[0] && typeof expectedMessages[0].content === 'string'
+      ? expectedMessages[0].content
+      : '');
+
+  if (!reference) {
+    return { score: 0, misses: ['No reference text provided'], reasoning: 'Missing reference.' };
+  }
+
+  const candNorm = candidateAnswer.trim().toLowerCase();
+  const refNorm = reference.trim().toLowerCase();
+
+  const distance = levenshteinDistance(candNorm, refNorm);
+  const maxLen = Math.max(candNorm.length, refNorm.length);
+  const score = maxLen === 0 ? 1 : 1 - distance / maxLen;
+
+  const hits: string[] = [];
+  const misses: string[] = [];
+
+  if (score >= 0.8) hits.push(`Edit similarity ${score.toFixed(3)} >= 0.8`);
+  else misses.push(`Edit similarity ${score.toFixed(3)} < 0.8`);
+
+  return {
+    score,
+    hits,
+    misses,
+    reasoning: `Levenshtein distance=${distance}, normalised similarity=${score.toFixed(3)}`,
+    details: { distance, maxLen, similarity: score },
+  };
+});

--- a/examples/nlp-metrics/judges/rouge.ts
+++ b/examples/nlp-metrics/judges/rouge.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env bun
+/**
+ * ROUGE-N Code Judge
+ *
+ * Computes ROUGE-1 and ROUGE-2 F1 scores between candidate and reference text.
+ * ROUGE (Recall-Oriented Understudy for Gisting Evaluation) measures n-gram
+ * overlap, commonly used for summarisation evaluation.
+ */
+import { defineCodeJudge } from '@agentv/eval';
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s]/g, '')
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function ngrams(tokens: string[], n: number): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (let i = 0; i <= tokens.length - n; i++) {
+    const gram = tokens.slice(i, i + n).join(' ');
+    counts.set(gram, (counts.get(gram) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function rougeN(candidate: string, reference: string, n: number) {
+  const candTokens = tokenize(candidate);
+  const refTokens = tokenize(reference);
+
+  const candGrams = ngrams(candTokens, n);
+  const refGrams = ngrams(refTokens, n);
+
+  let overlap = 0;
+  for (const [gram, count] of refGrams) {
+    overlap += Math.min(count, candGrams.get(gram) ?? 0);
+  }
+
+  const totalRef = Array.from(refGrams.values()).reduce((a, b) => a + b, 0);
+  const totalCand = Array.from(candGrams.values()).reduce((a, b) => a + b, 0);
+
+  const recall = totalRef === 0 ? 0 : overlap / totalRef;
+  const precision = totalCand === 0 ? 0 : overlap / totalCand;
+  const f1 = precision + recall === 0 ? 0 : (2 * precision * recall) / (precision + recall);
+
+  return { precision, recall, f1 };
+}
+
+export default defineCodeJudge(({ candidateAnswer, referenceAnswer, expectedMessages }) => {
+  const reference =
+    referenceAnswer ??
+    (expectedMessages[0] && typeof expectedMessages[0].content === 'string'
+      ? expectedMessages[0].content
+      : '');
+
+  if (!reference) {
+    return { score: 0, misses: ['No reference text provided'], reasoning: 'Missing reference.' };
+  }
+
+  const rouge1 = rougeN(candidateAnswer, reference, 1);
+  const rouge2 = rougeN(candidateAnswer, reference, 2);
+
+  const score = rouge1.f1;
+
+  const hits: string[] = [];
+  const misses: string[] = [];
+
+  if (rouge1.f1 >= 0.5) hits.push(`ROUGE-1 F1 ${rouge1.f1.toFixed(3)} >= 0.5`);
+  else misses.push(`ROUGE-1 F1 ${rouge1.f1.toFixed(3)} < 0.5`);
+
+  if (rouge2.f1 >= 0.3) hits.push(`ROUGE-2 F1 ${rouge2.f1.toFixed(3)} >= 0.3`);
+  else misses.push(`ROUGE-2 F1 ${rouge2.f1.toFixed(3)} < 0.3`);
+
+  return {
+    score,
+    hits,
+    misses,
+    reasoning: `ROUGE-1 F1=${rouge1.f1.toFixed(3)}, ROUGE-2 F1=${rouge2.f1.toFixed(3)}`,
+    details: { rouge1, rouge2 },
+  };
+});

--- a/examples/nlp-metrics/judges/similarity.ts
+++ b/examples/nlp-metrics/judges/similarity.ts
@@ -1,0 +1,91 @@
+#!/usr/bin/env bun
+/**
+ * Cosine Similarity Code Judge
+ *
+ * Computes cosine similarity between candidate and reference text using
+ * token-overlap (bag-of-words) vectors. This is a lightweight alternative to
+ * embedding-based similarity that requires no external dependencies.
+ */
+import { defineCodeJudge } from '@agentv/eval';
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s]/g, '')
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function termFrequency(tokens: string[]): Map<string, number> {
+  const tf = new Map<string, number>();
+  for (const t of tokens) {
+    tf.set(t, (tf.get(t) ?? 0) + 1);
+  }
+  return tf;
+}
+
+function cosineSimilarity(a: Map<string, number>, b: Map<string, number>): number {
+  let dotProduct = 0;
+  let normA = 0;
+  let normB = 0;
+
+  const allKeys = new Set([...a.keys(), ...b.keys()]);
+
+  for (const key of allKeys) {
+    const va = a.get(key) ?? 0;
+    const vb = b.get(key) ?? 0;
+    dotProduct += va * vb;
+    normA += va * va;
+    normB += vb * vb;
+  }
+
+  const denom = Math.sqrt(normA) * Math.sqrt(normB);
+  return denom === 0 ? 0 : dotProduct / denom;
+}
+
+function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+  const intersection = new Set([...a].filter((x) => b.has(x)));
+  const union = new Set([...a, ...b]);
+  return union.size === 0 ? 0 : intersection.size / union.size;
+}
+
+export default defineCodeJudge(({ candidateAnswer, referenceAnswer, expectedMessages }) => {
+  const reference =
+    referenceAnswer ??
+    (expectedMessages[0] && typeof expectedMessages[0].content === 'string'
+      ? expectedMessages[0].content
+      : '');
+
+  if (!reference) {
+    return { score: 0, misses: ['No reference text provided'], reasoning: 'Missing reference.' };
+  }
+
+  const candTokens = tokenize(candidateAnswer);
+  const refTokens = tokenize(reference);
+
+  const candTf = termFrequency(candTokens);
+  const refTf = termFrequency(refTokens);
+
+  const cosine = cosineSimilarity(candTf, refTf);
+  const jaccard = jaccardSimilarity(new Set(candTokens), new Set(refTokens));
+
+  // Use cosine as the primary score
+  const score = cosine;
+
+  const hits: string[] = [];
+  const misses: string[] = [];
+
+  if (cosine >= 0.7) hits.push(`Cosine similarity ${cosine.toFixed(3)} >= 0.7`);
+  else misses.push(`Cosine similarity ${cosine.toFixed(3)} < 0.7`);
+
+  if (jaccard >= 0.5) hits.push(`Jaccard similarity ${jaccard.toFixed(3)} >= 0.5`);
+  else misses.push(`Jaccard similarity ${jaccard.toFixed(3)} < 0.5`);
+
+  return {
+    score,
+    hits,
+    misses,
+    reasoning: `Cosine=${cosine.toFixed(3)}, Jaccard=${jaccard.toFixed(3)}`,
+    details: { cosine, jaccard },
+  };
+});


### PR DESCRIPTION
Adds ROUGE, BLEU, cosine similarity, and Levenshtein distance code judges — all from scratch with no external deps. 5 example test cases.

Closes #227
Orchestration tracked in agentevals-research#1