### PR TITLE
feat(otel): include per-span token usage metrics

### DIFF
--- a/packages/core/src/evaluation/providers/types.ts
+++ b/packages/core/src/evaluation/providers/types.ts
@@ -145,6 +145,8 @@ export interface Message {
   readonly durationMs?: number;
   /** Provider-specific metadata */
   readonly metadata?: Record<string, unknown>;
+  /** Per-message token usage metrics (optional) */
+  readonly tokenUsage?: ProviderTokenUsage;
 }
 
 /** @deprecated Use Message instead */

--- a/packages/core/src/observability/otel-exporter.ts
+++ b/packages/core/src/observability/otel-exporter.ts
@@ -231,6 +231,19 @@ export class OtelTraceExporter {
             span.setAttribute('gen_ai.response.model', model);
           }
 
+          // Per-span token usage (GenAI conventions)
+          if (msg.tokenUsage) {
+            if (msg.tokenUsage.input != null) {
+              span.setAttribute('gen_ai.usage.input_tokens', msg.tokenUsage.input);
+            }
+            if (msg.tokenUsage.output != null) {
+              span.setAttribute('gen_ai.usage.output_tokens', msg.tokenUsage.output);
+            }
+            if (msg.tokenUsage.cached != null) {
+              span.setAttribute('gen_ai.usage.cache_read.input_tokens', msg.tokenUsage.cached);
+            }
+          }
+
           if (captureContent && msg.content != null) {
             span.setAttribute(
               'gen_ai.output.messages',


### PR DESCRIPTION
## Summary
- Add optional `tokenUsage` field to `Message` type
- Emit GenAI semantic convention attributes on LLM child spans in OTel exporter
- Add 3 test cases verifying token usage attributes on child spans

Closes #299

## Risk
Low — additive optional field + new span attributes; no existing behavior changes