### PR TITLE
feat(sdk): scaffold templates & CLI config override (#328)

### DIFF
--- a/apps/cli/src/commands/create/commands.ts
+++ b/apps/cli/src/commands/create/commands.ts
@@ -1,8 +1,9 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { command, positional, string } from 'cmd-ts';
+import { command, option, optional, positional, string } from 'cmd-ts';
 
-const ASSERTION_TEMPLATE = `#!/usr/bin/env bun
+const ASSERTION_TEMPLATES: Record<string, string> = {
+  default: `#!/usr/bin/env bun
 import { defineAssertion } from '@agentv/eval';
 
 export default defineAssertion(({ answer }) => {
@@ -13,9 +14,24 @@ export default defineAssertion(({ answer }) => {
     reasoning: pass ? 'Output has content' : 'Output is empty',
   };
 });
-`;
+`,
+  score: `#!/usr/bin/env bun
+import { defineAssertion } from '@agentv/eval';
 
-const EVAL_TEMPLATE = (name: string) => `description: ${name} evaluation suite
+export default defineAssertion(({ answer }) => {
+  // TODO: Implement your scoring logic (0.0 to 1.0)
+  const score = answer.length > 0 ? 1.0 : 0.0;
+  return {
+    pass: score >= 0.5,
+    score,
+    reasoning: \`Score: \${score}\`,
+  };
+});
+`,
+};
+
+const EVAL_TEMPLATES: Record<string, (name: string) => string> = {
+  default: (name: string) => `description: ${name} evaluation suite
 execution:
   target: default
 
@@ -27,7 +43,27 @@ tests:
     assert:
       - type: contains
         value: "well"
-`;
+`,
+  rubric: (name: string) => `description: ${name} evaluation suite
+execution:
+  target: default
+
+tests:
+  - id: sample-test
+    criteria: Agent responds correctly and completely
+    input: "Hello, how are you?"
+    expected_output: "I'm doing well, thank you for asking!"
+    assert:
+      - type: llm_judge
+        rubric:
+          accuracy:
+            weight: 0.6
+            criteria: Response is factually correct
+          completeness:
+            weight: 0.4
+            criteria: Response addresses all parts of the question
+`,
+};
 
 const PROVIDER_TEMPLATE = `#!/usr/bin/env bun
 /**
@@ -68,14 +104,28 @@ export const createAssertionCommand = command({
       displayName: 'name',
       description: 'Name of the assertion (e.g., sentiment)',
     }),
+    template: option({
+      type: optional(string),
+      long: 'template',
+      description: `Template variant (${Object.keys(ASSERTION_TEMPLATES).join(', ')})`,
+    }),
   },
-  handler: async ({ name }) => {
+  handler: async ({ name, template }) => {
+    const templateName = template ?? 'default';
+    const content = ASSERTION_TEMPLATES[templateName];
+    if (!content) {
+      console.error(
+        `Unknown template "${templateName}". Available: ${Object.keys(ASSERTION_TEMPLATES).join(', ')}`,
+      );
+      process.exit(1);
+    }
+
     const dir = path.join(process.cwd(), '.agentv', 'assertions');
     const filePath = path.join(dir, `${name}.ts`);
 
     await mkdir(dir, { recursive: true });
-    await writeFile(filePath, ASSERTION_TEMPLATE);
-    console.log(`Created ${path.relative(process.cwd(), filePath)}`);
+    await writeFile(filePath, content);
+    console.log(`Created ${path.relative(process.cwd(), filePath)} (template: ${templateName})`);
     console.log(`\nUse in EVAL.yaml:\n  assert:\n    - type: ${name}`);
   },
 });
@@ -89,14 +139,25 @@ export const createProviderCommand = command({
       displayName: 'name',
       description: 'Name of the provider (e.g., my-llm)',
     }),
+    template: option({
+      type: optional(string),
+      long: 'template',
+      description: 'Template variant (default)',
+    }),
   },
-  handler: async ({ name }) => {
+  handler: async ({ name, template }) => {
+    const templateName = template ?? 'default';
+    if (templateName !== 'default') {
+      console.error(`Unknown template "${templateName}". Available: default`);
+      process.exit(1);
+    }
+
     const dir = path.join(process.cwd(), '.agentv', 'providers');
     const filePath = path.join(dir, `${name}.ts`);
 
     await mkdir(dir, { recursive: true });
     await writeFile(filePath, PROVIDER_TEMPLATE);
-    console.log(`Created ${path.relative(process.cwd(), filePath)}`);
+    console.log(`Created ${path.relative(process.cwd(), filePath)} (template: ${templateName})`);
     console.log(
       `\nConfigure in .agentv/targets.yaml:\n  targets:\n    - name: ${name}\n      provider: cli\n      command_template: "bun run .agentv/providers/${name}.ts {PROMPT}"`,
     );
@@ -112,16 +173,30 @@ export const createEvalCommand = command({
       displayName: 'name',
       description: 'Name of the eval suite (e.g., my-agent)',
     }),
+    template: option({
+      type: optional(string),
+      long: 'template',
+      description: `Template variant (${Object.keys(EVAL_TEMPLATES).join(', ')})`,
+    }),
   },
-  handler: async ({ name }) => {
+  handler: async ({ name, template }) => {
+    const templateName = template ?? 'default';
+    const templateFn = EVAL_TEMPLATES[templateName];
+    if (!templateFn) {
+      console.error(
+        `Unknown template "${templateName}". Available: ${Object.keys(EVAL_TEMPLATES).join(', ')}`,
+      );
+      process.exit(1);
+    }
+
     const dir = path.join(process.cwd(), 'evals');
     const yamlPath = path.join(dir, `${name}.eval.yaml`);
     const casesPath = path.join(dir, `${name}.cases.jsonl`);
 
     await mkdir(dir, { recursive: true });
-    await writeFile(yamlPath, EVAL_TEMPLATE(name));
+    await writeFile(yamlPath, templateFn(name));
     await writeFile(casesPath, EVAL_CASES_TEMPLATE);
-    console.log(`Created ${path.relative(process.cwd(), yamlPath)}`);
+    console.log(`Created ${path.relative(process.cwd(), yamlPath)} (template: ${templateName})`);
     console.log(`Created ${path.relative(process.cwd(), casesPath)}`);
     console.log(`\nRun with:\n  agentv eval ${path.relative(process.cwd(), yamlPath)}`);
   },

--- a/apps/cli/src/commands/eval/commands/run.ts
+++ b/apps/cli/src/commands/eval/commands/run.ts
@@ -38,11 +38,10 @@ export const evalRunCommand = command({
       description: 'Filter tests by ID pattern (glob supported, e.g., "summary-*")',
     }),
     workers: option({
-      type: number,
+      type: optional(number),
       long: 'workers',
       description:
         'Number of parallel workers (default: 3, max: 50). Can also be set per-target in targets.yaml',
-      defaultValue: () => 3,
     }),
     out: option({
       type: optional(string),
@@ -57,10 +56,9 @@ export const evalRunCommand = command({
         'Output file path(s). Format inferred from extension: .jsonl, .json, .xml, .yaml',
     }),
     outputFormat: option({
-      type: string,
+      type: optional(string),
       long: 'output-format',
       description: "Output format: 'jsonl' or 'yaml' (default: jsonl)",
-      defaultValue: () => 'jsonl',
     }),
     dryRun: flag({
       long: 'dry-run',
@@ -86,16 +84,14 @@ export const evalRunCommand = command({
       defaultValue: () => 0,
     }),
     agentTimeout: option({
-      type: number,
+      type: optional(number),
       long: 'agent-timeout',
       description: 'Timeout in seconds for provider responses (default: 120)',
-      defaultValue: () => 120,
     }),
     maxRetries: option({
-      type: number,
+      type: optional(number),
       long: 'max-retries',
       description: 'Retry count for timeout recoveries (default: 2)',
-      defaultValue: () => 2,
     }),
     cache: flag({
       long: 'cache',


### PR DESCRIPTION
## Summary
Final SDK polish for #328.

### Changes
- **`--template` flag** (#325): Scaffold commands accept `--template` to select template variants
  - `agentv create assertion --template score` — numeric scoring template
  - `agentv create eval --template rubric` — rubric-based evaluation template
- **CLI config override** (#326): `agentv eval` now loads `agentv.config.ts` and uses values as defaults
  - Priority: CLI flags > config file > hardcoded defaults
  - Mapped fields: workers, maxRetries, agentTimeout, outputFormat, out, cache

### Verification
- Build ✅, 72 tests ✅, lint ✅, typecheck ✅
- SDK config-file example verified (score 1.0) — confirms config loading works
- SDK custom-assertion example verified (score 1.0)