### PR TITLE
feat(otel): support trace composition via W3C traceparent

### DIFF
--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -500,7 +500,7 @@ async function runSingleEvalFile(params: {
       // Export to OTel if exporter is configured
       if (otelExporter) {
         try {
-          otelExporter.exportResult(result);
+          await otelExporter.exportResult(result);
         } catch (err) {
           // Export failures don't fail the evaluation
           if (options.verbose) {

--- a/bun.lock
+++ b/bun.lock
@@ -83,6 +83,7 @@
       },
       "optionalDependencies": {
         "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^2.5.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.212.0",
         "@opentelemetry/resources": "^2.5.1",
         "@opentelemetry/sdk-trace-node": "^2.5.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,7 @@
   },
   "optionalDependencies": {
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/core": "^2.5.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.212.0",
     "@opentelemetry/resources": "^2.5.1",
     "@opentelemetry/sdk-trace-node": "^2.5.1",


### PR DESCRIPTION
## Summary
- Support trace composition via W3C `TRACEPARENT` environment variable propagation
- When `TRACEPARENT` is set, the root span inherits the parent trace context using `W3CTraceContextPropagator` from `@opentelemetry/core`
- `TRACESTATE` is also propagated when present
- Malformed `TRACEPARENT` values fall back silently to standalone traces
- No behavior change when env vars are not set (identical to existing behavior)
- Added `@opentelemetry/core` to `optionalDependencies`
- Added 4 integration tests verifying propagation, fallback, and tracestate

Closes #301

## Risk
Low — additive feature behind env var check; no existing behavior changes when `TRACEPARENT` is unset.