### PR TITLE
feat(core): convention-based provider discovery from .agentv/providers/

### DIFF
--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -14,7 +14,8 @@ import {
   scoreToVerdict,
 } from './evaluators.js';
 import { readJsonFile } from './file-utils.js';
-import { createProvider } from './providers/index.js';
+import { createBuiltinProviderRegistry, createProvider } from './providers/index.js';
+import { discoverProviders } from './providers/provider-discovery.js';
 import { type ResolvedTarget, resolveTargetDefinition } from './providers/targets.js';
 import type {
   EnvLookup,
@@ -268,9 +269,13 @@ export async function runEvaluation(
   const evaluatorRegistry = buildEvaluatorRegistry(evaluators, resolveJudgeProvider);
   const typeRegistry = createBuiltinRegistry();
 
-  // Discover custom assertions from .agentv/assertions/ directory
+  // Discover custom assertions and providers from .agentv/ directory
   const discoveryBaseDir = evalFilePath ? path.dirname(path.resolve(evalFilePath)) : process.cwd();
   await discoverAssertions(typeRegistry, discoveryBaseDir);
+
+  // Discover custom providers from .agentv/providers/ directory
+  const providerRegistry = createBuiltinProviderRegistry();
+  await discoverProviders(providerRegistry, discoveryBaseDir);
 
   const primaryProvider = getOrCreateProvider(target);
   let providerSupportsBatch =

--- a/packages/core/src/evaluation/providers/index.ts
+++ b/packages/core/src/evaluation/providers/index.ts
@@ -69,6 +69,8 @@ export {
   type ProviderFactoryFn,
 } from './provider-registry.js';
 
+export { discoverProviders } from './provider-discovery.js';
+
 /**
  * Create and return the default provider registry with all built-in providers.
  */

--- a/packages/core/src/evaluation/providers/provider-discovery.ts
+++ b/packages/core/src/evaluation/providers/provider-discovery.ts
@@ -1,0 +1,78 @@
+/**
+ * Convention-based discovery of custom provider scripts.
+ *
+ * Scans `.agentv/providers/` for TypeScript/JavaScript files and registers
+ * them as CLI-like providers in the registry. The file name (without
+ * extension) becomes the provider kind name.
+ *
+ * Example: `.agentv/providers/my-llm.ts` -> provider kind "my-llm" in targets.yaml
+ */
+
+import path from 'node:path';
+import fg from 'fast-glob';
+
+import { CliProvider } from './cli.js';
+import type { ProviderRegistry } from './provider-registry.js';
+
+/**
+ * Discover custom provider scripts from `.agentv/providers/` and register
+ * them as provider kinds in the registry.
+ *
+ * Each discovered script is registered as a CLI-like provider that runs
+ * via `bun run <filePath> {PROMPT}`. The script receives the prompt as
+ * a CLI argument and should print its response to stdout.
+ *
+ * @param registry - The provider registry to register discovered providers into
+ * @param baseDir - The base directory to search from (typically project root or eval file dir)
+ * @returns Names of discovered provider kinds
+ */
+export async function discoverProviders(
+  registry: ProviderRegistry,
+  baseDir: string,
+): Promise<string[]> {
+  const patterns = ['*.ts', '*.js', '*.mts', '*.mjs'];
+
+  // Search baseDir and its ancestors for .agentv/providers/
+  const candidateDirs: string[] = [];
+  let dir = path.resolve(baseDir);
+  const root = path.parse(dir).root;
+  while (dir !== root) {
+    candidateDirs.push(path.join(dir, '.agentv', 'providers'));
+    dir = path.dirname(dir);
+  }
+
+  let files: string[] = [];
+  for (const providersDir of candidateDirs) {
+    try {
+      const found = await fg(patterns, {
+        cwd: providersDir,
+        absolute: true,
+        onlyFiles: true,
+      });
+      files = files.concat(found);
+    } catch {
+      // Directory doesn't exist — skip
+    }
+  }
+
+  const discoveredKinds: string[] = [];
+
+  for (const filePath of files) {
+    const basename = path.basename(filePath);
+    const kindName = basename.replace(/\.(ts|js|mts|mjs)$/, '');
+
+    // Don't override built-in kinds
+    if (registry.has(kindName)) {
+      continue;
+    }
+
+    registry.register(kindName, (target) => {
+      return new CliProvider(target.name, {
+        commandTemplate: `bun run ${filePath} {PROMPT}`,
+      });
+    });
+    discoveredKinds.push(kindName);
+  }
+
+  return discoveredKinds;
+}

--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -852,7 +852,20 @@ export function resolveTargetDefinition(
         config: resolveCliConfig(parsed, env, evalFilePath),
       };
     default:
-      throw new Error(`Unsupported provider '${parsed.provider}' in target '${parsed.name}'`);
+      // Unknown provider kind — resolve as CLI target.
+      // This enables convention-based provider discovery: scripts in
+      // .agentv/providers/ are registered in the ProviderRegistry under
+      // their filename, and users can reference them by name directly.
+      // The ProviderRegistry factory handles creating the appropriate
+      // CliProvider with the discovered script path.
+      return {
+        kind: 'cli',
+        name: parsed.name,
+        judgeTarget: parsed.judge_target,
+        workers: parsed.workers,
+        providerBatching,
+        config: resolveDiscoveredProviderConfig(parsed, provider, env, evalFilePath),
+      };
   }
 }
 
