### PR TITLE
feat(core): add LLM response caching with --no-cache flag (#234)

### DIFF
--- a/apps/cli/src/commands/eval/commands/run.ts
+++ b/apps/cli/src/commands/eval/commands/run.ts
@@ -99,7 +99,11 @@ export const evalRunCommand = command({
     }),
     cache: flag({
       long: 'cache',
-      description: 'Enable in-memory provider response cache',
+      description: 'Enable provider response cache (persisted to disk)',
+    }),
+    noCache: flag({
+      long: 'no-cache',
+      description: 'Disable caching (overrides YAML execution.cache)',
     }),
     verbose: flag({
       long: 'verbose',
@@ -143,6 +147,7 @@ export const evalRunCommand = command({
       agentTimeout: args.agentTimeout,
       maxRetries: args.maxRetries,
       cache: args.cache,
+      noCache: args.noCache,
       verbose: args.verbose,
       keepWorkspaces: args.keepWorkspaces,
       cleanupWorkspaces: args.cleanupWorkspaces,

--- a/packages/core/src/evaluation/cache/response-cache.ts
+++ b/packages/core/src/evaluation/cache/response-cache.ts
@@ -1,0 +1,72 @@
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { EvaluationCache } from '../orchestrator.js';
+import type { ProviderResponse } from '../providers/types.js';
+
+const DEFAULT_CACHE_PATH = '.agentv/cache';
+
+/**
+ * File-based LLM response cache.
+ * Stores provider responses as JSON files keyed by SHA-256 hash.
+ * Directory structure: <cache_path>/<first-2-chars>/<full-hash>.json
+ */
+export class ResponseCache implements EvaluationCache {
+  private readonly cachePath: string;
+
+  constructor(cachePath?: string) {
+    this.cachePath = cachePath ?? DEFAULT_CACHE_PATH;
+  }
+
+  async get(key: string): Promise<ProviderResponse | undefined> {
+    const filePath = this.keyToPath(key);
+    try {
+      const data = await readFile(filePath, 'utf8');
+      return JSON.parse(data) as ProviderResponse;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async set(key: string, value: ProviderResponse): Promise<void> {
+    const filePath = this.keyToPath(key);
+    const dir = path.dirname(filePath);
+    await mkdir(dir, { recursive: true });
+    await writeFile(filePath, JSON.stringify(value, null, 2), 'utf8');
+  }
+
+  private keyToPath(key: string): string {
+    const prefix = key.slice(0, 2);
+    return path.join(this.cachePath, prefix, `${key}.json`);
+  }
+}
+
+/**
+ * Determine whether caching should be active for a given run.
+ *
+ * Precedence:
+ *   1. --no-cache CLI flag → always disabled
+ *   2. --cache CLI flag OR execution.cache YAML → enabled
+ *   3. Default → disabled (safe for variability testing)
+ */
+export function shouldEnableCache(params: {
+  cliCache: boolean;
+  cliNoCache: boolean;
+  yamlCache?: boolean;
+}): boolean {
+  if (params.cliNoCache) return false;
+  return params.cliCache || params.yamlCache === true;
+}
+
+/**
+ * Check whether caching should be skipped for a target with temperature > 0.
+ * Non-deterministic responses should not be cached unless explicitly forced.
+ */
+export function shouldSkipCacheForTemperature(targetConfig: Record<string, unknown>): boolean {
+  const temp = targetConfig.temperature;
+  if (typeof temp === 'number' && temp > 0) {
+    return true;
+  }
+  return false;
+}

--- a/packages/core/src/evaluation/loaders/config-loader.ts
+++ b/packages/core/src/evaluation/loaders/config-loader.ts
@@ -225,6 +225,43 @@ export function extractTrialsConfig(suite: JsonObject): TrialsConfig | undefined
   return { count, strategy, costLimitUsd };
 }
 
+/**
+ * Cache configuration parsed from execution block.
+ */
+export interface CacheConfig {
+  readonly enabled: boolean;
+  readonly cachePath?: string;
+}
+
+/**
+ * Extract cache configuration from parsed eval suite's execution block.
+ * Returns undefined when no cache config is specified.
+ */
+export function extractCacheConfig(suite: JsonObject): CacheConfig | undefined {
+  const execution = suite.execution;
+  if (!execution || typeof execution !== 'object' || Array.isArray(execution)) {
+    return undefined;
+  }
+
+  const executionObj = execution as Record<string, unknown>;
+  const cache = executionObj.cache;
+
+  if (cache === undefined || cache === null) {
+    return undefined;
+  }
+
+  if (typeof cache !== 'boolean') {
+    logWarning(`Invalid execution.cache: ${cache}. Must be a boolean. Ignoring.`);
+    return undefined;
+  }
+
+  const cachePath = executionObj.cache_path ?? executionObj.cachePath;
+  const resolvedCachePath =
+    typeof cachePath === 'string' && cachePath.trim().length > 0 ? cachePath.trim() : undefined;
+
+  return { enabled: cache, cachePath: resolvedCachePath };
+}
+
 function logWarning(message: string): void {
   console.warn(`${ANSI_YELLOW}Warning: ${message}${ANSI_RESET}`);
 }

--- a/packages/core/src/evaluation/yaml-parser.ts
+++ b/packages/core/src/evaluation/yaml-parser.ts
@@ -5,6 +5,7 @@ import { parse } from 'yaml';
 
 import { expandFileReferences } from './loaders/case-file-loader.js';
 import {
+  extractCacheConfig,
   extractTargetFromSuite,
   extractTargetsFromSuite,
   extractTargetsFromTestCase,
@@ -35,6 +36,7 @@ import { isJsonObject, isTestMessage } from './types.js';
 export { buildPromptInputs, type PromptInputs } from './formatting/prompt-builder.js';
 export {
   DEFAULT_EVAL_PATTERNS,
+  extractCacheConfig,
   extractTargetFromSuite,
   extractTargetsFromSuite,
   extractTargetsFromTestCase,
@@ -42,7 +44,7 @@ export {
   isGuidelineFile,
   loadConfig,
 } from './loaders/config-loader.js';
-export type { AgentVConfig } from './loaders/config-loader.js';
+export type { AgentVConfig, CacheConfig } from './loaders/config-loader.js';
 export { detectFormat } from './loaders/jsonl-parser.js';
 
 const ANSI_YELLOW = '\u001b[33m';
@@ -133,6 +135,8 @@ export type EvalSuiteResult = {
   readonly trials?: TrialsConfig;
   /** Suite-level targets from execution.targets (matrix evaluation) */
   readonly targets?: readonly string[];
+  /** Suite-level cache config from execution.cache */
+  readonly cacheConfig?: import('./loaders/config-loader.js').CacheConfig;
 };
 
 /**
@@ -149,7 +153,12 @@ export async function loadTestSuite(
     return { tests: await loadTestsFromJsonl(evalFilePath, repoRoot, options) };
   }
   const { tests, parsed } = await loadTestsFromYaml(evalFilePath, repoRoot, options);
-  return { tests, trials: extractTrialsConfig(parsed), targets: extractTargetsFromSuite(parsed) };
+  return {
+    tests,
+    trials: extractTrialsConfig(parsed),
+    targets: extractTargetsFromSuite(parsed),
+    cacheConfig: extractCacheConfig(parsed),
+  };
 }
 
 /** @deprecated Use `loadTestSuite` instead */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,11 @@ export * from './evaluation/evaluators.js';
 export * from './evaluation/orchestrator.js';
 export * from './evaluation/generators/index.js';
 export * from './evaluation/workspace/index.js';
+export {
+  ResponseCache,
+  shouldEnableCache,
+  shouldSkipCacheForTemperature,
+} from './evaluation/cache/response-cache.js';
 export { toSnakeCaseDeep, toCamelCaseDeep } from './evaluation/case-conversion.js';
 export { trimBaselineResult } from './evaluation/baseline.js';
 

--- a/packages/core/test/evaluation/cache-config.test.ts
+++ b/packages/core/test/evaluation/cache-config.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'bun:test';
+
+import { extractCacheConfig } from '../../src/evaluation/loaders/config-loader.js';
+import type { JsonObject } from '../../src/evaluation/types.js';
+
+describe('extractCacheConfig', () => {
+  it('should return undefined when no execution block', () => {
+    const suite: JsonObject = { tests: [] };
+    expect(extractCacheConfig(suite)).toBeUndefined();
+  });
+
+  it('should return undefined when no cache field', () => {
+    const suite: JsonObject = { execution: { target: 'default' } };
+    expect(extractCacheConfig(suite)).toBeUndefined();
+  });
+
+  it('should parse cache: true', () => {
+    const suite: JsonObject = { execution: { cache: true } };
+    const result = extractCacheConfig(suite);
+    expect(result).toEqual({ enabled: true, cachePath: undefined });
+  });
+
+  it('should parse cache: false', () => {
+    const suite: JsonObject = { execution: { cache: false } };
+    const result = extractCacheConfig(suite);
+    expect(result).toEqual({ enabled: false, cachePath: undefined });
+  });
+
+  it('should parse cache_path', () => {
+    const suite: JsonObject = { execution: { cache: true, cache_path: '.agentv/my-cache' } };
+    const result = extractCacheConfig(suite);
+    expect(result).toEqual({ enabled: true, cachePath: '.agentv/my-cache' });
+  });
+
+  it('should accept camelCase cachePath', () => {
+    const suite: JsonObject = { execution: { cache: true, cachePath: 'custom/cache' } };
+    const result = extractCacheConfig(suite);
+    expect(result).toEqual({ enabled: true, cachePath: 'custom/cache' });
+  });
+
+  it('should return undefined for invalid cache value', () => {
+    const suite: JsonObject = { execution: { cache: 'yes' } };
+    expect(extractCacheConfig(suite)).toBeUndefined();
+  });
+});

--- a/packages/core/test/evaluation/response-cache.test.ts
+++ b/packages/core/test/evaluation/response-cache.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'bun:test';
+import { existsSync, mkdtempSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  ResponseCache,
+  shouldEnableCache,
+  shouldSkipCacheForTemperature,
+} from '../../src/evaluation/cache/response-cache.js';
+import type { ProviderResponse } from '../../src/evaluation/providers/types.js';
+
+describe('ResponseCache', () => {
+  function makeTempDir(): string {
+    return mkdtempSync(path.join(tmpdir(), 'agentv-cache-test-'));
+  }
+
+  const sampleResponse: ProviderResponse = {
+    raw: { text: 'Hello world' },
+    outputMessages: [{ role: 'assistant', content: 'Hello world' }],
+  };
+
+  it('should store and retrieve cached responses', async () => {
+    const cacheDir = makeTempDir();
+    const cache = new ResponseCache(cacheDir);
+    const key = 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+
+    await cache.set(key, sampleResponse);
+    const result = await cache.get(key);
+
+    expect(result).toEqual(sampleResponse);
+  });
+
+  it('should return undefined for cache miss', async () => {
+    const cacheDir = makeTempDir();
+    const cache = new ResponseCache(cacheDir);
+
+    const result = await cache.get('nonexistent');
+    expect(result).toBeUndefined();
+  });
+
+  it('should use directory structure with first 2 chars as prefix', async () => {
+    const cacheDir = makeTempDir();
+    const cache = new ResponseCache(cacheDir);
+    const key = 'ab12345678';
+
+    await cache.set(key, sampleResponse);
+
+    // Verify directory structure: <cache_path>/ab/ab12345678.json
+    const prefixDir = path.join(cacheDir, 'ab');
+    expect(existsSync(prefixDir)).toBe(true);
+    expect(existsSync(path.join(prefixDir, `${key}.json`))).toBe(true);
+  });
+
+  it('should return different results for different keys', async () => {
+    const cacheDir = makeTempDir();
+    const cache = new ResponseCache(cacheDir);
+
+    const response1: ProviderResponse = { raw: { text: 'Response 1' } };
+    const response2: ProviderResponse = { raw: { text: 'Response 2' } };
+
+    await cache.set('key1', response1);
+    await cache.set('key2', response2);
+
+    expect(await cache.get('key1')).toEqual(response1);
+    expect(await cache.get('key2')).toEqual(response2);
+  });
+
+  it('should overwrite existing cache entry', async () => {
+    const cacheDir = makeTempDir();
+    const cache = new ResponseCache(cacheDir);
+
+    const original: ProviderResponse = { raw: { text: 'Original' } };
+    const updated: ProviderResponse = { raw: { text: 'Updated' } };
+
+    await cache.set('key1', original);
+    await cache.set('key1', updated);
+
+    expect(await cache.get('key1')).toEqual(updated);
+  });
+});
+
+describe('shouldEnableCache', () => {
+  it('should default to disabled (no cache)', () => {
+    expect(shouldEnableCache({ cliCache: false, cliNoCache: false })).toBe(false);
+  });
+
+  it('should enable when --cache CLI flag is set', () => {
+    expect(shouldEnableCache({ cliCache: true, cliNoCache: false })).toBe(true);
+  });
+
+  it('should enable when YAML execution.cache is true', () => {
+    expect(shouldEnableCache({ cliCache: false, cliNoCache: false, yamlCache: true })).toBe(true);
+  });
+
+  it('should disable when --no-cache overrides --cache', () => {
+    expect(shouldEnableCache({ cliCache: true, cliNoCache: true })).toBe(false);
+  });
+
+  it('should disable when --no-cache overrides YAML cache: true', () => {
+    expect(shouldEnableCache({ cliCache: false, cliNoCache: true, yamlCache: true })).toBe(false);
+  });
+
+  it('should disable when YAML cache is false', () => {
+    expect(shouldEnableCache({ cliCache: false, cliNoCache: false, yamlCache: false })).toBe(false);
+  });
+});
+
+describe('shouldSkipCacheForTemperature', () => {
+  it('should skip cache when temperature > 0', () => {
+    expect(shouldSkipCacheForTemperature({ temperature: 0.5 })).toBe(true);
+    expect(shouldSkipCacheForTemperature({ temperature: 1.0 })).toBe(true);
+  });
+
+  it('should not skip when temperature is 0', () => {
+    expect(shouldSkipCacheForTemperature({ temperature: 0 })).toBe(false);
+  });
+
+  it('should not skip when temperature is not set', () => {
+    expect(shouldSkipCacheForTemperature({})).toBe(false);
+  });
+
+  it('should not skip when temperature is not a number', () => {
+    expect(shouldSkipCacheForTemperature({ temperature: 'high' })).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #234

## Summary
Adds opt-in LLM response caching to reduce redundant API calls during iterative evaluator development.

### Key Design Decisions
- **Default: NO caching** — fresh LLM calls every time (safe for variability testing)
- **Opt-in** via `execution.cache: true` in YAML or `--cache` CLI flag
- **`--no-cache` flag** explicitly bypasses any YAML cache config
- **Temperature > 0 skips cache** by default (non-deterministic responses)
- **Evaluator results never cached** — only provider/agent responses

### YAML Config
```yaml
execution:
  cache: true
  cache_path: .agentv/cache  # default
```

### CLI
```bash
agentv run evals/                # no cache (default)
agentv run evals/ --cache        # enable cache
agentv run evals/ --no-cache     # bypass (overrides YAML)
```

### Implementation
- File-based cache with SHA-256 keys: `<cache_path>/<2-char-prefix>/<hash>.json`
- Cache key: `hash(provider + model + input + config)`
- 22 new tests covering cache operations, config parsing, temperature skip, and enable logic