### PR TITLE
feat(cli): add agentv trace score for post-hoc evaluation

### DIFF
--- a/apps/cli/src/commands/trace/index.ts
+++ b/apps/cli/src/commands/trace/index.ts
@@ -1,6 +1,7 @@
 import { subcommands } from 'cmd-ts';
 
 import { traceListCommand } from './list.js';
+import { traceScoreCommand } from './score.js';
 import { traceShowCommand } from './show.js';
 import { traceStatsCommand } from './stats.js';
 
@@ -9,6 +10,7 @@ export const traceCommand = subcommands({
   description: 'Inspect and analyze evaluation traces and results',
   cmds: {
     list: traceListCommand,
+    score: traceScoreCommand,
     show: traceShowCommand,
     stats: traceStatsCommand,
   },

--- a/apps/cli/src/commands/trace/score.ts
+++ b/apps/cli/src/commands/trace/score.ts
@@ -1,0 +1,392 @@
+import {
+  type EvalTest,
+  type EvaluationContext,
+  type EvaluationScore,
+  type Evaluator,
+  type EvaluatorConfig,
+  type EvaluatorDispatchContext,
+  type Message,
+  type Provider,
+  type ProviderRequest,
+  type ProviderResponse,
+  type TraceSummary,
+  createBuiltinRegistry,
+  toCamelCaseDeep,
+} from '@agentv/core';
+import { command, oneOf, option, optional, positional, string } from 'cmd-ts';
+import { type RawResult, c, formatScore, loadResultFile, padLeft, padRight } from './utils.js';
+
+/**
+ * Evaluator types that work without an LLM provider.
+ */
+const SUPPORTED_TYPES = [
+  'contains',
+  'regex',
+  'is_json',
+  'equals',
+  'latency',
+  'cost',
+  'token_usage',
+  'execution_metrics',
+] as const;
+
+/**
+ * Parse key=value pairs from a string like "max_tool_calls=10,max_tokens=2000"
+ */
+function parseKeyValues(s: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  if (!s) return result;
+  for (const pair of s.split(',')) {
+    const eqIdx = pair.indexOf('=');
+    if (eqIdx === -1) continue;
+    result[pair.slice(0, eqIdx).trim()] = pair.slice(eqIdx + 1).trim();
+  }
+  return result;
+}
+
+/**
+ * Parse an inline evaluator spec string into an EvaluatorConfig.
+ *
+ * Supported formats:
+ *   contains:value
+ *   regex:pattern
+ *   is_json
+ *   equals:value
+ *   latency:<threshold_ms>
+ *   cost:<budget_usd>
+ *   token_usage:max_total=N,max_input=N,max_output=N
+ *   execution_metrics:max_tool_calls=N,max_tokens=N,max_llm_calls=N,...
+ */
+export function parseAssertSpec(spec: string): EvaluatorConfig {
+  const colonIdx = spec.indexOf(':');
+  const type = colonIdx === -1 ? spec : spec.slice(0, colonIdx);
+  const params = colonIdx === -1 ? '' : spec.slice(colonIdx + 1);
+
+  switch (type) {
+    case 'contains':
+      if (!params) throw new Error('contains requires a value: contains:<value>');
+      return { name: 'contains', type: 'contains', value: params } as EvaluatorConfig;
+
+    case 'regex':
+      if (!params) throw new Error('regex requires a pattern: regex:<pattern>');
+      return { name: 'regex', type: 'regex', value: params } as EvaluatorConfig;
+
+    case 'is_json':
+      return { name: 'is_json', type: 'is_json' } as EvaluatorConfig;
+
+    case 'equals':
+      if (!params) throw new Error('equals requires a value: equals:<value>');
+      return { name: 'equals', type: 'equals', value: params } as EvaluatorConfig;
+
+    case 'latency': {
+      const threshold = Number(params);
+      if (!params || Number.isNaN(threshold))
+        throw new Error('latency requires a threshold in ms: latency:<ms>');
+      return { name: 'latency', type: 'latency', threshold } as EvaluatorConfig;
+    }
+
+    case 'cost': {
+      const budget = Number(params);
+      if (!params || Number.isNaN(budget))
+        throw new Error('cost requires a budget in USD: cost:<usd>');
+      return { name: 'cost', type: 'cost', budget } as EvaluatorConfig;
+    }
+
+    case 'token_usage': {
+      const kv = parseKeyValues(params);
+      const config: Record<string, unknown> = { name: 'token_usage', type: 'token_usage' };
+      if (kv.max_total) config.max_total = Number(kv.max_total);
+      if (kv.max_input) config.max_input = Number(kv.max_input);
+      if (kv.max_output) config.max_output = Number(kv.max_output);
+      return config as EvaluatorConfig;
+    }
+
+    case 'execution_metrics': {
+      const kv = parseKeyValues(params);
+      const config: Record<string, unknown> = {
+        name: 'execution_metrics',
+        type: 'execution_metrics',
+      };
+      if (kv.max_tool_calls) config.max_tool_calls = Number(kv.max_tool_calls);
+      if (kv.max_llm_calls) config.max_llm_calls = Number(kv.max_llm_calls);
+      if (kv.max_tokens) config.max_tokens = Number(kv.max_tokens);
+      if (kv.max_cost_usd) config.max_cost_usd = Number(kv.max_cost_usd);
+      if (kv.max_duration_ms) config.max_duration_ms = Number(kv.max_duration_ms);
+      return config as EvaluatorConfig;
+    }
+
+    default:
+      throw new Error(
+        `Unsupported evaluator type: "${type}". Supported: ${SUPPORTED_TYPES.join(', ')}`,
+      );
+  }
+}
+
+/**
+ * Convert a snake_case RawResult trace to camelCase TraceSummary.
+ */
+function toTraceSummary(raw: RawResult): TraceSummary | undefined {
+  if (!raw.trace) return undefined;
+  return toCamelCaseDeep(raw.trace) as TraceSummary;
+}
+
+/**
+ * Extract candidate answer from a result record.
+ * Uses `answer` field, or stringifies output for deterministic assertions.
+ */
+function extractCandidate(raw: RawResult): string {
+  if (raw.answer !== undefined) return raw.answer;
+  if (raw.output !== undefined)
+    return typeof raw.output === 'string' ? raw.output : JSON.stringify(raw.output);
+  return '';
+}
+
+/**
+ * Build a minimal EvalTest stub from a result record.
+ * Only used to satisfy the EvaluationContext interface — deterministic and
+ * trace-based evaluators don't access these fields.
+ */
+function buildEvalTest(raw: RawResult): EvalTest {
+  return {
+    id: raw.test_id ?? 'unknown',
+    question: '',
+    input: [],
+    input_segments: [],
+    expected_output: [],
+    guideline_paths: [],
+    file_paths: [],
+    criteria: '',
+  };
+}
+
+/**
+ * A no-op provider stub for evaluators that don't call LLM providers.
+ */
+const stubProvider: Provider = {
+  id: 'trace-score-stub',
+  kind: 'mock',
+  targetName: 'trace-score-stub',
+  invoke(_request: ProviderRequest): Promise<ProviderResponse> {
+    throw new Error('trace score does not support LLM-based evaluators');
+  },
+};
+
+/**
+ * A no-op evaluator stub used as the required llmJudge in the dispatch context.
+ */
+const stubLlmJudge: Evaluator = {
+  kind: 'llm_judge',
+  evaluate(): EvaluationScore {
+    throw new Error('trace score does not support LLM-based evaluators');
+  },
+};
+
+interface ScoreResult {
+  testId: string;
+  candidate: string;
+  originalScore: number;
+  newScore: number;
+  verdict: string;
+  hits: readonly string[];
+  misses: readonly string[];
+  reasoning?: string;
+}
+
+async function runScore(
+  results: RawResult[],
+  evaluatorConfig: EvaluatorConfig,
+  testIdFilter?: string,
+): Promise<ScoreResult[]> {
+  const registry = createBuiltinRegistry();
+
+  const dispatchContext: EvaluatorDispatchContext = {
+    llmJudge: stubLlmJudge,
+    registry,
+  };
+
+  const evaluator = await registry.create(evaluatorConfig, dispatchContext);
+  const scored: ScoreResult[] = [];
+
+  for (const raw of results) {
+    if (testIdFilter && raw.test_id !== testIdFilter) continue;
+
+    const trace = toTraceSummary(raw);
+    const candidate = extractCandidate(raw);
+    const output = raw.output as readonly Message[] | undefined;
+
+    const evalContext: EvaluationContext = {
+      evalCase: buildEvalTest(raw),
+      candidate,
+      target: { kind: 'custom' as const, name: raw.target ?? 'unknown', config: {} } as never,
+      provider: stubProvider,
+      attempt: 1,
+      promptInputs: { question: '', guidelines: '' },
+      now: new Date(),
+      output: Array.isArray(output) ? output : undefined,
+      trace,
+    };
+
+    const score = await evaluator.evaluate(evalContext);
+    scored.push({
+      testId: raw.test_id ?? 'unknown',
+      candidate: candidate.slice(0, 80),
+      originalScore: raw.score,
+      newScore: score.score,
+      verdict: score.verdict,
+      hits: score.hits,
+      misses: score.misses,
+      reasoning: score.reasoning,
+    });
+  }
+
+  return scored;
+}
+
+function renderTable(scored: ScoreResult[], assertSpec: string): string {
+  const lines: string[] = [];
+
+  // Header
+  const cols = [
+    { header: 'Test ID', width: 24 },
+    { header: 'Orig', width: 6 },
+    { header: 'New', width: 6 },
+    { header: 'Verdict', width: 8 },
+    { header: 'Detail', width: 50 },
+  ];
+
+  const headerLine = cols
+    .map((col) => padRight(`${c.bold}${col.header}${c.reset}`, col.width))
+    .join('  ');
+  lines.push(headerLine);
+  lines.push(cols.map((col) => '─'.repeat(col.width)).join('──'));
+
+  for (const r of scored) {
+    const verdictColor = r.verdict === 'pass' ? c.green : c.red;
+    const detail =
+      r.misses.length > 0
+        ? r.misses[0].slice(0, 48)
+        : r.hits.length > 0
+          ? r.hits[0].slice(0, 48)
+          : (r.reasoning?.slice(0, 48) ?? '');
+
+    const row = [
+      padRight(r.testId.slice(0, 24), cols[0].width),
+      padLeft(formatScore(r.originalScore), cols[1].width),
+      padLeft(`${verdictColor}${formatScore(r.newScore)}${c.reset}`, cols[2].width),
+      padRight(`${verdictColor}${r.verdict.toUpperCase()}${c.reset}`, cols[3].width),
+      detail.slice(0, cols[4].width),
+    ].join('  ');
+    lines.push(row);
+  }
+
+  // Summary
+  const passCount = scored.filter((r) => r.verdict === 'pass').length;
+  const total = scored.length;
+  const meanScore = total > 0 ? scored.reduce((sum, r) => sum + r.newScore, 0) / total : 0;
+  lines.push('');
+  lines.push(
+    `${c.bold}Assert:${c.reset} ${assertSpec}  ${c.bold}Results:${c.reset} ${passCount}/${total} passed (${formatScore(passCount / (total || 1))})  ${c.bold}Mean:${c.reset} ${formatScore(meanScore)}`,
+  );
+
+  return lines.join('\n');
+}
+
+export const traceScoreCommand = command({
+  name: 'score',
+  description: 'Run evaluators against existing result files post-hoc',
+  args: {
+    file: positional({
+      type: string,
+      displayName: 'result-file',
+      description: 'Path to JSONL result file',
+    }),
+    assert: option({
+      type: string,
+      long: 'assert',
+      short: 'a',
+      description:
+        'Evaluator spec: contains:<val>, regex:<pat>, is_json, equals:<val>, latency:<ms>, cost:<usd>, token_usage:<params>, execution_metrics:<params>',
+    }),
+    testId: option({
+      type: optional(string),
+      long: 'test-id',
+      description: 'Filter to a specific test ID',
+    }),
+    format: option({
+      type: optional(oneOf(['json', 'table'])),
+      long: 'format',
+      short: 'f',
+      description: 'Output format (default: table)',
+    }),
+  },
+  handler: async ({ file, assert: assertSpec, testId, format }) => {
+    // Parse the evaluator spec
+    let evaluatorConfig: EvaluatorConfig;
+    try {
+      evaluatorConfig = parseAssertSpec(assertSpec);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`${c.red}Error:${c.reset} ${msg}`);
+      process.exit(1);
+    }
+
+    // Load results
+    let results: RawResult[];
+    try {
+      results = loadResultFile(file);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`${c.red}Error:${c.reset} Could not load result file: ${msg}`);
+      process.exit(1);
+    }
+
+    if (results.length === 0) {
+      console.error(`${c.yellow}Warning:${c.reset} No results found in ${file}`);
+      process.exit(0);
+    }
+
+    // Check for trace data if evaluator needs it
+    const traceRequired = ['latency', 'cost', 'token_usage', 'execution_metrics'].includes(
+      evaluatorConfig.type,
+    );
+    if (traceRequired) {
+      const hasTrace = results.some((r) => r.trace);
+      if (!hasTrace) {
+        console.error(
+          `${c.red}Error:${c.reset} Result file lacks trace data. Re-run eval with ${c.bold}--trace${c.reset} to capture trace summaries.`,
+        );
+        process.exit(1);
+      }
+    }
+
+    // Run scoring
+    let scored: ScoreResult[];
+    try {
+      scored = await runScore(results, evaluatorConfig, testId);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`${c.red}Error:${c.reset} Scoring failed: ${msg}`);
+      process.exit(1);
+    }
+
+    if (scored.length === 0) {
+      console.error(
+        `${c.yellow}Warning:${c.reset} No results matched${testId ? ` test ID "${testId}"` : ''}`,
+      );
+      process.exit(0);
+    }
+
+    // Output
+    if (format === 'json') {
+      console.log(JSON.stringify(scored, null, 2));
+    } else {
+      console.log(renderTable(scored, assertSpec));
+    }
+
+    // Exit with non-zero if any failed
+    const hasFailures = scored.some((r) => r.verdict !== 'pass');
+    if (hasFailures) {
+      process.exit(1);
+    }
+  },
+});

