### PR TITLE
refactor(cli): rename `agentv run` to `agentv eval` and restructure prompt subcommands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Unit tests alone are insufficient for evaluator changes. After implementing or m
 
 2. **Run an actual eval** with a real example file:
    ```bash
-   bun agentv run examples/features/rubric/evals/dataset.yaml --test-id <test-id>
+   bun agentv eval examples/features/rubric/evals/dataset.yaml --test-id <test-id>
    ```
 
 2. **Inspect the results JSONL** to verify:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ tests:
 
 **5. Run the eval:**
 ```bash
-agentv run ./evals/example.yaml
+agentv eval ./evals/example.yaml
 ```
 
 Results appear in `.agentv/results/eval_<timestamp>.jsonl` with scores, reasoning, and execution traces.
@@ -147,19 +147,19 @@ Benefits: Streaming-friendly, Git-friendly diffs, programmatic generation, indus
 agentv validate evals/my-eval.yaml
 
 # Run an eval with default target (from eval file or targets.yaml)
-agentv run evals/my-eval.yaml
+agentv eval evals/my-eval.yaml
 
 # Override target
-agentv run --target azure_base evals/**/*.yaml
+agentv eval --target azure_base evals/**/*.yaml
 
 # Run specific test
-agentv run --test-id case-123 evals/my-eval.yaml
+agentv eval --test-id case-123 evals/my-eval.yaml
 
 # Dry-run with mock provider
-agentv run --dry-run evals/my-eval.yaml
+agentv eval --dry-run evals/my-eval.yaml
 ```
 
-See `agentv run --help` for all options: workers, timeouts, output formats, trace dumping, and more.
+See `agentv eval --help` for all options: workers, timeouts, output formats, trace dumping, and more.
 
 ### Create Custom Evaluators
 
@@ -206,9 +206,9 @@ For complete templates, examples, and evaluator patterns, see: [custom-evaluator
 Run two evaluations and compare them:
 
 ```bash
-agentv run evals/my-eval.yaml --out before.jsonl
+agentv eval evals/my-eval.yaml --out before.jsonl
 # ... make changes to your agent ...
-agentv run evals/my-eval.yaml --out after.jsonl
+agentv eval evals/my-eval.yaml --out after.jsonl
 agentv compare before.jsonl after.jsonl --threshold 0.1
 ```
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -44,7 +44,7 @@ tests:
 
 **5. Run the eval:**
 ```bash
-agentv run ./evals/example.yaml
+agentv eval ./evals/example.yaml
 ```
 
 Results appear in `.agentv/results/eval_<timestamp>.jsonl` with scores, reasoning, and execution traces.
@@ -95,6 +95,25 @@ bun test
 
 See [AGENTS.md](AGENTS.md) for development guidelines and design principles.
 
+### Releasing
+
+Stable release:
+
+```bash
+bun run release          # patch bump
+bun run release minor
+bun run release major
+bun run publish          # publish to npm `latest`
+```
+
+Prerelease (`next`) channel:
+
+```bash
+bun run release:next         # bump/increment `-next.N`
+bun run release:next major   # start new major prerelease line
+bun run publish:next         # publish to npm `next`
+```
+
 ## Core Concepts
 
 **Evaluation files** (`.yaml` or `.jsonl`) define test cases with expected outcomes. **Targets** specify which agent/provider to evaluate. **Judges** (code or LLM) score results. **Results** are written as JSONL/YAML for analysis and comparison.
@@ -128,19 +147,19 @@ Benefits: Streaming-friendly, Git-friendly diffs, programmatic generation, indus
 agentv validate evals/my-eval.yaml
 
 # Run an eval with default target (from eval file or targets.yaml)
-agentv run evals/my-eval.yaml
+agentv eval evals/my-eval.yaml
 
 # Override target
-agentv run --target azure_base evals/**/*.yaml
+agentv eval --target azure_base evals/**/*.yaml
 
 # Run specific test
-agentv run --test-id case-123 evals/my-eval.yaml
+agentv eval --test-id case-123 evals/my-eval.yaml
 
 # Dry-run with mock provider
-agentv run --dry-run evals/my-eval.yaml
+agentv eval --dry-run evals/my-eval.yaml
 ```
 
-See `agentv run --help` for all options: workers, timeouts, output formats, trace dumping, and more.
+See `agentv eval --help` for all options: workers, timeouts, output formats, trace dumping, and more.
 
 ### Create Custom Evaluators
 
