### PR TITLE
feat(cli): add PROMPT_FILE placeholder for CLI targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ targets:
 
   - name: local_agent
     provider: cli
-    command_template: 'python agent.py --prompt {PROMPT}'
+    command_template: 'python agent.py --prompt-file {PROMPT_FILE} --output {OUTPUT_FILE}'
     judge_target: azure_base
 ```
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -308,7 +308,7 @@ targets:
 
   - name: local_agent
     provider: cli
-    command_template: 'python agent.py --prompt {PROMPT}'
+    command_template: 'python agent.py --prompt-file {PROMPT_FILE} --output {OUTPUT_FILE}'
     judge_target: azure_base
 ```
 

--- a/apps/web/src/content/docs/targets/coding-agents.mdx
+++ b/apps/web/src/content/docs/targets/coding-agents.mdx
@@ -106,14 +106,14 @@ Evaluate any command-line agent:
 targets:
   - name: local_agent
     provider: cli
-    command_template: 'python agent.py --prompt {PROMPT}'
+    command_template: 'python agent.py --prompt-file {PROMPT_FILE} --output {OUTPUT_FILE}'
     workspace_template: ./workspace-templates/my-project
     judge_target: azure_base
 ```
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `command_template` | Yes | Command to run. `{PROMPT}` is replaced with the input. |
+| `command_template` | Yes | Command to run. `{PROMPT}` is inline prompt text and `{PROMPT_FILE}` is a temp file path containing the prompt. |
 | `workspace_template` | No | Path to workspace template directory |
 | `cwd` | No | Working directory (mutually exclusive with workspace_template) |
 | `judge_target` | Yes | LLM target for evaluation |

--- a/apps/web/src/content/docs/targets/custom-providers.mdx
+++ b/apps/web/src/content/docs/targets/custom-providers.mdx
@@ -211,7 +211,7 @@ Use `provider: cli` when:
 targets:
   - name: python_agent
     provider: cli
-    command_template: 'python agent.py --prompt {PROMPT} --output {OUTPUT_FILE}'
+    command_template: 'python agent.py --prompt-file {PROMPT_FILE} --output {OUTPUT_FILE}'
 ```
 
 ### When to use native providers

