### PR TITLE
docs(examples): add trace-based evaluation examples (#231)

### DIFF
--- a/examples/trace-evaluation/README.md
+++ b/examples/trace-evaluation/README.md
@@ -1,0 +1,83 @@
+# Trace-Based Evaluation
+
+Demonstrates how to evaluate agent internals — LLM call counts, tool executions, errors, and step durations — using code judges that inspect `context.traceSummary`.
+
+## Judges
+
+| Judge | File | What it checks |
+|-------|------|----------------|
+| **Span Count** | `judges/span-count.ts` | Number of LLM calls and tool executions stay within limits |
+| **Error Spans** | `judges/error-spans.ts` | No errors in the trace; optionally checks for forbidden tool usage |
+| **Span Duration** | `judges/span-duration.ts` | No individual tool call exceeds a time threshold |
+
+## Available Trace Data
+
+Code judges receive `traceSummary` with these fields:
+
+```typescript
+interface TraceSummary {
+  eventCount: number;                        // Total tool call events
+  toolNames: string[];                       // Unique tool names used
+  toolCallsByName: Record<string, number>;   // Call count per tool
+  errorCount: number;                        // Number of errors
+  tokenUsage?: { input: number; output: number; cached?: number };
+  costUsd?: number;                          // Total cost in USD
+  durationMs?: number;                       // Total execution time
+  toolDurations?: Record<string, number[]>;  // Per-tool durations
+  llmCallCount?: number;                     // Number of LLM calls
+  startTime?: string;                        // ISO timestamp
+  endTime?: string;                          // ISO timestamp
+}
+```
+
+## Running
+
+```bash
+# From the repository root (dry-run mode for testing without a live agent)
+bun agentv run examples/trace-evaluation/evals/dataset.yaml --dry-run
+```
+
+## Patterns
+
+### Threshold validation
+Pass configurable limits via `config` in the YAML evaluator block:
+
+```yaml
+evaluators:
+  - name: span-count
+    type: code_judge
+    script: ["bun", "run", "../judges/span-count.ts"]
+    config:
+      maxLlmCalls: 5
+      maxToolCalls: 10
+```
+
+### Error detection
+Check for zero errors and block forbidden tools:
+
+```yaml
+evaluators:
+  - name: error-check
+    type: code_judge
+    script: ["bun", "run", "../judges/error-spans.ts"]
+    config:
+      maxErrors: 0
+      forbiddenTools:
+        - execute_code
+```
+
+### Duration limits
+Ensure no individual step or total execution exceeds time budgets:
+
+```yaml
+evaluators:
+  - name: duration-check
+    type: code_judge
+    script: ["bun", "run", "../judges/span-duration.ts"]
+    config:
+      maxSpanMs: 3000
+      maxTotalMs: 15000
+```
+
+### Combining judges
+Stack multiple trace judges on a single test for comprehensive checks — see the `comprehensive-trace-check` test in `evals/dataset.yaml`.

--- a/examples/trace-evaluation/evals/dataset.yaml
+++ b/examples/trace-evaluation/evals/dataset.yaml
@@ -1,0 +1,125 @@
+# Trace-Based Evaluation Examples
+#
+# Demonstrates how to evaluate agent internals (LLM calls, tool executions,
+# errors, and durations) using code judges that inspect traceSummary.
+#
+# Run with:
+#   bun agentv run examples/trace-evaluation/evals/dataset.yaml --dry-run
+
+description: Trace-based evaluation of agent internals using code judges
+
+tests:
+  # ==========================================
+  # Span Count - verify LLM/tool call counts
+  # ==========================================
+  - id: span-count-check
+    criteria: |-
+      Agent completes the task with a reasonable number of
+      LLM calls and tool executions.
+
+    input:
+      - role: user
+        content: Summarize the key points of this document.
+
+    execution:
+      evaluators:
+        - name: span-count
+          type: code_judge
+          script: ["bun", "run", "../judges/span-count.ts"]
+          config:
+            maxLlmCalls: 5
+            maxToolCalls: 10
+
+  # ==========================================
+  # Error Spans - detect errors in traces
+  # ==========================================
+  - id: error-free-execution
+    criteria: |-
+      Agent completes the task without any errors in the trace.
+
+    input:
+      - role: user
+        content: Look up the weather forecast for today.
+
+    execution:
+      evaluators:
+        - name: error-check
+          type: code_judge
+          script: ["bun", "run", "../judges/error-spans.ts"]
+          config:
+            maxErrors: 0
+
+  # ==========================================
+  # Error Spans with forbidden tools
+  # ==========================================
+  - id: no-forbidden-tools
+    criteria: |-
+      Agent completes the task without calling any forbidden tools
+      and without producing errors.
+
+    input:
+      - role: user
+        content: Answer the question using only approved data sources.
+
+    execution:
+      evaluators:
+        - name: error-and-tool-check
+          type: code_judge
+          script: ["bun", "run", "../judges/error-spans.ts"]
+          config:
+            maxErrors: 0
+            forbiddenTools:
+              - execute_code
+              - shell_command
+
+  # ==========================================
+  # Span Duration - no step exceeds threshold
+  # ==========================================
+  - id: duration-check
+    criteria: |-
+      No individual tool call exceeds the time threshold,
+      ensuring responsive agent behavior.
+
+    input:
+      - role: user
+        content: Retrieve and format the latest sales data.
+
+    execution:
+      evaluators:
+        - name: duration-check
+          type: code_judge
+          script: ["bun", "run", "../judges/span-duration.ts"]
+          config:
+            maxSpanMs: 3000
+            maxTotalMs: 15000
+
+  # ==========================================
+  # Combined - all trace checks together
+  # ==========================================
+  - id: comprehensive-trace-check
+    criteria: |-
+      Agent completes the task efficiently with no errors,
+      reasonable call counts, and fast execution.
+
+    input:
+      - role: user
+        content: Process this data and generate a summary report.
+
+    execution:
+      evaluators:
+        - name: span-count
+          type: code_judge
+          script: ["bun", "run", "../judges/span-count.ts"]
+          config:
+            maxLlmCalls: 8
+            maxToolCalls: 20
+
+        - name: error-check
+          type: code_judge
+          script: ["bun", "run", "../judges/error-spans.ts"]
+
+        - name: duration-check
+          type: code_judge
+          script: ["bun", "run", "../judges/span-duration.ts"]
+          config:
+            maxSpanMs: 5000

--- a/examples/trace-evaluation/judges/error-spans.ts
+++ b/examples/trace-evaluation/judges/error-spans.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env bun
+/**
+ * Error Spans Judge
+ *
+ * Detects errors in agent traces by inspecting traceSummary.errorCount
+ * and optionally checking for specific tool failures.
+ */
+import { defineCodeJudge } from '@agentv/eval';
+
+export default defineCodeJudge(({ traceSummary, config }) => {
+  if (!traceSummary) {
+    return {
+      score: 0,
+      misses: ['No traceSummary available'],
+      reasoning: 'Cannot detect errors without trace data',
+    };
+  }
+
+  const maxErrors = (config?.maxErrors as number) ?? 0;
+  const hits: string[] = [];
+  const misses: string[] = [];
+
+  // Check error count
+  if (traceSummary.errorCount <= maxErrors) {
+    hits.push(`Error count (${traceSummary.errorCount}) within limit (${maxErrors})`);
+  } else {
+    misses.push(`Too many errors: ${traceSummary.errorCount} (max: ${maxErrors})`);
+  }
+
+  // Check for tools that might indicate errors (if configured)
+  const forbiddenTools = (config?.forbiddenTools as string[]) ?? [];
+  for (const tool of forbiddenTools) {
+    const count = traceSummary.toolCallsByName[tool];
+    if (count !== undefined && count > 0) {
+      misses.push(`Forbidden tool "${tool}" was called ${count} time(s)`);
+    } else {
+      hits.push(`Forbidden tool "${tool}" was not called`);
+    }
+  }
+
+  const total = hits.length + misses.length;
+  const score = total > 0 ? hits.length / total : 1.0;
+
+  return {
+    score: Math.round(score * 100) / 100,
+    hits,
+    misses,
+    reasoning:
+      traceSummary.errorCount === 0
+        ? 'No errors detected in trace'
+        : `Found ${traceSummary.errorCount} error(s) in trace`,
+  };
+});

--- a/examples/trace-evaluation/judges/span-count.ts
+++ b/examples/trace-evaluation/judges/span-count.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env bun
+/**
+ * Span Count Judge
+ *
+ * Validates that the number of LLM calls and tool executions stays
+ * within configurable thresholds using traceSummary data.
+ */
+import { defineCodeJudge } from '@agentv/eval';
+
+const DEFAULTS = {
+  maxLlmCalls: 10,
+  maxToolCalls: 15,
+};
+
+export default defineCodeJudge(({ traceSummary, config }) => {
+  if (!traceSummary) {
+    return {
+      score: 0,
+      misses: ['No traceSummary available'],
+      reasoning: 'Cannot evaluate span counts without trace data',
+    };
+  }
+
+  const maxLlmCalls = (config?.maxLlmCalls as number) ?? DEFAULTS.maxLlmCalls;
+  const maxToolCalls = (config?.maxToolCalls as number) ?? DEFAULTS.maxToolCalls;
+
+  const hits: string[] = [];
+  const misses: string[] = [];
+
+  // Check LLM call count
+  if (traceSummary.llmCallCount !== undefined) {
+    if (traceSummary.llmCallCount <= maxLlmCalls) {
+      hits.push(`LLM calls (${traceSummary.llmCallCount}) within limit (${maxLlmCalls})`);
+    } else {
+      misses.push(`Too many LLM calls: ${traceSummary.llmCallCount} (max: ${maxLlmCalls})`);
+    }
+  }
+
+  // Check tool execution count
+  if (traceSummary.eventCount <= maxToolCalls) {
+    hits.push(`Tool calls (${traceSummary.eventCount}) within limit (${maxToolCalls})`);
+  } else {
+    misses.push(`Too many tool calls: ${traceSummary.eventCount} (max: ${maxToolCalls})`);
+  }
+
+  const total = hits.length + misses.length;
+  const score = total > 0 ? hits.length / total : 0.5;
+
+  return {
+    score: Math.round(score * 100) / 100,
+    hits,
+    misses,
+    reasoning: `Checked span counts: ${hits.length} passed, ${misses.length} failed`,
+  };
+});

--- a/examples/trace-evaluation/judges/span-duration.ts
+++ b/examples/trace-evaluation/judges/span-duration.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env bun
+/**
+ * Span Duration Judge
+ *
+ * Validates that no individual tool execution exceeds a time threshold
+ * using traceSummary.toolDurations data.
+ */
+import { defineCodeJudge } from '@agentv/eval';
+
+const DEFAULT_MAX_SPAN_MS = 5000;
+
+export default defineCodeJudge(({ traceSummary, config }) => {
+  if (!traceSummary) {
+    return {
+      score: 0,
+      misses: ['No traceSummary available'],
+      reasoning: 'Cannot evaluate durations without trace data',
+    };
+  }
+
+  const maxSpanMs = (config?.maxSpanMs as number) ?? DEFAULT_MAX_SPAN_MS;
+  const hits: string[] = [];
+  const misses: string[] = [];
+
+  // Check overall duration
+  if (traceSummary.durationMs !== undefined) {
+    const maxTotalMs = (config?.maxTotalMs as number) ?? maxSpanMs * 5;
+    if (traceSummary.durationMs <= maxTotalMs) {
+      hits.push(`Total duration (${traceSummary.durationMs}ms) within limit (${maxTotalMs}ms)`);
+    } else {
+      misses.push(`Total duration too long: ${traceSummary.durationMs}ms (max: ${maxTotalMs}ms)`);
+    }
+  }
+
+  // Check individual tool durations
+  if (traceSummary.toolDurations) {
+    for (const [tool, durations] of Object.entries(traceSummary.toolDurations)) {
+      for (const duration of durations) {
+        if (duration <= maxSpanMs) {
+          hits.push(`${tool} (${duration}ms) within limit`);
+        } else {
+          misses.push(`${tool} too slow: ${duration}ms (max: ${maxSpanMs}ms)`);
+        }
+      }
+    }
+  }
+
+  const total = hits.length + misses.length;
+  const score = total > 0 ? hits.length / total : 0.5;
+
+  return {
+    score: Math.round(score * 100) / 100,
+    hits: hits.slice(0, 5),
+    misses: misses.slice(0, 5),
+    reasoning: `Checked durations against ${maxSpanMs}ms threshold: ${hits.length} passed, ${misses.length} failed`,
+  };
+});

--- a/examples/trace-evaluation/package.json
+++ b/examples/trace-evaluation/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "agentv-example-trace-evaluation",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@agentv/eval": "file:../../packages/eval"
+  }
+}


### PR DESCRIPTION
Adds span-count, error-detection, and duration-threshold trace evaluation code judges. 5 example test cases.

Closes #231
Orchestration tracked in agentevals-research#1