### PR TITLE
docs(examples): add multi-model benchmark showcase

### DIFF
--- a/apps/web/src/content/docs/evaluation/examples.mdx
+++ b/apps/web/src/content/docs/evaluation/examples.mdx
@@ -360,3 +360,10 @@ See the [suite-level-input example](https://github.com/EntityProcess/agentv/tree
 - Allow for natural language variation
 - Focus on semantic correctness over exact matching
 - Evaluators handle the actual validation logic
+
+## Showcases
+
+For complete end-to-end workflows that combine multiple features, see the showcases in [`examples/showcase/`](https://github.com/EntityProcess/agentv/tree/main/examples/showcase):
+
+- **[Multi-Model Benchmark](https://github.com/EntityProcess/agentv/tree/main/examples/showcase/multi-model-benchmark)** — targets matrix × weighted metrics × trials × compare workflow. Runs the same tests against multiple models, scores with weighted evaluators, measures variability, and compares results side-by-side.
+- **[Export Screening](https://github.com/EntityProcess/agentv/tree/main/examples/showcase/export-screening)** — classification eval with confusion matrix metrics and CI gating.

--- a/examples/showcase/multi-model-benchmark/README.md
+++ b/examples/showcase/multi-model-benchmark/README.md
@@ -1,0 +1,223 @@
+# Multi-Model Benchmark Showcase
+
+Demonstrates a complete **multi-model × multi-metric × variability** evaluation workflow end-to-end. Run the same tests against multiple LLMs, score them on weighted metrics, measure variability with trials, and compare results.
+
+## What This Shows
+
+| Feature | How it's used |
+|---------|---------------|
+| **Targets matrix** | Every test runs against `copilot`, `claude`, and `gemini_base` |
+| **Weighted evaluators** | Accuracy (3×), completeness (2×), clarity (1×) |
+| **Trials (pass@k)** | 2 trials per test to surface non-determinism |
+| **Compare workflow** | Side-by-side model comparison from result files |
+
+## Files
+
+```
+multi-model-benchmark/
+├── README.md                        # This file
+├── evals/
+│   └── benchmark.eval.yaml          # Eval definition (targets + metrics + trials)
+└── prompts/
+    ├── accuracy-rubric.md           # Factual correctness judge (weight 3.0)
+    ├── completeness-rubric.md       # Coverage judge (weight 2.0)
+    └── clarity-rubric.md            # Readability judge (weight 1.0)
+```
+
+## Prerequisites
+
+1. Configure targets in `.agentv/targets.yaml` at the repository root. The eval references `copilot`, `claude`, and `gemini_base` — these must be defined with valid provider credentials.
+2. Install dependencies: `bun install`
+
+## Running the Evaluation
+
+From the repository root:
+
+```bash
+# Run the full matrix (all targets × all tests × 2 trials)
+bun agentv eval examples/showcase/multi-model-benchmark/evals/benchmark.eval.yaml
+```
+
+### Cost & Safety
+
+The eval uses **low-cost models by default** (the targets defined in `.agentv/targets.yaml` such as `gpt-5-mini`, `claude-haiku`, `gemini-flash`). With 5 tests × 3 targets × 2 trials × 3 judge calls each, expect roughly **90 LLM calls**. A `cost_limit_usd: 2.00` cap is set in the eval file.
+
+To run against a single target first:
+
+```bash
+# Test with just one model before running the full matrix
+bun agentv eval examples/showcase/multi-model-benchmark/evals/benchmark.eval.yaml --target copilot
+```
+
+### Saving Results for Comparison
+
+Save per-target results to separate files for the compare workflow:
+
+```bash
+# Run each target and save results
+bun agentv eval examples/showcase/multi-model-benchmark/evals/benchmark.eval.yaml \
+  --target copilot --out results-copilot.jsonl
+
+bun agentv eval examples/showcase/multi-model-benchmark/evals/benchmark.eval.yaml \
+  --target claude --out results-claude.jsonl
+
+bun agentv eval examples/showcase/multi-model-benchmark/evals/benchmark.eval.yaml \
+  --target gemini_base --out results-gemini.jsonl
+```
+
+## Comparing Models
+
+Use `agentv compare` to see score deltas between any two runs:
+
+```bash
+# Compare copilot vs claude
+bun agentv compare results-copilot.jsonl results-claude.jsonl
+
+# Compare copilot vs gemini
+bun agentv compare results-copilot.jsonl results-gemini.jsonl
+
+# JSON output for CI integration
+bun agentv compare results-copilot.jsonl results-claude.jsonl --json
+```
+
+### Expected Output
+
+```
+Comparing: results-copilot.jsonl → results-claude.jsonl
+
+  Test ID                Baseline  Candidate     Delta  Result
+  ─────────────────────  ────────  ─────────  ────────  ────────
+  factual-geography          0.92       0.95     +0.03  = tie
+  factual-science            0.88       0.91     +0.03  = tie
+  analytical-comparison      0.78       0.85     +0.07  = tie
+  creative-explanation       0.82       0.80     -0.02  = tie
+  structured-list            0.90       0.88     -0.02  = tie
+
+Summary: 0 wins, 0 losses, 5 ties | Mean Δ: +0.018 | Status: no change
+```
+
+> **Note:** Actual scores will vary — LLM outputs are non-deterministic. The trials configuration helps surface this variability. Scores above are illustrative.
+
+## How It Works
+
+### 1. Targets Matrix
+
+The `execution.targets` array runs every test against each listed model:
+
+```yaml
+execution:
+  targets:
+    - copilot       # e.g., gpt-5-mini
+    - claude        # e.g., claude-haiku
+    - gemini_base   # e.g., gemini-flash
+```
+
+### 2. Weighted Evaluators
+
+Three LLM judges score each response. Weights control their contribution to the aggregate score:
+
+```yaml
+assert:
+  - name: accuracy
+    weight: 3.0      # Most important — factual correctness
+  - name: completeness
+    weight: 2.0      # Important — full coverage
+  - name: clarity
+    weight: 1.0      # Nice to have — readability
+```
+
+Weighted average formula: `(3×accuracy + 2×completeness + 1×clarity) / 6`
+
+### 3. Trials
+
+Each test runs twice. The `pass_at_k` strategy means a test passes if **any** trial succeeds:
+
+```yaml
+execution:
+  trials:
+    count: 2
+    strategy: pass_at_k
+    cost_limit_usd: 2.00
+```
+
+This surfaces non-determinism — if a model passes on trial 1 but fails on trial 2, that signals inconsistency worth investigating.
+
+### 4. Compare
+
+The `agentv compare` command reads two JSONL result files and computes per-test score deltas:
+
+- **Win**: candidate score exceeds baseline by threshold (default 0.10)
+- **Loss**: baseline score exceeds candidate by threshold
+- **Tie**: scores within threshold
+
+## Evaluation Flow
+
+```
+benchmark.eval.yaml
+        │
+        ▼
+┌─────────────────────────┐
+│  agentv eval             │
+│  (per target × trials)  │
+└────────┬────────────────┘
+         │
+    ┌────┼────────┐
+    ▼    ▼        ▼
+copilot claude  gemini
+    │    │        │
+    ▼    ▼        ▼
+ .jsonl .jsonl  .jsonl
+    │    │        │
+    └────┼────────┘
+         │
+         ▼
+┌─────────────────────────┐
+│  agentv compare          │
+│  (pairwise deltas)      │
+└─────────────────────────┘
+```
+
+## Customization
+
+### Adding a model
+
+Add a new target to `.agentv/targets.yaml`, then reference it in the eval:
+
+```yaml
+execution:
+  targets:
+    - copilot
+    - claude
+    - gemini_base
+    - my_new_model    # Add here
+```
+
+### Adding an evaluator
+
+Add a new judge prompt in `prompts/` and reference it in the eval's `assert` block:
+
+```yaml
+assert:
+  - name: safety
+    type: llm_judge
+    prompt: ../prompts/safety-rubric.md
+    weight: 4.0    # Highest priority
+```
+
+### Adjusting trial count
+
+Increase `trials.count` for more variability data (at proportional cost):
+
+```yaml
+execution:
+  trials:
+    count: 5          # 5 trials for higher-confidence results
+    cost_limit_usd: 5.00
+```
+
+## See Also
+
+- [`examples/features/matrix-evaluation/`](../../features/matrix-evaluation/) — minimal targets matrix example
+- [`examples/features/weighted-evaluators/`](../../features/weighted-evaluators/) — per-evaluator weight patterns
+- [`examples/features/trials/`](../../features/trials/) — trial strategy configuration
+- [`examples/features/compare/`](../../features/compare/) — baseline vs candidate comparison

--- a/examples/showcase/multi-model-benchmark/evals/benchmark.eval.yaml
+++ b/examples/showcase/multi-model-benchmark/evals/benchmark.eval.yaml
@@ -1,0 +1,102 @@
+# Multi-Model Benchmark Evaluation
+#
+# Demonstrates multi-model × multi-metric × variability workflow:
+#   - Targets matrix: runs every test against multiple models
+#   - Weighted evaluators: accuracy (3×), completeness (2×), clarity (1×)
+#   - Trials: pass@k with 2 trials to measure variability
+#
+# Default targets use low-cost models for safe experimentation.
+# Override with: agentv eval ... --target <name>
+#
+# Usage:
+#   agentv eval examples/showcase/multi-model-benchmark/evals/benchmark.eval.yaml
+
+description: Multi-model benchmark — accuracy, completeness, and clarity across models
+
+execution:
+  targets:
+    - copilot
+    - claude
+    - gemini_base
+  trials:
+    count: 2
+    strategy: pass_at_k
+    cost_limit_usd: 2.00
+
+assert:
+  - name: accuracy
+    type: llm_judge
+    prompt: ../prompts/accuracy-rubric.md
+    weight: 3.0
+  - name: completeness
+    type: llm_judge
+    prompt: ../prompts/completeness-rubric.md
+    weight: 2.0
+  - name: clarity
+    type: llm_judge
+    prompt: ../prompts/clarity-rubric.md
+    weight: 1.0
+
+tests:
+  # --- Factual reasoning ---
+  - id: factual-geography
+    criteria: |
+      Correctly identifies that Mount Everest is the tallest mountain
+      above sea level and provides its height (~8,849 m / 29,032 ft).
+    input: What is the tallest mountain in the world and how tall is it?
+    expected_output: |
+      Mount Everest is the tallest mountain in the world, standing at
+      approximately 8,849 meters (29,032 feet) above sea level.
+
+  - id: factual-science
+    criteria: |
+      Correctly explains photosynthesis as the process by which plants
+      convert sunlight, water, and CO2 into glucose and oxygen.
+    input: Explain how photosynthesis works in 2-3 sentences.
+    expected_output: |
+      Photosynthesis is the process by which plants convert sunlight,
+      water, and carbon dioxide into glucose and oxygen. It occurs
+      primarily in the chloroplasts of plant cells, using chlorophyll
+      to capture light energy.
+
+  # --- Analytical reasoning ---
+  - id: analytical-comparison
+    criteria: |
+      Provides a balanced comparison covering key differences: typing
+      (static vs dynamic), performance, use cases, and ecosystem.
+    input: Compare Python and Rust. What are the key differences?
+    expected_output: |
+      Python is dynamically typed, interpreted, and prioritizes
+      developer productivity and readability. Rust is statically typed,
+      compiled, and prioritizes memory safety and performance. Python
+      excels in scripting, data science, and prototyping, while Rust
+      is suited for systems programming, embedded systems, and
+      performance-critical applications.
+
+  # --- Creative / open-ended ---
+  - id: creative-explanation
+    criteria: |
+      Uses a clear, accessible analogy to explain recursion. The analogy
+      should convey the concept of a function calling itself with a
+      base case that stops the recursion.
+    input: Explain recursion using an everyday analogy.
+    expected_output: |
+      Recursion is like looking up a word in a dictionary and finding
+      the definition uses another word you don't know, so you look that
+      up too. You keep looking up words until you find one you already
+      understand (the base case), then work your way back to the
+      original word.
+
+  # --- Structured output ---
+  - id: structured-list
+    criteria: |
+      Returns exactly 3 distinct advantages of version control. Each
+      advantage should be clearly stated and relevant.
+    input: List 3 advantages of using version control in software development.
+    expected_output: |
+      1. History tracking — every change is recorded, allowing you to
+         review, revert, or audit modifications over time.
+      2. Collaboration — multiple developers can work on the same
+         codebase simultaneously without overwriting each other's work.
+      3. Branching and experimentation — you can create isolated branches
+         to develop features or test ideas without affecting the main code.

--- a/examples/showcase/multi-model-benchmark/prompts/accuracy-rubric.md
+++ b/examples/showcase/multi-model-benchmark/prompts/accuracy-rubric.md
@@ -1,0 +1,32 @@
+# Accuracy Rubric
+
+Evaluate the factual accuracy of the response.
+
+## Task
+
+Assess whether the candidate response is factually correct and aligns with the reference answer.
+
+## Input
+
+- Question: {{ question }}
+- Reference Answer: {{ reference_answer }}
+- Answer: {{ answer }}
+
+## Scoring
+
+- **1.0**: Fully accurate — all facts match the reference and no incorrect claims
+- **0.7–0.9**: Mostly accurate — minor omissions or imprecise phrasing but no errors
+- **0.4–0.6**: Partially accurate — some correct content mixed with errors or key omissions
+- **0.1–0.3**: Mostly inaccurate — significant factual errors or missing critical information
+- **0.0**: Completely wrong or irrelevant
+
+## Output Format
+
+Return a JSON object:
+
+```json
+{
+  "score": 0.85,
+  "reasoning": "Brief explanation of accuracy assessment"
+}
+```

--- a/examples/showcase/multi-model-benchmark/prompts/clarity-rubric.md
+++ b/examples/showcase/multi-model-benchmark/prompts/clarity-rubric.md
@@ -1,0 +1,32 @@
+# Clarity Rubric
+
+Evaluate the clarity and readability of the response.
+
+## Task
+
+Assess whether the candidate response is clear, well-structured, and easy to understand.
+
+## Input
+
+- Question: {{ question }}
+- Reference Answer: {{ reference_answer }}
+- Answer: {{ answer }}
+
+## Scoring
+
+- **1.0**: Excellent clarity — well-organized, easy to follow, appropriate detail level
+- **0.7–0.9**: Good clarity — generally clear with minor structural issues
+- **0.4–0.6**: Moderate clarity — understandable but confusing or poorly organized in places
+- **0.1–0.3**: Poor clarity — difficult to follow, disorganized, or overly verbose/terse
+- **0.0**: Incomprehensible or incoherent
+
+## Output Format
+
+Return a JSON object:
+
+```json
+{
+  "score": 0.8,
+  "reasoning": "Brief explanation of clarity assessment"
+}
+```

--- a/examples/showcase/multi-model-benchmark/prompts/completeness-rubric.md
+++ b/examples/showcase/multi-model-benchmark/prompts/completeness-rubric.md
@@ -1,0 +1,32 @@
+# Completeness Rubric
+
+Evaluate whether the response covers all aspects of the question.
+
+## Task
+
+Assess whether the candidate response addresses every part of the question and includes all important details from the reference answer.
+
+## Input
+
+- Question: {{ question }}
+- Reference Answer: {{ reference_answer }}
+- Answer: {{ answer }}
+
+## Scoring
+
+- **1.0**: Fully complete — addresses every aspect, includes all key details
+- **0.7–0.9**: Mostly complete — covers main points with minor omissions
+- **0.4–0.6**: Partially complete — misses significant aspects of the question
+- **0.1–0.3**: Mostly incomplete — addresses only a small portion of the question
+- **0.0**: Does not address the question at all
+
+## Output Format
+
+Return a JSON object:
+
+```json
+{
+  "score": 0.9,
+  "reasoning": "Brief explanation of completeness assessment"
+}
+```


### PR DESCRIPTION
Closes #370

Part of #371 roadmap.

## Changes
- Added `examples/showcase/multi-model-benchmark/` with evals and README
- Multi-model × multi-metric × variability showcase
- Low-cost/default-safe execution with budget-friendly models
- Step-by-step workflow guide
- Linked from docs navigation