--- a/apps/cli/test/commands/trace/trace.test.ts
+++ b/apps/cli/test/commands/trace/trace.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
+import { parseAssertSpec } from '../../../src/commands/trace/score.js';
 import { percentile } from '../../../src/commands/trace/stats.js';
 import {
   extractTimestampFromFilename,
@@ -250,5 +251,106 @@ describe('percentile', () => {
   it('should work with two elements', () => {
     // P50 of [10, 20]: index = 0.5 * 1 = 0.5 → interpolate between 10 and 20
     expect(percentile([10, 20], 50)).toBe(15);
+  });
+});
+
+describe('parseAssertSpec', () => {
+  describe('deterministic evaluators', () => {
+    it('should parse contains spec', () => {
+      const config = parseAssertSpec('contains:Hello world');
+      expect(config.type).toBe('contains');
+      expect(config.name).toBe('contains');
+      expect((config as { value: string }).value).toBe('Hello world');
+    });
+
+    it('should parse contains with colons in value', () => {
+      const config = parseAssertSpec('contains:key: value');
+      expect(config.type).toBe('contains');
+      expect((config as { value: string }).value).toBe('key: value');
+    });
+
+    it('should throw on contains without value', () => {
+      expect(() => parseAssertSpec('contains')).toThrow('contains requires a value');
+    });
+
+    it('should parse regex spec', () => {
+      const config = parseAssertSpec('regex:^Dear User');
+      expect(config.type).toBe('regex');
+      expect((config as { value: string }).value).toBe('^Dear User');
+    });
+
+    it('should throw on regex without pattern', () => {
+      expect(() => parseAssertSpec('regex')).toThrow('regex requires a pattern');
+    });
+
+    it('should parse is_json spec', () => {
+      const config = parseAssertSpec('is_json');
+      expect(config.type).toBe('is_json');
+    });
+
+    it('should parse equals spec', () => {
+      const config = parseAssertSpec('equals:4');
+      expect(config.type).toBe('equals');
+      expect((config as { value: string }).value).toBe('4');
+    });
+
+    it('should throw on equals without value', () => {
+      expect(() => parseAssertSpec('equals')).toThrow('equals requires a value');
+    });
+  });
+
+  describe('trace-based evaluators', () => {
+    it('should parse latency spec', () => {
+      const config = parseAssertSpec('latency:5000');
+      expect(config.type).toBe('latency');
+      expect((config as { threshold: number }).threshold).toBe(5000);
+    });
+
+    it('should throw on invalid latency value', () => {
+      expect(() => parseAssertSpec('latency:abc')).toThrow('latency requires a threshold');
+    });
+
+    it('should throw on latency without value', () => {
+      expect(() => parseAssertSpec('latency')).toThrow('latency requires a threshold');
+    });
+
+    it('should parse cost spec', () => {
+      const config = parseAssertSpec('cost:0.10');
+      expect(config.type).toBe('cost');
+      expect((config as { budget: number }).budget).toBe(0.1);
+    });
+
+    it('should throw on cost without value', () => {
+      expect(() => parseAssertSpec('cost')).toThrow('cost requires a budget');
+    });
+
+    it('should parse token_usage spec with params', () => {
+      const config = parseAssertSpec('token_usage:max_total=2000,max_input=1500');
+      expect(config.type).toBe('token_usage');
+      expect((config as { max_total: number }).max_total).toBe(2000);
+      expect((config as { max_input: number }).max_input).toBe(1500);
+    });
+
+    it('should parse token_usage spec without params', () => {
+      const config = parseAssertSpec('token_usage');
+      expect(config.type).toBe('token_usage');
+    });
+
+    it('should parse execution_metrics spec', () => {
+      const config = parseAssertSpec('execution_metrics:max_tool_calls=10,max_tokens=3000');
+      expect(config.type).toBe('execution_metrics');
+      expect((config as { max_tool_calls: number }).max_tool_calls).toBe(10);
+      expect((config as { max_tokens: number }).max_tokens).toBe(3000);
+    });
+  });
+
+  describe('unsupported types', () => {
+    it('should throw on unknown evaluator type', () => {
+      expect(() => parseAssertSpec('llm_judge')).toThrow('Unsupported evaluator type');
+    });
+
+    it('should throw on empty spec', () => {
+      expect(() => parseAssertSpec('')).toThrow('Unsupported evaluator type');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `agentv trace score <result-file> --assert <spec>` for running evaluators against existing JSONL result files post-hoc
- Supports deterministic evaluators (contains, regex, is_json, equals) and trace-based evaluators (latency, cost, token_usage, execution_metrics) via inline `--assert` specs
- Includes 18 new unit tests for parseAssertSpec covering all evaluator types, error cases, and edge cases (39 total trace tests)

## Details

Completes Phase 3 of #340 (trace score). The command enables iterative scorer development — define new evaluators and test them against past results without re-running evals.

```bash
# Deterministic assertions against answer text
agentv trace score results.jsonl --assert "contains:Hello"
agentv trace score results.jsonl --assert "regex:^Dear"
agentv trace score results.jsonl --assert "is_json"

# Trace-based evaluators against execution metrics
agentv trace score results.jsonl --assert "latency:5000"
agentv trace score results.jsonl --assert "cost:0.10"
agentv trace score results.jsonl --assert "execution_metrics:max_tool_calls=10,max_tokens=3000"

# Filter to specific test and output JSON
agentv trace score results.jsonl --assert "contains:python" --test-id code-gen-python --format json
```

Exit code 1 on any failures (CI-friendly).

## Test plan
- [x] All 938 tests pass (770 core + 57 eval + 111 cli)
- [x] Build, typecheck, lint pass
- [x] E2e tested with `--dry-run` result files (deterministic assertions)
- [x] E2e tested with real Azure eval results (deterministic + trace-based)
- [x] Verified `--test-id` filtering, `--format json`, error cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)