### PR TITLE
fix(docs): migrate evaluator docs to assert syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,10 @@ tests:
 
     expected_output: "42"
 
-    execution:
-      evaluators:
-        - name: math_check
-          type: code_judge
-          script: ./validators/check_math.py
+    assert:
+      - name: math_check
+        type: code_judge
+        script: ./validators/check_math.py
 ```
 
 **5. Run the eval:**
@@ -192,11 +191,10 @@ print(json.dumps({
 Reference evaluators in your eval file:
 
 ```yaml
-execution:
-  evaluators:
-    - name: my_validator
-      type: code_judge
-      script: ./validators/check_answer.py
+assert:
+  - name: my_validator
+    type: code_judge
+    script: ./validators/check_answer.py
 ```
 
 For complete templates, examples, and evaluator patterns, see: [custom-evaluators](https://agentv.dev/evaluators/custom-evaluators/)
@@ -261,11 +259,10 @@ For complete examples and patterns, see:
 Create markdown judge files with evaluation criteria and scoring guidelines:
 
 ```yaml
-execution:
-  evaluators:
-    - name: semantic_check
-      type: llm_judge
-      prompt: ./judges/correctness.md
+assert:
+  - name: semantic_check
+    type: llm_judge
+    prompt: ./judges/correctness.md
 ```
 
 Your judge prompt file defines criteria and scoring guidelines.
@@ -281,10 +278,12 @@ tests:
 
     input: Explain quicksort algorithm
 
-    rubrics:
-      - Mentions divide-and-conquer approach
-      - Explains partition step
-      - States time complexity
+    assert:
+      - type: rubrics
+        criteria:
+          - Mentions divide-and-conquer approach
+          - Explains partition step
+          - States time complexity
 ```
 
 Scoring: `(satisfied weights) / (total weights)` → verdicts: `pass` (≥0.8), `borderline` (≥0.6), `fail`

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -35,11 +35,10 @@ tests:
 
     expected_output: "42"
 
-    execution:
-      evaluators:
-        - name: math_check
-          type: code_judge
-          script: ./validators/check_math.py
+    assert:
+      - name: math_check
+        type: code_judge
+        script: ./validators/check_math.py
 ```
 
 **5. Run the eval:**
@@ -192,11 +191,10 @@ print(json.dumps({
 Reference evaluators in your eval file:
 
 ```yaml
-execution:
-  evaluators:
-    - name: my_validator
-      type: code_judge
-      script: ./validators/check_answer.py
+assert:
+  - name: my_validator
+    type: code_judge
+    script: ./validators/check_answer.py
 ```
 
 For complete templates, examples, and evaluator patterns, see: [custom-evaluators](https://agentv.dev/evaluators/custom-evaluators/)
@@ -261,11 +259,10 @@ For complete examples and patterns, see:
 Create markdown judge files with evaluation criteria and scoring guidelines:
 
 ```yaml
-execution:
-  evaluators:
-    - name: semantic_check
-      type: llm_judge
-      prompt: ./judges/correctness.md
+assert:
+  - name: semantic_check
+    type: llm_judge
+    prompt: ./judges/correctness.md
 ```
 
 Your judge prompt file defines criteria and scoring guidelines.
@@ -281,10 +278,12 @@ tests:
 
     input: Explain quicksort algorithm
 
-    rubrics:
-      - Mentions divide-and-conquer approach
-      - Explains partition step
-      - States time complexity
+    assert:
+      - type: rubrics
+        criteria:
+          - Mentions divide-and-conquer approach
+          - Explains partition step
+          - States time complexity
 ```
 
 Scoring: `(satisfied weights) / (total weights)` → verdicts: `pass` (≥0.8), `borderline` (≥0.6), `fail`

--- a/apps/web/src/content/docs/evaluation/batch-cli.mdx
+++ b/apps/web/src/content/docs/evaluation/batch-cli.mdx
@@ -53,12 +53,11 @@ tests:
             name: Example A
             amount: 5000
 
-    execution:
-      evaluators:
-        - name: decision-check
-          type: code_judge
-          script: bun run ./scripts/check-output.ts
-          cwd: .
+    assert:
+      - name: decision-check
+        type: code_judge
+        script: bun run ./scripts/check-output.ts
+        cwd: .
 
   - id: case-002
     criteria: |-
@@ -82,12 +81,11 @@ tests:
             name: Example B
             amount: 25000
 
