### PR TITLE
feat(sdk): provider scaffold command & example links (#328)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ assert:
     value: "Hello"
 ```
 
+See the [sdk-custom-assertion example](examples/features/sdk-custom-assertion).
+
 #### Programmatic API with `evaluate()`
 
 Use AgentV as a library — no YAML needed:
@@ -247,7 +249,7 @@ const { results, summary } = await evaluate({
 console.log(`${summary.passed}/${summary.total} passed`);
 ```
 
-Auto-discovers `default` target from `.agentv/targets.yaml` and `.env` credentials.
+Auto-discovers `default` target from `.agentv/targets.yaml` and `.env` credentials. See the [sdk-programmatic-api example](examples/features/sdk-programmatic-api).
 
 #### Typed Configuration with `defineConfig()`
 
@@ -262,6 +264,8 @@ export default defineConfig({
   limits: { maxCostUsd: 10.0 },
 });
 ```
+
+See the [sdk-config-file example](examples/features/sdk-config-file).
 
 #### Scaffold Commands
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -227,6 +227,8 @@ assert:
     value: "Hello"
 ```
 
+See the [sdk-custom-assertion example](examples/features/sdk-custom-assertion).
+
 #### Programmatic API with `evaluate()`
 
 Use AgentV as a library — no YAML needed:
@@ -247,7 +249,7 @@ const { results, summary } = await evaluate({
 console.log(`${summary.passed}/${summary.total} passed`);
 ```
 
-Auto-discovers `default` target from `.agentv/targets.yaml` and `.env` credentials.
+Auto-discovers `default` target from `.agentv/targets.yaml` and `.env` credentials. See the [sdk-programmatic-api example](examples/features/sdk-programmatic-api).
 
 #### Typed Configuration with `defineConfig()`
 
@@ -262,6 +264,8 @@ export default defineConfig({
   limits: { maxCostUsd: 10.0 },
 });
 ```
+
+See the [sdk-config-file example](examples/features/sdk-config-file).
 
 #### Scaffold Commands
 

--- a/apps/cli/src/commands/create/index.ts
+++ b/apps/cli/src/commands/create/index.ts
@@ -1,6 +1,6 @@
 import { subcommands } from 'cmd-ts';
 
-import { createAssertionCommand, createEvalCommand } from './commands.js';
+import { createAssertionCommand, createEvalCommand, createProviderCommand } from './commands.js';
 
 export const createCommand = subcommands({
   name: 'create',
@@ -8,5 +8,6 @@ export const createCommand = subcommands({
   cmds: {
     assertion: createAssertionCommand,
     eval: createEvalCommand,
+    provider: createProviderCommand,
   },
 });

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,13 +41,20 @@ Focused demonstrations of specific AgentV capabilities. Each example includes it
 - [composite](features/composite/) - Composite evaluator patterns
 - [weighted-evaluators](features/weighted-evaluators/) - Weighted evaluators
 - [execution-metrics](features/execution-metrics/) - Metrics tracking (tokens, cost, latency)
-- [code-judge-sdk](features/code-judge-sdk/) - TypeScript SDK for code judges
 - [code-judge-with-llm-calls](features/code-judge-with-llm-calls/) - Code judges with target proxy for LLM calls
 - [batch-cli](features/batch-cli/) - Batch CLI evaluation
 - [document-extraction](features/document-extraction/) - Document data extraction
 - [local-cli](features/local-cli/) - Local CLI targets
 - [compare](features/compare/) - Baseline comparison
 - [deterministic-evaluators](features/deterministic-evaluators/) - Deterministic assertions (contains, regex, JSON validation)
+
+### SDK
+
+- [code-judge-sdk](features/code-judge-sdk/) - TypeScript SDK for code judges using `defineCodeJudge()`
+- [sdk-custom-assertion](features/sdk-custom-assertion/) - Custom assertion types using `defineAssertion()`
+- [sdk-programmatic-api](features/sdk-programmatic-api/) - Programmatic evaluation using `evaluate()`
+- [sdk-config-file](features/sdk-config-file/) - Typed configuration with `defineConfig()`
+- [prompt-template-sdk](features/prompt-template-sdk/) - Custom LLM judge prompts using `definePromptTemplate()`
 
 ---
 


### PR DESCRIPTION
## Summary
Closes remaining gaps from SDK issue audit (#328).

### Changes
- **Provider scaffold**: `agentv create provider <name>` generates `.agentv/providers/<name>.ts` with CLI provider template (#325)
- **Examples README**: Added SDK examples section listing all 5 SDK examples (#327)
- **Root README**: Added direct links to SDK examples from TypeScript SDK section

### Verification
- Build ✅, 72 tests ✅, lint ✅
- Provider scaffold tested: generates valid template with targets.yaml instructions