### PR TITLE
chore(core): remove deprecated command_template alias

### DIFF
--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -78,64 +78,52 @@ export const CliHealthcheckInputSchema = z.union([
  *       url: http://localhost:8080/health
  * ```
  */
-export const CliTargetInputSchema = z
-  .object({
-    name: z.string().min(1, 'target name is required'),
-    provider: z
-      .string()
-      .refine((p) => p.toLowerCase() === 'cli', { message: "provider must be 'cli'" }),
+export const CliTargetInputSchema = z.object({
+  name: z.string().min(1, 'target name is required'),
+  provider: z
+    .string()
+    .refine((p) => p.toLowerCase() === 'cli', { message: "provider must be 'cli'" }),
 
-    // Command - required (accept both naming conventions)
-    command: z.string().optional(),
-    command_template: z.string().optional(),
-    commandTemplate: z.string().optional(),
+  // Command - required
+  command: z.string(),
 
-    // Files format - optional
-    files_format: z.string().optional(),
-    filesFormat: z.string().optional(),
-    attachments_format: z.string().optional(),
-    attachmentsFormat: z.string().optional(),
+  // Files format - optional
+  files_format: z.string().optional(),
+  filesFormat: z.string().optional(),
+  attachments_format: z.string().optional(),
+  attachmentsFormat: z.string().optional(),
 
-    // Working directory - optional
-    cwd: z.string().optional(),
+  // Working directory - optional
+  cwd: z.string().optional(),
 
-    // Workspace template directory - optional (mutually exclusive with cwd)
-    workspace_template: z.string().optional(),
-    workspaceTemplate: z.string().optional(),
+  // Workspace template directory - optional (mutually exclusive with cwd)
+  workspace_template: z.string().optional(),
+  workspaceTemplate: z.string().optional(),
 
-    // Timeout in seconds - optional
-    timeout_seconds: z.number().positive().optional(),
-    timeoutSeconds: z.number().positive().optional(),
+  // Timeout in seconds - optional
+  timeout_seconds: z.number().positive().optional(),
+  timeoutSeconds: z.number().positive().optional(),
 
-    // Healthcheck configuration - optional
-    healthcheck: CliHealthcheckInputSchema.optional(),
+  // Healthcheck configuration - optional
+  healthcheck: CliHealthcheckInputSchema.optional(),
 
-    // Verbose mode - optional
-    verbose: z.boolean().optional(),
-    cli_verbose: z.boolean().optional(),
-    cliVerbose: z.boolean().optional(),
+  // Verbose mode - optional
+  verbose: z.boolean().optional(),
+  cli_verbose: z.boolean().optional(),
+  cliVerbose: z.boolean().optional(),
 
-    // Keep temp files - optional
-    keep_temp_files: z.boolean().optional(),
-    keepTempFiles: z.boolean().optional(),
-    keep_output_files: z.boolean().optional(),
-    keepOutputFiles: z.boolean().optional(),
+  // Keep temp files - optional
+  keep_temp_files: z.boolean().optional(),
+  keepTempFiles: z.boolean().optional(),
+  keep_output_files: z.boolean().optional(),
+  keepOutputFiles: z.boolean().optional(),
 
-    // Common target fields
-    judge_target: z.string().optional(),
-    workers: z.number().int().min(1).optional(),
-    provider_batching: z.boolean().optional(),
-    providerBatching: z.boolean().optional(),
-  })
-  .refine(
-    (data) =>
-      data.command !== undefined ||
-      data.command_template !== undefined ||
-      data.commandTemplate !== undefined,
-    {
-      message: "'command' is required",
-    },
-  );
+  // Common target fields
+  judge_target: z.string().optional(),
+  workers: z.number().int().min(1).optional(),
+  provider_batching: z.boolean().optional(),
+  providerBatching: z.boolean().optional(),
+});
 
 /**
  * Strict normalized schema for HTTP healthcheck configuration.
@@ -296,13 +284,7 @@ export function normalizeCliTargetInput(
 ): CliNormalizedConfig {
   const targetName = input.name;
 
-  // Coalesce command variants - at least one is required by schema refinement
-  // Precedence: command > command_template > commandTemplate (backwards compat)
-  const commandSource = input.command ?? input.command_template ?? input.commandTemplate;
-  if (commandSource === undefined) {
-    throw new Error(`${targetName}: 'command' is required`);
-  }
-  const command = resolveString(commandSource, env, `${targetName} CLI command`, true);
+  const command = resolveString(input.command, env, `${targetName} CLI command`, true);
 
   // Coalesce files format variants
   const filesFormatSource =
@@ -1644,9 +1626,8 @@ function resolveDiscoveredProviderConfig(
   evalFilePath?: string,
 ): CliResolvedConfig {
   // Use explicit command if provided, otherwise derive from convention
-  const commandSource = target.command ?? target.command_template ?? target.commandTemplate;
-  const command = commandSource
-    ? resolveString(commandSource, env, `${target.name} command`, true)
+  const command = target.command
+    ? resolveString(target.command, env, `${target.name} command`, true)
     : `bun run .agentv/providers/${providerKind}.ts {PROMPT}`;
 
   // Resolve optional fields using the same patterns as CLI providers

--- a/packages/core/src/evaluation/providers/types.ts
+++ b/packages/core/src/evaluation/providers/types.ts
@@ -317,9 +317,7 @@ export interface TargetDefinition {
   readonly subagentRoot?: string | unknown | undefined;
   readonly workspace_template?: string | unknown | undefined;
   readonly workspaceTemplate?: string | unknown | undefined;
-  // CLI fields (command is the canonical field; command_template/commandTemplate are deprecated aliases)
-  readonly command_template?: string | unknown | undefined;
-  readonly commandTemplate?: string | unknown | undefined;
+  // CLI fields
   readonly files_format?: string | unknown | undefined;
   readonly filesFormat?: string | unknown | undefined;
   readonly attachments_format?: string | unknown | undefined;

--- a/packages/core/src/evaluation/validation/targets-validator.ts
+++ b/packages/core/src/evaluation/validation/targets-validator.ts
@@ -275,8 +275,8 @@ export async function validateTargetsFile(filePath: string): Promise<ValidationR
     location: string,
     errors: ValidationError[],
   ): void {
-    // Critical check: command is required (accept legacy command_template/commandTemplate too)
-    const command = target.command ?? target.command_template ?? target.commandTemplate;
+    // Critical check: command is required
+    const command = target.command;
     if (typeof command !== 'string' || command.trim().length === 0) {
       errors.push({
         severity: 'error',

--- a/packages/core/test/evaluation/providers/cli-schema.test.ts
+++ b/packages/core/test/evaluation/providers/cli-schema.test.ts
@@ -54,17 +54,6 @@ describe('CliTargetInputSchema', () => {
     }
   });
 
-  it('accepts legacy command_template field', () => {
-    const input = {
-      name: 'test-target',
-      provider: 'cli',
-      command_template: 'agent run {PROMPT}', // legacy field
-    };
-
-    const result = CliTargetInputSchema.safeParse(input);
-    expect(result.success).toBe(true);
-  });
-
   it('allows unknown properties (passthrough mode)', () => {
     const input = {
       name: 'test-target',
@@ -179,11 +168,6 @@ describe('CliTargetConfigSchema (strict)', () => {
     const input = { command: 'agent run {PROMPT}', unknownField: 'value' };
     expect(CliTargetConfigSchema.safeParse(input).success).toBe(false);
   });
-
-  it('rejects legacy commandTemplate in strict config', () => {
-    const input = { commandTemplate: 'agent run {PROMPT}' };
-    expect(CliTargetConfigSchema.safeParse(input).success).toBe(false);
-  });
 });
 
 describe('normalizeCliHealthcheck', () => {
@@ -254,33 +238,6 @@ describe('normalizeCliTargetInput', () => {
     expect(result.timeoutMs).toBe(60000);
     expect(result.keepTempFiles).toBe(true);
     expect(result.verbose).toBe(true);
-  });
-
-  it('prefers command over legacy command_template', () => {
-    const input = {
-      name: 'test-target',
-      provider: 'cli',
-      command: 'new command',
-      command_template: 'legacy command',
-    };
-
-    const result = normalizeCliTargetInput(input, {});
-
-    expect(result.command).toBe('new command');
-  });
-
-  it('accepts legacy command_template field', () => {
-    const input = {
-      name: 'test-target',
-      provider: 'cli',
-      command_template: 'legacy version',
-      commandTemplate: 'camel version',
-    };
-
-    const result = normalizeCliTargetInput(input, {});
-
-    // command_template takes precedence over commandTemplate
-    expect(result.command).toBe('legacy version');
   });
 
   it('resolves environment variables in command and cwd', () => {

--- a/packages/core/test/evaluation/providers/targets.test.ts
+++ b/packages/core/test/evaluation/providers/targets.test.ts
@@ -439,7 +439,7 @@ describe('resolveTargetDefinition', () => {
       {
         name: 'shell-cli-prompt-file',
         provider: 'cli',
-        command_template: 'agent run --prompt-file {PROMPT_FILE} --out {OUTPUT_FILE}',
+        command: 'agent run --prompt-file {PROMPT_FILE} --out {OUTPUT_FILE}',
       },
       {},
     );


### PR DESCRIPTION
## Summary
- Remove `command_template` and `commandTemplate` deprecated aliases from `CliTargetInputSchema`, `normalizeCliTargetInput`, `resolveDiscoveredProviderConfig`, `validateCliSettings`, and `TargetDefinition` interface
- `command` is now the only accepted field name for CLI target and discovered provider configuration
- Update tests to verify deprecated aliases are rejected and fix test fixtures using the old field name

Closes #358