-    execution:
-      evaluators:
-        - name: decision-check
-          type: code_judge
-          script: bun run ./scripts/check-output.ts
-          cwd: .
+    assert:
+      - name: decision-check
+        type: code_judge
+        script: bun run ./scripts/check-output.ts
+        cwd: .
 ```
 
 ## Batch Runner Contract

--- a/apps/web/src/content/docs/evaluation/eval-cases.mdx
+++ b/apps/web/src/content/docs/evaluation/eval-cases.mdx
@@ -27,11 +27,11 @@ tests:
 | `criteria` | Yes | Description of what a correct response should contain |
 | `input` | Yes | Input sent to the target (string, object, or message array). Alias: `input` |
 | `expected_output` | No | Expected response for comparison (string, object, or message array). Alias: `expected_output` |
-| `execution` | No | Per-case execution overrides (target, evaluators) |
+| `execution` | No | Per-case execution overrides (for example `target`, `skip_defaults`) |
 | `workspace` | No | Per-case workspace config (overrides suite-level) |
 | `metadata` | No | Arbitrary key-value pairs passed to setup/teardown scripts |
 | `rubrics` | No | Structured evaluation criteria |
-| `assert` | No | Per-test assertion evaluators (alternative to `execution.evaluators`) |
+| `assert` | No | Per-test evaluators |
 | `sidecar` | No | Additional metadata passed to evaluators |
 
 ## Input
@@ -80,36 +80,35 @@ tests:
 
     execution:
       target: gpt4_target
-      evaluators:
-        - name: depth_check
-          type: llm_judge
-          prompt: ./judges/depth.md
+    assert:
+      - name: depth_check
+        type: llm_judge
+        prompt: ./judges/depth.md
 ```
 
-Per-case evaluators are **merged** with root-level `execution.evaluators` — test-specific evaluators run first, then root-level defaults are appended. To opt out of root-level evaluators for a specific test, set `skip_defaults: true`:
+Per-case `assert` evaluators are **merged** with root-level `assert` evaluators — test-specific evaluators run first, then root-level defaults are appended. To opt out of root-level defaults for a specific test, set `execution.skip_defaults: true`:
 
 ```yaml
-execution:
-  evaluators:
-    - name: latency_check
-      type: latency
-      threshold: 5000
+assert:
+  - name: latency_check
+    type: latency
+    threshold: 5000
 
 tests:
   - id: normal-case
     criteria: Returns correct answer
     input: What is 2+2?
-    # Gets latency_check from root-level evaluators
+    # Gets latency_check from root-level assert
 
   - id: special-case
     criteria: Handles edge case
     input: Handle this edge case
     execution:
       skip_defaults: true
-      evaluators:
-        - name: custom_eval
-          type: llm_judge
-      # Does NOT get latency_check
+    assert:
+      - name: custom_eval
+        type: llm_judge
+    # Does NOT get latency_check
 ```
 
 ## Per-Case Workspace Config
@@ -158,7 +157,7 @@ The `metadata` field is included in the stdin JSON passed to setup and teardown 
 
 ## Per-Test Assertions
 
-The `assert` field provides a concise way to attach evaluators directly to a test, as an alternative to nesting them inside `execution.evaluators`. It supports both deterministic assertion types and LLM-based rubric evaluation.
+The `assert` field defines evaluators directly on a test. It supports both deterministic assertion types and LLM-based rubric evaluation.
 
 ### Deterministic Assertions
 
@@ -214,7 +213,7 @@ tests:
 
 ### Required Gates
 
-Any evaluator (in `assert` or `execution.evaluators`) can be marked as `required`. When a required evaluator fails, the overall test verdict is `fail` regardless of the aggregate score.
+Any evaluator in `assert` can be marked as `required`. When a required evaluator fails, the overall test verdict is `fail` regardless of the aggregate score.
 
 | Value | Behavior |
 |-------|----------|
@@ -236,14 +235,13 @@ assert:
 
 Required gates are evaluated after all evaluators run. If any required evaluator falls below its threshold, the verdict is forced to `fail`.
 
-### Assert vs execution.evaluators
+### Assert Merge Behavior
 
-`assert` and `execution.evaluators` serve the same purpose — both define evaluators for a test. Choose whichever fits your style:
+`assert` can be defined at both suite and test levels:
 
-- **`assert`**: Flat, concise syntax at the test level. Best for assertion-heavy evals.
-- **`execution.evaluators`**: Nested under `execution`. Useful when you also set `target` or `skip_defaults`.
-
-When both are present on the same test, `assert` takes precedence over `execution.evaluators`. Suite-level `assert` and `execution.evaluators` follow the same merge rules — they are appended to per-test evaluators unless `skip_defaults: true` is set.
+- Per-test `assert` evaluators run first.
+- Suite-level `assert` evaluators are appended automatically.
+- Set `execution.skip_defaults: true` on a test to skip suite-level defaults.
 
 ## Sidecar Metadata
 

