### PR TITLE
fix(examples): use correct stdin field name in code_judge scripts

### DIFF
--- a/examples/features/basic/evals/check_python_keywords.py
+++ b/examples/features/basic/evals/check_python_keywords.py
@@ -83,8 +83,8 @@ def main():
         # Read input from stdin
         input_data = json.loads(sys.stdin.read())
         
-        # Extract the generated output (AgentV uses snake_case in JSON payloads)
-        output = input_data.get("candidate_answer", "")
+        # Extract the generated output (field is "answer" in the payload)
+        output = input_data.get("answer", "")
         
         # Extract code from markdown if present
         code = extract_code_from_markdown(output)

--- a/examples/features/rubric/evals/check_syntax.py
+++ b/examples/features/rubric/evals/check_syntax.py
@@ -13,7 +13,7 @@ def main():
             # Fallback if no input or invalid JSON
             input_data = {}
             
-        candidate_answer = input_data.get("candidate_answer", "")
+        candidate_answer = input_data.get("answer", "")
 
         # Extract code block if present (simple heuristic)
         if "```python" in candidate_answer:

--- a/examples/showcase/cw-incident-triage/evals/validate_output.py
+++ b/examples/showcase/cw-incident-triage/evals/validate_output.py
@@ -81,7 +81,7 @@ def main():
         sys.exit(1)
     
     # Extract candidate answer
-    candidate_answer = eval_data.get("candidate_answer", "")
+    candidate_answer = eval_data.get("answer", "")
     
     # Required keys for CargoWise criticality rating
     required_keys = ["criticalityRating", "reasoning"]

--- a/examples/showcase/psychotherapy/evals/validate_output.py
+++ b/examples/showcase/psychotherapy/evals/validate_output.py
@@ -229,7 +229,7 @@ def main():
         sys.exit(1)
     
     # Extract candidate answer - we only validate the candidate's structure
-    candidate_answer = eval_data.get("candidate_answer", "")
+    candidate_answer = eval_data.get("answer", "")
     
     # Auto-detect required keys from candidate answer
     required_keys = detect_framework_keys(candidate_answer)


### PR DESCRIPTION
## Summary
- Fixed all 4 example code_judge Python scripts that were reading `candidate_answer` from stdin instead of the correct field name `answer`
- The code-evaluator payload key is `answer` (after snake_case conversion), but the scripts used `candidate_answer` which doesn't exist, causing them to always evaluate an empty string and score 0

## Affected files
- `examples/features/basic/evals/check_python_keywords.py`
- `examples/features/rubric/evals/check_syntax.py`
- `examples/showcase/cw-incident-triage/evals/validate_output.py`
- `examples/showcase/psychotherapy/evals/validate_output.py`

## Test plan
- [ ] Re-run `bun agentv eval examples/features/basic/evals/dataset.eval.yaml --test-id code-gen-python-comprehensive` and verify `keyword_check` scores 1.0 instead of 0.0
- [ ] Verify overall score for `code-gen-python-comprehensive` is ~0.95+ (matching baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)