@@ -1624,6 +1637,52 @@ function resolveCliConfig(
   }
 
   return normalized;
+}
+
+/**
+ * Resolves configuration for a discovered (convention-based) provider.
+ *
+ * When the provider kind doesn't match any built-in provider, it is assumed
+ * to be a convention-based provider discovered from `.agentv/providers/`.
+ * The command template defaults to `bun run .agentv/providers/<kind>.ts {PROMPT}`
+ * but can be overridden via command_template in the target definition.
+ */
+function resolveDiscoveredProviderConfig(
+  target: z.infer<typeof BASE_TARGET_SCHEMA>,
+  providerKind: string,
+  env: EnvLookup,
+  evalFilePath?: string,
+): CliResolvedConfig {
+  // Use explicit command_template if provided, otherwise derive from convention
+  const commandTemplateSource = target.command_template ?? target.commandTemplate;
+  const commandTemplate = commandTemplateSource
+    ? resolveString(commandTemplateSource, env, `${target.name} command template`, true)
+    : `bun run .agentv/providers/${providerKind}.ts {PROMPT}`;
+
+  // Resolve optional fields using the same patterns as CLI providers
+  const timeoutSeconds = target.timeout_seconds ?? target.timeoutSeconds;
+  const timeoutMs = resolveTimeoutMs(timeoutSeconds, `${target.name} timeout`);
+
+  let cwd = resolveOptionalString(target.cwd, env, `${target.name} working directory`, {
+    allowLiteral: true,
+    optionalEnv: true,
+  });
+
+  // Resolve relative cwd paths against eval file directory
+  if (cwd && evalFilePath && !path.isAbsolute(cwd)) {
+    cwd = path.resolve(path.dirname(path.resolve(evalFilePath)), cwd);
+  }
+
+  // Fallback: if cwd is not set and we have an eval file path, use the eval directory
+  if (!cwd && evalFilePath) {
+    cwd = path.dirname(path.resolve(evalFilePath));
+  }
+
+  return {
+    commandTemplate,
+    cwd,
+    timeoutMs,
+  };
 }
 
 function resolveTimeoutMs(source: unknown, description: string): number | undefined {

--- a/packages/core/test/evaluation/providers/provider-discovery.test.ts
+++ b/packages/core/test/evaluation/providers/provider-discovery.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { discoverProviders } from '../../../src/evaluation/providers/provider-discovery.js';
+import { ProviderRegistry } from '../../../src/evaluation/providers/provider-registry.js';
+
+describe('discoverProviders', () => {
+  const tempDirs: string[] = [];
+
+  async function createTempDir(): Promise<string> {
+    const dir = path.join(
+      os.tmpdir(),
+      `agentv-provider-discovery-test-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+    );
+    await mkdir(dir, { recursive: true });
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true }).catch(() => {})),
+    );
+    tempDirs.length = 0;
+  });
+
+  it('discovers .ts provider scripts from .agentv/providers/', async () => {
+    const baseDir = await createTempDir();
+    const providersDir = path.join(baseDir, '.agentv', 'providers');
+    await mkdir(providersDir, { recursive: true });
+    await writeFile(path.join(providersDir, 'my-llm.ts'), 'console.log("hello")');
+
+    const registry = new ProviderRegistry();
+    const discovered = await discoverProviders(registry, baseDir);
+
+    expect(discovered).toEqual(['my-llm']);
+    expect(registry.has('my-llm')).toBe(true);
+  });
+
+  it('discovers multiple file extensions (.ts, .js, .mts, .mjs)', async () => {
+    const baseDir = await createTempDir();
+    const providersDir = path.join(baseDir, '.agentv', 'providers');
+    await mkdir(providersDir, { recursive: true });
+    await writeFile(path.join(providersDir, 'provider-a.ts'), '');
+    await writeFile(path.join(providersDir, 'provider-b.js'), '');
+    await writeFile(path.join(providersDir, 'provider-c.mts'), '');
+    await writeFile(path.join(providersDir, 'provider-d.mjs'), '');
+
+    const registry = new ProviderRegistry();
+    const discovered = await discoverProviders(registry, baseDir);
+
+    expect(discovered).toContain('provider-a');
+    expect(discovered).toContain('provider-b');
+    expect(discovered).toContain('provider-c');
+    expect(discovered).toContain('provider-d');
+    expect(discovered).toHaveLength(4);
+  });
+
+  it('does not override built-in kinds', async () => {
+    const baseDir = await createTempDir();
+    const providersDir = path.join(baseDir, '.agentv', 'providers');
+    await mkdir(providersDir, { recursive: true });
+    // "cli" is a built-in kind name
+    await writeFile(path.join(providersDir, 'cli.ts'), 'console.log("custom cli")');
+    await writeFile(path.join(providersDir, 'custom.ts'), 'console.log("custom")');
+
+    const registry = new ProviderRegistry();
+    // Register a built-in "cli" factory
+    registry.register('cli', () => ({ id: 'built-in-cli' }) as never);
+
+    const discovered = await discoverProviders(registry, baseDir);
+
+    // "cli" should NOT be in discovered list since it's a built-in
+    expect(discovered).toEqual(['custom']);
+    // The built-in "cli" factory should remain unchanged
+    expect(registry.has('cli')).toBe(true);
+  });
+
+  it('returns empty array when .agentv/providers/ does not exist', async () => {
+    const baseDir = await createTempDir();
+
+    const registry = new ProviderRegistry();
+    const discovered = await discoverProviders(registry, baseDir);
+
+    expect(discovered).toEqual([]);
+  });
+
+  it('ignores non-script files', async () => {
+    const baseDir = await createTempDir();
+    const providersDir = path.join(baseDir, '.agentv', 'providers');
+    await mkdir(providersDir, { recursive: true });
+    await writeFile(path.join(providersDir, 'readme.md'), '# docs');
+    await writeFile(path.join(providersDir, 'config.json'), '{}');
+    await writeFile(path.join(providersDir, 'valid.ts'), 'console.log("ok")');
+
+    const registry = new ProviderRegistry();
+    const discovered = await discoverProviders(registry, baseDir);
+
+    expect(discovered).toEqual(['valid']);
+  });
+
+  it('walks up directory tree to find .agentv/providers/', async () => {
+    const baseDir = await createTempDir();
+    const nestedDir = path.join(baseDir, 'level1', 'level2');
+    await mkdir(nestedDir, { recursive: true });
+
+    const providersDir = path.join(baseDir, '.agentv', 'providers');
+    await mkdir(providersDir, { recursive: true });
+    await writeFile(path.join(providersDir, 'parent-provider.ts'), '');
+
+    const registry = new ProviderRegistry();
+    const discovered = await discoverProviders(registry, nestedDir);
+
+    expect(discovered).toContain('parent-provider');
+  });
+
+  it('creates CliProvider with correct command template', async () => {
+    const baseDir = await createTempDir();
+    const providersDir = path.join(baseDir, '.agentv', 'providers');
+    await mkdir(providersDir, { recursive: true });
+    const scriptPath = path.join(providersDir, 'my-llm.ts');
+    await writeFile(scriptPath, 'console.log("hello")');
+
+    const registry = new ProviderRegistry();
+    await discoverProviders(registry, baseDir);
+
+    // Get the factory and create a provider
+    const factory = registry.get('my-llm');
+    expect(factory).toBeDefined();
+
+    const provider = factory?.({
+      kind: 'cli',
+      name: 'test-target',
+      config: {},
+    } as never);
+
+    expect(provider).toBeDefined();
+    expect(provider.kind).toBe('cli');
+    expect(provider.targetName).toBe('test-target');
+  });
+
+  it('derives kind name from filename without extension', async () => {
+    const baseDir = await createTempDir();
+    const providersDir = path.join(baseDir, '.agentv', 'providers');
+    await mkdir(providersDir, { recursive: true });
+    await writeFile(path.join(providersDir, 'my-custom-agent.ts'), '');
+
+    const registry = new ProviderRegistry();
+    const discovered = await discoverProviders(registry, baseDir);
+
+    expect(discovered).toEqual(['my-custom-agent']);
+    expect(registry.has('my-custom-agent')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `discoverProviders()` function that scans `.agentv/providers/` for TypeScript/JavaScript files and auto-registers them as CLI-like providers in the `ProviderRegistry`, mirroring the existing `discoverAssertions()` pattern
- Unknown provider kinds in target definitions now resolve as CLI targets with convention-based command templates (`bun run .agentv/providers/<kind>.ts {PROMPT}`) instead of throwing, enabling users to reference discovered providers by name in `targets.yaml`
- Integrated into the eval pipeline alongside `discoverAssertions()` in the orchestrator

## Test plan
- [x] Unit tests for `discoverProviders()` covering: basic discovery, multiple file extensions, built-in kind protection, missing directory, non-script file filtering, directory tree walking, factory creation
- [x] Existing target resolution tests pass (no regressions)
- [x] Full test suite passes (899 tests across all packages)
- [x] Build, typecheck, and lint all pass

Closes part of #343