### PR TITLE
feat(eval): add matrix evaluation — evaluate multiple targets (#179)

### DIFF
--- a/apps/cli/src/commands/eval/commands/run.ts
+++ b/apps/cli/src/commands/eval/commands/run.ts
@@ -22,11 +22,10 @@ export const evalRunCommand = command({
       displayName: 'eval-paths',
       description: 'Path(s) or glob(s) to evaluation .yaml file(s)',
     }),
-    target: option({
-      type: string,
+    target: multioption({
+      type: array(string),
       long: 'target',
-      description: 'Override target name from targets.yaml',
-      defaultValue: () => 'default',
+      description: 'Override target name(s) from targets.yaml (repeatable for matrix evaluation)',
     }),
     targets: option({
       type: optional(string),

--- a/apps/cli/test/unit/matrix-summary.test.ts
+++ b/apps/cli/test/unit/matrix-summary.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { EvaluationResult } from '@agentv/core';
+import { formatMatrixSummary } from '../../src/commands/eval/statistics.js';
+
+function makeResult(testId: string, target: string, score: number): EvaluationResult {
+  return {
+    timestamp: new Date().toISOString(),
+    testId,
+    score,
+    hits: [],
+    misses: [],
+    candidateAnswer: '',
+    target,
+  };
+}
+
+describe('formatMatrixSummary', () => {
+  it('returns empty string for single target', () => {
+    const results = [makeResult('test-1', 'copilot', 0.8)];
+    expect(formatMatrixSummary(results)).toBe('');
+  });
+
+  it('formats matrix table for multiple targets', () => {
+    const results = [
+      makeResult('test-1', 'copilot', 0.9),
+      makeResult('test-1', 'claude', 0.7),
+      makeResult('test-2', 'copilot', 0.6),
+      makeResult('test-2', 'claude', 0.8),
+    ];
+    const output = formatMatrixSummary(results);
+    expect(output).toContain('MATRIX RESULTS');
+    expect(output).toContain('copilot');
+    expect(output).toContain('claude');
+    expect(output).toContain('test-1');
+    expect(output).toContain('test-2');
+    expect(output).toContain('Average');
+    expect(output).toContain('0.900');
+    expect(output).toContain('0.700');
+  });
+
+  it('handles missing test-target pairs with dash', () => {
+    const results = [makeResult('test-1', 'copilot', 0.9), makeResult('test-2', 'claude', 0.8)];
+    const output = formatMatrixSummary(results);
+    expect(output).toContain('-');
+  });
+});

--- a/examples/features/matrix-evaluation/evals/dataset.yaml
+++ b/examples/features/matrix-evaluation/evals/dataset.yaml
@@ -1,0 +1,31 @@
+# Matrix Evaluation Example
+#
+# Runs tests against multiple targets and displays
+# a cross-target comparison matrix.
+#
+# Usage:
+#   agentv run examples/features/matrix-evaluation/evals/dataset.yaml
+#
+# Or with CLI override:
+#   agentv run examples/features/matrix-evaluation/evals/dataset.yaml --target copilot --target claude
+
+execution:
+  targets:
+    - copilot
+    - claude
+
+tests:
+  - id: general-greeting
+    input: "Say hello"
+    criteria: "The response should contain a greeting"
+
+  - id: copilot-only-task
+    input: "Create a GitHub issue"
+    criteria: "The response should reference GitHub"
+    execution:
+      targets:
+        - copilot
+
+  - id: code-generation
+    input: "Write a fibonacci function in Python"
+    criteria: "The response should contain a valid Python function"

--- a/packages/core/src/evaluation/loaders/config-loader.ts
+++ b/packages/core/src/evaluation/loaders/config-loader.ts
@@ -119,6 +119,44 @@ export function extractTargetFromSuite(suite: JsonObject): string | undefined {
   return undefined;
 }
 
+/**
+ * Extract targets array from parsed eval suite.
+ * Precedence: execution.targets (array) > execution.target (singular).
+ * Returns undefined when no targets array is specified.
+ */
+export function extractTargetsFromSuite(suite: JsonObject): readonly string[] | undefined {
+  const execution = suite.execution;
+  if (!execution || typeof execution !== 'object' || Array.isArray(execution)) {
+    return undefined;
+  }
+
+  const targets = (execution as Record<string, unknown>).targets;
+  if (Array.isArray(targets)) {
+    const valid = targets.filter((t): t is string => typeof t === 'string' && t.trim().length > 0);
+    return valid.length > 0 ? valid.map((t) => t.trim()) : undefined;
+  }
+
+  return undefined;
+}
+
+/**
+ * Extract per-test targets array from a raw test case object.
+ */
+export function extractTargetsFromTestCase(testCase: JsonObject): readonly string[] | undefined {
+  const execution = testCase.execution;
+  if (!execution || typeof execution !== 'object' || Array.isArray(execution)) {
+    return undefined;
+  }
+
+  const targets = (execution as Record<string, unknown>).targets;
+  if (Array.isArray(targets)) {
+    const valid = targets.filter((t): t is string => typeof t === 'string' && t.trim().length > 0);
+    return valid.length > 0 ? valid.map((t) => t.trim()) : undefined;
+  }
+
+  return undefined;
+}
+
 const VALID_TRIAL_STRATEGIES: ReadonlySet<string> = new Set([
   'pass_at_k',
   'mean',

--- a/packages/core/src/evaluation/types.ts
+++ b/packages/core/src/evaluation/types.ts
@@ -480,6 +480,8 @@ export interface EvalTest {
   readonly workspace?: WorkspaceConfig;
   /** Arbitrary metadata passed to workspace scripts via stdin */
   readonly metadata?: Record<string, unknown>;
+  /** Per-test target override (matrix evaluation) */
+  readonly targets?: readonly string[];
 }
 
 /** @deprecated Use `EvalTest` instead */

--- a/packages/core/test/evaluation/loaders/config-loader.test.ts
+++ b/packages/core/test/evaluation/loaders/config-loader.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'bun:test';
 
 import {
   extractTargetFromSuite,
+  extractTargetsFromSuite,
+  extractTargetsFromTestCase,
   extractTrialsConfig,
 } from '../../../src/evaluation/loaders/config-loader.js';
 import type { JsonObject } from '../../../src/evaluation/types.js';
@@ -150,5 +152,75 @@ describe('extractTargetFromSuite', () => {
   it('returns undefined when no target specified', () => {
     const suite: JsonObject = { tests: [] };
     expect(extractTargetFromSuite(suite)).toBeUndefined();
+  });
+});
+
+describe('extractTargetsFromSuite', () => {
+  it('returns undefined when no execution block', () => {
+    const suite: JsonObject = { tests: [] };
+    expect(extractTargetsFromSuite(suite)).toBeUndefined();
+  });
+
+  it('returns undefined when no targets array in execution', () => {
+    const suite: JsonObject = { execution: { target: 'default' } };
+    expect(extractTargetsFromSuite(suite)).toBeUndefined();
+  });
+
+  it('extracts targets array from execution.targets', () => {
+    const suite: JsonObject = {
+      execution: { targets: ['copilot', 'claude'] },
+    };
+    expect(extractTargetsFromSuite(suite)).toEqual(['copilot', 'claude']);
+  });
+
+  it('filters out non-string entries', () => {
+    const suite: JsonObject = {
+      execution: { targets: ['copilot', 123, null, 'claude'] },
+    };
+    expect(extractTargetsFromSuite(suite)).toEqual(['copilot', 'claude']);
+  });
+
+  it('returns undefined for empty targets array', () => {
+    const suite: JsonObject = {
+      execution: { targets: [] },
+    };
+    expect(extractTargetsFromSuite(suite)).toBeUndefined();
+  });
+
+  it('trims whitespace from target names', () => {
+    const suite: JsonObject = {
+      execution: { targets: ['  copilot  ', 'claude  '] },
+    };
+    expect(extractTargetsFromSuite(suite)).toEqual(['copilot', 'claude']);
+  });
+
+  it('returns undefined when targets is not an array', () => {
+    const suite: JsonObject = {
+      execution: { targets: 'copilot' },
+    };
+    expect(extractTargetsFromSuite(suite)).toBeUndefined();
+  });
+});
+
+describe('extractTargetsFromTestCase', () => {
+  it('returns undefined when no execution block', () => {
+    const testCase: JsonObject = { id: 'test-1' };
+    expect(extractTargetsFromTestCase(testCase)).toBeUndefined();
+  });
+
+  it('extracts targets from test case execution.targets', () => {
+    const testCase: JsonObject = {
+      id: 'test-1',
+      execution: { targets: ['copilot'] },
+    };
+    expect(extractTargetsFromTestCase(testCase)).toEqual(['copilot']);
+  });
+
+  it('returns undefined when targets is empty', () => {
+    const testCase: JsonObject = {
+      id: 'test-1',
+      execution: { targets: [] },
+    };
+    expect(extractTargetsFromTestCase(testCase)).toBeUndefined();
   });
 });

--- a/packages/core/test/evaluation/matrix-targets.test.ts
+++ b/packages/core/test/evaluation/matrix-targets.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { loadTestSuite } from '../../src/evaluation/yaml-parser.js';
+
+function createTempYaml(content: string): { filePath: string; dir: string } {
+  const dir = mkdtempSync(path.join(tmpdir(), 'matrix-test-'));
+  const filePath = path.join(dir, 'dataset.yaml');
+  writeFileSync(filePath, content);
+  return { filePath, dir };
+}
+
+describe('matrix evaluation - loadTestSuite', () => {
+  it('extracts suite-level targets from execution.targets', async () => {
+    const { filePath, dir } = createTempYaml(`
+execution:
+  targets:
+    - copilot
+    - claude
+tests:
+  - id: test-1
+    input: "Hello"
+    criteria: "Greet"
+`);
+
+    const suite = await loadTestSuite(filePath, dir);
+    expect(suite.targets).toEqual(['copilot', 'claude']);
+  });
+
+  it('returns undefined targets when not specified', async () => {
+    const { filePath, dir } = createTempYaml(`
+execution:
+  target: copilot
+tests:
+  - id: test-1
+    input: "Hello"
+    criteria: "Greet"
+`);
+
+    const suite = await loadTestSuite(filePath, dir);
+    expect(suite.targets).toBeUndefined();
+  });
+
+  it('populates per-test targets from test-level execution.targets', async () => {
+    const { filePath, dir } = createTempYaml(`
+execution:
+  targets:
+    - copilot
+    - claude
+tests:
+  - id: general-test
+    input: "Hello"
+    criteria: "Greet"
+  - id: copilot-only
+    input: "GitHub task"
+    criteria: "Reference GitHub"
+    execution:
+      targets:
+        - copilot
+`);
+
+    const suite = await loadTestSuite(filePath, dir);
+    expect(suite.targets).toEqual(['copilot', 'claude']);
+    expect(suite.tests.length).toBe(2);
+
+    const generalTest = suite.tests.find((t) => t.id === 'general-test');
+    expect(generalTest?.targets).toBeUndefined();
+
+    const copilotOnly = suite.tests.find((t) => t.id === 'copilot-only');
+    expect(copilotOnly?.targets).toEqual(['copilot']);
+  });
+});


### PR DESCRIPTION
Closes #179

## Summary
Adds matrix evaluation: run every test against multiple targets, producing a targets × tests comparison matrix.

### Changes
- **YAML**: `execution.targets` array at root + per-test level with precedence rules
- **CLI**: `--target` accepts multiple values (additive, backward compatible)
- **Runner**: Loops over targets × tests, each result tagged with target name
- **Output**: Matrix summary table when multiple targets detected
- **16 new tests** covering config extraction, YAML parsing, and display formatting
- **Example** in `examples/features/matrix-evaluation/`

### Precedence
1. CLI `--target` flags override YAML
2. Per-test `execution.targets` overrides root
3. Root `execution.targets` (array) > `execution.target` (string)
4. Fallback: `'default'`