### PR TITLE
fix(build): externalize OpenTelemetry packages and fix lint errors

### DIFF
--- a/packages/core/src/evaluation/providers/claude.ts
+++ b/packages/core/src/evaluation/providers/claude.ts
@@ -441,7 +441,7 @@ function summarizeMessage(msg: Record<string, unknown>): string | undefined {
  */
 function sanitizeEnvForClaudeSdk(): Record<string, string | undefined> {
   const env = { ...process.env };
-  delete env.CLAUDECODE;
+  env.CLAUDECODE = undefined;
   return env;
 }
 

--- a/packages/core/test/evaluation/providers/claude.test.ts
+++ b/packages/core/test/evaluation/providers/claude.test.ts
@@ -303,7 +303,7 @@ describe('ClaudeProvider', () => {
       if (originalClaudeCode !== undefined) {
         process.env.CLAUDECODE = originalClaudeCode;
       } else {
-        delete process.env.CLAUDECODE;
+        process.env.CLAUDECODE = undefined;
       }
     }
   });

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -13,6 +13,13 @@ export default defineConfig({
   },
   target: 'node20',
   tsconfig: './tsconfig.build.json',
+  external: [
+    '@opentelemetry/api',
+    '@opentelemetry/exporter-trace-otlp-http',
+    '@opentelemetry/resources',
+    '@opentelemetry/sdk-trace-node',
+    '@opentelemetry/semantic-conventions',
+  ],
   outExtension({ format }) {
     return {
       js: format === 'cjs' ? '.cjs' : '.js',


### PR DESCRIPTION
## Summary
- Add OpenTelemetry packages to `external` in `packages/core/tsup.config.ts` so tsup doesn't try to resolve dynamically imported optional dependencies at bundle time
- Replace `delete` operator with `undefined` assignment per biome lint rule (`noDelete`) in `claude.ts` and `claude.test.ts`

Together these fix all pre-push hook failures on `main` (build + lint). The test failure reported in #288 was a downstream effect — the stale `@agentv/eval` dist (with old schema field names) was never rebuilt because the core build step failed first.

Fixes #288

## Risk
Low — config-only change for tsup externals + mechanical lint fix. No behavioral changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)