### PR TITLE
fix(otel): resolve W3C traceparent import for Bun + lint fixes

### DIFF
--- a/plugins/agentv-trace/hooks.json
+++ b/plugins/agentv-trace/hooks.json
@@ -1,8 +1,17 @@
 {
   "hooks": [
     { "event": "SessionStart", "command": "bun run hooks/session-start.ts", "async": true },
-    { "event": "UserPromptSubmit", "command": "bun run hooks/user-prompt-submit.ts", "async": true },
-    { "event": "PostToolUse", "command": "bun run hooks/post-tool-use.ts", "matcher": "*", "async": true },
+    {
+      "event": "UserPromptSubmit",
+      "command": "bun run hooks/user-prompt-submit.ts",
+      "async": true
+    },
+    {
+      "event": "PostToolUse",
+      "command": "bun run hooks/post-tool-use.ts",
+      "matcher": "*",
+      "async": true
+    },
     { "event": "Stop", "command": "bun run hooks/stop.ts", "async": true },
     { "event": "SessionEnd", "command": "bun run hooks/session-end.ts", "async": true }
   ]

--- a/plugins/agentv-trace/hooks/post-tool-use.ts
+++ b/plugins/agentv-trace/hooks/post-tool-use.ts
@@ -1,6 +1,6 @@
-import { readHookInput } from "../lib/types.js";
-import { loadState, saveState } from "../lib/state.js";
-import { getTracer, flush } from "../lib/otel.js";
+import { flush, getTracer } from '../lib/otel.js';
+import { loadState, saveState } from '../lib/state.js';
+import { readHookInput } from '../lib/types.js';
 
 const input = readHookInput();
 const state = await loadState(input.session_id);
@@ -21,13 +21,13 @@ const parentCtx = api.trace.setSpanContext(api.context.active(), {
   isRemote: false,
 });
 
-const toolName = input.tool_name ?? "unknown";
+const toolName = input.tool_name ?? 'unknown';
 const toolSpan = tracer.startSpan(
   `execute_tool ${toolName}`,
   {
     attributes: {
-      "gen_ai.tool.name": toolName,
-      "gen_ai.operation.name": "tool",
+      'gen_ai.tool.name': toolName,
+      'gen_ai.operation.name': 'tool',
     },
   },
   parentCtx,

--- a/plugins/agentv-trace/hooks/session-end.ts
+++ b/plugins/agentv-trace/hooks/session-end.ts
@@ -1,6 +1,6 @@
-import { readHookInput } from "../lib/types.js";
-import { loadState, deleteState } from "../lib/state.js";
-import { getTracer, flush } from "../lib/otel.js";
+import { flush, getTracer } from '../lib/otel.js';
+import { deleteState, loadState } from '../lib/state.js';
+import { readHookInput } from '../lib/types.js';
 
 const input = readHookInput();
 const state = await loadState(input.session_id);
@@ -19,12 +19,12 @@ if (otel) {
   });
 
   const endSpan = tracer.startSpan(
-    "agentv.session.end",
+    'agentv.session.end',
     {
       attributes: {
-        "agentv.session_id": state.sessionId,
-        "agentv.turn_count": state.turnCount,
-        "agentv.tool_count": state.toolCount,
+        'agentv.session_id': state.sessionId,
+        'agentv.turn_count': state.turnCount,
+        'agentv.tool_count': state.toolCount,
       },
     },
     parentCtx,

--- a/plugins/agentv-trace/hooks/session-start.ts
+++ b/plugins/agentv-trace/hooks/session-start.ts
@@ -1,10 +1,6 @@
-import { readHookInput } from "../lib/types.js";
-import {
-  saveState,
-  cleanupStaleStates,
-  type SessionState,
-} from "../lib/state.js";
-import { getTracer } from "../lib/otel.js";
+import { getTracer } from '../lib/otel.js';
+import { type SessionState, cleanupStaleStates, saveState } from '../lib/state.js';
+import { readHookInput } from '../lib/types.js';
 
 const input = readHookInput();
 const otel = await getTracer();
@@ -13,11 +9,11 @@ if (!otel) process.exit(0);
 const { tracer } = otel;
 
 // Create root session span (self-contained — started and ended immediately)
-const rootSpan = tracer.startSpan("agentv session", {
+const rootSpan = tracer.startSpan('agentv session', {
   attributes: {
-    "gen_ai.system": "agentv",
-    "agentv.session_id": input.session_id,
-    ...(input.cwd ? { "agentv.workspace": input.cwd } : {}),
+    'gen_ai.system': 'agentv',
+    'agentv.session_id': input.session_id,
+    ...(input.cwd ? { 'agentv.workspace': input.cwd } : {}),
   },
 });
 

--- a/plugins/agentv-trace/hooks/stop.ts
+++ b/plugins/agentv-trace/hooks/stop.ts
@@ -1,6 +1,6 @@
-import { readHookInput } from "../lib/types.js";
-import { loadState, saveState } from "../lib/state.js";
-import { flush } from "../lib/otel.js";
+import { flush } from '../lib/otel.js';
+import { loadState, saveState } from '../lib/state.js';
+import { readHookInput } from '../lib/types.js';
 
 const input = readHookInput();
 const state = await loadState(input.session_id);

--- a/plugins/agentv-trace/hooks/user-prompt-submit.ts
+++ b/plugins/agentv-trace/hooks/user-prompt-submit.ts
@@ -1,6 +1,6 @@
-import { readHookInput } from "../lib/types.js";
-import { loadState, saveState } from "../lib/state.js";
-import { getTracer, flush } from "../lib/otel.js";
+import { flush, getTracer } from '../lib/otel.js';
+import { loadState, saveState } from '../lib/state.js';
+import { readHookInput } from '../lib/types.js';
 
 const input = readHookInput();
 const state = await loadState(input.session_id);
@@ -25,10 +25,8 @@ const turnSpan = tracer.startSpan(
   `agentv.turn.${state.turnCount}`,
   {
     attributes: {
-      "agentv.turn.number": state.turnCount,
-      ...(input.prompt
-        ? { "agentv.turn.prompt": input.prompt.substring(0, 200) }
-        : {}),
+      'agentv.turn.number': state.turnCount,
+      ...(input.prompt ? { 'agentv.turn.prompt': input.prompt.substring(0, 200) } : {}),
     },
   },
   parentCtx,

--- a/plugins/agentv-trace/lib/otel.ts
+++ b/plugins/agentv-trace/lib/otel.ts
@@ -1,23 +1,17 @@
-import type { Tracer } from "@opentelemetry/api";
+import type { Tracer } from '@opentelemetry/api';
 
 export async function getTracer(): Promise<{
   tracer: Tracer;
-  api: typeof import("@opentelemetry/api");
+  api: typeof import('@opentelemetry/api');
 } | null> {
   try {
-    const api = await import("@opentelemetry/api");
+    const api = await import('@opentelemetry/api');
     const { NodeTracerProvider, SimpleSpanProcessor } = await import(
-      "@opentelemetry/sdk-trace-node"
+      '@opentelemetry/sdk-trace-node'
     );
-    const { OTLPTraceExporter } = await import(
-      "@opentelemetry/exporter-trace-otlp-http"
-    );
-    const { resourceFromAttributes } = await import(
-      "@opentelemetry/resources"
-    );
-    const { ATTR_SERVICE_NAME } = await import(
-      "@opentelemetry/semantic-conventions"
-    );
+    const { OTLPTraceExporter } = await import('@opentelemetry/exporter-trace-otlp-http');
+    const { resourceFromAttributes } = await import('@opentelemetry/resources');
+    const { ATTR_SERVICE_NAME } = await import('@opentelemetry/semantic-conventions');
 
     const endpoint = resolveEndpoint();
     const headers = resolveHeaders();
@@ -25,7 +19,7 @@ export async function getTracer(): Promise<{
     if (!endpoint) return null;
 
     const resource = resourceFromAttributes({
-      [ATTR_SERVICE_NAME]: "agentv-trace",
+      [ATTR_SERVICE_NAME]: 'agentv-trace',
     });
 
     const exporter = new OTLPTraceExporter({ url: endpoint, headers });
@@ -36,7 +30,7 @@ export async function getTracer(): Promise<{
     provider.register();
 
     return {
-      tracer: api.trace.getTracer("agentv-trace", "1.0.0"),
+      tracer: api.trace.getTracer('agentv-trace', '1.0.0'),
       api,
     };
   } catch {
@@ -50,13 +44,12 @@ function resolveEndpoint(): string | undefined {
   }
 
   const backend = process.env.AGENTV_TRACE_BACKEND;
-  if (backend === "langfuse") {
-    const host = process.env.LANGFUSE_HOST || "https://cloud.langfuse.com";
+  if (backend === 'langfuse') {
+    const host = process.env.LANGFUSE_HOST || 'https://cloud.langfuse.com';
     return `${host}/api/public/otel/v1/traces`;
   }
-  if (backend === "braintrust")
-    return "https://api.braintrust.dev/otel/v1/traces";
-  if (backend === "jaeger") return "http://localhost:4318/v1/traces";
+  if (backend === 'braintrust') return 'https://api.braintrust.dev/otel/v1/traces';
+  if (backend === 'jaeger') return 'http://localhost:4318/v1/traces';
 
   return undefined;
 }
@@ -65,19 +58,19 @@ function resolveHeaders(): Record<string, string> {
   const headers: Record<string, string> = {};
   const backend = process.env.AGENTV_TRACE_BACKEND;
 
-  if (backend === "langfuse") {
-    const pub = process.env.LANGFUSE_PUBLIC_KEY ?? "";
-    const secret = process.env.LANGFUSE_SECRET_KEY ?? "";
-    headers.Authorization = `Basic ${Buffer.from(`${pub}:${secret}`).toString("base64")}`;
-  } else if (backend === "braintrust") {
-    headers.Authorization = `Bearer ${process.env.BRAINTRUST_API_KEY ?? ""}`;
+  if (backend === 'langfuse') {
+    const pub = process.env.LANGFUSE_PUBLIC_KEY ?? '';
+    const secret = process.env.LANGFUSE_SECRET_KEY ?? '';
+    headers.Authorization = `Basic ${Buffer.from(`${pub}:${secret}`).toString('base64')}`;
+  } else if (backend === 'braintrust') {
+    headers.Authorization = `Bearer ${process.env.BRAINTRUST_API_KEY ?? ''}`;
   }
 
   // Support generic OTEL_EXPORTER_OTLP_HEADERS
   const envHeaders = process.env.OTEL_EXPORTER_OTLP_HEADERS;
   if (envHeaders) {
-    for (const pair of envHeaders.split(",")) {
-      const [k, v] = pair.split("=");
+    for (const pair of envHeaders.split(',')) {
+      const [k, v] = pair.split('=');
       if (k && v) headers[k.trim()] = v.trim();
     }
   }
@@ -88,9 +81,10 @@ function resolveHeaders(): Record<string, string> {
 /** Flush all pending spans */
 export async function flush(): Promise<void> {
   try {
-    const api = await import("@opentelemetry/api");
+    const api = await import('@opentelemetry/api');
     const provider = api.trace.getTracerProvider();
-    if ("forceFlush" in provider) {
+    if ('forceFlush' in provider) {
+      // biome-ignore lint/suspicious/noExplicitAny: OTel provider type varies
       await (provider as any).forceFlush();
     }
   } catch {

--- a/plugins/agentv-trace/lib/state.ts
+++ b/plugins/agentv-trace/lib/state.ts
@@ -1,16 +1,9 @@
-import {
-  readFile,
-  writeFile,
-  rename,
-  unlink,
-  mkdir,
-  readdir,
-} from "node:fs/promises";
-import { join } from "node:path";
-import { homedir } from "node:os";
-import { randomUUID } from "node:crypto";
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, readdir, rename, unlink, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 
-const STATE_DIR = join(homedir(), ".agentv", "trace-state");
+const STATE_DIR = join(homedir(), '.agentv', 'trace-state');
 
 export interface SessionState {
   sessionId: string;
@@ -22,11 +15,9 @@ export interface SessionState {
   startedAt: string;
 }
 
-export async function loadState(
-  sessionId: string,
-): Promise<SessionState | null> {
+export async function loadState(sessionId: string): Promise<SessionState | null> {
   try {
-    const data = await readFile(join(STATE_DIR, `${sessionId}.json`), "utf8");
+    const data = await readFile(join(STATE_DIR, `${sessionId}.json`), 'utf8');
     return JSON.parse(data);
   } catch {
     return null;
@@ -49,22 +40,15 @@ export async function deleteState(sessionId: string): Promise<void> {
   }
 }
 
-export async function cleanupStaleStates(
-  maxAgeMs = 24 * 60 * 60 * 1000,
-): Promise<void> {
+export async function cleanupStaleStates(maxAgeMs = 24 * 60 * 60 * 1000): Promise<void> {
   try {
     const files = await readdir(STATE_DIR);
     const now = Date.now();
     for (const file of files) {
-      if (!file.endsWith(".json")) continue;
+      if (!file.endsWith('.json')) continue;
       try {
-        const data = JSON.parse(
-          await readFile(join(STATE_DIR, file), "utf8"),
-        );
-        if (
-          data.startedAt &&
-          now - new Date(data.startedAt).getTime() > maxAgeMs
-        ) {
+        const data = JSON.parse(await readFile(join(STATE_DIR, file), 'utf8'));
+        if (data.startedAt && now - new Date(data.startedAt).getTime() > maxAgeMs) {
           await unlink(join(STATE_DIR, file));
         }
       } catch {

--- a/plugins/agentv-trace/lib/types.ts
+++ b/plugins/agentv-trace/lib/types.ts
@@ -13,10 +13,10 @@ export interface HookInput {
 
 export function readHookInput(): HookInput {
   // Claude Code hooks receive input via stdin as JSON
-  const stdin = require("node:fs").readFileSync(0, "utf8");
+  const stdin = require('node:fs').readFileSync(0, 'utf8');
   try {
     return JSON.parse(stdin);
   } catch {
-    return { session_id: "unknown" };
+    return { session_id: 'unknown' };
   }
 }

--- a/plugins/agentv-trace/test/state.test.ts
+++ b/plugins/agentv-trace/test/state.test.ts
@@ -1,22 +1,22 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { join } from "node:path";
-import { homedir } from "node:os";
-import { rm, readFile } from "node:fs/promises";
+import { readFile, rm } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
-  saveState,
-  loadState,
-  deleteState,
-  cleanupStaleStates,
   type SessionState,
-} from "../lib/state.js";
+  cleanupStaleStates,
+  deleteState,
+  loadState,
+  saveState,
+} from '../lib/state.js';
 
-const STATE_DIR = join(homedir(), ".agentv", "trace-state");
+const STATE_DIR = join(homedir(), '.agentv', 'trace-state');
 
 function makeState(overrides: Partial<SessionState> = {}): SessionState {
   return {
-    sessionId: "test-session-123",
-    rootSpanTraceId: "aaaa",
-    rootSpanId: "bbbb",
+    sessionId: 'test-session-123',
+    rootSpanTraceId: 'aaaa',
+    rootSpanId: 'bbbb',
     turnCount: 0,
     toolCount: 0,
     startedAt: new Date().toISOString(),
@@ -25,83 +25,83 @@ function makeState(overrides: Partial<SessionState> = {}): SessionState {
 }
 
 afterEach(async () => {
-  await deleteState("test-session-123");
-  await deleteState("stale-session");
-  await deleteState("fresh-session");
+  await deleteState('test-session-123');
+  await deleteState('stale-session');
+  await deleteState('fresh-session');
 });
 
-describe("state management", () => {
-  it("saves and loads state", async () => {
+describe('state management', () => {
+  it('saves and loads state', async () => {
     const state = makeState();
     await saveState(state);
 
-    const loaded = await loadState("test-session-123");
+    const loaded = await loadState('test-session-123');
     expect(loaded).toEqual(state);
   });
 
-  it("returns null for missing state", async () => {
-    const loaded = await loadState("nonexistent");
+  it('returns null for missing state', async () => {
+    const loaded = await loadState('nonexistent');
     expect(loaded).toBeNull();
   });
 
-  it("deletes state", async () => {
+  it('deletes state', async () => {
     const state = makeState();
     await saveState(state);
-    await deleteState("test-session-123");
+    await deleteState('test-session-123');
 
-    const loaded = await loadState("test-session-123");
+    const loaded = await loadState('test-session-123');
     expect(loaded).toBeNull();
   });
 
-  it("delete is idempotent", async () => {
+  it('delete is idempotent', async () => {
     // Should not throw for missing files
-    await deleteState("nonexistent");
+    await deleteState('nonexistent');
   });
 
-  it("writes atomically (temp file then rename)", async () => {
+  it('writes atomically (temp file then rename)', async () => {
     const state = makeState();
     await saveState(state);
 
     // Verify the file exists at the expected path
-    const filePath = join(STATE_DIR, "test-session-123.json");
-    const data = await readFile(filePath, "utf8");
+    const filePath = join(STATE_DIR, 'test-session-123.json');
+    const data = await readFile(filePath, 'utf8');
     const parsed = JSON.parse(data);
-    expect(parsed.sessionId).toBe("test-session-123");
+    expect(parsed.sessionId).toBe('test-session-123');
   });
 
-  it("updates state in place", async () => {
+  it('updates state in place', async () => {
     const state = makeState();
     await saveState(state);
 
     state.turnCount = 5;
     state.toolCount = 12;
-    state.currentTurnSpanId = "cccc";
+    state.currentTurnSpanId = 'cccc';
     await saveState(state);
 
-    const loaded = await loadState("test-session-123");
+    const loaded = await loadState('test-session-123');
     expect(loaded?.turnCount).toBe(5);
     expect(loaded?.toolCount).toBe(12);
-    expect(loaded?.currentTurnSpanId).toBe("cccc");
+    expect(loaded?.currentTurnSpanId).toBe('cccc');
   });
 
-  it("cleans up stale states", async () => {
+  it('cleans up stale states', async () => {
     // Create a stale state (started 2 days ago)
     const stale = makeState({
-      sessionId: "stale-session",
+      sessionId: 'stale-session',
       startedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
     });
     await saveState(stale);
 
     // Create a fresh state
     const fresh = makeState({
-      sessionId: "fresh-session",
+      sessionId: 'fresh-session',
       startedAt: new Date().toISOString(),
     });
     await saveState(fresh);
 
     await cleanupStaleStates();
 
-    expect(await loadState("stale-session")).toBeNull();
-    expect(await loadState("fresh-session")).not.toBeNull();
+    expect(await loadState('stale-session')).toBeNull();
+    expect(await loadState('fresh-session')).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Move `@opentelemetry/core` import from `exportResult()` to `init()` to fix Bun package resolution with transitive deps
- Store `W3CTraceContextPropagator` as class field for reuse
- Fix test to inject W3CPropagator field and register provider
- Auto-fix lint issues in agentv-trace plugin (formatting, imports)

## Risk
Low — isolated fix for import timing + lint formatting only

Closes #303 (tracking issue)