### PR TITLE
fix: add agentv-trace plugin to marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,6 +19,14 @@
         "./skills/agentv-prompt-optimizer"
       ],
       "category": "development"
+    },
+    {
+      "name": "agentv-trace",
+      "description": "Session tracing plugin — exports Claude Code session traces via OpenTelemetry",
+      "source": "./plugins/agentv-trace",
+      "strict": false,
+      "hooks": "./hooks.json",
+      "category": "observability"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds the `agentv-trace` plugin entry to `marketplace.json`, restoring it after it was accidentally omitted during the skills-to-plugins refactoring in #318
- The `plugins/agentv-trace` directory already exists with hooks, lib, and tests — only the marketplace registration was missing

## Changes
- `.claude-plugin/marketplace.json`: Added `agentv-trace` plugin with source `./plugins/agentv-trace`, hooks reference, and `observability` category

## Test plan
- [x] JSON validates correctly
- [x] Pre-push hooks pass (build, typecheck, lint, test)
- [x] Source path `./plugins/agentv-trace` exists in repo
- [x] Hooks path `./hooks.json` exists in plugin directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)