### PR TITLE
feat(showcase): add evaluator conformance harness (#119)

### DIFF
--- a/examples/showcase/evaluator-conformance/EVAL.yaml
+++ b/examples/showcase/evaluator-conformance/EVAL.yaml
@@ -1,0 +1,31 @@
+# Evaluator Conformance Demo
+# Demonstrates using the keyword-judge evaluator in a standard AgentV eval.
+#
+# Run: cd examples/showcase/evaluator-conformance
+#      npx agentv run EVAL.yaml --dry-run
+#
+# The conformance harness validates this evaluator separately:
+#      bun run conformance-check.ts
+
+description: Keyword-matching evaluator used for conformance testing demo
+
+tests:
+  - id: exact-match
+    criteria: "Answer must name the capital city of France."
+    input: "What is the capital of France?"
+    expected_output: "Paris"
+    execution:
+      evaluators:
+        - name: keyword-judge
+          type: code_judge
+          script: ["bun", "run", "evaluators/keyword-judge.ts"]
+
+  - id: partial-match
+    criteria: "Answer must mention red, blue, and yellow."
+    input: "Name the primary colors."
+    expected_output: "red, blue, yellow"
+    execution:
+      evaluators:
+        - name: keyword-judge
+          type: code_judge
+          script: ["bun", "run", "evaluators/keyword-judge.ts"]

--- a/examples/showcase/evaluator-conformance/README.md
+++ b/examples/showcase/evaluator-conformance/README.md
@@ -1,0 +1,122 @@
+# Evaluator Conformance Harness
+
+A showcase demonstrating how to verify that an evaluator is **compatible** (produces valid output) and **consistent** (produces stable scores across repeated runs).
+
+## Problem
+
+LLM-based and heuristic evaluators can be non-deterministic. Before trusting an evaluator in CI, you need to know:
+
+1. **Compatibility** — Does the evaluator always return valid `{ score, hits, misses }` output?
+2. **Consistency** — Does it produce stable verdicts on unambiguous inputs?
+
+## How It Works
+
+The harness runs an evaluator N times against a labeled fixture dataset:
+
+| Label | Expectation |
+|-----------|---------------------------------------------|
+| `pass` | Must always score exactly `1.0` |
+| `fail` | Must always score exactly `0.0` |
+| `ambiguous`| Score may vary but must stay within `score_bounds` |
+
+It then computes per-fixture metrics:
+
+- **Flip rate** — fraction of runs where the verdict (pass/borderline/fail) differs from the first run
+- **Mean / Variance** — statistical summary of scores across runs
+- **Bound violations** — scores outside the expected range for ambiguous fixtures
+
+## Quick Start
+
+```bash
+cd examples/showcase/evaluator-conformance
+bun install
+bun run conformance-check.ts
+```
+
+## CLI Flags
+
+| Flag | Default | Description |
+|---------------------|-----------------|----------------------------------------------|
+| `--fixture <path>` | `fixtures.yaml` | Path to fixture dataset |
+| `--runs <N>` | `5` | Number of runs per fixture |
+| `--max-flip-rate <X>`| `0` | Max allowed flip-rate for unambiguous cases |
+| `--output <path>` | — | Write structured JSON results to file |
+
+## Example Output
+
+```
+  Evaluator Conformance Harness
+  evaluator:  bun run evaluators/keyword-judge.ts
+  fixtures:   9
+  runs/each:  5
+  max-flip:   0
+
+  ✓  [PASS     ] clear-pass-exact-match       mean=1.00  var=0.0000  flip=0.00
+  ✓  [PASS     ] clear-pass-contains-answer    mean=1.00  var=0.0000  flip=0.00
+  ✓  [PASS     ] clear-pass-multi-keyword      mean=1.00  var=0.0000  flip=0.00
+  ✓  [FAIL     ] clear-fail-wrong-answer       mean=0.00  var=0.0000  flip=0.00
+  ✓  [FAIL     ] clear-fail-irrelevant         mean=0.00  var=0.0000  flip=0.00
+  ✓  [FAIL     ] clear-fail-empty              mean=0.00  var=0.0000  flip=0.00
+  ✓  [AMBIGUOUS] ambiguous-partial-overlap      mean=0.33  var=0.0000  flip=0.00
+  ✓  [AMBIGUOUS] ambiguous-verbose-correct      mean=1.00  var=0.0000  flip=0.00
+  ✓  [AMBIGUOUS] ambiguous-near-miss            mean=0.00  var=0.0000  flip=0.00
+
+  ── Summary ──
+  Compatible:  ✓
+  Consistent:  ✓
+  Passed:      9/9
+  Failed:      0/9
+```
+
+## CI Integration
+
+Use the exit code for gating:
+
+```bash
+bun run conformance-check.ts --runs 10 --max-flip-rate 0 --output results.json
+```
+
+Exit code `0` = all fixtures pass. Exit code `1` = at least one failure.
+
+The `--output` flag writes a structured JSON report for programmatic consumption:
+
+```json
+{
+  "evaluator": ["bun", "run", "evaluators/keyword-judge.ts"],
+  "total_fixtures": 9,
+  "total_runs": 45,
+  "compatible": true,
+  "consistent": true,
+  "fixtures": [
+    {
+      "id": "clear-pass-exact-match",
+      "label": "pass",
+      "runs": 5,
+      "scores": [1, 1, 1, 1, 1],
+      "mean": 1,
+      "variance": 0,
+      "flip_rate": 0,
+      "compatible": true,
+      "consistent": true,
+      "errors": []
+    }
+  ]
+}
+```
+
+## Adapting for Your Evaluator
+
+1. Replace `evaluators/keyword-judge.ts` with your evaluator script
+2. Update `fixtures.yaml` with domain-specific test cases
+3. Set `score_bounds` on ambiguous fixtures based on acceptable variance
+4. Adjust `--max-flip-rate` for LLM-based evaluators (e.g., `0.1` allows 10% flip rate)
+
+## Files
+
+| File | Purpose |
+|--------------------------------|-----------------------------------------------|
+| `conformance-check.ts` | Harness script — runs evaluator, validates |
+| `fixtures.yaml` | Labeled fixture dataset |
+| `evaluators/keyword-judge.ts` | Sample deterministic evaluator under test |
+| `EVAL.yaml` | Standard AgentV eval using the same evaluator |
+| `package.json` | Dependencies |

--- a/examples/showcase/evaluator-conformance/bun.lock
+++ b/examples/showcase/evaluator-conformance/bun.lock
@@ -1,0 +1,20 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "agentv-example-evaluator-conformance",
+      "dependencies": {
+        "@agentv/eval": "file:../../../packages/eval",
+        "yaml": "^2.7.1",
+      },
+    },
+  },
+  "packages": {
+    "@agentv/eval": ["@agentv/eval@file:../../../packages/eval", { "dependencies": { "zod": "^3.23.8" } }],
+
+    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+  }
+}

