### PR TITLE
fix(cli): move @agentv/core to devDependencies

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -28,7 +28,6 @@
     "test:watch": "bun test --watch"
   },
   "dependencies": {
-    "@agentv/core": "workspace:*",
     "@anthropic-ai/claude-agent-sdk": "^0.2.49",
     "@github/copilot-sdk": "^0.1.25",
     "@inquirer/prompts": "^8.2.1",
@@ -43,6 +42,7 @@
     "yaml": "^2.6.1"
   },
   "devDependencies": {
+    "@agentv/core": "workspace:*",
     "execa": "^9.3.0"
   }
 }


### PR DESCRIPTION
## Summary
- Moved `@agentv/core` from `dependencies` to `devDependencies` in the CLI package
- tsup already bundles `@agentv/core` into the dist via `noExternal: [/^@agentv\//]`, so it's not needed as a runtime dependency
- Having it in `dependencies` caused `workspace:*` to resolve to a non-existent version on npm, breaking `npm install -g agentv@next`

## Test plan
- [x] Build succeeds (`bun run build`)
- [x] All 938 tests pass (`bun run test`)
- [x] Pre-push hooks pass (build, typecheck, lint, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)