### PR TITLE
fix(cli): self update fails on Windows

### DIFF
--- a/apps/cli/src/commands/self/index.ts
+++ b/apps/cli/src/commands/self/index.ts
@@ -19,7 +19,7 @@ function detectPackageManager(): 'bun' | 'npm' {
 
 function runCommand(cmd: string, args: string[]): Promise<{ exitCode: number; stdout: string }> {
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { stdio: ['inherit', 'pipe', 'inherit'] });
+    const child = spawn(cmd, args, { stdio: ['inherit', 'pipe', 'inherit'], shell: true });
     let stdout = '';
     child.stdout?.on('data', (data: Buffer) => {
       process.stdout.write(data);


### PR DESCRIPTION
## Summary
- `agentv self update` fails on Windows with "npm not found" because `spawn()` without `shell: true` cannot resolve `.cmd`/`.bat` wrappers like `npm.cmd`
- Added `shell: true` to the `spawn()` options for cross-platform compatibility

## Test plan
- [x] Verified build passes (`bun run build`)
- [ ] Test `agentv self update` on Windows
- [ ] Test `agentv self update` on Linux/macOS (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)