### PR TITLE
refactor(core): rename code_judge script to command

### DIFF
--- a/apps/cli/src/commands/eval/commands/prompt/judge.ts
+++ b/apps/cli/src/commands/eval/commands/prompt/judge.ts
@@ -99,7 +99,7 @@ async function processEvaluator(
   switch (config.type) {
     case 'code': {
       const codeConfig = config as Extract<EvaluatorConfig, { type: 'code' }>;
-      const script = codeConfig.script;
+      const script = codeConfig.command ?? codeConfig.script ?? [];
       const scriptCwd = codeConfig.resolvedCwd ?? codeConfig.cwd;
 
       const payload = {

--- a/apps/web/src/content/docs/evaluation/batch-cli.mdx
+++ b/apps/web/src/content/docs/evaluation/batch-cli.mdx
@@ -56,7 +56,7 @@ tests:
     assert:
       - name: decision-check
         type: code_judge
-        script: bun run ./scripts/check-output.ts
+        command: [bun, run, ./scripts/check-output.ts]
         cwd: .
 
   - id: case-002
@@ -84,7 +84,7 @@ tests:
     assert:
       - name: decision-check
         type: code_judge
-        script: bun run ./scripts/check-output.ts
+        command: [bun, run, ./scripts/check-output.ts]
         cwd: .
 ```
 

--- a/apps/web/src/content/docs/evaluation/eval-cases.mdx
+++ b/apps/web/src/content/docs/evaluation/eval-cases.mdx
@@ -120,7 +120,7 @@ Override the suite-level workspace config for individual tests. Test-level field
 ```yaml
 workspace:
   before_all:
-    script: ["bun", "run", "default-setup.ts"]
+    command: ["bun", "run", "default-setup.ts"]
 
 tests:
   - id: case-1
@@ -128,7 +128,7 @@ tests:
     input: Do something
     workspace:
       before_all:
-        script: ["bun", "run", "custom-setup.ts"]
+        command: ["bun", "run", "custom-setup.ts"]
 
   - id: case-2
     criteria: Should also work
@@ -140,7 +140,7 @@ See [Workspace Lifecycle Hooks](/targets/configuration/#workspace-lifecycle-hook
 
 ## Per-Case Metadata
 
-Pass arbitrary key-value pairs to lifecycle scripts via the `metadata` field. This is useful for benchmark datasets where each case needs repo info, commit hashes, or other context:
+Pass arbitrary key-value pairs to lifecycle commands via the `metadata` field. This is useful for benchmark datasets where each case needs repo info, commit hashes, or other context:
 
 ```yaml
 tests:
@@ -152,10 +152,10 @@ tests:
       base_commit: "abc123def"
     workspace:
       before_all:
-        script: ["python", "checkout_repo.py"]
+        command: ["python", "checkout_repo.py"]
 ```
 
-The `metadata` field is included in the stdin JSON passed to lifecycle scripts as `case_metadata`.
+The `metadata` field is included in the stdin JSON passed to lifecycle commands as `case_metadata`.
 
 ## Per-Test Assertions
 

--- a/apps/web/src/content/docs/evaluation/examples.mdx
+++ b/apps/web/src/content/docs/evaluation/examples.mdx
@@ -85,7 +85,7 @@ tests:
     assert:
       - name: json_format_validator
         type: code_judge
-        script: uv run validate_json.py
+        command: [uv, run, validate_json.py]
         cwd: ./evaluators
       - name: content_evaluator
         type: llm_judge
@@ -261,7 +261,7 @@ tests:
     assert:
       - name: decision-check
         type: code_judge
-        script: bun run ./scripts/check-batch-cli-output.ts
+        command: [bun, run, ./scripts/check-batch-cli-output.ts]
         cwd: .
 
   - id: aml-002
@@ -294,7 +294,7 @@ tests:
     assert:
       - name: decision-check
         type: code_judge
-        script: bun run ./scripts/check-batch-cli-output.ts
+        command: [bun, run, ./scripts/check-batch-cli-output.ts]
         cwd: .
 ```
 

--- a/apps/web/src/content/docs/evaluation/rubrics.mdx
+++ b/apps/web/src/content/docs/evaluation/rubrics.mdx
@@ -125,5 +125,5 @@ tests:
           - Includes docstring
       - name: syntax_check
         type: code_judge
-        script: ./validators/check_python.py
+        command: [./validators/check_python.py]
 ```

--- a/apps/web/src/content/docs/evaluation/sdk.mdx
+++ b/apps/web/src/content/docs/evaluation/sdk.mdx
@@ -64,7 +64,7 @@ Convention-based discovery maps filename → assertion type:
 .agentv/assertions/sentiment.ts   →  type: sentiment
 ```
 
-Reference directly in your eval file — no `script:` needed:
+Reference directly in your eval file — no `command:` needed:
 
 ```yaml
 assert:
@@ -87,7 +87,7 @@ export default defineCodeJudge(({ trace, answer }) => ({
 }));
 ```
 
-`defineCodeJudge` scripts are referenced in YAML with `type: code_judge` and `script: bun run judge.ts`. `defineAssertion` uses convention-based discovery instead — just place in `.agentv/assertions/` and reference by name.
+`defineCodeJudge` judges are referenced in YAML with `type: code_judge` and `command: [bun, run, judge.ts]`. `defineAssertion` uses convention-based discovery instead — just place in `.agentv/assertions/` and reference by name.
 
 For detailed patterns, input/output contracts, and language-agnostic examples, see [Code Judges](/evaluators/code-judges/).
 

--- a/apps/web/src/content/docs/evaluators/code-judges.mdx
+++ b/apps/web/src/content/docs/evaluators/code-judges.mdx
@@ -97,7 +97,7 @@ console.log(JSON.stringify({
 assert:
   - name: my_validator
     type: code_judge
-    script: ./validators/check_answer.py
+    command: [./validators/check_answer.py]
 ```
 
 ## @agentv/eval SDK
@@ -142,7 +142,7 @@ Add a `target` block to the evaluator config:
 assert:
   - name: contextual-precision
     type: code_judge
-    script: bun scripts/contextual-precision.ts
+    command: [bun, scripts/contextual-precision.ts]
     target:
       max_calls: 10  # Default: 50
 ```
@@ -289,7 +289,7 @@ tests:
     assert:
       - name: functional-check
         type: code_judge
-        script: bun scripts/functional-check.ts
+        command: [bun, scripts/functional-check.ts]
 ```
 
 See `examples/features/functional-grading/` for a complete working example.

--- a/apps/web/src/content/docs/evaluators/composite.mdx
+++ b/apps/web/src/content/docs/evaluators/composite.mdx
@@ -21,7 +21,7 @@ assert:
         prompt: ./prompts/check1.md
       - name: evaluator_2
         type: code_judge
-        script: uv run check2.py
+        command: [uv, run, check2.py]
     aggregator:
       type: weighted_average
       weights:
@@ -59,7 +59,7 @@ final_score = sum(score_i * weight_i) / sum(weight_i)
 
 ### Code Judge Aggregator
 
-Run a custom script to decide the final score based on all evaluator results:
+Run a custom command to decide the final score based on all evaluator results:
 
 ```yaml
 aggregator:
@@ -68,7 +68,7 @@ aggregator:
   cwd: ./evaluators  # optional working directory
 ```
 
-The script receives the evaluator results on stdin and must print a result to stdout.
+The command receives the evaluator results on stdin and must print a result to stdout.
 
 **Input (stdin):**
 ```json
@@ -131,7 +131,7 @@ tests:
           path: ./scripts/safety-gate.js
 ```
 
-The `safety-gate.js` script can return a score of 0.0 whenever the safety evaluator fails, regardless of the quality score.
+The `safety-gate.js` command can return a score of 0.0 whenever the safety evaluator fails, regardless of the quality score.
 
 ### Multi-Criteria Weighted
 
@@ -146,7 +146,7 @@ Assign different importance to each evaluation dimension:
       prompt: ./prompts/correctness.md
     - name: style
       type: code_judge
-      script: uv run style_checker.py
+      command: [uv, run, style_checker.py]
     - name: security
       type: llm_judge
       prompt: ./prompts/security.md

--- a/apps/web/src/content/docs/evaluators/custom-assertions.mdx
+++ b/apps/web/src/content/docs/evaluators/custom-assertions.mdx
@@ -14,11 +14,11 @@ AgentV provides two SDK functions for custom evaluation logic:
 | Function | Best For | Discovery |
 |----------|----------|-----------|
 | `defineAssertion()` | Pass/fail checks, reusable assertion types | Convention-based (`.agentv/assertions/`) |
-| `defineCodeJudge()` | Full scoring control with explicit hits/misses | Referenced via `type: code_judge` + `script:` |
+| `defineCodeJudge()` | Full scoring control with explicit hits/misses | Referenced via `type: code_judge` + `command:` |
 
-**Use `defineAssertion()`** when you want a named assertion type that can be referenced across eval files without specifying a script path. It uses a simplified result contract focused on `pass` and optional `score`.
+**Use `defineAssertion()`** when you want a named assertion type that can be referenced across eval files without specifying a command path. It uses a simplified result contract focused on `pass` and optional `score`.
 
-**Use `defineCodeJudge()`** when you need full control over scoring with explicit `hits`/`misses` arrays, or when the evaluator is a one-off script tied to a specific eval. See [Code Judges](/evaluators/code-judges/) for details.
+**Use `defineCodeJudge()`** when you need full control over scoring with explicit `hits`/`misses` arrays, or when the evaluator is a one-off judge tied to a specific eval. See [Code Judges](/evaluators/code-judges/) for details.
 
 Both functions handle stdin/stdout JSON parsing, snake_case-to-camelCase conversion, Zod validation, and error handling automatically.
 
@@ -46,7 +46,7 @@ Custom assertion types cannot override built-in types (`contains`, `equals`, `is
 
 ### Using in YAML
 
-Reference the assertion by type name directly -- no `script:` path needed:
+Reference the assertion by type name directly -- no `command:` path needed:
 
 ```yaml
 assert:

--- a/apps/web/src/content/docs/evaluators/custom-evaluators.mdx
+++ b/apps/web/src/content/docs/evaluators/custom-evaluators.mdx
@@ -11,7 +11,7 @@ AgentV supports multiple evaluator types that can be combined for comprehensive 
 
 | Type | Description | Use Case |
 |------|-------------|----------|
-| `code_judge` | Deterministic script (Python/TS/any) | Exact matching, format validation, programmatic checks |
+| `code_judge` | Deterministic command (Python/TS/any) | Exact matching, format validation, programmatic checks |
 | `llm_judge` | LLM-based evaluation with custom prompt | Semantic evaluation, nuance, subjective quality |
 | `rubrics` | Structured rubric evaluator via `assert` | Multi-criterion grading with weights |
 
@@ -44,7 +44,7 @@ tests:
     assert:
       - name: json_check
         type: code_judge
-        script: ./validators/check_json.py
+        command: [./validators/check_json.py]
 ```
 
 ## Combining Evaluators
@@ -64,7 +64,7 @@ tests:
           - Uses appropriate algorithm
       - name: syntax_check
         type: code_judge
-        script: ./validators/check_syntax.py
+        command: [./validators/check_syntax.py]
       - name: quality_review
         type: llm_judge
         prompt: ./judges/code_quality.md

--- a/apps/web/src/content/docs/evaluators/execution-metrics.mdx
+++ b/apps/web/src/content/docs/evaluators/execution-metrics.mdx
@@ -112,7 +112,7 @@ Fails if total token usage exceeds the threshold.
 |----------|----------------------|
 | Check multiple metrics at once | `execution_metrics` |
 | Simple single-threshold check | `latency`, `cost`, or `token_usage` |
-| Complex custom formulas | `code_judge` with custom script |
+| Complex custom formulas | `code_judge` with custom command |
 
 ## Combining with Other Evaluators
 

--- a/apps/web/src/content/docs/evaluators/llm-judges.mdx
+++ b/apps/web/src/content/docs/evaluators/llm-judges.mdx
@@ -90,16 +90,16 @@ Evaluate and provide a score from 0 to 1.`;
 3. The LLM returns a structured evaluation with score, hits, misses, and reasoning
 4. Results are recorded in the output JSONL
 
-## Script Configuration
+## Command Configuration
 
-When using TypeScript templates, configure them in YAML with optional `config` data passed to the script:
+When using TypeScript templates, configure them in YAML with optional `config` data passed to the command:
 
 ```yaml
 assert:
   - name: custom-eval
     type: llm_judge
     prompt:
-      script: [bun, run, ../prompts/custom-evaluator.ts]
+      command: [bun, run, ../prompts/custom-evaluator.ts]
       config:
         rubric: "Your rubric here"
         strictMode: true

--- a/apps/web/src/content/docs/getting-started/quickstart.mdx
+++ b/apps/web/src/content/docs/getting-started/quickstart.mdx
@@ -47,7 +47,7 @@ tests:
     assert:
       - name: math_check
         type: code_judge
-        script: ./validators/check_math.py
+        command: [./validators/check_math.py]
 ```
 
 ## 5. Run the eval

--- a/apps/web/src/content/docs/guides/agent-eval-layers.mdx
+++ b/apps/web/src/content/docs/guides/agent-eval-layers.mdx
@@ -114,7 +114,7 @@ Covers prompt injection resilience, policy adherence, bias, and content safety. 
 | Concern | AgentV evaluator |
 |---------|-----------------|
 | Content safety | `llm_judge` with safety prompt |
-| Policy enforcement | `code_judge` with policy script |
+| Policy enforcement | `code_judge` with policy command |
 | "Must NOT" assertions | Any evaluator with `negate: true` |
 
 ```yaml

--- a/apps/web/src/content/docs/guides/autoevals-integration.mdx
+++ b/apps/web/src/content/docs/guides/autoevals-integration.mdx
@@ -13,7 +13,7 @@ sidebar:
 
 - Works standalone — no Braintrust platform account required
 - Uses any OpenAI-compatible endpoint for LLM-based scorers
-- Integrates with AgentV via `code_judge` evaluator type: wrap any autoevals scorer in a script that reads stdin and writes the AgentV judge result to stdout
+- Integrates with AgentV via `code_judge` evaluator type: wrap any autoevals scorer in a command that reads stdin and writes the AgentV judge result to stdout
 
 ## Installation
 
@@ -64,7 +64,7 @@ tests:
     assert:
       - name: factuality
         type: code_judge
-        script: ["bun", "run", "judges/factuality.ts"]
+        command: ["bun", "run", "judges/factuality.ts"]
 ```
 
 **judges/factuality.ts:**
@@ -113,7 +113,7 @@ tests:
     assert:
       - name: faithfulness
         type: code_judge
-        script: ["python", "judges/faithfulness.py"]
+        command: ["python", "judges/faithfulness.py"]
 ```
 
 **judges/faithfulness.py:**
@@ -201,7 +201,7 @@ tests:
     assert:
       - name: rag-quality
         type: code_judge
-        script: ["bun", "run", "judges/rag-suite.ts"]
+        command: ["bun", "run", "judges/rag-suite.ts"]
         weight: 1.0
 ```
 

--- a/apps/web/src/content/docs/targets/configuration.mdx
+++ b/apps/web/src/content/docs/targets/configuration.mdx
@@ -105,20 +105,20 @@ When `workspace_template` is set:
 
 ### Workspace Lifecycle Hooks
 
-Run scripts at different points in the evaluation lifecycle using the `workspace` block. This can be defined at the suite level (applies to all tests) or per test (overrides suite-level).
+Run commands at different points in the evaluation lifecycle using the `workspace` block. This can be defined at the suite level (applies to all tests) or per test (overrides suite-level).
 
 ```yaml
 workspace:
   template: ./workspace-templates/my-project
   before_all:
-    script: ["bun", "run", "setup.ts"]
+    command: ["bun", "run", "setup.ts"]
     timeout_ms: 120000
     cwd: ./scripts
   after_each:
-    script: ["bun", "run", "reset.ts"]
+    command: ["bun", "run", "reset.ts"]
     timeout_ms: 5000
   after_all:
-    script: ["bun", "run", "cleanup.ts"]
+    command: ["bun", "run", "cleanup.ts"]
     timeout_ms: 30000
 ```
 
@@ -130,11 +130,11 @@ workspace:
 | `before_each` | Runs before each test |
 | `after_each` | Runs after each test (e.g., reset workspace state for reuse) |
 
-Each script config accepts:
+Each hook config accepts:
 
 | Field | Description |
 |-------|-------------|
-| `script` | Command array (e.g., `["bun", "run", "setup.ts"]`) |
+| `command` | Command array (e.g., `["bun", "run", "setup.ts"]`) |
 | `timeout_ms` | Timeout in milliseconds (default: 60000 for `before_all`, 30000 for others) |
 | `cwd` | Working directory (relative paths resolved against eval file directory) |
 

--- a/apps/web/src/content/docs/tools/validate.mdx
+++ b/apps/web/src/content/docs/tools/validate.mdx
@@ -23,7 +23,7 @@ agentv validate evals/**/*.yaml
 
 - YAML/JSONL syntax
 - Required fields (id, input, criteria)
-- Evaluator references (script paths, prompt files)
+- Evaluator references (command paths, prompt files)
 - Target references match entries in `targets.yaml`
 - Rubric structure and field types
 

--- a/examples/features/basic/evals/dataset.eval.yaml
+++ b/examples/features/basic/evals/dataset.eval.yaml
@@ -77,7 +77,7 @@ tests:
     assert:
       - name: keyword_check
         type: code_judge  # Code evaluators handle regex, keywords, linting, etc.
-        script: ["uv", "run", "check_python_keywords.py"]
+        command: ["uv", "run", "check_python_keywords.py"]
         cwd: .  # Working directory for script execution
       - name: code_correctness
         type: llm_judge  # LLM-based evaluation

--- a/examples/features/batch-cli/evals/dataset.eval.yaml
+++ b/examples/features/batch-cli/evals/dataset.eval.yaml
@@ -45,7 +45,7 @@ tests:
     assert:
       - name: decision-check
         type: code_judge
-        script: ["bun", "run", "../judges/check-batch-cli-output.ts"]
+        command: ["bun", "run", "../judges/check-batch-cli-output.ts"]
         cwd: .
       # Verify the aml_screening tool was called using trace extracted from output
       - name: tool-trajectory-check
@@ -84,7 +84,7 @@ tests:
     assert:
       - name: decision-check
         type: code_judge
-        script: ["bun", "run", "../judges/check-batch-cli-output.ts"]
+        command: ["bun", "run", "../judges/check-batch-cli-output.ts"]
         cwd: .
       # Verify the aml_screening tool was called using trace extracted from output
       - name: tool-trajectory-check
@@ -123,7 +123,7 @@ tests:
     assert:
       - name: decision-check
         type: code_judge
-        script: ["bun", "run", "../judges/check-batch-cli-output.ts"]
+        command: ["bun", "run", "../judges/check-batch-cli-output.ts"]
         cwd: .
       # Verify the aml_screening tool was called using trace extracted from output
       - name: tool-trajectory-check
@@ -162,7 +162,7 @@ tests:
     assert:
       - name: decision-check
         type: code_judge
-        script: ["bun", "run", "../judges/check-batch-cli-output.ts"]
+        command: ["bun", "run", "../judges/check-batch-cli-output.ts"]
         cwd: .
       # Verify the aml_screening tool was called using trace extracted from output
       - name: tool-trajectory-check

--- a/examples/features/code-judge-sdk/evals/dataset.eval.yaml
+++ b/examples/features/code-judge-sdk/evals/dataset.eval.yaml
@@ -32,4 +32,4 @@ tests:
     assert:
       - name: attachment-check
         type: code_judge
-        script: ["bun", "run", "../scripts/verify-attachments.ts"]
+        command: ["bun", "run", "../scripts/verify-attachments.ts"]

--- a/examples/features/code-judge-with-llm-calls/evals/contextual-precision.eval.yaml
+++ b/examples/features/code-judge-with-llm-calls/evals/contextual-precision.eval.yaml
@@ -20,7 +20,7 @@
 assert:
   - name: contextual_precision
     type: code_judge
-    script: [bun, run, ../scripts/contextual-precision.ts]
+    command: [bun, run, ../scripts/contextual-precision.ts]
     # Target access config - allows script to invoke configured targets
     # max_calls should be >= number of retrieval context nodes
     target:

--- a/examples/features/code-judge-with-llm-calls/evals/contextual-recall.eval.yaml
+++ b/examples/features/code-judge-with-llm-calls/evals/contextual-recall.eval.yaml
@@ -24,7 +24,7 @@
 assert:
   - name: contextual_recall
     type: code_judge
-    script: [bun, run, ../scripts/contextual-recall.ts]
+    command: [bun, run, ../scripts/contextual-recall.ts]
     # max_calls: 1 for statement extraction + 1 per statement for attribution
     target:
       max_calls: 15

--- a/examples/features/document-extraction/evals/confusion-metrics.eval.yaml
+++ b/examples/features/document-extraction/evals/confusion-metrics.eval.yaml
@@ -33,7 +33,7 @@ execution:
 assert:
   - name: header_confusion
     type: code_judge
-    script: ["bun", "run", "../judges/header_confusion_metrics.ts"]
+    command: ["bun", "run", "../judges/header_confusion_metrics.ts"]
     fields:
       - path: invoice_number
       - path: invoice_date

--- a/examples/features/document-extraction/evals/field-accuracy.eval.yaml
+++ b/examples/features/document-extraction/evals/field-accuracy.eval.yaml
@@ -214,7 +214,7 @@ tests:
       # Multi-field fuzzy match with config pass-through
       - name: party_names_fuzzy
         type: code_judge
-        script: ["bun", "run", "../judges/multi_field_fuzzy.ts"]
+        command: ["bun", "run", "../judges/multi_field_fuzzy.ts"]
         # These properties are passed to the script via stdin config
         fields:
           - path: supplier.name
@@ -394,7 +394,7 @@ tests:
     assert:
       - name: line_items_matched
         type: code_judge
-        script: ["bun", "run", "../judges/line_item_matching.ts"]
+        command: ["bun", "run", "../judges/line_item_matching.ts"]
         match_fields: ["description"]
         score_fields: ["description", "quantity", "line_total"]
         threshold: 0.8

--- a/examples/features/execution-metrics/evals/dataset.eval.yaml
+++ b/examples/features/execution-metrics/evals/dataset.eval.yaml
@@ -154,4 +154,4 @@ tests:
       # Custom evaluation logic (for more complex checks)
       - name: custom-check
         type: code_judge
-        script: ["bun", "run", "../scripts/check-metrics-present.ts"]
+        command: ["bun", "run", "../scripts/check-metrics-present.ts"]

--- a/examples/features/file-changes/evals/dataset.eval.yaml
+++ b/examples/features/file-changes/evals/dataset.eval.yaml
@@ -30,7 +30,7 @@ tests:
     assert:
       - name: check-edits-and-creates
         type: code_judge
-        script: ["uv", "run", "../check_file_changes.py"]
+        command: ["uv", "run", "../check_file_changes.py"]
         # Pass-through properties become config.expect_edited etc. in the payload
         expect_edited: ["hello.txt", "config.json"]
         expect_created: ["src/utils.ts", "tests/main.test.ts"]
@@ -50,7 +50,7 @@ tests:
     assert:
       - name: check-deletes-and-structure
         type: code_judge
-        script: ["uv", "run", "../check_file_changes.py"]
+        command: ["uv", "run", "../check_file_changes.py"]
         expect_deleted: ["obsolete.log"]
         expect_edited: ["hello.txt", "config.json"]
         expect_created: ["src/utils.ts", "tests/main.test.ts"]

--- a/examples/features/functional-grading/evals/dataset.eval.yaml
+++ b/examples/features/functional-grading/evals/dataset.eval.yaml
@@ -27,4 +27,4 @@ tests:
     assert:
       - name: functional-check
         type: code_judge
-        script: ["bun", "run", "../scripts/functional-check.ts"]
+        command: ["bun", "run", "../scripts/functional-check.ts"]

--- a/examples/features/nlp-metrics/evals/dataset.eval.yaml
+++ b/examples/features/nlp-metrics/evals/dataset.eval.yaml
@@ -22,7 +22,7 @@ tests:
     assert:
       - name: rouge-score
         type: code_judge
-        script: ["bun", "run", "../judges/rouge.ts"]
+        command: ["bun", "run", "../judges/rouge.ts"]
 
   - id: translation-bleu
     criteria: Translation preserves meaning and word choice of the reference.
@@ -38,7 +38,7 @@ tests:
     assert:
       - name: bleu-score
         type: code_judge
-        script: ["bun", "run", "../judges/bleu.ts"]
+        command: ["bun", "run", "../judges/bleu.ts"]
 
   - id: paraphrase-similarity
     criteria: Paraphrase conveys the same meaning as the reference.
@@ -54,7 +54,7 @@ tests:
     assert:
       - name: cosine-similarity
         type: code_judge
-        script: ["bun", "run", "../judges/similarity.ts"]
+        command: ["bun", "run", "../judges/similarity.ts"]
 
   - id: extraction-levenshtein
     criteria: Extracted text closely matches the expected value.
@@ -70,7 +70,7 @@ tests:
     assert:
       - name: edit-distance
         type: code_judge
-        script: ["bun", "run", "../judges/levenshtein.ts"]
+        command: ["bun", "run", "../judges/levenshtein.ts"]
 
   - id: multi-metric-evaluation
     criteria: Response is evaluated by multiple NLP metrics simultaneously.
@@ -86,10 +86,10 @@ tests:
     assert:
       - name: rouge-score
         type: code_judge
-        script: ["bun", "run", "../judges/rouge.ts"]
+        command: ["bun", "run", "../judges/rouge.ts"]
       - name: cosine-similarity
         type: code_judge
-        script: ["bun", "run", "../judges/similarity.ts"]
+        command: ["bun", "run", "../judges/similarity.ts"]
       - name: edit-distance
         type: code_judge
-        script: ["bun", "run", "../judges/levenshtein.ts"]
+        command: ["bun", "run", "../judges/levenshtein.ts"]

--- a/examples/features/prompt-template-sdk/evals/dataset.eval.yaml
+++ b/examples/features/prompt-template-sdk/evals/dataset.eval.yaml
@@ -26,7 +26,7 @@ tests:
         type: llm_judge
         # Executable prompt template using explicit script array (matches code_judge pattern)
         prompt:
-          script: [bun, run, ../prompts/custom-evaluator.ts]
+          command: [bun, run, ../prompts/custom-evaluator.ts]
 
   - id: prompt-template-with-config
     criteria: The CLI explains async/await correctly.
@@ -45,7 +45,7 @@ tests:
         type: llm_judge
         # Executable prompt template with config
         prompt:
-          script: [bun, run, ../prompts/custom-evaluator.ts]
+          command: [bun, run, ../prompts/custom-evaluator.ts]
           config:
             rubric: |-
               - Must mention Promises

--- a/examples/features/rubric/evals/dataset.eval.yaml
+++ b/examples/features/rubric/evals/dataset.eval.yaml
@@ -146,7 +146,7 @@ tests:
       # Additional code evaluator for syntax checking
       - name: python_syntax
         type: code_judge
-        script: ["uv", "run", "python", "check_syntax.py"]
+        command: ["uv", "run", "python", "check_syntax.py"]
 
   # ==========================================
   # Example 4: Using criteria without rubrics

--- a/examples/features/tool-evaluation-plugins/evals/dataset.eval.yaml
+++ b/examples/features/tool-evaluation-plugins/evals/dataset.eval.yaml
@@ -29,7 +29,7 @@ tests:
     assert:
       - name: tool-f1
         type: code_judge
-        script: ["bun", "run", "../judges/tool-call-f1.ts"]
+        command: ["bun", "run", "../judges/tool-call-f1.ts"]
         expected_tools: ["search", "fetch"]
 
   # ==========================================
@@ -47,7 +47,7 @@ tests:
     assert:
       - name: tool-args-f1
         type: code_judge
-        script: ["bun", "run", "../judges/tool-args-f1.ts"]
+        command: ["bun", "run", "../judges/tool-args-f1.ts"]
         expected_tools:
           - tool: search
             args: { query: "weather tokyo" }
@@ -76,5 +76,5 @@ tests:
       # Plugin: F1 score over expected tools
       - name: tool-f1
         type: code_judge
-        script: ["bun", "run", "../judges/tool-call-f1.ts"]
+        command: ["bun", "run", "../judges/tool-call-f1.ts"]
         expected_tools: ["search", "validate", "process"]

--- a/examples/features/trace-evaluation/evals/dataset.eval.yaml
+++ b/examples/features/trace-evaluation/evals/dataset.eval.yaml
@@ -24,7 +24,7 @@ tests:
     assert:
       - name: span-count
         type: code_judge
-        script: ["bun", "run", "../judges/span-count.ts"]
+        command: ["bun", "run", "../judges/span-count.ts"]
         config:
           maxLlmCalls: 5
           maxToolCalls: 10
@@ -43,7 +43,7 @@ tests:
     assert:
       - name: error-check
         type: code_judge
-        script: ["bun", "run", "../judges/error-spans.ts"]
+        command: ["bun", "run", "../judges/error-spans.ts"]
         config:
           maxErrors: 0
 
@@ -62,7 +62,7 @@ tests:
     assert:
       - name: error-and-tool-check
         type: code_judge
-        script: ["bun", "run", "../judges/error-spans.ts"]
+        command: ["bun", "run", "../judges/error-spans.ts"]
         config:
           maxErrors: 0
           forbiddenTools:
@@ -84,7 +84,7 @@ tests:
     assert:
       - name: duration-check
         type: code_judge
-        script: ["bun", "run", "../judges/span-duration.ts"]
+        command: ["bun", "run", "../judges/span-duration.ts"]
         config:
           maxSpanMs: 3000
           maxTotalMs: 15000
@@ -104,17 +104,17 @@ tests:
     assert:
       - name: span-count
         type: code_judge
-        script: ["bun", "run", "../judges/span-count.ts"]
+        command: ["bun", "run", "../judges/span-count.ts"]
         config:
           maxLlmCalls: 8
           maxToolCalls: 20
 
       - name: error-check
         type: code_judge
-        script: ["bun", "run", "../judges/error-spans.ts"]
+        command: ["bun", "run", "../judges/error-spans.ts"]
 
       - name: duration-check
         type: code_judge
-        script: ["bun", "run", "../judges/span-duration.ts"]
+        command: ["bun", "run", "../judges/span-duration.ts"]
         config:
           maxSpanMs: 5000

--- a/examples/showcase/cross-repo-sync/evals/dataset.eval.yaml
+++ b/examples/showcase/cross-repo-sync/evals/dataset.eval.yaml
@@ -6,11 +6,11 @@ tags: [showcase, workspace, cross-repo]
 workspace:
   template: ../workspace-template
   before_each:
-    script: ["bash", "../scripts/run-ts.sh", "../scripts/setup.ts"]
+    command: ["bash", "../scripts/run-ts.sh", "../scripts/setup.ts"]
     timeout_ms: 900000
     cwd: .
   after_each:
-    script: ["bash", "../scripts/run-ts.sh", "../scripts/reset.ts"]
+    command: ["bash", "../scripts/run-ts.sh", "../scripts/reset.ts"]
     timeout_ms: 5000
     cwd: .
 
@@ -34,7 +34,7 @@ tests:
     assert:
       - name: sync-check
         type: code_judge
-        script: ["bash", "../scripts/run-ts.sh", "../scripts/validate-sync.ts"]
+        command: ["bash", "../scripts/run-ts.sh", "../scripts/validate-sync.ts"]
         expected_files_modified:
           - agentevals/docs/src/content/docs/specification/evaluators.mdx
           - agentevals/docs/src/content/docs/specification/eval-format.mdx
@@ -54,7 +54,7 @@ tests:
     assert:
       - name: sync-check
         type: code_judge
-        script: ["bash", "../scripts/run-ts.sh", "../scripts/validate-sync.ts"]
+        command: ["bash", "../scripts/run-ts.sh", "../scripts/validate-sync.ts"]
         expected_files_modified:
           - agentevals/docs/src/content/docs/specification/eval-format.mdx
           - agentevals/docs/src/content/docs/specification/evalcase-schema.mdx
@@ -75,7 +75,7 @@ tests:
     assert:
       - name: sync-check
         type: code_judge
-        script: ["bash", "../scripts/run-ts.sh", "../scripts/validate-sync.ts"]
+        command: ["bash", "../scripts/run-ts.sh", "../scripts/validate-sync.ts"]
         expected_files_modified:
           - agentevals/docs/src/content/docs/specification/eval-format.mdx
           - agentevals/docs/src/content/docs/specification/evalcase-schema.mdx

--- a/examples/showcase/cw-incident-triage/evals/dataset.eval.yaml
+++ b/examples/showcase/cw-incident-triage/evals/dataset.eval.yaml
@@ -12,7 +12,7 @@ execution:
 assert:
   - name: json_schema_validator
     type: code_judge
-    script: ["uv", "run", "validate_output.py"]
+    command: ["uv", "run", "validate_output.py"]
   - name: content_evaluator
     type: llm_judge
 

--- a/examples/showcase/evaluator-conformance/EVAL.yaml
+++ b/examples/showcase/evaluator-conformance/EVAL.yaml
@@ -17,7 +17,7 @@ tests:
     assert:
       - name: keyword-judge
         type: code_judge
-        script: ["bun", "run", "evaluators/keyword-judge.ts"]
+        command: ["bun", "run", "evaluators/keyword-judge.ts"]
 
   - id: partial-match
     criteria: "Answer must mention red, blue, and yellow."
@@ -26,4 +26,4 @@ tests:
     assert:
       - name: keyword-judge
         type: code_judge
-        script: ["bun", "run", "evaluators/keyword-judge.ts"]
+        command: ["bun", "run", "evaluators/keyword-judge.ts"]

--- a/examples/showcase/evaluator-conformance/fixtures.yaml
+++ b/examples/showcase/evaluator-conformance/fixtures.yaml
@@ -8,7 +8,7 @@
 # The evaluator under test receives: question, criteria, answer, expected_output
 
 evaluator:
-  script: ["bun", "run", "evaluators/keyword-judge.ts"]
+  command: ["bun", "run", "evaluators/keyword-judge.ts"]
 
 fixtures:
   # ── Unambiguous Pass Cases ─────────────────────────────────────────────

--- a/examples/showcase/export-screening/evals/dataset.eval.yaml
+++ b/examples/showcase/export-screening/evals/dataset.eval.yaml
@@ -23,7 +23,7 @@ execution:
 assert:
   - name: risk_assessment_quality
     type: code_judge
-    script: ["bun", "run", "validate_risk_output.ts"]
+    command: ["bun", "run", "validate_risk_output.ts"]
 
 tests:
   # ============================================

--- a/examples/showcase/psychotherapy/evals/encouragement.eval.yaml
+++ b/examples/showcase/psychotherapy/evals/encouragement.eval.yaml
@@ -9,7 +9,7 @@ execution:
 assert:
   - name: json_schema_validator
     type: code_judge
-    script: ["uv", "run", "validate_output.py"]
+    command: ["uv", "run", "validate_output.py"]
   - name: content_evaluator
     type: llm_judge
 

--- a/examples/showcase/psychotherapy/evals/listening.eval.yaml
+++ b/examples/showcase/psychotherapy/evals/listening.eval.yaml
@@ -8,7 +8,7 @@ execution:
 assert:
   - name: json_schema_validator
     type: code_judge
-    script: ["uv", "run", "validate_output.py"]
+    command: ["uv", "run", "validate_output.py"]
   - name: content_evaluator
     type: llm_judge
 

--- a/examples/showcase/psychotherapy/evals/routing.eval.yaml
+++ b/examples/showcase/psychotherapy/evals/routing.eval.yaml
@@ -7,7 +7,7 @@ execution:
 assert:
   - name: json_schema_validator
     type: code_judge
-    script: ["uv", "run", "validate_output.py"]
+    command: ["uv", "run", "validate_output.py"]
   - name: content_evaluator
     type: llm_judge
 

--- a/examples/showcase/tool-evaluation-plugins/tool-eval-demo.yaml
+++ b/examples/showcase/tool-evaluation-plugins/tool-eval-demo.yaml
@@ -40,7 +40,7 @@ tests:
       # Plugin: Semantic tool selection evaluation
       - name: selection-quality
         type: code_judge
-        script: ["bun", "run", "scripts/tool-selection-judge.ts"]
+        command: ["bun", "run", "scripts/tool-selection-judge.ts"]
 
   # ==========================================
   # Example 2: Efficiency Scoring
@@ -61,7 +61,7 @@ tests:
       # Plugin: Efficiency metrics scoring
       - name: efficiency-check
         type: code_judge
-        script: ["bun", "run", "scripts/efficiency-scorer.ts"]
+        command: ["bun", "run", "scripts/efficiency-scorer.ts"]
 
   # ==========================================
   # Example 3: Combined Built-in + Plugin Evaluation
@@ -94,12 +94,12 @@ tests:
       # Plugin: Check if tools were appropriate choices
       - name: selection-check
         type: code_judge
-        script: ["bun", "run", "scripts/tool-selection-judge.ts"]
+        command: ["bun", "run", "scripts/tool-selection-judge.ts"]
 
       # Plugin: Evaluate efficiency
       - name: efficiency
         type: code_judge
-        script: ["bun", "run", "scripts/efficiency-scorer.ts"]
+        command: ["bun", "run", "scripts/efficiency-scorer.ts"]
 
   # ==========================================
   # Example 4: Pairwise Comparison
@@ -129,4 +129,4 @@ tests:
       # Plugin: Pairwise comparison with position bias mitigation
       - name: pairwise-quality
         type: code_judge
-        script: ["bun", "run", "scripts/pairwise-tool-compare.ts"]
+        command: ["bun", "run", "scripts/pairwise-tool-compare.ts"]

--- a/packages/core/src/evaluation/evaluators/code-evaluator.ts
+++ b/packages/core/src/evaluation/evaluators/code-evaluator.ts
@@ -17,26 +17,28 @@ import type { EvaluationContext, EvaluationScore, Evaluator } from './types.js';
 const FILE_BACKED_OUTPUT_THRESHOLD = 50_000;
 
 export interface CodeEvaluatorOptions {
-  readonly script: readonly string[];
+  readonly command: readonly string[];
+  /** @deprecated Use `command` instead */
+  readonly script?: readonly string[];
   readonly cwd?: string;
   readonly agentTimeoutMs?: number;
   /** Pass-through configuration from YAML (any unrecognized properties) */
   readonly config?: Record<string, unknown>;
-  /** Target access config - when present, enables target invocation for the script */
+  /** Target access config - when present, enables target invocation */
   readonly target?: TargetAccessConfig;
 }
 
 export class CodeEvaluator implements Evaluator {
   readonly kind = 'code';
 
-  private readonly script: readonly string[];
+  private readonly command: readonly string[];
   private readonly cwd?: string;
   private readonly agentTimeoutMs?: number;
   private readonly config?: Record<string, unknown>;
   private readonly target?: TargetAccessConfig;
 
   constructor(options: CodeEvaluatorOptions) {
-    this.script = options.script;
+    this.command = options.command ?? options.script ?? [];
     this.cwd = options.cwd;
     this.agentTimeoutMs = options.agentTimeoutMs;
     this.config = options.config;
@@ -111,7 +113,7 @@ export class CodeEvaluator implements Evaluator {
 
     try {
       const stdout = await executeScript(
-        this.script,
+        this.command,
         inputPayload,
         this.agentTimeoutMs,
         this.cwd,
@@ -131,7 +133,7 @@ export class CodeEvaluator implements Evaluator {
       // Build evaluator raw request with proxy metadata if used
       const proxyUsage = getProxyUsage?.();
       const evaluatorRawRequest: JsonObject = {
-        script: this.script,
+        command: this.command,
         ...(this.cwd ? { cwd: this.cwd } : {}),
         ...(proxyUsage
           ? {
@@ -164,7 +166,7 @@ export class CodeEvaluator implements Evaluator {
         expectedAspectCount: 1,
         reasoning: message,
         evaluatorRawRequest: {
-          script: this.script,
+          command: this.command,
           ...(this.cwd ? { cwd: this.cwd } : {}),
           ...(proxyUsage
             ? {

--- a/packages/core/src/evaluation/loaders/evaluator-parser.ts
+++ b/packages/core/src/evaluation/loaders/evaluator-parser.ts
@@ -125,26 +125,27 @@ async function parseEvaluatorList(
     }
 
     if (typeValue === 'code_judge') {
-      let script: string[] | undefined;
-      const rawScript = rawEvaluator.script;
+      let command: string[] | undefined;
+      // Precedence: command > script (deprecated alias)
+      const rawCommand = rawEvaluator.command ?? rawEvaluator.script;
 
-      if (typeof rawScript === 'string') {
-        const trimmed = rawScript.trim();
+      if (typeof rawCommand === 'string') {
+        const trimmed = rawCommand.trim();
         if (trimmed.length === 0) {
           throw new Error(
-            `Invalid code_judge script for evaluator '${name}' in '${evalId}': script cannot be empty`,
+            `Invalid code_judge command for evaluator '${name}' in '${evalId}': command cannot be empty`,
           );
         }
-        script = parseCommandToArgv(trimmed);
+        command = parseCommandToArgv(trimmed);
       } else {
-        script = asStringArray(
-          rawScript,
-          `code_judge script for evaluator '${name}' in '${evalId}'`,
+        command = asStringArray(
+          rawCommand,
+          `code_judge command for evaluator '${name}' in '${evalId}'`,
         );
       }
 
-      if (!script) {
-        logWarning(`Skipping code_judge evaluator '${name}' in '${evalId}': missing script`);
+      if (!command) {
+        logWarning(`Skipping code_judge evaluator '${name}' in '${evalId}': missing command`);
         continue;
       }
 
@@ -200,6 +201,7 @@ async function parseEvaluatorList(
       const knownProps = new Set([
         'name',
         'type',
+        'command',
         'script',
         'cwd',
         'weight',
@@ -217,7 +219,7 @@ async function parseEvaluatorList(
       evaluators.push({
         name,
         type: 'code',
-        script,
+        command,
         cwd,
         resolvedCwd,
         ...(weight !== undefined ? { weight } : {}),
@@ -983,26 +985,27 @@ async function parseEvaluatorList(
     let promptScriptConfig: Record<string, unknown> | undefined;
 
     if (isJsonObject(rawPrompt)) {
-      // Executable prompt template: { script: [...], config: {...} }
-      const scriptArray = asStringArray(
-        rawPrompt.script,
-        `prompt.script for evaluator '${name}' in '${evalId}'`,
+      // Executable prompt template: { command: [...], config: {...} }
+      // Precedence: command > script (deprecated alias)
+      const commandArray = asStringArray(
+        rawPrompt.command ?? rawPrompt.script,
+        `prompt.command for evaluator '${name}' in '${evalId}'`,
       );
 
-      if (!scriptArray) {
-        throw new Error(`Evaluator '${name}' in '${evalId}': prompt object requires script array`);
+      if (!commandArray) {
+        throw new Error(`Evaluator '${name}' in '${evalId}': prompt object requires command array`);
       }
 
-      // Resolve the script path (last element is typically the file path)
-      const scriptPath = scriptArray[scriptArray.length - 1];
-      const resolved = await resolveFileReference(scriptPath, searchRoots);
+      // Resolve the command path (last element is typically the file path)
+      const commandPath = commandArray[commandArray.length - 1];
+      const resolved = await resolveFileReference(commandPath, searchRoots);
 
       if (resolved.resolvedPath) {
         // Replace the last element with the resolved path
-        resolvedPromptScript = [...scriptArray.slice(0, -1), path.resolve(resolved.resolvedPath)];
+        resolvedPromptScript = [...commandArray.slice(0, -1), path.resolve(resolved.resolvedPath)];
       } else {
         throw new Error(
-          `Evaluator '${name}' in '${evalId}': prompt script file not found: ${resolved.displayPath}`,
+          `Evaluator '${name}' in '${evalId}': prompt command file not found: ${resolved.displayPath}`,
         );
       }
 

--- a/packages/core/src/evaluation/registry/assertion-discovery.ts
+++ b/packages/core/src/evaluation/registry/assertion-discovery.ts
@@ -65,7 +65,7 @@ export async function discoverAssertions(
 
     const factory: EvaluatorFactoryFn = (_config, context) => {
       return new CodeEvaluator({
-        script: ['bun', 'run', filePath],
+        command: ['bun', 'run', filePath],
         agentTimeoutMs: context.agentTimeoutMs,
       });
     };

--- a/packages/core/src/evaluation/registry/builtin-evaluators.ts
+++ b/packages/core/src/evaluation/registry/builtin-evaluators.ts
@@ -87,7 +87,7 @@ export const llmJudgeFactory: EvaluatorFactoryFn = (config, context) => {
 export const codeFactory: EvaluatorFactoryFn = (config, context) => {
   const c = config as CodeEvaluatorConfig;
   return new CodeEvaluator({
-    script: c.script,
+    command: c.command ?? c.script ?? [],
     cwd: c.resolvedCwd ?? c.cwd,
     agentTimeoutMs: context.agentTimeoutMs,
     config: c.config,

--- a/packages/core/src/evaluation/types.ts
+++ b/packages/core/src/evaluation/types.ts
@@ -185,16 +185,18 @@ export type TargetAccessConfig = {
 };
 
 /**
- * Configuration for workspace lifecycle scripts (before_all, after_all, before_each, after_each).
- * Scripts are executed with workspace context passed via stdin.
+ * Configuration for workspace lifecycle commands (before_all, after_all, before_each, after_each).
+ * Commands are executed with workspace context passed via stdin.
  */
 export type WorkspaceScriptConfig = {
   /** Command array to execute (e.g., ["bun", "run", "setup.ts"]) */
-  readonly script: readonly string[];
+  readonly command: readonly string[];
+  /** @deprecated Use `command` instead */
+  readonly script?: readonly string[];
   /** Optional timeout in milliseconds (default: 60000 for setup, 30000 for teardown) */
   readonly timeout_ms?: number;
   readonly timeoutMs?: number;
-  /** Optional working directory for script execution */
+  /** Optional working directory for command execution */
   readonly cwd?: string;
 };
 
@@ -213,20 +215,22 @@ export type WorkspaceConfig = {
   /** Template directory or .code-workspace file. Directories are copied to temp workspace.
    *  .code-workspace files are used by VS Code providers; CLI providers use the parent directory. */
   readonly template?: string;
-  /** Script to run once before first test (after workspace creation, before git baseline) */
+  /** Command to run once before first test (after workspace creation, before git baseline) */
   readonly before_all?: WorkspaceScriptConfig;
-  /** Script to run once after last test (before workspace cleanup) */
+  /** Command to run once after last test (before workspace cleanup) */
   readonly after_all?: WorkspaceScriptConfig;
-  /** Script to run before each test */
+  /** Command to run before each test */
   readonly before_each?: WorkspaceScriptConfig;
-  /** Script to run after each test (e.g., git reset for workspace reuse) */
+  /** Command to run after each test (e.g., git reset for workspace reuse) */
   readonly after_each?: WorkspaceScriptConfig;
 };
 
 export type CodeEvaluatorConfig = {
   readonly name: string;
   readonly type: 'code';
-  readonly script: readonly string[];
+  readonly command: readonly string[];
+  /** @deprecated Use `command` instead */
+  readonly script?: readonly string[];
   readonly resolvedScriptPath?: string;
   readonly cwd?: string;
   readonly resolvedCwd?: string;
@@ -234,9 +238,9 @@ export type CodeEvaluatorConfig = {
   readonly required?: boolean | number;
   /** When true, inverts the evaluator score (1 - score) and swaps pass/fail verdict */
   readonly negate?: boolean;
-  /** Pass-through configuration for the code_judge script (any unrecognized YAML properties) */
+  /** Pass-through configuration for the code_judge (any unrecognized YAML properties) */
   readonly config?: JsonObject;
-  /** When present, enables target access for the script via local proxy */
+  /** When present, enables target access via local proxy */
   readonly target?: TargetAccessConfig;
 };
 
@@ -246,7 +250,9 @@ export type CodeEvaluatorConfig = {
  */
 export type PromptScriptConfig = {
   /** Command array to execute (e.g., ["bun", "run", "template.ts"]) */
-  readonly script: readonly string[];
+  readonly command: readonly string[];
+  /** @deprecated Use `command` instead */
+  readonly script?: readonly string[];
   /** Pass-through configuration for the prompt template */
   readonly config?: Record<string, unknown>;
 };

--- a/packages/core/src/evaluation/workspace/script-executor.ts
+++ b/packages/core/src/evaluation/workspace/script-executor.ts
@@ -15,13 +15,13 @@ export interface ScriptExecutionContext {
 export type ScriptFailureMode = 'fatal' | 'warn';
 
 /**
- * Executes a workspace lifecycle script (before_all, after_all, before_each, after_each).
+ * Executes a workspace lifecycle command (before_all, after_all, before_each, after_each).
  *
- * @param config - Workspace script configuration (script, timeout_ms, cwd)
- * @param context - Context passed to script via stdin (JSON)
+ * @param config - Workspace command configuration (command, timeout_ms, cwd)
+ * @param context - Context passed to command via stdin (JSON)
  * @param failureMode - 'fatal' throws on non-zero exit; 'warn' logs warning
- * @returns Captured stdout from the script
- * @throws Error if script exits with non-zero code (fatal mode) or times out
+ * @returns Captured stdout from the command
+ * @throws Error if command exits with non-zero code (fatal mode) or times out
  */
 export async function executeWorkspaceScript(
   config: WorkspaceScriptConfig,
@@ -39,7 +39,10 @@ export async function executeWorkspaceScript(
   const timeoutMs = config.timeout_ms ?? (failureMode === 'fatal' ? 60000 : 30000);
   const cwd = config.cwd;
 
-  const result = await execFileWithStdin(config.script, stdin, {
+  // Support both command (canonical) and script (deprecated alias)
+  const commandArray = config.command ?? config.script ?? [];
+
+  const result = await execFileWithStdin(commandArray, stdin, {
     timeoutMs,
     cwd,
   });

--- a/packages/core/src/evaluation/yaml-parser.ts
+++ b/packages/core/src/evaluation/yaml-parser.ts
@@ -473,6 +473,7 @@ export const loadEvalCaseById = loadTestById;
 
 /**
  * Parse a WorkspaceScriptConfig from raw YAML value.
+ * Accepts both `command` (preferred) and `script` (deprecated alias).
  */
 function parseWorkspaceScriptConfig(
   raw: unknown,
@@ -480,10 +481,11 @@ function parseWorkspaceScriptConfig(
 ): WorkspaceScriptConfig | undefined {
   if (!isJsonObject(raw)) return undefined;
   const obj = raw as Record<string, unknown>;
-  const script = obj.script;
-  if (!Array.isArray(script) || script.length === 0) return undefined;
-  const scriptArr = script.filter((s): s is string => typeof s === 'string');
-  if (scriptArr.length === 0) return undefined;
+  // Precedence: command > script (deprecated)
+  const commandSource = obj.command ?? obj.script;
+  if (!Array.isArray(commandSource) || commandSource.length === 0) return undefined;
+  const commandArr = commandSource.filter((s): s is string => typeof s === 'string');
+  if (commandArr.length === 0) return undefined;
 
   const timeoutMs = typeof obj.timeout_ms === 'number' ? obj.timeout_ms : undefined;
   let cwd = typeof obj.cwd === 'string' ? obj.cwd : undefined;
@@ -493,7 +495,7 @@ function parseWorkspaceScriptConfig(
     cwd = path.resolve(evalFileDir, cwd);
   }
 
-  const config: WorkspaceScriptConfig = { script: scriptArr };
+  const config: WorkspaceScriptConfig = { command: commandArr };
   if (timeoutMs !== undefined) {
     return { ...config, timeout_ms: timeoutMs, ...(cwd !== undefined && { cwd }) };
   }

--- a/packages/core/test/evaluation/code-evaluator-file-backed.test.ts
+++ b/packages/core/test/evaluation/code-evaluator-file-backed.test.ts
@@ -65,7 +65,7 @@ describe('CodeEvaluator file-backed output', () => {
     const script = await createEchoJudge(tmpDir);
     const smallOutput = [{ role: 'assistant' as const, content: 'short response' }];
 
-    const evaluator = new CodeEvaluator({ script: ['bash', script] });
+    const evaluator = new CodeEvaluator({ command: ['bash', script] });
     const result = await evaluator.evaluate({
       evalCase: baseTestCase,
       candidate: 'answer',
@@ -82,7 +82,7 @@ describe('CodeEvaluator file-backed output', () => {
     const largeContent = 'x'.repeat(60_000);
     const largeOutput = [{ role: 'assistant' as const, content: largeContent }];
 
-    const evaluator = new CodeEvaluator({ script: ['bash', script] });
+    const evaluator = new CodeEvaluator({ command: ['bash', script] });
     const result = await evaluator.evaluate({
       evalCase: baseTestCase,
       candidate: 'answer',
@@ -103,7 +103,7 @@ describe('CodeEvaluator file-backed output', () => {
     const largeContent = 'x'.repeat(60_000);
     const largeOutput = [{ role: 'assistant' as const, content: largeContent }];
 
-    const evaluator = new CodeEvaluator({ script: ['bash', script] });
+    const evaluator = new CodeEvaluator({ command: ['bash', script] });
     const result = await evaluator.evaluate({
       evalCase: baseTestCase,
       candidate: 'answer',

--- a/packages/core/test/evaluation/evaluators.test.ts
+++ b/packages/core/test/evaluation/evaluators.test.ts
@@ -452,7 +452,7 @@ describe('CodeEvaluator', () => {
     const __dirname = dirname(fileURLToPath(import.meta.url));
     const script = ['node', join(__dirname, '../fixtures/test-judge.cjs')];
 
-    const evaluator = new CodeEvaluator({ script });
+    const evaluator = new CodeEvaluator({ command: script });
 
     const result = await evaluator.evaluate({
       evalCase: evalCaseWithExpectedMessages,
@@ -477,7 +477,7 @@ describe('CodeEvaluator', () => {
     const __dirname = dirname(fileURLToPath(import.meta.url));
     const script = ['node', join(__dirname, '../fixtures/test-judge-error.cjs')];
 
-    const evaluator = new CodeEvaluator({ script });
+    const evaluator = new CodeEvaluator({ command: script });
 
     const result = await evaluator.evaluate({
       evalCase: baseTestCase,
@@ -500,7 +500,7 @@ describe('CodeEvaluator', () => {
     const __dirname = dirname(fileURLToPath(import.meta.url));
     const script = ['bun', 'run', join(__dirname, '../fixtures/test-define-judge.ts')];
 
-    const evaluator = new CodeEvaluator({ script });
+    const evaluator = new CodeEvaluator({ command: script });
 
     const result = await evaluator.evaluate({
       evalCase: baseTestCase,
@@ -524,7 +524,7 @@ describe('CodeEvaluator', () => {
     const __dirname = dirname(fileURLToPath(import.meta.url));
     const script = ['node', join(__dirname, '../fixtures/test-judge-with-details.cjs')];
 
-    const evaluator = new CodeEvaluator({ script });
+    const evaluator = new CodeEvaluator({ command: script });
 
     const result = await evaluator.evaluate({
       evalCase: {
@@ -555,7 +555,7 @@ describe('CodeEvaluator', () => {
     const __dirname = dirname(fileURLToPath(import.meta.url));
     const script = ['node', join(__dirname, '../fixtures/test-judge-workspace.cjs')];
 
-    const evaluator = new CodeEvaluator({ script });
+    const evaluator = new CodeEvaluator({ command: script });
 
     const result = await evaluator.evaluate({
       evalCase: baseTestCase,
@@ -581,7 +581,7 @@ describe('CodeEvaluator', () => {
     const __dirname = dirname(fileURLToPath(import.meta.url));
     const script = ['node', join(__dirname, '../fixtures/test-judge.cjs')];
 
-    const evaluator = new CodeEvaluator({ script });
+    const evaluator = new CodeEvaluator({ command: script });
 
     const result = await evaluator.evaluate({
       evalCase: {

--- a/packages/core/test/evaluation/execution-metrics.test.ts
+++ b/packages/core/test/evaluation/execution-metrics.test.ts
@@ -278,7 +278,7 @@ describe('Code Judge Metrics Integration', () => {
     const __dirname = dirname(fileURLToPath(import.meta.url));
     const script = ['node', join(__dirname, '../fixtures/test-trace-summary.cjs')];
 
-    const evaluator = new CodeEvaluator({ script });
+    const evaluator = new CodeEvaluator({ command: script });
 
     const trace: TraceSummary = {
       eventCount: 3,
@@ -312,7 +312,7 @@ describe('Code Judge Metrics Integration', () => {
     const __dirname = dirname(fileURLToPath(import.meta.url));
     const script = ['node', join(__dirname, '../fixtures/test-no-trace-summary.cjs')];
 
-    const evaluator = new CodeEvaluator({ script });
+    const evaluator = new CodeEvaluator({ command: script });
 
     const result = await evaluator.evaluate({
       evalCase: baseTestCase,

--- a/packages/core/test/evaluation/loaders/evaluator-parser.test.ts
+++ b/packages/core/test/evaluation/loaders/evaluator-parser.test.ts
@@ -551,9 +551,9 @@ describe('parseEvaluators - code_judge config pass-through', () => {
     expect(evaluators).toHaveLength(1);
     const config = evaluators?.[0] as CodeEvaluatorConfig;
     if (process.platform === 'win32') {
-      expect(config.script).toEqual(['cmd.exe', '/c', './test_script.ts']);
+      expect(config.command).toEqual(['cmd.exe', '/c', './test_script.ts']);
     } else {
-      expect(config.script).toEqual(['sh', '-lc', './test_script.ts']);
+      expect(config.command).toEqual(['sh', '-lc', './test_script.ts']);
     }
   });
 });

--- a/packages/core/test/evaluation/orchestrator.test.ts
+++ b/packages/core/test/evaluation/orchestrator.test.ts
@@ -1406,7 +1406,7 @@ rl.on('close', () => {
       workspace: {
         template: templateDir,
         before_all: {
-          script: ['node', setupScript],
+          command: ['node', setupScript],
           timeout_ms: 10000,
         },
       },
@@ -1446,7 +1446,7 @@ rl.on('close', () => {
       workspace: {
         template: templateDir,
         before_all: {
-          script: ['node', failingScript],
+          command: ['node', failingScript],
           timeout_ms: 5000,
         },
       },
@@ -1503,7 +1503,7 @@ rl.on('close', () => {
       workspace: {
         template: templateDir,
         after_each: {
-          script: ['node', teardownScript],
+          command: ['node', teardownScript],
           timeout_ms: 10000,
         },
       },

--- a/packages/core/test/evaluation/workspace-config-parsing.test.ts
+++ b/packages/core/test/evaluation/workspace-config-parsing.test.ts
@@ -40,11 +40,11 @@ tests:
     expect(cases).toHaveLength(1);
     expect(cases[0].workspace).toBeDefined();
     expect(cases[0].workspace?.before_all).toEqual({
-      script: ['bun', 'run', 'setup.ts'],
+      command: ['bun', 'run', 'setup.ts'],
       timeout_ms: 120000,
     });
     expect(cases[0].workspace?.after_each).toEqual({
-      script: ['bun', 'run', 'teardown.ts'],
+      command: ['bun', 'run', 'teardown.ts'],
       timeout_ms: 30000,
     });
   });
@@ -95,10 +95,10 @@ tests:
     expect(cases).toHaveLength(2);
     // Both cases should inherit suite-level workspace
     expect(cases[0].workspace?.before_all).toEqual({
-      script: ['bun', 'run', 'default-setup.ts'],
+      command: ['bun', 'run', 'default-setup.ts'],
     });
     expect(cases[1].workspace?.before_all).toEqual({
-      script: ['bun', 'run', 'default-setup.ts'],
+      command: ['bun', 'run', 'default-setup.ts'],
     });
   });
 
@@ -131,14 +131,14 @@ tests:
     const overrideCase = cases.find((c) => c.id === 'case-override');
     expect(overrideCase).toBeDefined();
     expect(overrideCase.workspace?.before_all).toEqual({
-      script: ['bun', 'run', 'custom-setup.ts'],
+      command: ['bun', 'run', 'custom-setup.ts'],
     });
 
     // case-default: inherits suite-level workspace entirely
     const defaultCase = cases.find((c) => c.id === 'case-default');
     expect(defaultCase).toBeDefined();
     expect(defaultCase.workspace?.before_all).toEqual({
-      script: ['bun', 'run', 'default-setup.ts'],
+      command: ['bun', 'run', 'default-setup.ts'],
     });
   });
 

--- a/packages/core/test/evaluation/workspace/script-executor.test.ts
+++ b/packages/core/test/evaluation/workspace/script-executor.test.ts
@@ -71,7 +71,7 @@ process.exit(1);
 
   it('should execute workspace script successfully (fatal mode)', async () => {
     const config: WorkspaceScriptConfig = {
-      script: ['node', setupScript],
+      command: ['node', setupScript],
       timeout_ms: 5000,
     };
 
@@ -89,7 +89,7 @@ process.exit(1);
 
   it('should execute workspace script successfully (warn mode)', async () => {
     const config: WorkspaceScriptConfig = {
-      script: ['node', teardownScript],
+      command: ['node', teardownScript],
       timeout_ms: 5000,
     };
 
@@ -106,7 +106,7 @@ process.exit(1);
 
   it('should fail on script error in fatal mode', async () => {
     const config: WorkspaceScriptConfig = {
-      script: ['node', failingScript],
+      command: ['node', failingScript],
       timeout_ms: 5000,
     };
 
@@ -121,7 +121,7 @@ process.exit(1);
 
   it('should handle script error gracefully in warn mode', async () => {
     const config: WorkspaceScriptConfig = {
-      script: ['node', failingScript],
+      command: ['node', failingScript],
       timeout_ms: 5000,
     };
 
@@ -161,7 +161,7 @@ rl.on('close', () => {
     );
 
     const config: WorkspaceScriptConfig = {
-      script: ['node', contextCheckScript],
+      command: ['node', contextCheckScript],
       timeout_ms: 5000,
     };
 
@@ -203,7 +203,7 @@ rl.on('close', () => {
     );
 
     const config: WorkspaceScriptConfig = {
-      script: ['node', metadataCheckScript],
+      command: ['node', metadataCheckScript],
       timeout_ms: 5000,
     };
 
@@ -222,7 +222,7 @@ rl.on('close', () => {
 
   it('should support optional timeout_ms (defaults apply)', async () => {
     const config: WorkspaceScriptConfig = {
-      script: ['node', setupScript],
+      command: ['node', setupScript],
       // No timeout_ms specified - should use default (60000 for setup)
     };
 

--- a/plugins/agentv-dev/skills/agentv-chat-to-eval/README.md
+++ b/plugins/agentv-dev/skills/agentv-chat-to-eval/README.md
@@ -68,7 +68,7 @@ tests:
 #     prompt: ./prompts/quality.md
 #   - name: accuracy
 #     type: code_judge
-#     script: ./scripts/check_accuracy.py
+#     command: [./scripts/check_accuracy.py]
 ```
 
 ## When to Use

--- a/plugins/agentv-dev/skills/agentv-chat-to-eval/SKILL.md
+++ b/plugins/agentv-dev/skills/agentv-chat-to-eval/SKILL.md
@@ -100,7 +100,7 @@ Append a commented evaluator configuration based on the test content:
 #     prompt: ./prompts/quality.md
 #   - name: accuracy
 #     type: code_judge
-#     script: ./scripts/check_accuracy.py
+#     command: [./scripts/check_accuracy.py]
 ```
 
 - Recommend `llm_judge` for subjective quality (tone, helpfulness, completeness)

--- a/plugins/agentv-dev/skills/agentv-chat-to-eval/examples/transcript-json.md
+++ b/plugins/agentv-dev/skills/agentv-chat-to-eval/examples/transcript-json.md
@@ -60,7 +60,7 @@ tests:
 # assert:
 #   - name: accuracy
 #     type: code_judge
-#     script: ./scripts/check_conversion.py
+#     command: [./scripts/check_conversion.py]
 #   - name: quality
 #     type: llm_judge
 #     prompt: ./prompts/quality.md

--- a/plugins/agentv-dev/skills/agentv-eval-builder/SKILL.md
+++ b/plugins/agentv-dev/skills/agentv-eval-builder/SKILL.md
@@ -157,10 +157,10 @@ Run scripts before/after each test. Define at suite level or override per case:
 workspace:
   template: ./workspace-templates/my-project
   setup:
-    script: ["bun", "run", "setup.ts"]
+    command: ["bun", "run", "setup.ts"]
     timeout_ms: 120000
   teardown:
-    script: ["bun", "run", "teardown.ts"]
+    command: ["bun", "run", "teardown.ts"]
 
 tests:
   - id: case-1
@@ -171,12 +171,12 @@ tests:
       base_commit: "abc123"
     workspace:
       setup:
-        script: ["python", "custom-setup.py"]  # overrides suite-level
+        command: ["python", "custom-setup.py"]  # overrides suite-level
 ```
 
 **Lifecycle:** template copy → setup → git baseline → agent → file changes → teardown → cleanup
 **Merge:** Case-level fields replace suite-level fields.
-**Scripts receive stdin JSON:** `{workspace_path, test_id, eval_run_id, case_input, case_metadata}`
+**Commands receive stdin JSON:** `{workspace_path, test_id, eval_run_id, case_input, case_metadata}`
 **Setup failure:** aborts case. **Teardown failure:** non-fatal (warning).
 See https://agentv.dev/targets/configuration/#workspace-setupteardown
 
@@ -188,7 +188,7 @@ Configure via `assert` array. Multiple evaluators produce a weighted average sco
 ```yaml
 - name: format_check
   type: code_judge
-  script: uv run validate.py
+  command: [uv, run, validate.py]
   cwd: ./scripts          # optional working directory
   target: {}              # optional: enable LLM target proxy (max_calls: 50)
 ```
@@ -201,9 +201,9 @@ See docs at https://agentv.dev/evaluators/code-judges/
 ```yaml
 - name: quality
   type: llm_judge
-  prompt: ./prompts/eval.md     # markdown template or script config
+  prompt: ./prompts/eval.md     # markdown template or command config
   model: gpt-5-chat            # optional model override
-  config:                       # passed to script templates as context.config
+  config:                       # passed to prompt templates as context.config
     strictness: high
 ```
 Variables: `{{question}}`, `{{criteria}}`, `{{answer}}`, `{{reference_answer}}`, `{{input}}`, `{{expected_output}}`, `{{output}}`, `{{file_changes}}`
@@ -391,7 +391,7 @@ export default defineCodeJudge(({ trace, answer }) => ({
 }));
 ```
 
-Both are used via `type: code_judge` in YAML with `script: bun run judge.ts`.
+Both are used via `type: code_judge` in YAML with `command: [bun, run, judge.ts]`.
 
 ### Convention-Based Discovery
 
@@ -402,7 +402,7 @@ Place assertion files in `.agentv/assertions/` — they auto-register by filenam
 .agentv/assertions/sentiment.ts   →  type: sentiment
 ```
 
-No `script:` needed in YAML — just use `type: <filename>`.
+No `command:` needed in YAML — just use `type: <filename>`.
 
 ## Programmatic API
 

--- a/plugins/agentv-dev/skills/agentv-eval-builder/references/eval-schema.json
+++ b/plugins/agentv-dev/skills/agentv-eval-builder/references/eval-schema.json
@@ -44,9 +44,10 @@
                 ],
                 "description": "Evaluator type: 'code' for scripts/regex/keywords, 'llm_judge' for LLM-based evaluation"
               },
-              "script": {
-                "type": "string",
-                "description": "Path to evaluator script (for type: code)"
+              "command": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Command array to execute evaluator (for type: code), e.g. [\"bun\", \"run\", \"judge.ts\"]"
               },
               "prompt": {
                 "type": "string",
@@ -277,9 +278,10 @@
                       "enum": ["code", "llm_judge"],
                       "description": "Evaluator type: 'code' for scripts/regex/keywords, 'llm_judge' for LLM-based evaluation"
                     },
-                    "script": {
-                      "type": "string",
-                      "description": "Path to evaluator script (for type: code)"
+                    "command": {
+                      "type": "array",
+                      "items": { "type": "string" },
+                      "description": "Command array to execute evaluator (for type: code), e.g. [\"bun\", \"run\", \"judge.ts\"]"
                     },
                     "prompt": {
                       "type": "string",


### PR DESCRIPTION
Closes #359

## Summary

Renames the `script` field to `command` across code_judge evaluators, workspace lifecycle hooks, and prompt script configs for schema consistency with the target `command` field rename in #357.

- **Types**: `WorkspaceScriptConfig`, `CodeEvaluatorConfig`, `PromptScriptConfig` now use `command` as canonical field with `script` as deprecated optional alias
- **Parsers**: YAML parser and evaluator parser resolve `command ?? script` with precedence to the new field
- **Runtime**: Code evaluator, assertion discovery, builtin evaluators, script executor, and CLI all updated
- **YAML files**: All 24 eval files in `examples/` updated from `script:` to `command:`
- **Documentation**: All 17 `.mdx` docs updated
- **Plugins**: SKILL.md files and eval-schema.json updated
- **Tests**: All 7 test files updated; 952 tests pass

## Backward Compatibility

`script` is preserved as a deprecated alias everywhere. Existing YAML files using `script:` will continue to work without changes. The parser resolves `command ?? script` at parse time.

## Risk

Low -- backward-compatible refactoring with full test coverage. Follows the same deprecation alias pattern established in #357.