--- a/apps/web/src/content/docs/evaluation/eval-files.mdx
+++ b/apps/web/src/content/docs/evaluation/eval-files.mdx
@@ -15,10 +15,11 @@ The primary format. A single file contains metadata, execution config, and tests
 description: Math problem solving evaluation
 execution:
   target: default
-  evaluators:
-    - name: correctness
-      type: llm_judge
-      prompt: ./judges/correctness.md
+
+assert:
+  - name: correctness
+    type: llm_judge
+    prompt: ./judges/correctness.md
 
 tests:
   - id: addition
@@ -33,10 +34,10 @@ tests:
 |-------|-------------|
 | `description` | Human-readable description of the evaluation |
 | `dataset` | Optional dataset identifier |
-| `execution` | Default execution config (target, evaluators). Root-level evaluators are appended to every test's evaluators unless the test sets `skip_defaults: true` |
+| `execution` | Default execution config (for example `target`) |
 | `workspace` | Suite-level workspace config (setup/teardown scripts, template) |
 | `tests` | Array of individual tests, or a string path to an external file |
-| `assert` | Suite-level assertion evaluators (alternative to `execution.evaluators`) |
+| `assert` | Suite-level evaluators appended to each test unless `execution.skip_defaults: true` is set on the test |
 
 ### Metadata Fields
 
@@ -70,7 +71,7 @@ tests:
 
 ### Suite-level Assert
 
-The `assert` field provides a concise way to define evaluators at the suite level, as an alternative to nesting them inside `execution.evaluators`. Suite-level assertions are appended to every test's evaluators (same merge behavior as `execution.evaluators`).
+The `assert` field is the canonical way to define suite-level evaluators. Suite-level assertions are appended to every test's evaluators unless a test sets `execution.skip_defaults: true`.
 
 ```yaml
 description: API response validation
@@ -86,7 +87,7 @@ tests:
     input: Check API health
 ```
 