@@ -187,9 +206,9 @@ For complete templates, examples, and evaluator patterns, see: [custom-evaluator
 Run two evaluations and compare them:
 
 ```bash
-agentv run evals/my-eval.yaml --out before.jsonl
+agentv eval evals/my-eval.yaml --out before.jsonl
 # ... make changes to your agent ...
-agentv run evals/my-eval.yaml --out after.jsonl
+agentv eval evals/my-eval.yaml --out after.jsonl
 agentv compare before.jsonl after.jsonl --threshold 0.1
 ```
 

--- a/apps/cli/src/commands/eval/commands/prompt/index.ts
+++ b/apps/cli/src/commands/eval/commands/prompt/index.ts
@@ -4,12 +4,20 @@ import { evalPromptInputCommand } from './input.js';
 import { evalPromptJudgeCommand } from './judge.js';
 import { evalPromptOverviewCommand } from './overview.js';
 
-export const evalPromptCommand = subcommands({
-  name: 'prompt',
+export const evalPromptEvalSubcommand = subcommands({
+  name: 'eval',
   description: 'Eval prompt commands (overview, input, judge)',
   cmds: {
     overview: evalPromptOverviewCommand,
     input: evalPromptInputCommand,
     judge: evalPromptJudgeCommand,
+  },
+});
+
+export const evalPromptCommand = subcommands({
+  name: 'prompt',
+  description: 'Prompt commands',
+  cmds: {
+    eval: evalPromptEvalSubcommand,
   },
 });

--- a/apps/cli/src/commands/eval/commands/prompt/judge.ts
+++ b/apps/cli/src/commands/eval/commands/prompt/judge.ts
@@ -169,7 +169,7 @@ async function processEvaluator(
         type: config.type,
         status: 'prompt_ready',
         result: {
-          message: `Evaluator type "${config.type}" requires the full eval pipeline. Use \`agentv run\` instead.`,
+          message: `Evaluator type "${config.type}" requires the full eval pipeline. Use \`agentv eval\` instead.`,
         },
       };
     }

--- a/apps/cli/src/commands/eval/commands/prompt/overview.ts
+++ b/apps/cli/src/commands/eval/commands/prompt/overview.ts
@@ -34,7 +34,7 @@ export const evalPromptOverviewCommand = command({
       '',
       '## Step 1: Get Task Input',
       '',
-      'Run `agentv prompt input <path> --test-id <id>` to get the task as JSON.',
+      'Run `agentv prompt eval input <path> --test-id <id>` to get the task as JSON.',
       '',
       'The output contains:',
       '- `input_messages` — `[{role, content}]` array. Content segments are either `{type: "text", value: "..."}` or `{type: "file", path: "/absolute/path"}`. Read file segments from the filesystem.',
@@ -47,7 +47,7 @@ export const evalPromptOverviewCommand = command({
       '',
       '## Step 3: Judge the Result',
       '',
-      'Run `agentv prompt judge <path> --test-id <id> --answer-file <response-file>`.',
+      'Run `agentv prompt eval judge <path> --test-id <id> --answer-file <response-file>`.',
       '',
       'The output contains an `evaluators` array. Each evaluator has a `status`:',
       '',
@@ -70,9 +70,9 @@ export const evalPromptOverviewCommand = command({
         }
         lines.push('');
         lines.push('```bash');
-        lines.push(`agentv prompt input ${evalPath} --test-id ${evalCase.id}`);
+        lines.push(`agentv prompt eval input ${evalPath} --test-id ${evalCase.id}`);
         lines.push(
-          `agentv prompt judge ${evalPath} --test-id ${evalCase.id} --answer-file <response-file>`,
+          `agentv prompt eval judge ${evalPath} --test-id ${evalCase.id} --answer-file <response-file>`,
         );
         lines.push('```');
         lines.push('');

--- a/apps/cli/src/commands/eval/commands/run.ts
+++ b/apps/cli/src/commands/eval/commands/run.ts
@@ -14,7 +14,7 @@ import { runEvalCommand } from '../run-eval.js';
 import { resolveEvalPaths } from '../shared.js';
 
 export const evalRunCommand = command({
-  name: 'run',
+  name: 'eval',
   description: 'Run eval suites and report results',
   args: {
     evalPaths: restPositionals({

--- a/apps/cli/src/commands/eval/interactive.ts
+++ b/apps/cli/src/commands/eval/interactive.ts
@@ -28,7 +28,7 @@ export interface InteractiveConfig {
 }
 
 /**
- * Launch the interactive wizard when `agentv run` is called with no arguments.
+ * Launch the interactive wizard when `agentv eval` is called with no arguments.
  */
 export async function launchInteractiveWizard(): Promise<void> {
   const cwd = process.cwd();
@@ -112,7 +112,7 @@ async function promptNewEvaluation(cwd: string): Promise<InteractiveConfig | und
     console.log(
       '\n⚠  No eval files found in the current directory.\n' +
         '   Place .yaml or .jsonl eval files in your project, or use:\n' +
-        '   agentv run <path-to-eval.yaml>\n',
+        '   agentv eval <path-to-eval.yaml>\n',
     );
     return undefined;
   }

--- a/apps/cli/test/eval.integration.test.ts
+++ b/apps/cli/test/eval.integration.test.ts
@@ -142,12 +142,12 @@ afterEach(async () => {
   }
 });
 
-describe('agentv run CLI', () => {
+describe('agentv eval CLI', () => {
   it('writes results, summary, and prompt dumps using default directories', async () => {
     const fixture = await createFixture();
     fixtures.push(fixture.baseDir);
 
-    const { stdout } = await runCli(fixture, ['run', fixture.testFilePath, '--verbose']);
+    const { stdout } = await runCli(fixture, ['eval', fixture.testFilePath, '--verbose']);
 
     // Don't check stderr - it may contain stack traces or other diagnostics
     expect(stdout).toContain('Using target (test-file): file-target [provider=mock]');
@@ -171,21 +171,5 @@ describe('agentv run CLI', () => {
     });
 
     // Prompt dump feature has been removed, so we no longer check for it
-  });
-});
-
-describe('agentv eval backward compatibility', () => {
-  it('`agentv eval` still works as deprecated alias for `agentv run`', async () => {
-    const fixture = await createFixture();
-    fixtures.push(fixture.baseDir);
-
-    const { stdout, stderr } = await runCli(fixture, ['eval', fixture.testFilePath, '--verbose']);
-
-    // Should print deprecation warning
-    expect(stderr).toContain('`agentv eval` is deprecated');
-    expect(stderr).toContain('Use `agentv run` instead');
-
-    // Should still work
-    expect(stdout).toContain('Mean score: 0.750');
   });
 });

--- a/apps/web/src/components/Lander.astro
+++ b/apps/web/src/components/Lander.astro
@@ -55,9 +55,9 @@ import type { Props } from '@astrojs/starlight/props';
             <span class="av-terminal-title">agentv</span>
           </div>
           <div class="av-terminal-body">
-            <!-- Scene 1: agentv run -->
+            <!-- Scene 1: agentv eval -->
             <div class="av-scene av-scene-1">
-              <div class="av-line av-line-cmd"><span class="av-prompt">$</span> <span class="av-typing">agentv run ./evals/math.yaml</span></div>
+              <div class="av-line av-line-cmd"><span class="av-prompt">$</span> <span class="av-typing">agentv eval ./evals/math.yaml</span></div>
               <div class="av-line av-line-out av-line-delay-1"><span class="av-dim">Running 3 tests...</span></div>
               <div class="av-line av-line-out av-line-delay-2"><span class="av-pass">PASS</span> addition <span class="av-dim">score: 1.0</span></div>
               <div class="av-line av-line-out av-line-delay-3"><span class="av-pass">PASS</span> multiplication <span class="av-dim">score: 1.0</span></div>
@@ -179,7 +179,7 @@ tests:
             <h3>Run</h3>
             <div class="av-mini-terminal">
               <div class="av-mini-bar"><span class="av-mini-dots"></span></div>
-              <pre><code>agentv run ./evals/example.yaml</code></pre>
+              <pre><code>agentv eval ./evals/example.yaml</code></pre>
             </div>
           </div>
         </div>

--- a/apps/web/src/content/docs/evaluation/running-evals.mdx
+++ b/apps/web/src/content/docs/evaluation/running-evals.mdx
@@ -8,7 +8,7 @@ sidebar:
 ## Run an Evaluation
 
 ```bash
-agentv run evals/my-eval.yaml
+agentv eval evals/my-eval.yaml
 ```
 
 Results are written to `.agentv/results/eval_<timestamp>.jsonl`.
@@ -20,7 +20,7 @@ Results are written to `.agentv/results/eval_<timestamp>.jsonl`.
 Run against a different target than specified in the eval file:
 
 ```bash
-agentv run --target azure_base evals/**/*.yaml
+agentv eval --target azure_base evals/**/*.yaml
 ```
 
 ### Run Specific Test
@@ -28,7 +28,7 @@ agentv run --target azure_base evals/**/*.yaml
 Run a single test by ID:
 
 ```bash
-agentv run --test-id case-123 evals/my-eval.yaml
+agentv eval --test-id case-123 evals/my-eval.yaml
 ```
 
 ### Dry Run
@@ -36,7 +36,7 @@ agentv run --test-id case-123 evals/my-eval.yaml
 Test the harness flow with mock responses (does not call real providers):
 
 ```bash
-agentv run --dry-run evals/my-eval.yaml
+agentv eval --dry-run evals/my-eval.yaml
 ```
 
 :::note
@@ -46,7 +46,7 @@ Dry-run returns mock responses that don't match evaluator output schemas. Use it
 ### Output to Specific File
 
 ```bash
-agentv run evals/my-eval.yaml --out results/baseline.jsonl
+agentv eval evals/my-eval.yaml --out results/baseline.jsonl
 ```
 
 ### Trace Persistence
@@ -54,7 +54,7 @@ agentv run evals/my-eval.yaml --out results/baseline.jsonl
 Persist full execution traces (tool calls, timing, spans) to disk for debugging and analysis:
 
 ```bash
-agentv run evals/my-eval.yaml --trace
+agentv eval evals/my-eval.yaml --trace
 ```
 
 Traces are written to `.agentv/traces/<timestamp>/<eval-file>.trace.jsonl` as JSONL records containing:
@@ -70,10 +70,10 @@ When using `workspace_template` or the `workspace` config block, temporary works
 
 ```bash
 # Always keep workspaces (for debugging)
-agentv run evals/my-eval.yaml --keep-workspaces
+agentv eval evals/my-eval.yaml --keep-workspaces
 
 # Always cleanup workspaces (even on failure)
-agentv run evals/my-eval.yaml --cleanup-workspaces
+agentv eval evals/my-eval.yaml --cleanup-workspaces
 ```
 
 Workspaces are stored at `~/.agentv/workspaces/<eval-run-id>/<test-id>/`.
@@ -93,7 +93,7 @@ Run evaluations without API keys by letting an external agent (e.g., Claude Code
 ### Overview
 
 ```bash
-agentv prompt evals/my-eval.yaml
+agentv prompt eval evals/my-eval.yaml
 ```
 
 Outputs a step-by-step orchestration prompt listing all tests and the commands to run for each.
@@ -101,7 +101,7 @@ Outputs a step-by-step orchestration prompt listing all tests and the commands t
 ### Get Task Input
 
 ```bash
-agentv prompt input evals/my-eval.yaml --test-id case-123
+agentv prompt eval input evals/my-eval.yaml --test-id case-123
 ```
 
 Returns JSON with:
@@ -112,7 +112,7 @@ Returns JSON with:
 ### Judge the Result
 
 ```bash
-agentv prompt judge evals/my-eval.yaml --test-id case-123 --answer-file response.txt
+agentv prompt eval judge evals/my-eval.yaml --test-id case-123 --answer-file response.txt
 ```
 
 Runs code judges deterministically and returns LLM judge prompts for the agent to execute. Each evaluator in the output has a `status`:
@@ -124,9 +124,9 @@ Runs code judges deterministically and returns LLM judge prompts for the agent t
 
 | Scenario | Command |
 |----------|---------|
-| Have API keys, want end-to-end automation | `agentv run` |
+| Have API keys, want end-to-end automation | `agentv eval` |
 | No API keys, agent can act as the LLM | `agentv prompt` |
 
 ## All Options
 
-Run `agentv run --help` for the full list of options including workers, timeouts, output formats, and trace dumping.
+Run `agentv eval --help` for the full list of options including workers, timeouts, output formats, and trace dumping.

--- a/apps/web/src/content/docs/evaluators/tool-trajectory.mdx
+++ b/apps/web/src/content/docs/evaluators/tool-trajectory.mdx
@@ -171,10 +171,10 @@ The evaluator extracts tool calls from `output_messages[].tool_calls[]`. The `to
 
 ```bash
 # Write trace files to disk
-agentv run evals/test.yaml --dump-traces
+agentv eval evals/test.yaml --dump-traces
 
 # Include full trace in result output
-agentv run evals/test.yaml --include-trace
+agentv eval evals/test.yaml --include-trace
 ```
 
 Use `--dump-traces` to inspect actual traces and understand agent behavior before writing evaluators.

--- a/apps/web/src/content/docs/getting-started/quickstart.mdx
+++ b/apps/web/src/content/docs/getting-started/quickstart.mdx
@@ -54,7 +54,7 @@ tests:
 ## 5. Run the eval
 
 ```bash
-agentv run ./evals/example.yaml
+agentv eval ./evals/example.yaml
 ```
 
 Results appear in `.agentv/results/eval_<timestamp>.jsonl` with scores, reasoning, and execution traces.

--- a/apps/web/src/content/docs/tools/compare.mdx
+++ b/apps/web/src/content/docs/tools/compare.mdx
@@ -12,9 +12,9 @@ The `compare` command computes deltas between two evaluation runs for A/B testin
 Run two evaluations and compare them:
 
 ```bash
-agentv run evals/my-eval.yaml --out before.jsonl
+agentv eval evals/my-eval.yaml --out before.jsonl
 # ... make changes to your agent ...
-agentv run evals/my-eval.yaml --out after.jsonl
+agentv eval evals/my-eval.yaml --out after.jsonl
 agentv compare before.jsonl after.jsonl
 ```
 
@@ -102,10 +102,10 @@ Compare different model versions:
 
 ```bash
 # Run baseline evaluation
-agentv run evals/*.yaml --target gpt-4 --out baseline.jsonl
+agentv eval evals/*.yaml --target gpt-4 --out baseline.jsonl
 
 # Run candidate evaluation
-agentv run evals/*.yaml --target gpt-4o --out candidate.jsonl
+agentv eval evals/*.yaml --target gpt-4o --out candidate.jsonl
 
 # Compare results
 agentv compare baseline.jsonl candidate.jsonl
@@ -117,10 +117,10 @@ Compare before/after prompt changes:
 
 ```bash
 # Run with original prompt
-agentv run evals/*.yaml --out before.jsonl
+agentv eval evals/*.yaml --out before.jsonl
 
 # Modify prompt, then run again
-agentv run evals/*.yaml --out after.jsonl
+agentv eval evals/*.yaml --out after.jsonl
 
 # Compare with strict threshold
 agentv compare before.jsonl after.jsonl --threshold 0.05

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -55,8 +55,8 @@ No network round-trips, no waiting for managed infrastructure:
 **3. CLI-Native, Not UI-Native**
 ```bash
 # AgentV workflow
-agentv run evals/my-eval.yaml
-agentv run evals/**/*.yaml --workers 10  # Parallel
+agentv eval evals/my-eval.yaml
+agentv eval evals/**/*.yaml --workers 10  # Parallel
 agentv compare before.jsonl after.jsonl   # A/B testing
 ```
 
@@ -70,7 +70,7 @@ agentv compare before.jsonl after.jsonl   # A/B testing
 ```
 
 AgentV integrates into:
-- **CI/CD pipelines** (`agentv run evals/ --out results.jsonl`)
+- **CI/CD pipelines** (`agentv eval evals/ --out results.jsonl`)
 - **Git hooks** (block PRs if eval scores drop)
 - **Scripts** (parse JSONL results, trigger alerts)
 - **Notebooks** (iterate on eval logic)
@@ -79,7 +79,7 @@ AgentV integrates into:
 ```bash
 npm install -g agentv
 agentv init
-agentv run evals/example.yaml
+agentv eval evals/example.yaml
 # Done. No Docker, no K8s, no managed service.
 ```
 
@@ -107,7 +107,7 @@ Evaluate if the answer is mathematically correct.
 - 0.0: Wrong answer
 ```
 
-Then re-run: `agentv run evals/math.yaml`
+Then re-run: `agentv eval evals/math.yaml`
 
 Alternative approaches:
 - Langfuse/LangWatch: Go to UI, modify prompt, save, re-run
@@ -139,7 +139,7 @@ Single eval run scores all three dimensions. Other approaches:
 
 ```yaml
 # .github/workflows/eval.yml
-- run: agentv run evals/**/*.yaml --out results.jsonl
+- run: agentv eval evals/**/*.yaml --out results.jsonl
 - run: agentv compare baseline.jsonl results.jsonl --threshold 0.05
   # Fail if performance drops > 5%
 ```
@@ -152,7 +152,7 @@ Other tools face challenges here:
 ### Scenario: Fast Iteration Feedback Loop
 
 ```
-Edit eval → Save → agentv run (1-2 sec) → Review results
+Edit eval → Save → agentv eval (1-2 sec) → Review results
 vs
 Edit in UI → Click Save → Wait for backend → Refresh dashboard (10-20 sec)
 ```

--- a/evals/README.md
+++ b/evals/README.md
@@ -23,10 +23,10 @@ The pi-coding-agent provider has issues passing multi-line prompts on Windows. W
 
 ```bash
 # Dry run to verify structure
-bun agentv run evals/design-principles.yaml --targets evals/targets.yaml --dry-run
+bun agentv eval evals/design-principles.yaml --targets evals/targets.yaml --dry-run
 
 # Full run (requires working pi-coding-agent or alternative target)
-bun agentv run evals/design-principles.yaml --targets evals/targets.yaml
+bun agentv eval evals/design-principles.yaml --targets evals/targets.yaml
 ```
 
 ## Test Cases

--- a/evals/architecture/dataset.yaml
+++ b/evals/architecture/dataset.yaml
@@ -46,7 +46,7 @@ tests:
 
               **Proposed change**: Update the skill to include these exact steps:
               1. Run `agentv init`
-              2. Run `agentv run --file evals/test.yaml --output json`
+              2. Run `agentv eval --file evals/test.yaml --output json`
               3. Run `agentv report --input results.json --format html`
               4. Open the generated report in your browser
 

--- a/examples/features/.agentv/config.yaml
+++ b/examples/features/.agentv/config.yaml
@@ -12,7 +12,7 @@ guideline_patterns:
   - "**/SKILL.md"
 
 # Customize which YAML files are discovered as evals during interactive mode
-# (`agentv run` with no args). Defaults to dataset*.yaml and eval.yaml under evals/.
+# (`agentv eval` with no args). Defaults to dataset*.yaml and eval.yaml under evals/.
 eval_patterns:
   - "**/evals/**/dataset*.yaml"
   - "**/evals/**/eval.yaml"

--- a/examples/features/basic/README.md
+++ b/examples/features/basic/README.md
@@ -14,10 +14,10 @@ Demonstrates core AgentV schema features with minimal setup.
 
 ```bash
 # From repository root
-bun agentv run examples/features/basic/evals/dataset.yaml
+bun agentv eval examples/features/basic/evals/dataset.yaml
 
 # With specific target
-bun agentv run examples/features/basic/evals/dataset.yaml --target default
+bun agentv eval examples/features/basic/evals/dataset.yaml --target default
 ```
 
 ## Key Files

--- a/examples/features/batch-cli/README.md
+++ b/examples/features/batch-cli/README.md
@@ -63,5 +63,5 @@ cd examples/features/batch-cli
 
 # Run AgentV against the batch CLI target
 # NOTE: This requires the CLI provider to support batching + JSONL batch output.
-bun agentv run ./evals/dataset.yaml --target batch_cli
+bun agentv eval ./evals/dataset.yaml --target batch_cli
 ```

--- a/examples/features/code-judge-sdk/README.md
+++ b/examples/features/code-judge-sdk/README.md
@@ -44,7 +44,7 @@ From the repository root:
 
 ```bash
 cd examples/features
-bun agentv run code-judge-sdk/evals/dataset.yaml --target local_cli
+bun agentv eval code-judge-sdk/evals/dataset.yaml --target local_cli
 ```
 
 This requires a CLI target named `local_cli` configured in `.agentv/targets.yaml`.

--- a/examples/features/code-judge-with-llm-calls/README.md
+++ b/examples/features/code-judge-with-llm-calls/README.md
@@ -231,10 +231,10 @@ The `createTargetClient()` function reads these automatically.
 # From the agentv monorepo root:
 
 # Run contextual precision evaluation
-bun run agentv run examples/features/code-judge-with-llm-calls/evals/dataset-contextual-precision.yaml --target gemini_base
+bun run agentv eval examples/features/code-judge-with-llm-calls/evals/dataset-contextual-precision.yaml --target gemini_base
 
 # Run contextual recall evaluation
-bun run agentv run examples/features/code-judge-with-llm-calls/evals/dataset-contextual-recall.yaml --target gemini_base
+bun run agentv eval examples/features/code-judge-with-llm-calls/evals/dataset-contextual-recall.yaml --target gemini_base
 ```
 
 ### Expected Results

--- a/examples/features/composite/README.md
+++ b/examples/features/composite/README.md
@@ -13,7 +13,7 @@ Demonstrates composite evaluator patterns for combining multiple evaluation crit
 
 ```bash
 # From repository root
-bun agentv run examples/features/composite/evals/dataset.yaml
+bun agentv eval examples/features/composite/evals/dataset.yaml
 ```
 
 ## Key Files

--- a/examples/features/deterministic-evaluators/README.md
+++ b/examples/features/deterministic-evaluators/README.md
@@ -47,7 +47,7 @@ bun run build
 
 ```bash
 # From examples/features
-bun agentv run deterministic-evaluators/evals/dataset.yaml --target <your-target>
+bun agentv eval deterministic-evaluators/evals/dataset.yaml --target <your-target>
 ```
 
 ## Standalone Test

--- a/examples/features/document-extraction/README.md
+++ b/examples/features/document-extraction/README.md
@@ -18,10 +18,10 @@ From repo root:
 
 ```bash
 # Pattern 1: Field accuracy (per-evalcase scoring)
-bun agentv run examples/features/document-extraction/evals/dataset-field-accuracy.yaml
+bun agentv eval examples/features/document-extraction/evals/dataset-field-accuracy.yaml
 
 # Pattern 2: Confusion metrics (cross-document aggregation)
-bun agentv run examples/features/document-extraction/evals/dataset-confusion-metrics.yaml
+bun agentv eval examples/features/document-extraction/evals/dataset-confusion-metrics.yaml
 
 # Aggregate TP/TN/FP/FN into a table (only works with dataset-confusion-metrics.yaml)
 bun run examples/features/document-extraction/scripts/aggregate_metrics.ts \

--- a/examples/features/document-extraction/evals/dataset-confusion-metrics.yaml
+++ b/examples/features/document-extraction/evals/dataset-confusion-metrics.yaml
@@ -7,7 +7,7 @@
 # Use case: Measuring field-level extraction accuracy across a document corpus.
 #
 # Run:
-#   bun agentv run examples/features/document-extraction/evals/confusion-metrics.yaml
+#   bun agentv eval examples/features/document-extraction/evals/confusion-metrics.yaml
 #
 # Aggregate:
 #   bun run examples/features/document-extraction/scripts/aggregate_metrics.ts \

--- a/examples/features/execution-metrics/README.md
+++ b/examples/features/execution-metrics/README.md
@@ -15,7 +15,7 @@ Demonstrates execution metrics tracking (tokens, cost, latency) in evaluations.
 ```bash
 # From repository root
 cd examples/features
-bun agentv run execution-metrics/evals/dataset.yaml --target mock_metrics_agent
+bun agentv eval execution-metrics/evals/dataset.yaml --target mock_metrics_agent
 ```
 
 ## Setup

--- a/examples/features/execution-metrics/evals/dataset.yaml
+++ b/examples/features/execution-metrics/evals/dataset.yaml
@@ -13,7 +13,7 @@
 # Score is proportional: hits / (hits + misses)
 #
 # Run with:
-#   bun agentv run examples/features/execution-metrics/evals/dataset.yaml --dry-run
+#   bun agentv eval examples/features/execution-metrics/evals/dataset.yaml --dry-run
 
 description: Demonstrates the built-in execution_metrics evaluator
 

--- a/examples/features/external-datasets/README.md
+++ b/examples/features/external-datasets/README.md
@@ -13,7 +13,7 @@ Demonstrates loading test cases from external files using `file://` references.
 
 ```bash
 # From repository root
-bun agentv run examples/features/external-datasets/evals/dataset.yaml
+bun agentv eval examples/features/external-datasets/evals/dataset.yaml
 ```
 
 ## Key Files

--- a/examples/features/latency-assertions/README.md
+++ b/examples/features/latency-assertions/README.md
@@ -51,10 +51,10 @@ For latency assertions to work, providers must include `duration_ms` in tool cal
 
 ```bash
 # Dry-run to validate YAML parsing
-npx agentv run examples/features/latency-assertions/evals/dataset.yaml --dry-run
+npx agentv eval examples/features/latency-assertions/evals/dataset.yaml --dry-run
 
 # With a real provider that returns duration_ms in tool calls
-npx agentv run examples/features/latency-assertions/evals/dataset.yaml --target <your-target>
+npx agentv eval examples/features/latency-assertions/evals/dataset.yaml --target <your-target>
 ```
 
 ## Best Practices

--- a/examples/features/local-cli/README.md
+++ b/examples/features/local-cli/README.md
@@ -13,7 +13,7 @@ Demonstrates CLI target configuration with file attachments.
 
 ```bash
 # From repository root
-bun agentv run examples/features/local-cli/evals/dataset.yaml
+bun agentv eval examples/features/local-cli/evals/dataset.yaml
 ```
 
 ## Key Files

--- a/examples/features/matrix-evaluation/evals/dataset.yaml
+++ b/examples/features/matrix-evaluation/evals/dataset.yaml
@@ -4,10 +4,10 @@
 # a cross-target comparison matrix.
 #
 # Usage:
-#   agentv run examples/features/matrix-evaluation/evals/dataset.yaml
+#   agentv eval examples/features/matrix-evaluation/evals/dataset.yaml
 #
 # Or with CLI override:
-#   agentv run examples/features/matrix-evaluation/evals/dataset.yaml --target copilot --target claude
+#   agentv eval examples/features/matrix-evaluation/evals/dataset.yaml --target copilot --target claude
 
 execution:
   targets:

--- a/examples/features/prompt-template-sdk/README.md
+++ b/examples/features/prompt-template-sdk/README.md
@@ -43,7 +43,7 @@ The template receives evaluation context via stdin (JSON) and outputs the prompt
 ## Running
 
 ```bash
-bun agentv run examples/features/prompt-template-sdk/evals/dataset.yaml --dry-run
+bun agentv eval examples/features/prompt-template-sdk/evals/dataset.yaml --dry-run
 ```
 
 ## File Structure

--- a/examples/features/rubric/README.md
+++ b/examples/features/rubric/README.md
@@ -14,7 +14,7 @@ Demonstrates rubric-based evaluation with weights, required flags, and auto-gene
 
 ```bash
 # From repository root
-bun agentv run examples/features/rubric/evals/dataset.yaml --target default
+bun agentv eval examples/features/rubric/evals/dataset.yaml --target default
 ```
 
 ## Key Files

--- a/examples/features/tool-trajectory-advanced/README.md
+++ b/examples/features/tool-trajectory-advanced/README.md
@@ -15,7 +15,7 @@ Demonstrates tool trajectory evaluation combined with expected output validation
 ```bash
 # From repository root
 cd examples/features
-bun agentv run tool-trajectory-advanced/evals/dataset-trace-file-demo.yaml --target static_trace
+bun agentv eval tool-trajectory-advanced/evals/dataset-trace-file-demo.yaml --target static_trace
 ```
 
 ## Setup

--- a/examples/features/tool-trajectory-advanced/evals/dataset-trace-file-demo.yaml
+++ b/examples/features/tool-trajectory-advanced/evals/dataset-trace-file-demo.yaml
@@ -7,7 +7,7 @@
 # Setup:
 #   1. Create examples/features/.env with:
 #      TOOL_TRAJECTORY_DIR=/absolute/path/to/examples/features/tool-trajectory-advanced
-#   2. Run: cd examples/features && npx agentv run tool-trajectory-advanced/evals/dataset-trace-file-demo.yaml --target static_trace
+#   2. Run: cd examples/features && npx agentv eval tool-trajectory-advanced/evals/dataset-trace-file-demo.yaml --target static_trace
 
 description: Static trace file evaluation demo - Product Research Agent
 

--- a/examples/features/tool-trajectory-simple/README.md
+++ b/examples/features/tool-trajectory-simple/README.md
@@ -15,7 +15,7 @@ Demonstrates tool trajectory evaluation with different matching modes.
 ```bash
 # From repository root
 cd examples/features
-bun agentv run tool-trajectory-simple/evals/dataset.yaml --target mock_agent
+bun agentv eval tool-trajectory-simple/evals/dataset.yaml --target mock_agent
 ```
 
 ## Setup

--- a/examples/features/tool-trajectory-simple/evals/dataset.yaml
+++ b/examples/features/tool-trajectory-simple/evals/dataset.yaml
@@ -20,7 +20,7 @@
 # Setup:
 #   1. Create examples/features/.env with:
 #      TOOL_TRAJECTORY_DIR=/absolute/path/to/examples/features/tool-trajectory-simple
-#   2. Run: cd examples/features && npx agentv run tool-trajectory-simple/evals/dataset.yaml --target mock_agent
+#   2. Run: cd examples/features && npx agentv eval tool-trajectory-simple/evals/dataset.yaml --target mock_agent
 
 description: Tool trajectory evaluator examples for agent execution validation
 

--- a/examples/features/weighted-evaluators/README.md
+++ b/examples/features/weighted-evaluators/README.md
@@ -13,7 +13,7 @@ Demonstrates weighted evaluator configurations for prioritizing different evalua
 
 ```bash
 # From repository root
-bun agentv run examples/features/weighted-evaluators/evals/dataset.yaml
+bun agentv eval examples/features/weighted-evaluators/evals/dataset.yaml
 ```
 
 ## Key Files

--- a/examples/nlp-metrics/README.md
+++ b/examples/nlp-metrics/README.md
@@ -17,13 +17,13 @@ Each judge is a standalone TypeScript file that uses `defineCodeJudge` from `@ag
 
 ```bash
 # From the repository root
-bun agentv run examples/nlp-metrics/evals/dataset.yaml
+bun agentv eval examples/nlp-metrics/evals/dataset.yaml
 ```
 
 Run a single test:
 
 ```bash
-bun agentv run examples/nlp-metrics/evals/dataset.yaml --test-id summarisation-rouge
+bun agentv eval examples/nlp-metrics/evals/dataset.yaml --test-id summarisation-rouge
 ```
 
 ## How It Works

--- a/examples/showcase/evaluator-conformance/EVAL.yaml
+++ b/examples/showcase/evaluator-conformance/EVAL.yaml
@@ -2,7 +2,7 @@
 # Demonstrates using the keyword-judge evaluator in a standard AgentV eval.
 #
 # Run: cd examples/showcase/evaluator-conformance
-#      npx agentv run EVAL.yaml --dry-run
+#      npx agentv eval EVAL.yaml --dry-run
 #
 # The conformance harness validates this evaluator separately:
 #      bun run conformance-check.ts

--- a/examples/showcase/export-screening/README.md
+++ b/examples/showcase/export-screening/README.md
@@ -41,7 +41,7 @@ From the repository root:
 cd examples/showcase/export-screening
 
 # Run evaluation (produces per-case results)
-bun agentv run ./evals/dataset.yaml --out results.jsonl
+bun agentv eval ./evals/dataset.yaml --out results.jsonl
 ```
 
 ### Computing Metrics
@@ -67,7 +67,7 @@ This is useful when LLM outputs are non-deterministic — aggregating over multi
 
 ```mermaid
 flowchart LR
-    A[dataset.yaml] --> B[bun agentv run]
+    A[dataset.yaml] --> B[bun agentv eval]
     B --> C[results.jsonl<br/>per-case scores]
     C --> D[ci_check.ts<br/>confusion matrix + P/R/F1 + policy-weighted overall]
 ```
@@ -158,7 +158,7 @@ bun run ./evals/ci_check.ts results.jsonl --threshold 0.95
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--eval` | - | Run agentv run on this dataset first |
+| `--eval` | - | Run agentv eval on this dataset first |
 | `--samples` | `1` | Number of eval runs to aggregate |
 | `--threshold` | `0.95` | F1 score threshold (0.0-1.0) |
 | `--check-class` | `High` | Risk class to validate (`Low`, `Medium`, `High`) |

--- a/examples/showcase/tool-evaluation-plugins/README.md
+++ b/examples/showcase/tool-evaluation-plugins/README.md
@@ -56,7 +56,7 @@ evaluators:
 export TOOL_EVAL_PLUGINS_DIR=$(pwd)/examples/showcase/tool-evaluation-plugins
 
 # Run the demo
-npx agentv run examples/showcase/tool-evaluation-plugins/tool-eval-demo.yaml
+npx agentv eval examples/showcase/tool-evaluation-plugins/tool-eval-demo.yaml
 ```
 
 ## Input Contract

--- a/examples/showcase/tool-evaluation-plugins/tool-eval-demo.yaml
+++ b/examples/showcase/tool-evaluation-plugins/tool-eval-demo.yaml
@@ -5,7 +5,7 @@
 # semantic evaluation capabilities that require domain-specific logic.
 #
 # Run: cd examples/showcase/tool-evaluation-plugins
-#      npx agentv run tool-eval-demo.yaml --target mock_agent
+#      npx agentv eval tool-eval-demo.yaml --target mock_agent
 
 description: Showcase of tool evaluation plugin patterns
 

--- a/examples/tool-evaluation-plugins/README.md
+++ b/examples/tool-evaluation-plugins/README.md
@@ -39,7 +39,7 @@ evaluators:
 
 ```bash
 cd examples/tool-evaluation-plugins
-bun agentv run evals/dataset.yaml --target <your-target>
+bun agentv eval evals/dataset.yaml --target <your-target>
 ```
 
 ## Output

--- a/examples/tool-evaluation-plugins/evals/dataset.yaml
+++ b/examples/tool-evaluation-plugins/evals/dataset.yaml
@@ -6,10 +6,10 @@
 #
 # Run:
 #   cd examples/tool-evaluation-plugins
-#   bun agentv run evals/dataset.yaml --target <your-target>
+#   bun agentv eval evals/dataset.yaml --target <your-target>
 #
 # Or dry-run (mock responses — useful for testing harness flow only):
-#   bun agentv run evals/dataset.yaml --dry-run
+#   bun agentv eval evals/dataset.yaml --dry-run
 
 description: Tool-call F1 scoring examples
 

--- a/examples/trace-evaluation/README.md
+++ b/examples/trace-evaluation/README.md
@@ -34,7 +34,7 @@ interface TraceSummary {
 
 ```bash
 # From the repository root (dry-run mode for testing without a live agent)
-bun agentv run examples/trace-evaluation/evals/dataset.yaml --dry-run
+bun agentv eval examples/trace-evaluation/evals/dataset.yaml --dry-run
 ```
 
 ## Patterns

--- a/examples/trace-evaluation/evals/dataset.yaml
+++ b/examples/trace-evaluation/evals/dataset.yaml
@@ -4,7 +4,7 @@
 # errors, and durations) using code judges that inspect traceSummary.
 #
 # Run with:
-#   bun agentv run examples/trace-evaluation/evals/dataset.yaml --dry-run
+#   bun agentv eval examples/trace-evaluation/evals/dataset.yaml --dry-run
 
 description: Trace-based evaluation of agent internals using code judges
 

--- a/skills/agentv-eval-builder/SKILL.md
+++ b/skills/agentv-eval-builder/SKILL.md
@@ -209,15 +209,15 @@ See `references/rubric-evaluator.md` for score-range mode and scoring formula.
 
 ```bash
 # Run evaluation (requires API keys)
-agentv run <file.yaml> [--test-id <id>] [--target <name>] [--dry-run]
+agentv eval <file.yaml> [--test-id <id>] [--target <name>] [--dry-run]
 
 # Run with trace persistence (writes to .agentv/traces/)
-agentv run <file.yaml> --trace
+agentv eval <file.yaml> --trace
 
 # Agent-orchestrated evals (no API keys needed)
-agentv prompt <file.yaml>                                      # orchestration overview
-agentv prompt input <file.yaml> --test-id <id>                 # task input JSON (file paths, not embedded content)
-agentv prompt judge <file.yaml> --test-id <id> --answer-file f # judge prompts / code judge results
+agentv prompt eval <file.yaml>                                      # orchestration overview
+agentv prompt eval input <file.yaml> --test-id <id>                 # task input JSON (file paths, not embedded content)
+agentv prompt eval judge <file.yaml> --test-id <id> --answer-file f # judge prompts / code judge results
 
 # Validate eval file
 agentv validate <file.yaml>

--- a/skills/agentv-eval-builder/references/config-schema.json
+++ b/skills/agentv-eval-builder/references/config-schema.json
@@ -23,7 +23,7 @@
     },
     "eval_patterns": {
       "type": "array",
-      "description": "Glob patterns for discovering eval files during interactive mode (`agentv run` with no args). Defaults to ['**/evals/**/dataset*.yaml', '**/evals/**/eval.yaml'] if not specified.",
+      "description": "Glob patterns for discovering eval files during interactive mode (`agentv eval` with no args). Defaults to ['**/evals/**/dataset*.yaml', '**/evals/**/eval.yaml'] if not specified.",
       "items": {
         "type": "string",
         "description": "Glob pattern (e.g., '**/evals/**/dataset*.yaml', '**/evals/**/eval.yaml')"

--- a/skills/agentv-eval-orchestrator/SKILL.md
+++ b/skills/agentv-eval-orchestrator/SKILL.md
@@ -10,7 +10,7 @@ Run AgentV evaluations by acting as the LLM yourself — no API keys needed.
 ## Quick Start
 
 ```bash
-agentv prompt <eval-file.yaml>
+agentv prompt eval <eval-file.yaml>
 ```
 
 This outputs a complete orchestration prompt with step-by-step instructions and all test IDs. Follow its instructions.
@@ -22,7 +22,7 @@ For each test, run these three steps:
 ### 1. Get Task Input
 
 ```bash
-agentv prompt input <path> --test-id <id>
+agentv prompt eval input <path> --test-id <id>
 ```
 
 Returns JSON with `input_messages`, `guideline_paths`, and `criteria`. File references in messages use absolute paths — read them from the filesystem.
@@ -36,7 +36,7 @@ You ARE the candidate LLM. Read `input_messages` from step 1, read any reference
 ### 3. Judge the Result
 
 ```bash
-agentv prompt judge <path> --test-id <id> --answer-file /tmp/eval_<id>.txt
+agentv prompt eval judge <path> --test-id <id> --answer-file /tmp/eval_<id>.txt
 ```
 
 Returns JSON with an `evaluators` array. Each evaluator has a `status`:
@@ -44,7 +44,7 @@ Returns JSON with an `evaluators` array. Each evaluator has a `status`:
 - **`"completed"`** — Deterministic score is final. Read `result.score` (0.0–1.0).
 - **`"prompt_ready"`** — LLM grading required. Send `prompt.system_prompt` as system and `prompt.user_prompt` as user to yourself. Parse the JSON response to get `score`, `hits`, `misses`.
 
-## When to use this vs `agentv run`
+## When to use this vs `agentv eval`
 
-- **`agentv run`** — You have API keys configured. Runs everything end-to-end automatically.
+- **`agentv eval`** — You have API keys configured. Runs everything end-to-end automatically.
 - **`agentv prompt`** — No API keys. You orchestrate: get input, answer the task yourself, judge the result.

--- a/skills/agentv-prompt-optimizer/SKILL.md
+++ b/skills/agentv-prompt-optimizer/SKILL.md
@@ -23,7 +23,7 @@ description: Iteratively optimize prompt files against AgentV evaluation dataset
     - Read content of the identified prompt file.
 
 2.  **Optimization Loop** (Max 10 iterations)
-    - **Execute (The Generator)**: Run `agentv run <eval-path>`.
+    - **Execute (The Generator)**: Run `agentv eval <eval-path>`.
         - *Targeted Run*: If iterating on specific stubborn failures, use `--test-id <test_id>` to run only the relevant tests.
     - **Analyze (The Reflector)**:
         - Locate the results file path from the console output (e.g., `.agentv/results/eval_...jsonl`).


### PR DESCRIPTION
## Summary

- Primary command is now `agentv eval` instead of `agentv run`, aligning with industry convention (promptfoo, openbench)
- Prompt subcommands restructured under `agentv prompt eval` namespace: `agentv prompt eval` (overview), `agentv prompt eval input`, `agentv prompt eval judge`
- `agentv run` removed entirely (no deprecated alias — clean break)
- `--eval-id` kept as silent convenience alias for `--test-id`
- Updated all docs, skills, examples, web content, and tests (54 files)

## New command tree

```
agentv eval <files>              # primary (was: agentv run)
agentv prompt eval <files>       # orchestration overview (was: agentv prompt overview)
agentv prompt eval input <file>  # task input (was: agentv prompt input)
agentv prompt eval judge <file>  # judge result (was: agentv prompt judge)
```

## Test plan

- [x] All 690 tests pass (553 core + 52 eval + 85 CLI)
- [x] Build, typecheck, lint pass
- [x] Pre-push hooks pass
- [x] `--eval-id` silently rewrites to `--test-id`
- [x] `agentv prompt file.yaml` auto-inserts `eval overview`
- [x] Zero remaining stale `agentv run` references in docs/skills/examples