### PR TITLE
fix: shutdown race in trace exporter + end plugin spans

### DIFF
--- a/plugins/agentv-trace/hooks/user-prompt-submit.ts
+++ b/plugins/agentv-trace/hooks/user-prompt-submit.ts
@@ -35,5 +35,7 @@ const turnSpan = tracer.startSpan(
 state.currentTurnSpanId = turnSpan.spanContext().spanId;
 await saveState(state);
 
-// Don't end turn span yet — tool calls will be children
+// End turn span immediately — each hook runs in a separate process so we can't
+// keep spans open across hooks. Tool call spans link via stored spanId.
+turnSpan.end();
 await flush();


### PR DESCRIPTION
## Summary
Fixes from code review of OTel observability suite (#303):

1. **SimpleTraceFileExporter shutdown race** — Added `_shuttingDown` guard to reject new exports during shutdown, preventing late-arriving spans from being lost
2. **Plugin unclosed spans** — End root span and turn spans immediately in hooks. Each hook runs in a separate process, so spans cannot persist — they serve as trace ID anchors for child spans in subsequent hooks

## Risk
Low — isolated fixes, no API changes