### PR TITLE
feat(eval): tool_trajectory evaluator v2

### DIFF
--- a/examples/features/tool-trajectory-simple/evals/dataset.eval.yaml
+++ b/examples/features/tool-trajectory-simple/evals/dataset.eval.yaml
@@ -11,7 +11,7 @@
 # - superset: Every expected tool must be found in actual (extras OK, greedy matching)
 # - subset: Every actual call must be in the allowed set (expected items reusable)
 #
-# Argument matching modes (per-item `args_match` or evaluator-level `default_args_match`):
+# Argument matching modes (per-item `args_match` or evaluator-level `args_match`):
 # - exact: Bidirectional deep equality, no extra keys (default)
 # - superset: Actual args must contain all expected keys (extras OK)
 # - subset: Actual args must be a subset of expected (no unexpected keys)
@@ -181,7 +181,7 @@ tests:
         type: tool_trajectory
         mode: in_order
         # Use superset args matching to allow extra keys in actual args
-        default_args_match: superset
+        args_match: superset
         expected:
           - tool: search
             args:
@@ -242,7 +242,7 @@ tests:
       - name: required-tools
         type: tool_trajectory
         mode: superset
-        default_args_match: superset
+        args_match: superset
         expected:
           - tool: knowledgeSearch
           - tool: documentRetrieve
@@ -288,7 +288,7 @@ tests:
       - name: mixed-precision
         type: tool_trajectory
         mode: in_order
-        default_args_match: ignore  # Default: don't check args
+        args_match: ignore  # Default: don't check args
         expected:
           - tool: fetchData
           - tool: validateSchema

--- a/packages/core/src/evaluation/evaluators/tool-trajectory.ts
+++ b/packages/core/src/evaluation/evaluators/tool-trajectory.ts
@@ -33,13 +33,13 @@ function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
 
 /**
  * Resolve the effective args match mode for an expected item.
- * Priority: per-item argsMatch > evaluator-level defaultArgsMatch > 'exact'
+ * Priority: per-item argsMatch > evaluator-level argsMatch > 'exact'
  */
 function resolveArgsMatchMode(
   item: ToolTrajectoryExpectedItem,
   config: ToolTrajectoryEvaluatorConfig,
 ): ArgsMatchMode | readonly string[] {
-  return item.argsMatch ?? config.defaultArgsMatch ?? 'exact';
+  return item.argsMatch ?? config.argsMatch ?? 'exact';
 }
 
 /**

--- a/packages/core/src/evaluation/loaders/evaluator-parser.ts
+++ b/packages/core/src/evaluation/loaders/evaluator-parser.ts
@@ -378,29 +378,29 @@ async function parseEvaluatorList(
         }
       }
 
-      // Parse default_args_match at evaluator level (snake_case from YAML -> camelCase)
-      const rawDefaultArgsMatch = rawEvaluator.default_args_match ?? rawEvaluator.defaultArgsMatch;
-      let defaultArgsMatch: import('../trace.js').ArgsMatchMode | readonly string[] | undefined;
-      if (rawDefaultArgsMatch !== undefined) {
-        if (Array.isArray(rawDefaultArgsMatch)) {
+      // Parse args_match at evaluator level (snake_case from YAML -> camelCase)
+      const rawArgsMatch = rawEvaluator.args_match ?? rawEvaluator.argsMatch;
+      let argsMatch: import('../trace.js').ArgsMatchMode | readonly string[] | undefined;
+      if (rawArgsMatch !== undefined) {
+        if (Array.isArray(rawArgsMatch)) {
           // Field list mode: string array of field paths
-          const fieldList = rawDefaultArgsMatch.filter(
+          const fieldList = rawArgsMatch.filter(
             (f): f is string => typeof f === 'string' && f.length > 0,
           );
           if (fieldList.length > 0) {
-            defaultArgsMatch = fieldList;
+            argsMatch = fieldList;
           }
-        } else if (typeof rawDefaultArgsMatch === 'string') {
+        } else if (typeof rawArgsMatch === 'string') {
           if (
-            rawDefaultArgsMatch === 'exact' ||
-            rawDefaultArgsMatch === 'superset' ||
-            rawDefaultArgsMatch === 'subset' ||
-            rawDefaultArgsMatch === 'ignore'
+            rawArgsMatch === 'exact' ||
+            rawArgsMatch === 'superset' ||
+            rawArgsMatch === 'subset' ||
+            rawArgsMatch === 'ignore'
           ) {
-            defaultArgsMatch = rawDefaultArgsMatch;
+            argsMatch = rawArgsMatch;
           } else {
             logWarning(
-              `Invalid default_args_match '${rawDefaultArgsMatch}' for tool_trajectory evaluator '${name}' in '${evalId}': must be exact, superset, subset, ignore, or a string array`,
+              `Invalid args_match '${rawArgsMatch}' for tool_trajectory evaluator '${name}' in '${evalId}': must be exact, superset, subset, ignore, or a string array`,
             );
           }
         }
@@ -500,7 +500,7 @@ async function parseEvaluatorList(
         ...(weight !== undefined ? { weight } : {}),
         ...(required !== undefined ? { required } : {}),
         ...(negate !== undefined ? { negate } : {}),
-        ...(defaultArgsMatch !== undefined ? { defaultArgsMatch } : {}),
+        ...(argsMatch !== undefined ? { argsMatch } : {}),
       };
 
       evaluators.push(config);

--- a/packages/core/src/evaluation/trace.ts
+++ b/packages/core/src/evaluation/trace.ts
@@ -71,7 +71,7 @@ export interface ToolTrajectoryEvaluatorConfig {
   /** When true, inverts the evaluator score (1 - score) and swaps pass/fail verdict */
   readonly negate?: boolean;
   /** Default argument matching mode for all expected items (defaults to 'exact') */