--- a/examples/showcase/evaluator-conformance/conformance-check.ts
+++ b/examples/showcase/evaluator-conformance/conformance-check.ts
@@ -1,0 +1,352 @@
+#!/usr/bin/env bun
+/**
+ * Evaluator Conformance Harness
+ *
+ * Runs an evaluator N times per fixture and validates:
+ *   - Compatibility: output matches CodeJudgeResult schema (score, hits, misses)
+ *   - Consistency: flip-rate, agreement, and variance meet thresholds
+ *
+ * Usage:
+ *   bun run conformance-check.ts [options]
+ *
+ * Options:
+ *   --fixture <path>       Path to fixture YAML (default: fixtures.yaml)
+ *   --runs <N>             Runs per fixture (default: 5)
+ *   --max-flip-rate <X>    Max flip-rate for unambiguous fixtures (default: 0)
+ *   --output <path>        Write structured JSON results to file
+ */
+
+import { spawn } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+import { parse } from 'yaml';
+
+// ── Types ───────────────────────────────────────────────────────────────
+
+interface Fixture {
+  id: string;
+  label: 'pass' | 'fail' | 'ambiguous';
+  question: string;
+  criteria: string;
+  expected_output: string;
+  candidate_answer: string;
+  score_bounds?: [number, number];
+}
+
+interface FixtureFile {
+  evaluator: { script: string[] };
+  fixtures: Fixture[];
+}
+
+interface EvaluatorResult {
+  score: number;
+  hits?: string[];
+  misses?: string[];
+  reasoning?: string;
+}
+
+interface FixtureReport {
+  id: string;
+  label: string;
+  runs: number;
+  scores: number[];
+  mean: number;
+  variance: number;
+  flip_rate: number;
+  expected_score: number | null;
+  score_bounds: [number, number] | null;
+  compatible: boolean;
+  consistent: boolean;
+  errors: string[];
+}
+
+interface ConformanceReport {
+  evaluator: string[];
+  total_fixtures: number;
+  total_runs: number;
+  compatible: boolean;
+  consistent: boolean;
+  fixtures: FixtureReport[];
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────────
+
+const { values } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    fixture: { type: 'string', short: 'f', default: 'fixtures.yaml' },
+    runs: { type: 'string', short: 'n', default: '5' },
+    'max-flip-rate': { type: 'string', default: '0' },
+    output: { type: 'string', short: 'o' },
+  },
+});
+
+const fixturePath = resolve(values.fixture ?? 'fixtures.yaml');
+const runs = Number.parseInt(values.runs ?? '5', 10);
+const maxFlipRate = Number.parseFloat(values['max-flip-rate'] ?? '0');
+
+// ── Evaluator invocation ────────────────────────────────────────────────
+
+function buildCodeJudgeInput(fixture: Fixture): string {
+  // Build a minimal CodeJudgeInput in the snake_case wire format
+  return JSON.stringify({
+    question: fixture.question,
+    criteria: fixture.criteria,
+    candidate_answer: fixture.candidate_answer,
+    reference_answer: fixture.expected_output,
+    expected_messages: [],
+    input_messages: [{ role: 'user', content: fixture.question }],
+    output_messages: [{ role: 'assistant', content: fixture.candidate_answer }],
+    guideline_files: [],
+    input_files: [],
+  });
+}
+
+function runEvaluator(script: string[], input: string): Promise<EvaluatorResult> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(script[0], script.slice(1), {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: import.meta.dir,
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (d: Buffer) => {
+      stdout += d.toString();
+    });
+    proc.stderr.on('data', (d: Buffer) => {
+      stderr += d.toString();
+    });
+
+    proc.on('error', reject);
+    proc.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`Evaluator exited with code ${code}: ${stderr}`));
+        return;
+      }
+      try {
+        const result = JSON.parse(stdout);
+        resolve(result as EvaluatorResult);
+      } catch {
+        reject(new Error(`Invalid JSON output: ${stdout}`));
+      }
+    });
+
+    proc.stdin.write(input);
+    proc.stdin.end();
+  });
+}
+
+// ── Schema validation ───────────────────────────────────────────────────
+
+function validateResult(result: unknown): string[] {
+  const errors: string[] = [];
+  if (typeof result !== 'object' || result === null) {
+    errors.push('Result is not an object');
+    return errors;
+  }
+
+  const r = result as Record<string, unknown>;
+
+  if (typeof r.score !== 'number') {
+    errors.push('Missing or non-numeric "score"');
+  } else if (r.score < 0 || r.score > 1) {
+    errors.push(`Score ${r.score} out of range [0, 1]`);
+  }
+
+  if (r.hits !== undefined && !Array.isArray(r.hits)) {
+    errors.push('"hits" must be an array');
+  }
+  if (r.misses !== undefined && !Array.isArray(r.misses)) {
+    errors.push('"misses" must be an array');
+  }
+
+  return errors;
+}
+
+// ── Statistics ──────────────────────────────────────────────────────────
+
+function mean(values: number[]): number {
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+function variance(values: number[]): number {
+  const m = mean(values);
+  return values.reduce((sum, v) => sum + (v - m) ** 2, 0) / values.length;
+}
+
+function toVerdict(score: number): 'pass' | 'borderline' | 'fail' {
+  if (score >= 0.8) return 'pass';
+  if (score >= 0.6) return 'borderline';
+  return 'fail';
+}
+
+function flipRate(scores: number[]): number {
+  if (scores.length <= 1) return 0;
+  const verdicts = scores.map(toVerdict);
+  const primary = verdicts[0];
+  const flips = verdicts.filter((v) => v !== primary).length;
+  return flips / (verdicts.length - 1);
+}
+
+// ── Main ────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const raw = readFileSync(fixturePath, 'utf-8');
+  const data = parse(raw) as FixtureFile;
+
+  const { evaluator, fixtures } = data;
+  console.log('\n  Evaluator Conformance Harness');
+  console.log(`  evaluator:  ${evaluator.script.join(' ')}`);
+  console.log(`  fixtures:   ${fixtures.length}`);
+  console.log(`  runs/each:  ${runs}`);
+  console.log(`  max-flip:   ${maxFlipRate}\n`);
+
+  const reports: FixtureReport[] = [];
+  let allCompatible = true;
+  let allConsistent = true;
+
+  for (const fixture of fixtures) {
+    const input = buildCodeJudgeInput(fixture);
+    const scores: number[] = [];
+    const errors: string[] = [];
+    let compatible = true;
+
+    for (let i = 0; i < runs; i++) {
+      try {
+        const result = await runEvaluator(evaluator.script, input);
+        const schemaErrors = validateResult(result);
+        if (schemaErrors.length > 0) {
+          compatible = false;
+          for (const e of schemaErrors) errors.push(`Run ${i + 1}: ${e}`);
+        } else {
+          scores.push(result.score);
+        }
+      } catch (err) {
+        compatible = false;
+        errors.push(`Run ${i + 1}: ${(err as Error).message}`);
+      }
+    }
+
+    // Consistency checks
+    let consistent = true;
+    const expectedScore = fixture.label === 'pass' ? 1.0 : fixture.label === 'fail' ? 0.0 : null;
+    const bounds = fixture.label === 'ambiguous' ? (fixture.score_bounds ?? null) : null;
+
+    if (scores.length > 0) {
+      const fr = flipRate(scores);
+
+      if (fixture.label !== 'ambiguous' && fr > maxFlipRate) {
+        consistent = false;
+        errors.push(`Flip rate ${fr.toFixed(2)} exceeds max ${maxFlipRate}`);
+      }
+
+      if (expectedScore !== null) {
+        const allMatch = scores.every((s) => s === expectedScore);
+        if (!allMatch) {
+          consistent = false;
+          errors.push(
+            `Expected all scores to be ${expectedScore}, got [${scores.map((s) => s.toFixed(2)).join(', ')}]`,
+          );
+        }
+      }
+
+      if (bounds) {
+        const oob = scores.filter((s) => s < bounds[0] || s > bounds[1]);
+        if (oob.length > 0) {
+          consistent = false;
+          errors.push(
+            `${oob.length} score(s) outside bounds [${bounds[0]}, ${bounds[1]}]: [${oob.map((s) => s.toFixed(2)).join(', ')}]`,
+          );
+        }
+      }
+
+      const report: FixtureReport = {
+        id: fixture.id,
+        label: fixture.label,
+        runs: scores.length,
+        scores,
+        mean: mean(scores),
+        variance: variance(scores),
+        flip_rate: fr,
+        expected_score: expectedScore,
+        score_bounds: bounds,
+        compatible,
+        consistent,
+        errors,
+      };
+      reports.push(report);
+
+      // Print per-fixture result
+      const status = compatible && consistent ? '✓' : '✗';
+      const tag = fixture.label.toUpperCase().padEnd(9);
+      console.log(
+        `  ${status}  [${tag}] ${fixture.id}  mean=${report.mean.toFixed(2)}  var=${report.variance.toFixed(4)}  flip=${fr.toFixed(2)}`,
+      );
+      for (const e of errors) {
+        console.log(`              ↳ ${e}`);
+      }
+    } else {
+      compatible = false;
+      consistent = false;
+      reports.push({
+        id: fixture.id,
+        label: fixture.label,
+        runs: 0,
+        scores: [],
+        mean: 0,
+        variance: 0,
+        flip_rate: 0,
+        expected_score: expectedScore,
+        score_bounds: bounds,
+        compatible: false,
+        consistent: false,
+        errors,
+      });
+      console.log(`  ✗  [${fixture.label.toUpperCase().padEnd(9)}] ${fixture.id}  NO VALID RUNS`);
+      for (const e of errors) {
+        console.log(`              ↳ ${e}`);
+      }
+    }
+
+    if (!compatible) allCompatible = false;
+    if (!consistent) allConsistent = false;
+  }
+
+  // Summary
+  const passed = reports.filter((r) => r.compatible && r.consistent).length;
+  const failed = reports.length - passed;
+
+  console.log('\n  ── Summary ──');
+  console.log(`  Compatible:  ${allCompatible ? '✓' : '✗'}`);
+  console.log(`  Consistent:  ${allConsistent ? '✓' : '✗'}`);
+  console.log(`  Passed:      ${passed}/${reports.length}`);
+  console.log(`  Failed:      ${failed}/${reports.length}`);
+
+  // Write output
+  if (values.output) {
+    const output: ConformanceReport = {
+      evaluator: evaluator.script,
+      total_fixtures: fixtures.length,
+      total_runs: runs * fixtures.length,
+      compatible: allCompatible,
+      consistent: allConsistent,
+      fixtures: reports,
+    };
+    writeFileSync(values.output, JSON.stringify(output, null, 2));
+    console.log(`\n  Results written to ${values.output}`);
+  }
+
+  console.log('');
+
+  if (!allCompatible || !allConsistent) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/showcase/evaluator-conformance/evaluators/keyword-judge.ts
+++ b/examples/showcase/evaluator-conformance/evaluators/keyword-judge.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env bun
+/**
+ * Sample evaluator for conformance testing.
+ *
+ * Deterministic keyword-matching judge: checks whether expected keywords
+ * appear in the candidate answer. Produces stable scores for unambiguous
+ * cases and variable scores for partial matches.
+ */
+import { defineCodeJudge } from '@agentv/eval';
+
+export default defineCodeJudge(({ candidateAnswer, referenceAnswer, criteria }) => {
+  const candidate = (candidateAnswer ?? '').toLowerCase().trim();
+  const expected = (referenceAnswer ?? '').toLowerCase().trim();
+
+  if (!candidate) {
+    return {
+      score: 0,
+      hits: [],
+      misses: ['Empty candidate answer'],
+      reasoning: 'Candidate answer is empty.',
+    };
+  }
+
+  // Extract keywords from expected output (split on commas, spaces, punctuation)
+  const keywords = expected.split(/[\s,.:;!?]+/).filter((w) => w.length > 1);
+
+  if (keywords.length === 0) {
+    return {
+      score: 0.5,
+      hits: [],
+      misses: [],
+      reasoning: 'No keywords to match against.',
+    };
+  }
+
+  const hits: string[] = [];
+  const misses: string[] = [];
+
+  for (const kw of keywords) {
+    if (candidate.includes(kw)) {
+      hits.push(`Contains "${kw}"`);
+    } else {
+      misses.push(`Missing "${kw}"`);
+    }
+  }
+
+  const score = hits.length / keywords.length;
+
+  return {
+    score: Math.round(score * 100) / 100,
+    hits,
+    misses,
+    reasoning: `Matched ${hits.length}/${keywords.length} keywords from expected output. Criteria: ${criteria}`,
+  };
+});

--- a/examples/showcase/evaluator-conformance/fixtures.yaml
+++ b/examples/showcase/evaluator-conformance/fixtures.yaml
@@ -1,0 +1,84 @@
+# Evaluator Conformance Fixture Dataset
+#
+# Each fixture has a label indicating the expected evaluator behavior:
+#   - pass:      Unambiguous pass — evaluator must always score 1.0
+#   - fail:      Unambiguous fail — evaluator must always score 0.0
+#   - ambiguous: Allowed to vary within score_bounds
+#
+# The evaluator under test receives: question, criteria, candidate_answer, expected_output
+
+evaluator:
+  script: ["bun", "run", "evaluators/keyword-judge.ts"]
+
+fixtures:
+  # ── Unambiguous Pass Cases ─────────────────────────────────────────────
+
+  - id: clear-pass-exact-match
+    label: pass
+    question: "What is the capital of France?"
+    criteria: "Answer must name the capital city of France."
+    expected_output: "Paris"
+    candidate_answer: "Paris"
+
+  - id: clear-pass-contains-answer
+    label: pass
+    question: "What is 7 * 8?"
+    criteria: "Answer must contain the correct numerical result."
+    expected_output: "56"
+    candidate_answer: "The answer is 56."
+
+  - id: clear-pass-multi-keyword
+    label: pass
+    question: "Name the primary colors."
+    criteria: "Answer must mention red, blue, and yellow."
+    expected_output: "red, blue, yellow"
+    candidate_answer: "The primary colors are red, blue, and yellow."
+
+  # ── Unambiguous Fail Cases ─────────────────────────────────────────────
+
+  - id: clear-fail-wrong-answer
+    label: fail
+    question: "What is the capital of France?"
+    criteria: "Answer must name the capital city of France."
+    expected_output: "Paris"
+    candidate_answer: "London"
+
+  - id: clear-fail-irrelevant
+    label: fail
+    question: "What is 7 * 8?"
+    criteria: "Answer must contain the correct numerical result."
+    expected_output: "56"
+    candidate_answer: "I like pizza."
+
+  - id: clear-fail-empty
+    label: fail
+    question: "Name the primary colors."
+    criteria: "Answer must mention red, blue, and yellow."
+    expected_output: "red, blue, yellow"
+    candidate_answer: ""
+
+  # ── Ambiguous Cases ────────────────────────────────────────────────────
+
+  - id: ambiguous-partial-overlap
+    label: ambiguous
+    score_bounds: [0.2, 0.8]
+    question: "Name the primary colors."
+    criteria: "Answer must mention red, blue, and yellow."
+    expected_output: "red, blue, yellow"
+    candidate_answer: "Red and green are colors."
+
+  - id: ambiguous-verbose-correct
+    label: ambiguous
+    score_bounds: [0.4, 1.0]
+    question: "What is the capital of France?"
+    criteria: "Answer must name the capital city of France."
+    expected_output: "Paris"
+    candidate_answer: "France is a country in Europe. Its capital city is Paris, which is known for the Eiffel Tower."
+
+  - id: ambiguous-near-miss
+    label: ambiguous
+    score_bounds: [0.0, 0.6]
+    question: "What is 7 * 8?"
+    criteria: "Answer must contain the correct numerical result."
+    expected_output: "56"
+    candidate_answer: "The answer is approximately 55."

--- a/examples/showcase/evaluator-conformance/package.json
+++ b/examples/showcase/evaluator-conformance/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "agentv-example-evaluator-conformance",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@agentv/eval": "file:../../../packages/eval",
+    "yaml": "^2.7.1"
+  }
+}


### PR DESCRIPTION
Closes #119

Adds evaluator conformance harness showcase:
- Fixture dataset with labeled pass/fail/ambiguous cases
- conformance-check.ts wrapper with --runs, --max-flip-rate, --output flags
- Schema compatibility and consistency validation
- CI gating (exit 0/1) with structured output