### PR TITLE
feat(otel): add turn-level span grouping (#302)

### DIFF
--- a/apps/cli/src/commands/eval/commands/run.ts
+++ b/apps/cli/src/commands/eval/commands/run.ts
@@ -135,6 +135,11 @@ export const evalRunCommand = command({
       long: 'otel-capture-content',
       description: 'Include message content in exported OTel spans (privacy: disabled by default)',
     }),
+    otelGroupTurns: flag({
+      long: 'otel-group-turns',
+      description:
+        'Group messages into turn spans for multi-turn evaluations (requires --export-otel)',
+    }),
   },
   handler: async (args) => {
     // Launch interactive wizard when no eval paths and stdin is a TTY
@@ -168,6 +173,7 @@ export const evalRunCommand = command({
       exportOtel: args.exportOtel,
       otelBackend: args.otelBackend,
       otelCaptureContent: args.otelCaptureContent,
+      otelGroupTurns: args.otelGroupTurns,
     };
     await runEvalCommand({ testFiles: resolvedPaths, rawOptions });
   },

--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -69,6 +69,7 @@ interface NormalizedOptions {
   readonly exportOtel: boolean;
   readonly otelBackend?: string;
   readonly otelCaptureContent: boolean;
+  readonly otelGroupTurns: boolean;
 }
 
 function normalizeBoolean(value: unknown): boolean {
@@ -146,6 +147,7 @@ function normalizeOptions(rawOptions: Record<string, unknown>): NormalizedOption
     exportOtel: normalizeBoolean(rawOptions.exportOtel),
     otelBackend: normalizeString(rawOptions.otelBackend),
     otelCaptureContent: normalizeBoolean(rawOptions.otelCaptureContent),
+    otelGroupTurns: normalizeBoolean(rawOptions.otelGroupTurns),
   } satisfies NormalizedOptions;
 }
 
@@ -586,6 +588,7 @@ export async function runEvalCommand(input: RunEvalCommandInput): Promise<void> 
         endpoint,
         headers,
         captureContent,
+        groupTurns: options.otelGroupTurns,
       });
 
       const initialized = await otelExporter.init();

--- a/packages/core/src/observability/types.ts
+++ b/packages/core/src/observability/types.ts
@@ -8,6 +8,8 @@ export interface OtelExportOptions {
   readonly captureContent?: boolean;
   /** Service name for OTel resource */
   readonly serviceName?: string;
+  /** When true, group messages into turn spans for multi-turn evals */
+  readonly groupTurns?: boolean;
 }
 
 /** Preset configuration for a known observability backend. */

--- a/packages/core/test/observability/otel-group-turns.test.ts
+++ b/packages/core/test/observability/otel-group-turns.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import type { Message } from '../../src/evaluation/providers/types.js';
+
+// Extract and test the groupMessagesIntoTurns logic directly
+interface Turn {
+  messages: Message[];
+}
+
+function groupMessagesIntoTurns(messages: readonly Message[]): Turn[] {
+  const turns: Turn[] = [];
+  let current: Message[] = [];
+  for (const msg of messages) {
+    if (msg.role === 'user' && current.length > 0) {
+      turns.push({ messages: current });
+      current = [];
+    }
+    current.push(msg);
+  }
+  if (current.length > 0) turns.push({ messages: current });
+  return turns;
+}
+
+describe('groupMessagesIntoTurns', () => {
+  it('returns a single turn for single-turn conversation', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+    ];
+    const turns = groupMessagesIntoTurns(messages);
+    expect(turns).toHaveLength(1);
+    expect(turns[0].messages).toHaveLength(2);
+    expect(turns[0].messages[0].role).toBe('user');
+    expect(turns[0].messages[1].role).toBe('assistant');
+  });
+
+  it('splits multi-turn conversation at each user message', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'Turn 1' },
+      { role: 'assistant', content: 'Response 1' },
+      { role: 'user', content: 'Turn 2' },
+      { role: 'assistant', content: 'Response 2' },
+      { role: 'user', content: 'Turn 3' },
+      { role: 'assistant', content: 'Response 3' },
+    ];
+    const turns = groupMessagesIntoTurns(messages);
+    expect(turns).toHaveLength(3);
+    expect(turns[0].messages).toEqual([
+      { role: 'user', content: 'Turn 1' },
+      { role: 'assistant', content: 'Response 1' },
+    ]);
+    expect(turns[1].messages).toEqual([
+      { role: 'user', content: 'Turn 2' },
+      { role: 'assistant', content: 'Response 2' },
+    ]);
+    expect(turns[2].messages).toEqual([
+      { role: 'user', content: 'Turn 3' },
+      { role: 'assistant', content: 'Response 3' },
+    ]);
+  });
+
+  it('handles assistant-only messages (no user prefix)', () => {
+    const messages: Message[] = [
+      { role: 'assistant', content: 'System greeting' },
+      { role: 'assistant', content: 'Another message' },
+    ];
+    const turns = groupMessagesIntoTurns(messages);
+    expect(turns).toHaveLength(1);
+    expect(turns[0].messages).toHaveLength(2);
+  });
+
+  it('handles empty input', () => {
+    const turns = groupMessagesIntoTurns([]);
+    expect(turns).toHaveLength(0);
+  });
+
+  it('handles user message with tool calls before next user message', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'Do something' },
+      { role: 'assistant', content: 'OK', toolCalls: [{ tool: 'search', input: 'query' }] },
+      { role: 'tool', content: 'result' },
+      { role: 'assistant', content: 'Here is the answer' },
+      { role: 'user', content: 'Follow up' },
+      { role: 'assistant', content: 'Sure' },
+    ];
+    const turns = groupMessagesIntoTurns(messages);
+    expect(turns).toHaveLength(2);
+    expect(turns[0].messages).toHaveLength(4);
+    expect(turns[1].messages).toHaveLength(2);
+  });
+});
+
+describe('OtelTraceExporter groupTurns integration', () => {
+  it('OtelExportOptions accepts groupTurns field', async () => {
+    const { OtelTraceExporter } = await import('../../src/observability/otel-exporter.js');
+    // Verify the exporter can be constructed with groupTurns option
+    const exporter = new OtelTraceExporter({
+      endpoint: 'http://localhost:4318/v1/traces',
+      groupTurns: true,
+    });
+    expect(exporter).toBeDefined();
+  });
+
+  it('OtelExportOptions works without groupTurns (default behavior)', async () => {
+    const { OtelTraceExporter } = await import('../../src/observability/otel-exporter.js');
+    const exporter = new OtelTraceExporter({
+      endpoint: 'http://localhost:4318/v1/traces',
+    });
+    expect(exporter).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `groupTurns` option to `OtelExportOptions` interface
- Add `groupMessagesIntoTurns` helper that splits messages at each `user` role boundary
- When `groupTurns` is enabled and multiple turns exist, create intermediate `agentv.turn.N` spans
- Add `--otel-group-turns` CLI flag wired through to the exporter
- Add tests for turn grouping logic and exporter option acceptance

Closes #302

## Risk
Low — additive feature behind a new opt-in flag, no existing behavior changes