-`assert` supports the same evaluator types as `execution.evaluators`, including the new deterministic assertion types (`contains`, `regex`, `is_json`, `equals`) and `rubrics`. See [Tests](/evaluation/eval-cases/#per-test-assertions) for per-test assert usage.
+`assert` supports all evaluator types, including deterministic assertion types (`contains`, `regex`, `is_json`, `equals`) and `rubrics`. See [Tests](/evaluation/eval-cases/#per-test-assertions) for per-test assert usage.
 
 ### Tests as String Path
 
@@ -122,7 +123,10 @@ description: Math evaluation dataset
 dataset: math-tests
 execution:
   target: azure_base
-evaluator: llm_judge
+assert:
+  - name: correctness
+    type: llm_judge
+    prompt: ./judges/correctness.md
 ```
 
 ### Benefits of JSONL

--- a/apps/web/src/content/docs/evaluation/rubrics.mdx
+++ b/apps/web/src/content/docs/evaluation/rubrics.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 3
 ---
 
-Rubrics define structured evaluation criteria directly in your tests. They support binary checklist grading and score-range analytic grading.
+Rubrics are defined with `assert` entries using `type: rubrics`. They support binary checklist grading and score-range analytic grading.
 
 ## Basic Usage
 
@@ -16,10 +16,12 @@ tests:
   - id: quicksort-explain
     criteria: Explain how quicksort works
     input: Explain quicksort algorithm
-    rubrics:
-      - Mentions divide-and-conquer approach
-      - Explains partition step
-      - States time complexity
+    assert:
+      - type: rubrics
+        criteria:
+          - Mentions divide-and-conquer approach
+          - Explains partition step
+          - States time complexity
 ```
 
 ## Checklist Mode
@@ -27,17 +29,19 @@ tests:
 For fine-grained control, use rubric objects with weights and requirements:
 
 ```yaml
-rubrics:
-  - id: core-concept
-    outcome: Explains divide-and-conquer
-    weight: 2.0
-    required: true
-  - id: partition
-    outcome: Describes partition step
-    weight: 1.5
-  - id: complexity
-    outcome: States O(n log n) average time
-    weight: 1.0
+assert:
+  - type: rubrics
+    criteria:
+      - id: core-concept
+        outcome: Explains divide-and-conquer
+        weight: 2.0
+        required: true
+      - id: partition
+        outcome: Describes partition step
+        weight: 1.5
+      - id: complexity
+        outcome: States O(n log n) average time
+        weight: 1.0
 ```
 
 ### Rubric Object Fields
@@ -56,16 +60,18 @@ rubrics:
 For quality gradients instead of binary pass/fail, use score ranges:
 
 ```yaml
-rubrics:
-  - id: accuracy
-    outcome: Provides correct answer
-    weight: 2.0
-    score_ranges:
-      0: Completely wrong
-      3: Partially correct with major errors
-      5: Mostly correct with minor issues
-      7: Correct with minor omissions
-      10: Perfectly accurate and complete
+assert:
+  - type: rubrics
+    criteria:
+      - id: accuracy
+        outcome: Provides correct answer
+        weight: 2.0
+        score_ranges:
+          0: Completely wrong
+          3: Partially correct with major errors
+          5: Mostly correct with minor issues
+          7: Correct with minor omissions
+          10: Perfectly accurate and complete
 ```
 
 Each criterion is scored 0–10 by the LLM judge with granular feedback.
@@ -111,13 +117,13 @@ tests:
   - id: code-quality
     criteria: Generates correct, clean Python code
     input: Write a fibonacci function
-    rubrics:
-      - Returns correct values for n=0,1,2,10
-      - Uses meaningful variable names
-      - Includes docstring
-    execution:
-      evaluators:
-        - name: syntax_check
-          type: code_judge
-          script: ./validators/check_python.py
+    assert:
+      - type: rubrics
+        criteria:
+          - Returns correct values for n=0,1,2,10
+          - Uses meaningful variable names
+          - Includes docstring
+      - name: syntax_check
+        type: code_judge
+        script: ./validators/check_python.py
 ```

--- a/apps/web/src/content/docs/evaluators/code-judges.mdx
+++ b/apps/web/src/content/docs/evaluators/code-judges.mdx
@@ -94,11 +94,10 @@ console.log(JSON.stringify({
 ## Referencing in Eval Files
 
 ```yaml
-execution:
-  evaluators:
-    - name: my_validator
-      type: code_judge
-      script: ./validators/check_answer.py
+assert:
+  - name: my_validator
+    type: code_judge
+    script: ./validators/check_answer.py
 ```
 
 ## @agentv/eval SDK
@@ -140,7 +139,7 @@ Code judges can call an LLM through a target proxy for metrics that require mult
 Add a `target` block to the evaluator config:
 
 ```yaml
-evaluators:
+assert:
   - name: contextual-precision
     type: code_judge
     script: bun scripts/contextual-precision.ts
@@ -287,7 +286,7 @@ tests:
   - id: implement-feature
     criteria: Agent implements the feature correctly
     input: "Implement the TODO functions in src/index.ts"
-    evaluators:
+    assert:
       - name: functional-check
         type: code_judge
         script: bun scripts/functional-check.ts

--- a/apps/web/src/content/docs/evaluators/composite.mdx
+++ b/apps/web/src/content/docs/evaluators/composite.mdx
@@ -12,22 +12,21 @@ Composite evaluators combine multiple evaluators and aggregate their results int
 A composite evaluator wraps two or more sub-evaluators and an aggregator that determines the final score:
 
 ```yaml
-execution:
-  evaluators:
-    - name: my_composite
-      type: composite
-      evaluators:
-        - name: evaluator_1
-          type: llm_judge
-          prompt: ./prompts/check1.md
-        - name: evaluator_2
-          type: code_judge
-          script: uv run check2.py
-      aggregator:
-        type: weighted_average
-        weights:
-          evaluator_1: 0.6
-          evaluator_2: 0.4
+assert:
+  - name: my_composite
+    type: composite
+    evaluators:
+      - name: evaluator_1
+        type: llm_judge
+        prompt: ./prompts/check1.md
+      - name: evaluator_2
+        type: code_judge
+        script: uv run check2.py
+    aggregator:
+      type: weighted_average
+      weights:
+        evaluator_1: 0.6
+        evaluator_2: 0.4
 ```
 
 Each sub-evaluator runs independently, then the aggregator combines their results.
@@ -113,20 +112,19 @@ tests:
 
     input: Explain quantum computing
 
-    execution:
-      evaluators:
-        - name: safety_gate
-          type: composite
-          evaluators:
-            - name: safety
-              type: llm_judge
-              prompt: ./prompts/safety-check.md
-            - name: quality
-              type: llm_judge
-              prompt: ./prompts/quality-check.md
-          aggregator:
-            type: code_judge
-            path: ./scripts/safety-gate.js
+    assert:
+      - name: safety_gate
+        type: composite
+        evaluators:
+          - name: safety
+            type: llm_judge
+            prompt: ./prompts/safety-check.md
+          - name: quality
+            type: llm_judge
+            prompt: ./prompts/quality-check.md
+        aggregator:
+          type: code_judge
+          path: ./scripts/safety-gate.js
 ```
 
 The `safety-gate.js` script can return a score of 0.0 whenever the safety evaluator fails, regardless of the quality score.

--- a/apps/web/src/content/docs/evaluators/custom-evaluators.mdx
+++ b/apps/web/src/content/docs/evaluators/custom-evaluators.mdx
@@ -13,21 +13,20 @@ AgentV supports multiple evaluator types that can be combined for comprehensive 
 |------|-------------|----------|
 | `code_judge` | Deterministic script (Python/TS/any) | Exact matching, format validation, programmatic checks |
 | `llm_judge` | LLM-based evaluation with custom prompt | Semantic evaluation, nuance, subjective quality |
-| Rubrics | Structured criteria in test | Multi-criterion grading with weights |
+| `rubrics` | Structured rubric evaluator via `assert` | Multi-criterion grading with weights |
 
 ## Referencing Evaluators
 
-Evaluators are configured at the execution level — either top-level (applies to all tests) or per-test:
+Evaluators are configured using `assert` — either top-level (applies to all tests) or per-test:
 
 ### Top-Level (Default for All Tests)
 
 ```yaml
 description: My evaluation
-execution:
-  evaluators:
-    - name: correctness
-      type: llm_judge
-      prompt: ./judges/correctness.md
+assert:
+  - name: correctness
+    type: llm_judge
+    prompt: ./judges/correctness.md
 
 tests:
   - id: test-1
@@ -42,11 +41,10 @@ tests:
   - id: test-1
     criteria: Returns valid JSON
     input: Generate a JSON config
-    execution:
-      evaluators:
-        - name: json_check
-          type: code_judge
-          script: ./validators/check_json.py
+    assert:
+      - name: json_check
+        type: code_judge
+        script: ./validators/check_json.py
 ```
 
 ## Combining Evaluators
@@ -58,18 +56,18 @@ tests:
   - id: code-generation
     criteria: Generates correct Python code
     input: Write a sorting function
-    rubrics:
-      - Code is syntactically valid
-      - Handles edge cases (empty list, single element)
-      - Uses appropriate algorithm
-    execution:
-      evaluators:
-        - name: syntax_check
-          type: code_judge
-          script: ./validators/check_syntax.py
-        - name: quality_review
-          type: llm_judge
-          prompt: ./judges/code_quality.md
+    assert:
+      - type: rubrics
+        criteria:
+          - Code is syntactically valid
+          - Handles edge cases (empty list, single element)
+          - Uses appropriate algorithm
+      - name: syntax_check
+        type: code_judge
+        script: ./validators/check_syntax.py
+      - name: quality_review
+        type: llm_judge
+        prompt: ./judges/code_quality.md
 ```
 
 Each evaluator produces its own score. Results appear in `scores[]` in the output JSONL.

--- a/apps/web/src/content/docs/evaluators/execution-metrics.mdx
+++ b/apps/web/src/content/docs/evaluators/execution-metrics.mdx
@@ -12,7 +12,7 @@ AgentV provides built-in evaluators for checking execution metrics against thres
 The `execution_metrics` evaluator provides declarative threshold-based checks on multiple metrics in a single evaluator.
 
 ```yaml
-evaluators:
+assert:
   - name: efficiency
     type: execution_metrics
     max_tool_calls: 10        # Maximum tool invocations
@@ -50,15 +50,14 @@ tests:
   - id: efficient-research
     criteria: Agent researches and summarizes efficiently
     input: Research the topic and provide a summary
-    execution:
-      evaluators:
-        - name: efficiency
-          type: execution_metrics
-          max_tool_calls: 15
-          max_llm_calls: 5
-          max_tokens: 8000
-          max_cost_usd: 0.10
-          max_duration_ms: 60000
+    assert:
+      - name: efficiency
+        type: execution_metrics
+        max_tool_calls: 15
+        max_llm_calls: 5
+        max_tokens: 8000
+        max_cost_usd: 0.10
+        max_duration_ms: 60000
 ```
 
 ### Example: Exploration Balance
@@ -66,7 +65,7 @@ tests:
 Check that an agent maintains a good balance between reading (exploration) and writing (action):
 
 ```yaml
-evaluators:
+assert:
   - name: exploration-balance
     type: execution_metrics
     target_exploration_ratio: 0.6  # 60% should be read-only tools
@@ -124,16 +123,15 @@ tests:
   - id: code-generation
     criteria: Generates correct, efficient code
     input: Write a sorting algorithm
-    execution:
-      evaluators:
-        # Semantic quality
-        - name: quality
-          type: llm_judge
-          prompt: ./prompts/code-quality.md
+    assert:
+      # Semantic quality
+      - name: quality
+        type: llm_judge
+        prompt: ./prompts/code-quality.md
 
-        # Efficiency constraints
-        - name: efficiency
-          type: execution_metrics
-          max_tool_calls: 10
-          max_duration_ms: 30000
+      # Efficiency constraints
+      - name: efficiency
+        type: execution_metrics
+        max_tool_calls: 10
+        max_duration_ms: 30000
 ```

--- a/apps/web/src/content/docs/evaluators/llm-judges.mdx
+++ b/apps/web/src/content/docs/evaluators/llm-judges.mdx
@@ -12,11 +12,10 @@ LLM judges use a language model to evaluate agent responses against custom crite
 Reference an LLM judge in your eval file:
 
 ```yaml
-execution:
-  evaluators:
-    - name: semantic_check
-      type: llm_judge
-      prompt: ./judges/correctness.md
+assert:
+  - name: semantic_check
+    type: llm_judge
+    prompt: ./judges/correctness.md
 ```
 
 ## Prompt Files
@@ -96,7 +95,7 @@ Evaluate and provide a score from 0 to 1.`;
 When using TypeScript templates, configure them in YAML with optional `config` data passed to the script:
 
 ```yaml
-evaluators:
+assert:
   - name: custom-eval
     type: llm_judge
     prompt:

--- a/apps/web/src/content/docs/evaluators/structured-data.mdx
+++ b/apps/web/src/content/docs/evaluators/structured-data.mdx
@@ -29,22 +29,21 @@ tests:
 Use `field_accuracy` to compare fields in the candidate JSON against the ground-truth object in `expected_output`.
 
 ```yaml
-execution:
-  evaluators:
-    - name: invoice_fields
-      type: field_accuracy
-      aggregation: weighted_average
-      fields:
-        - path: invoice_number
-          match: exact
-          required: true
-          weight: 2.0
-        - path: invoice_date
-          match: date
-          formats: ["DD-MMM-YYYY", "YYYY-MM-DD"]
-        - path: net_total
-          match: numeric_tolerance
-          tolerance: 1.0
+assert:
+  - name: invoice_fields
+    type: field_accuracy
+    aggregation: weighted_average
+    fields:
+      - path: invoice_number
+        match: exact
+        required: true
+        weight: 2.0
+      - path: invoice_date
+        match: date
+        formats: ["DD-MMM-YYYY", "YYYY-MM-DD"]
+      - path: net_total
+        match: numeric_tolerance
+        tolerance: 1.0
 ```
 
 ### Match Types
@@ -69,11 +68,10 @@ For fuzzy string matching, use a `code_judge` evaluator (e.g. Levenshtein distan
 Gate on execution time (in milliseconds) reported by the provider via `trace`.
 
 ```yaml
-execution:
-  evaluators:
-    - name: performance
-      type: latency
-      threshold: 2000
+assert:
+  - name: performance
+    type: latency
+    threshold: 2000
 ```
 
 ## Cost
@@ -81,11 +79,10 @@ execution:
 Gate on monetary cost reported by the provider via `trace`.
 
 ```yaml
-execution:
-  evaluators:
-    - name: budget
-      type: cost
-      budget: 0.10
+assert:
+  - name: budget
+    type: cost
+    budget: 0.10
 ```
 
 ## Token Usage
@@ -93,14 +90,13 @@ execution:
 Gate on provider-reported token usage. Useful when cost is unavailable or model pricing differs.
 
 ```yaml
-execution:
-  evaluators:
-    - name: token-budget
-      type: token_usage
-      max_total: 10000
-      # or:
-      # max_input: 8000
-      # max_output: 2000
+assert:
+  - name: token-budget
+    type: token_usage
+    max_total: 10000
+    # or:
+    # max_input: 8000
+    # max_output: 2000
 ```
 
 ## Combining with Composite Evaluators
@@ -108,30 +104,29 @@ execution:
 Use a `composite` evaluator to produce a single "release gate" score from multiple checks:
 
 ```yaml
-execution:
-  evaluators:
-    - name: release_gate
-      type: composite
-      evaluators:
-        - name: correctness
-          type: field_accuracy
-          fields:
-            - path: invoice_number
-              match: exact
-        - name: latency
-          type: latency
-          threshold: 2000
-        - name: cost
-          type: cost
-          budget: 0.10
-        - name: tokens
-          type: token_usage
-          max_total: 10000
-      aggregator:
-        type: weighted_average
-        weights:
-          correctness: 0.8
-          latency: 0.1
-          cost: 0.05
-          tokens: 0.05
+assert:
+  - name: release_gate
+    type: composite
+    evaluators:
+      - name: correctness
+        type: field_accuracy
+        fields:
+          - path: invoice_number
+            match: exact
+      - name: latency
+        type: latency
+        threshold: 2000
+      - name: cost
+        type: cost
+        budget: 0.10
+      - name: tokens
+        type: token_usage
+        max_total: 10000
+    aggregator:
+      type: weighted_average
+      weights:
+        correctness: 0.8
+        latency: 0.1
+        cost: 0.05
+        tokens: 0.05
 ```

--- a/apps/web/src/content/docs/evaluators/tool-trajectory.mdx
+++ b/apps/web/src/content/docs/evaluators/tool-trajectory.mdx
@@ -14,14 +14,13 @@ Tool trajectory evaluators validate that an agent used the expected tools during
 Validates that each tool was called at least N times, regardless of order:
 
 ```yaml
-execution:
-  evaluators:
-    - name: tool-usage
-      type: tool_trajectory
-      mode: any_order
-      minimums:
-        knowledgeSearch: 2    # Must be called at least twice
-        documentRetrieve: 1   # Must be called at least once
+assert:
+  - name: tool-usage
+    type: tool_trajectory
+    mode: any_order
+    minimums:
+      knowledgeSearch: 2    # Must be called at least twice
+      documentRetrieve: 1   # Must be called at least once
 ```
 
 Use `any_order` when you want to ensure required tools are used but don't care about execution order.
@@ -31,16 +30,15 @@ Use `any_order` when you want to ensure required tools are used but don't care a
 Validates tools appear in the expected sequence, but allows gaps (other tools can appear between expected ones):
 
 ```yaml
-execution:
-  evaluators:
-    - name: workflow-sequence
-      type: tool_trajectory
-      mode: in_order
-      expected:
-        - tool: fetchData
-        - tool: validateSchema
-        - tool: transformData
-        - tool: saveResults
+assert:
+  - name: workflow-sequence
+    type: tool_trajectory
+    mode: in_order
+    expected:
+      - tool: fetchData
+      - tool: validateSchema
+      - tool: transformData
+      - tool: saveResults
 ```
 
 Use `in_order` when you need to verify logical workflow order while allowing the agent to use additional helper tools between steps.
@@ -50,15 +48,14 @@ Use `in_order` when you need to verify logical workflow order while allowing the
 Validates the exact tool sequence with no gaps or extra tools:
 
 ```yaml
-execution:
-  evaluators:
-    - name: auth-sequence
-      type: tool_trajectory
-      mode: exact
-      expected:
-        - tool: checkCredentials
-        - tool: generateToken
-        - tool: auditLog
+assert:
+  - name: auth-sequence
+    type: tool_trajectory
+    mode: exact
+    expected:
+      - tool: checkCredentials
+      - tool: generateToken
+      - tool: auditLog
 ```
 
 Use `exact` for security-critical workflows, strict protocol validation, or regression testing specific behavior.
@@ -68,22 +65,21 @@ Use `exact` for security-critical workflows, strict protocol validation, or regr
 For `in_order` and `exact` modes, you can optionally validate tool arguments:
 
 ```yaml
-execution:
-  evaluators:
-    - name: search-validation
-      type: tool_trajectory
-      mode: in_order
-      expected:
-        # Partial match — only specified keys are checked
-        - tool: search
-          args: { query: "machine learning" }
+assert:
+  - name: search-validation
+    type: tool_trajectory
+    mode: in_order
+    expected:
+      # Partial match — only specified keys are checked
+      - tool: search
+        args: { query: "machine learning" }
 
-        # Skip argument validation for this tool
-        - tool: process
-          args: any
+      # Skip argument validation for this tool
+      - tool: process
+        args: any
 
-        # No args field = no argument validation (same as args: any)
-        - tool: saveResults
+      # No args field = no argument validation (same as args: any)
+      - tool: saveResults
 ```
 
 | Syntax | Behavior |
@@ -97,17 +93,16 @@ execution:
 For `in_order` and `exact` modes, you can validate per-tool timing with `max_duration_ms`:
 
 ```yaml
-execution:
-  evaluators:
-    - name: perf-check
-      type: tool_trajectory
-      mode: in_order
-      expected:
-        - tool: Read
-          max_duration_ms: 100    # Must complete within 100ms
-        - tool: Edit
-          max_duration_ms: 500    # Allow 500ms for edits
-        - tool: Write             # No timing requirement
+assert:
+  - name: perf-check
+    type: tool_trajectory
+    mode: in_order
+    expected:
+      - tool: Read
+        max_duration_ms: 100    # Must complete within 100ms
+      - tool: Edit
+        max_duration_ms: 500    # Allow 500ms for edits
+      - tool: Write             # No timing requirement
 ```
 
 Each `max_duration_ms` assertion counts as a separate scoring aspect. The rules:
@@ -194,25 +189,24 @@ tests:
 
     input: Research machine learning frameworks
 
-    execution:
-      evaluators:
-        # Check minimum tool usage
-        - name: coverage
-          type: tool_trajectory
-          mode: any_order
-          minimums:
-            webSearch: 1
-            documentRead: 2
-            noteTaking: 1
+    assert:
+      # Check minimum tool usage
+      - name: coverage
+        type: tool_trajectory
+        mode: any_order
+        minimums:
+          webSearch: 1
+          documentRead: 2
+          noteTaking: 1
 
-        # Check workflow order
-        - name: workflow
-          type: tool_trajectory
-          mode: in_order
-          expected:
-            - tool: webSearch
-            - tool: documentRead
-            - tool: summarize
+      # Check workflow order
+      - name: workflow
+        type: tool_trajectory
+        mode: in_order
+        expected:
+          - tool: webSearch
+          - tool: documentRead
+          - tool: summarize
 ```
 
 ### Multi-Step Pipeline
@@ -224,16 +218,15 @@ tests:
 
     input: Process the customer dataset
 
-    execution:
-      evaluators:
-        - name: pipeline-check
-          type: tool_trajectory
-          mode: exact
-          expected:
-            - tool: loadData
-            - tool: validate
-            - tool: transform
-            - tool: export
+    assert:
+      - name: pipeline-check
+        type: tool_trajectory
+        mode: exact
+        expected:
+          - tool: loadData
+          - tool: validate
+          - tool: transform
+          - tool: export
 ```
 
 ### Pipeline with Latency Assertions
@@ -245,19 +238,18 @@ tests:
 
     input: Process the customer dataset quickly
 
-    execution:
-      evaluators:
-        - name: pipeline-perf
-          type: tool_trajectory
-          mode: in_order
-          expected:
-            - tool: loadData
-              max_duration_ms: 1000   # Network fetch within 1s
-            - tool: validate           # No timing requirement
-            - tool: transform
-              max_duration_ms: 500    # Transform must be fast
-            - tool: export
-              max_duration_ms: 200    # Export should be quick
+    assert:
+      - name: pipeline-perf
+        type: tool_trajectory
+        mode: in_order
+        expected:
+          - tool: loadData
+            max_duration_ms: 1000   # Network fetch within 1s
+          - tool: validate           # No timing requirement
+          - tool: transform
+            max_duration_ms: 500    # Transform must be fast
+          - tool: export
+            max_duration_ms: 200    # Export should be quick
 ```
 
 ## Best Practices

--- a/apps/web/src/content/docs/getting-started/quickstart.mdx
+++ b/apps/web/src/content/docs/getting-started/quickstart.mdx
@@ -44,11 +44,10 @@ tests:
 
     expected_output: "42"
 
-    execution:
-      evaluators:
-        - name: math_check
-          type: code_judge
-          script: ./validators/check_math.py
+    assert:
+      - name: math_check
+        type: code_judge
+        script: ./validators/check_math.py
 ```
 
 ## 5. Run the eval

--- a/apps/web/src/content/docs/tools/generate.mdx
+++ b/apps/web/src/content/docs/tools/generate.mdx
@@ -22,7 +22,7 @@ This analyzes each test's `criteria` field and creates structured rubric criteri
 1. Reads each test's `criteria`
 2. Uses an LLM to decompose the criteria into individual checkable rubric items
 3. Assigns weights based on importance
-4. Writes the rubrics back to the eval file
+4. Writes rubric criteria back under `assert: - type: rubrics`
 
 ## Example
 
@@ -42,9 +42,11 @@ tests:
   - id: quicksort
     criteria: Explains quicksort with time complexity and examples
     input: Explain quicksort
-    rubrics:
-      - Explains divide-and-conquer approach
-      - Describes partition step
-      - States O(n log n) average time complexity
-      - Provides a concrete example
+    assert:
+      - type: rubrics
+        criteria:
+          - Explains divide-and-conquer approach
+          - Describes partition step
+          - States O(n log n) average time complexity
+          - Provides a concrete example
 ```


### PR DESCRIPTION
## Summary
- migrate evaluator configuration examples from deprecated `execution.evaluators` nesting to canonical `assert` usage across README, CLI README, and docs pages
- update rubric documentation and custom evaluator docs to use `assert` with `type: rubrics` and `criteria`
- align generate/eval file docs with current output/config shape so examples match actual code behavior

## Validation
- `cd apps/web && bun run build`

## Risk
low - docs-only changes with no runtime code changes