-  readonly defaultArgsMatch?: ArgsMatchMode | readonly string[];
+  readonly argsMatch?: ArgsMatchMode | readonly string[];
 }
 
 /**
@@ -83,7 +83,7 @@ export interface ToolTrajectoryExpectedItem {
   readonly args?: 'any' | Record<string, unknown>;
   /** Optional maximum duration in milliseconds for latency assertions */
   readonly maxDurationMs?: number;
-  /** Per-item argument matching mode override (takes precedence over evaluator-level defaultArgsMatch) */
+  /** Per-item argument matching mode override (takes precedence over evaluator-level argsMatch) */
   readonly argsMatch?: ArgsMatchMode | readonly string[];
 }
 

--- a/packages/core/test/evaluation/tool-trajectory-evaluator.test.ts
+++ b/packages/core/test/evaluation/tool-trajectory-evaluator.test.ts
@@ -706,8 +706,8 @@ describe('ToolTrajectoryEvaluator', () => {
       });
     });
 
-    describe('default_args_match at evaluator level', () => {
-      it('applies defaultArgsMatch to all items without per-item override', () => {
+    describe('args_match at evaluator level', () => {
+      it('applies argsMatch to all items without per-item override', () => {
         const output: Message[] = [
           {
             role: 'assistant',
@@ -722,7 +722,7 @@ describe('ToolTrajectoryEvaluator', () => {
           name: 'test',
           type: 'tool_trajectory',
           mode: 'exact',
-          defaultArgsMatch: 'superset',
+          argsMatch: 'superset',
           expected: [
             { tool: 'search', args: { query: 'test' } },
             { tool: 'analyze', args: { format: 'json' } },
@@ -737,7 +737,7 @@ describe('ToolTrajectoryEvaluator', () => {
         expect(result.verdict).toBe('pass');
       });
 
-      it('per-item argsMatch overrides defaultArgsMatch', () => {
+      it('per-item argsMatch overrides evaluator-level argsMatch', () => {
         const output: Message[] = [
           {
             role: 'assistant',
@@ -752,7 +752,7 @@ describe('ToolTrajectoryEvaluator', () => {
           name: 'test',
           type: 'tool_trajectory',
           mode: 'exact',
-          defaultArgsMatch: 'superset',
+          argsMatch: 'superset',
           expected: [
             // Uses default superset - extras OK
             { tool: 'search', args: { query: 'test' } },
@@ -769,7 +769,7 @@ describe('ToolTrajectoryEvaluator', () => {
         expect(result.verdict).toBe('fail');
       });
 
-      it('defaultArgsMatch with field list', () => {
+      it('argsMatch with field list', () => {
         const output: Message[] = [
           {
             role: 'assistant',
@@ -784,7 +784,7 @@ describe('ToolTrajectoryEvaluator', () => {
           name: 'test',
           type: 'tool_trajectory',
           mode: 'exact',
-          defaultArgsMatch: ['query', 'format'],
+          argsMatch: ['query', 'format'],
           expected: [
             { tool: 'search', args: { query: 'test', limit: 10 } },
             { tool: 'analyze', args: { format: 'xml', depth: 1 } },
@@ -816,7 +816,7 @@ describe('ToolTrajectoryEvaluator', () => {
           name: 'test',
           type: 'tool_trajectory',
           mode: 'in_order',
-          defaultArgsMatch: 'superset',
+          argsMatch: 'superset',
           expected: [
             { tool: 'search', args: { query: 'test' } },
             { tool: 'analyze', args: { format: 'json' } },
@@ -1218,7 +1218,7 @@ describe('ToolTrajectoryEvaluator', () => {
         name: 'test',
         type: 'tool_trajectory',
         mode: 'superset',
-        defaultArgsMatch: 'superset',
+        argsMatch: 'superset',
         expected: [{ tool: 'search', args: { query: 'test' } }, { tool: 'analyze' }],
       };
       const evaluator = new ToolTrajectoryEvaluator({ config });
@@ -1303,7 +1303,7 @@ describe('ToolTrajectoryEvaluator', () => {
       expect(result.verdict).toBe('pass');
     });
 
-    it('matches with args using evaluator-level defaultArgsMatch', () => {
+    it('matches with args using evaluator-level argsMatch', () => {
       const output: Message[] = [
         {
           role: 'assistant',
@@ -1315,7 +1315,7 @@ describe('ToolTrajectoryEvaluator', () => {
         name: 'test',
         type: 'tool_trajectory',
         mode: 'superset',
-        defaultArgsMatch: 'superset',
+        argsMatch: 'superset',
         expected: [{ tool: 'search', args: { query: 'test' } }],
       };
       const evaluator = new ToolTrajectoryEvaluator({ config });


### PR DESCRIPTION
## Summary
- Add configurable argument matching modes to `tool_trajectory` evaluator: `exact` (new default), `superset`, `subset`, `ignore`, and field-list (dot-notation supported)
- Add `default_args_match` at evaluator level and per-item `argsMatch` override for fine-grained control
- Add `subset` and `superset` trajectory modes: superset ensures all expected tools are found (extras OK, greedy matching); subset ensures all actual calls are in the allowed set (safety guardrail)
- **Breaking change**: default argument matching changed from implicit `superset` (partial match) to `exact` (bidirectional deep equality). Existing configs that rely on partial matching should add `default_args_match: superset`

## Changes

| File | Changes |
|------|---------|
| `packages/core/src/evaluation/trace.ts` | Add `ArgsMatchMode` type, `defaultArgsMatch` on config, `argsMatch` on item, extend `mode` union with `subset`/`superset` |
| `packages/core/src/evaluation/evaluators/tool-trajectory.ts` | Replace `argsMatch()` with mode-aware version, add `getNestedValue()` for dot-notation, add `evaluateSubset()` and `evaluateSuperset()` methods |
| `packages/core/src/evaluation/loaders/evaluator-parser.ts` | Parse `default_args_match`/`args_match` fields, validate values, support snake_case YAML to camelCase TypeScript, validate new modes |
| `packages/core/test/evaluation/tool-trajectory-evaluator.test.ts` | 53 test cases covering all args matching modes, field-list, dot-notation, default/override, subset/superset trajectory modes, edge cases |
| `examples/features/tool-trajectory-simple/evals/dataset.eval.yaml` | Updated examples + new examples for superset/subset modes, mixed args matching, field-list matching |

## Test plan
- [x] All 53 tool-trajectory evaluator tests pass
- [x] All 76 evaluator-parser tests pass (including new mode validation)
- [x] Full test suite passes: 843 tests across all packages (706 core + 52 eval + 85 cli)
- [x] Build, typecheck, and lint all pass (verified by pre-push hooks)
- [ ] Verify with a real eval run against mock agent target

Closes #296, closes #295, closes #294