--- a/packages/core/src/evaluation/providers/cli.ts
+++ b/packages/core/src/evaluation/providers/cli.ts
@@ -244,7 +244,11 @@ export class CliProvider implements Provider {
     const effectiveCwd = request.cwd ?? this.config.cwd;
 
     const outputFilePath = generateOutputFilePath(request.evalCaseId);
-    const templateValues = buildTemplateValues(request, this.config, outputFilePath);
+    const { values: templateValues, promptFilePath } = await buildTemplateValues(
+      request,
+      this.config,
+      outputFilePath,
+    );
     const renderedCommand = renderTemplate(this.config.commandTemplate, templateValues);
 
     if (this.verbose) {
@@ -254,49 +258,53 @@ export class CliProvider implements Provider {
     }
 
     // Measure wall-clock time as fallback for duration
-    const startTime = Date.now();
-    const result = await this.runCommand(renderedCommand, {
-      cwd: effectiveCwd,
-      env: process.env,
-      timeoutMs: this.config.timeoutMs,
-      signal: request.signal,
-    });
-    const measuredDurationMs = Date.now() - startTime;
-
-    if (result.failed || (result.exitCode ?? 0) !== 0) {
-      if (request.signal?.aborted) {
-        throw new Error('CLI provider request was aborted');
-      }
-      if (result.timedOut) {
-        throw new Error(
-          `CLI provider timed out${formatTimeoutSuffix(this.config.timeoutMs ?? undefined)}`,
-        );
-      }
-      const codeText = result.exitCode !== null ? result.exitCode : 'unknown';
-      const detail = result.stderr.trim() || result.stdout.trim();
-      const message = detail
-        ? `${detail} (exit code ${codeText})`
-        : `CLI exited with code ${codeText}`;
-      throw new Error(message);
-    }
-
-    // Read from output file and parse as JSON if possible
-    const responseContent = await this.readAndCleanupOutputFile(outputFilePath);
-    const parsed = this.parseOutputContent(responseContent);
-
-    return {
-      output: parsed.output,
-      tokenUsage: parsed.tokenUsage,
-      costUsd: parsed.costUsd,
-      durationMs: parsed.durationMs ?? measuredDurationMs,
-      raw: {
-        command: renderedCommand,
-        stderr: result.stderr,
-        exitCode: result.exitCode ?? 0,
+    try {
+      const startTime = Date.now();
+      const result = await this.runCommand(renderedCommand, {
         cwd: effectiveCwd,
-        outputFile: outputFilePath,
-      },
-    };
+        env: process.env,
+        timeoutMs: this.config.timeoutMs,
+        signal: request.signal,
+      });
+      const measuredDurationMs = Date.now() - startTime;
+
+      if (result.failed || (result.exitCode ?? 0) !== 0) {
+        if (request.signal?.aborted) {
+          throw new Error('CLI provider request was aborted');
+        }
+        if (result.timedOut) {
+          throw new Error(
+            `CLI provider timed out${formatTimeoutSuffix(this.config.timeoutMs ?? undefined)}`,
+          );
+        }
+        const codeText = result.exitCode !== null ? result.exitCode : 'unknown';
+        const detail = result.stderr.trim() || result.stdout.trim();
+        const message = detail
+          ? `${detail} (exit code ${codeText})`
+          : `CLI exited with code ${codeText}`;
+        throw new Error(message);
+      }
+
+      // Read from output file and parse as JSON if possible
+      const responseContent = await this.readAndCleanupOutputFile(outputFilePath);
+      const parsed = this.parseOutputContent(responseContent);
+
+      return {
+        output: parsed.output,
+        tokenUsage: parsed.tokenUsage,
+        costUsd: parsed.costUsd,
+        durationMs: parsed.durationMs ?? measuredDurationMs,
+        raw: {
+          command: renderedCommand,
+          stderr: result.stderr,
+          exitCode: result.exitCode ?? 0,
+          cwd: effectiveCwd,
+          outputFile: outputFilePath,
+        },
+      };
+    } finally {
+      await cleanupTempFile(promptFilePath, this.keepTempFiles);
+    }
   }
 
   async invokeBatch(requests: readonly ProviderRequest[]): Promise<readonly ProviderResponse[]> {
@@ -326,7 +334,7 @@ export class CliProvider implements Provider {
       }
     }
 
-    const templateValues = buildTemplateValues(
+    const { values: templateValues, promptFilePath } = await buildTemplateValues(
       {
         question: '',
         guidelines: '',
@@ -346,93 +354,97 @@ export class CliProvider implements Provider {
     }
 
     // Measure wall-clock time for batch (used as fallback if records don't provide duration)
-    const startTime = Date.now();
-    const result = await this.runCommand(renderedCommand, {
-      cwd: this.config.cwd,
-      env: process.env,
-      timeoutMs: this.config.timeoutMs,
-      signal: controller.signal,
-    });
-    const measuredDurationMs = Date.now() - startTime;
+    try {
+      const startTime = Date.now();
+      const result = await this.runCommand(renderedCommand, {
+        cwd: this.config.cwd,
+        env: process.env,
+        timeoutMs: this.config.timeoutMs,
+        signal: controller.signal,
+      });
+      const measuredDurationMs = Date.now() - startTime;
 
-    if (result.failed || (result.exitCode ?? 0) !== 0) {
-      if (controller.signal.aborted) {
-        throw new Error('CLI provider request was aborted');
-      }
-      if (result.timedOut) {
-        throw new Error(
-          `CLI provider timed out${formatTimeoutSuffix(this.config.timeoutMs ?? undefined)}`,
-        );
-      }
-      const codeText = result.exitCode !== null ? result.exitCode : 'unknown';
-      const detail = result.stderr.trim() || result.stdout.trim();
-      const message = detail
-        ? `${detail} (exit code ${codeText})`
-        : `CLI exited with code ${codeText}`;
-      throw new Error(message);
-    }
-
-    const responseContent = await this.readAndCleanupOutputFile(outputFilePath);
-    const recordsById = this.parseJsonlBatchOutput(responseContent);
-
-    // Calculate per-request fallback duration (total time / number of requests)
-    const perRequestFallbackMs = Math.round(measuredDurationMs / requests.length);
-
-    const responses: ProviderResponse[] = requests.map((request) => {
-      const evalCaseId = request.evalCaseId;
-      if (!evalCaseId) {
-        return {
-          output: [],
-          durationMs: perRequestFallbackMs,
-          raw: {
-            command: renderedCommand,
-            stderr: result.stderr,
-            exitCode: result.exitCode ?? 0,
-            cwd: this.config.cwd,
-            outputFile: outputFilePath,
-          },
-        };
-      }
-
-      const parsed = recordsById.get(evalCaseId);
-      if (!parsed) {
-        // Return error response for missing IDs instead of throwing.
-        // This allows other eval cases with matching IDs to be evaluated correctly.
-        const errorMessage = `Batch output missing id '${evalCaseId}'`;
-        if (this.verbose) {
-          console.warn(`[cli-provider:${this.targetName}] ${errorMessage}`);
+      if (result.failed || (result.exitCode ?? 0) !== 0) {
+        if (controller.signal.aborted) {
+          throw new Error('CLI provider request was aborted');
         }
+        if (result.timedOut) {
+          throw new Error(
+            `CLI provider timed out${formatTimeoutSuffix(this.config.timeoutMs ?? undefined)}`,
+          );
+        }
+        const codeText = result.exitCode !== null ? result.exitCode : 'unknown';
+        const detail = result.stderr.trim() || result.stdout.trim();
+        const message = detail
+          ? `${detail} (exit code ${codeText})`
+          : `CLI exited with code ${codeText}`;
+        throw new Error(message);
+      }
+
+      const responseContent = await this.readAndCleanupOutputFile(outputFilePath);
+      const recordsById = this.parseJsonlBatchOutput(responseContent);
+
+      // Calculate per-request fallback duration (total time / number of requests)
+      const perRequestFallbackMs = Math.round(measuredDurationMs / requests.length);
+
+      const responses: ProviderResponse[] = requests.map((request) => {
+        const evalCaseId = request.evalCaseId;
+        if (!evalCaseId) {
+          return {
+            output: [],
+            durationMs: perRequestFallbackMs,
+            raw: {
+              command: renderedCommand,
+              stderr: result.stderr,
+              exitCode: result.exitCode ?? 0,
+              cwd: this.config.cwd,
+              outputFile: outputFilePath,
+            },
+          };
+        }
+
+        const parsed = recordsById.get(evalCaseId);
+        if (!parsed) {
+          // Return error response for missing IDs instead of throwing.
+          // This allows other eval cases with matching IDs to be evaluated correctly.
+          const errorMessage = `Batch output missing id '${evalCaseId}'`;
+          if (this.verbose) {
+            console.warn(`[cli-provider:${this.targetName}] ${errorMessage}`);
+          }
+          return {
+            output: [{ role: 'assistant', content: `Error: ${errorMessage}` }],
+            durationMs: perRequestFallbackMs,
+            raw: {
+              command: renderedCommand,
+              stderr: result.stderr,
+              exitCode: result.exitCode ?? 0,
+              cwd: this.config.cwd,
+              outputFile: outputFilePath,
+              error: errorMessage,
+            },
+          };
+        }
+
         return {
-          output: [{ role: 'assistant', content: `Error: ${errorMessage}` }],
-          durationMs: perRequestFallbackMs,
+          output: parsed.output,
+          tokenUsage: parsed.tokenUsage,
+          costUsd: parsed.costUsd,
+          durationMs: parsed.durationMs ?? perRequestFallbackMs,
           raw: {
             command: renderedCommand,
             stderr: result.stderr,
             exitCode: result.exitCode ?? 0,
             cwd: this.config.cwd,
             outputFile: outputFilePath,
-            error: errorMessage,
+            recordId: evalCaseId,
           },
         };
-      }
+      });
 
-      return {
-        output: parsed.output,
-        tokenUsage: parsed.tokenUsage,
-        costUsd: parsed.costUsd,
-        durationMs: parsed.durationMs ?? perRequestFallbackMs,
-        raw: {
-          command: renderedCommand,
-          stderr: result.stderr,
-          exitCode: result.exitCode ?? 0,
-          cwd: this.config.cwd,
-          outputFile: outputFilePath,
-          recordId: evalCaseId,
-        },
-      };
-    });
-
-    return responses;
+      return responses;
+    } finally {
+      await cleanupTempFile(promptFilePath, this.keepTempFiles);
+    }
   }
 
   /**
@@ -637,61 +649,82 @@ export class CliProvider implements Provider {
       return;
     }
 
-    const renderedCommand = renderTemplate(
-      healthcheck.commandTemplate,
-      buildTemplateValues(
-        {
-          question: '',
-          guidelines: '',
-          inputFiles: [],
-          evalCaseId: 'healthcheck',
-          attempt: 0,
-        },
-        this.config,
-        generateOutputFilePath('healthcheck'),
-      ),
+    const { values: templateValues, promptFilePath } = await buildTemplateValues(
+      {
+        question: '',
+        guidelines: '',
+        inputFiles: [],
+        evalCaseId: 'healthcheck',
+        attempt: 0,
+      },
+      this.config,
+      generateOutputFilePath('healthcheck'),
     );
+    const renderedCommand = renderTemplate(healthcheck.commandTemplate, templateValues);
     if (this.verbose) {
       console.log(
         `[cli-provider:${this.targetName}] (healthcheck) cwd=${healthcheck.cwd ?? this.config.cwd ?? ''} command=${renderedCommand}`,
       );
     }
 
-    const result = await this.runCommand(renderedCommand, {
-      cwd: healthcheck.cwd ?? this.config.cwd,
-      env: process.env,
-      timeoutMs,
-      signal,
-    });
+    try {
+      const result = await this.runCommand(renderedCommand, {
+        cwd: healthcheck.cwd ?? this.config.cwd,
+        env: process.env,
+        timeoutMs,
+        signal,
+      });
 
-    if (result.failed || (result.exitCode ?? 0) !== 0) {
-      const codeText = result.exitCode !== null ? result.exitCode : 'unknown';
-      const detail = result.stderr.trim() || result.stdout.trim();
-      const message = detail
-        ? `${detail} (exit code ${codeText})`
-        : `CLI healthcheck command exited with code ${codeText}`;
-      throw new Error(`CLI healthcheck failed for '${this.targetName}': ${message}`);
+      if (result.failed || (result.exitCode ?? 0) !== 0) {
+        const codeText = result.exitCode !== null ? result.exitCode : 'unknown';
+        const detail = result.stderr.trim() || result.stdout.trim();
+        const message = detail
+          ? `${detail} (exit code ${codeText})`
+          : `CLI healthcheck command exited with code ${codeText}`;
+        throw new Error(`CLI healthcheck failed for '${this.targetName}': ${message}`);
+      }
+    } finally {
+      await cleanupTempFile(promptFilePath, this.keepTempFiles);
     }
   }
 }
 
-function buildTemplateValues(
+async function buildTemplateValues(
   request: Pick<
     ProviderRequest,
     'question' | 'guidelines' | 'inputFiles' | 'evalCaseId' | 'attempt'
   >,
   config: CliResolvedConfig,
   outputFilePath: string,
-): Record<string, string> {
+): Promise<{ values: Record<string, string>; promptFilePath: string }> {
   const inputFiles = normalizeInputFiles(request.inputFiles);
+  const promptFilePath = generateOutputFilePath(request.evalCaseId, '.prompt.txt');
+  await fs.writeFile(promptFilePath, request.question ?? '', 'utf8');
+
   return {
-    PROMPT: shellEscape(request.question ?? ''),
-    GUIDELINES: shellEscape(request.guidelines ?? ''),
-    EVAL_ID: shellEscape(request.evalCaseId ?? ''),
-    ATTEMPT: shellEscape(String(request.attempt ?? 0)),
-    FILES: formatFileList(inputFiles, config.filesFormat),
-    OUTPUT_FILE: shellEscape(outputFilePath),
+    values: {
+      PROMPT: shellEscape(request.question ?? ''),
+      PROMPT_FILE: shellEscape(promptFilePath),
+      GUIDELINES: shellEscape(request.guidelines ?? ''),
+      EVAL_ID: shellEscape(request.evalCaseId ?? ''),
+      ATTEMPT: shellEscape(String(request.attempt ?? 0)),
+      FILES: formatFileList(inputFiles, config.filesFormat),
+      OUTPUT_FILE: shellEscape(outputFilePath),
+    },
+    promptFilePath,
   };
+}
+
+async function cleanupTempFile(
+  filePath: string | undefined,
+  keepTempFiles: boolean,
+): Promise<void> {
+  if (!filePath || keepTempFiles) {
+    return;
+  }
+  await fs.unlink(filePath).catch(() => {
+    /* ignore cleanup errors */
+  });
 }
 
 function normalizeInputFiles(

--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -405,6 +405,7 @@ export function normalizeCliTargetInput(
  */
 export const CLI_PLACEHOLDERS = new Set([
   'PROMPT',
+  'PROMPT_FILE',
   'GUIDELINES',
   'EVAL_ID',
   'ATTEMPT',

--- a/packages/core/test/evaluation/providers/cli.test.ts
+++ b/packages/core/test/evaluation/providers/cli.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, mock } from 'bun:test';
-import { unlink, writeFile } from 'node:fs/promises';
+import { readFile, unlink, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -67,6 +67,45 @@ describe('CliProvider', () => {
     const command = runner.mock.calls[0]?.[0] as string;
     expect(command).toContain('--file');
     expect(command).toContain('Hello world');
+  });
+
+  it('writes prompt to PROMPT_FILE placeholder and passes its path to the command', async () => {
+    let promptFileContent = '';
+    const promptFileConfig: CliResolvedConfig = {
+      ...baseConfig,
+      commandTemplate: 'agent-cli run --prompt-file {PROMPT_FILE} {OUTPUT_FILE}',
+    };
+
+    const runner = mock(async (command: string): Promise<CommandRunResult> => {
+      const promptFileMatch = command.match(/agentv-case-1-\d+-\w+\.prompt\.txt/);
+      if (promptFileMatch) {
+        const promptFilePath = path.join(os.tmpdir(), promptFileMatch[0]);
+        promptFileContent = await readFile(promptFilePath, 'utf8');
+        createdFiles.push(promptFilePath);
+      }
+
+      const outputFileMatch = command.match(/agentv-case-1-\d+-\w+\.json/);
+      if (outputFileMatch) {
+        const outputFilePath = path.join(os.tmpdir(), outputFileMatch[0]);
+        await writeFile(outputFilePath, 'Response via prompt file', 'utf-8');
+        createdFiles.push(outputFilePath);
+      }
+
+      return {
+        stdout: command,
+        stderr: '',
+        exitCode: 0,
+        failed: false,
+      };
+    });
+
+    const provider = new CliProvider('cli-target', promptFileConfig, runner);
+    const response = await provider.invoke(baseRequest);
+
+    expect(extractLastAssistantContent(response.output)).toBe('Response via prompt file');
+    expect(promptFileContent).toBe('Hello world');
+    const command = runner.mock.calls[0]?.[0] as string;
+    expect(command).toContain('.prompt.txt');
   });
 
   it('throws on non-zero exit codes with stderr context', async () => {

--- a/packages/core/test/evaluation/providers/targets.test.ts
+++ b/packages/core/test/evaluation/providers/targets.test.ts
@@ -434,6 +434,24 @@ describe('resolveTargetDefinition', () => {
     expect(target.config.filesFormat).toBe('--file {path}');
   });
 
+  it('accepts PROMPT_FILE as a supported cli placeholder', () => {
+    const target = resolveTargetDefinition(
+      {
+        name: 'shell-cli-prompt-file',
+        provider: 'cli',
+        command_template: 'agent run --prompt-file {PROMPT_FILE} --out {OUTPUT_FILE}',
+      },
+      {},
+    );
+
+    expect(target.kind).toBe('cli');
+    if (target.kind !== 'cli') {
+      throw new Error('expected cli target');
+    }
+
+    expect(target.config.commandTemplate).toContain('{PROMPT_FILE}');
+  });
+
   it('throws for unknown cli placeholders', () => {
     expect(() =>
       resolveTargetDefinition(


### PR DESCRIPTION
## Summary\n- add {PROMPT_FILE} to supported CLI placeholders\n- materialize prompt content into a temp file per CLI invocation\n- pass {PROMPT_FILE} as an escaped path in command templates\n- clean up temp prompt files after invoke/batch/healthcheck runs\n- add tests for placeholder acceptance and prompt-file behavior\n- update docs/examples to show file-based prompt usage\n\n## Validation\n- bun test packages/core/test/evaluation/providers/cli.test.ts\n- bun test packages/core/test/evaluation/providers/targets.test.ts\n- bun test packages/core/test/evaluation/providers/cli-schema.test.ts\n- bun run build\n