### PR TITLE
refactor(cli): remove bundled skills from CLI dist

### DIFF
--- a/apps/cli/src/templates/index.ts
+++ b/apps/cli/src/templates/index.ts
@@ -11,32 +11,6 @@ export function getAgentvTemplates(): Template[] {
   return getTemplatesFromDir('.agentv');
 }
 
-export function getAgentsTemplates(): Template[] {
-  if (isDistRuntime()) {
-    return getTemplatesFromDir('.agents');
-  }
-
-  // Dev mode: use repo-root plugins/agentv-dev/skills/ folder (marketplace-compatible location)
-  const repoRoot = getRepoRootFromDev();
-  const skillsRoot = path.join(repoRoot, 'plugins', 'agentv-dev', 'skills');
-
-  const skillsToInclude = [
-    'agentv-chat-to-eval',
-    'agentv-eval-builder',
-    'agentv-eval-orchestrator',
-    'agentv-prompt-optimizer',
-  ];
-
-  const templates: Template[] = [];
-  for (const skill of skillsToInclude) {
-    const skillDir = path.join(skillsRoot, skill);
-    const skillTemplates = readTemplatesRecursively(skillDir, path.join('skills', skill));
-    templates.push(...skillTemplates);
-  }
-
-  return templates;
-}
-
 function getTemplatesFromDir(subdir: string): Template[] {
   const currentDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -51,17 +25,6 @@ function getTemplatesFromDir(subdir: string): Template[] {
   }
 
   return readTemplatesRecursively(templatesDir, '');
-}
-
-function isDistRuntime(): boolean {
-  const currentDir = path.dirname(fileURLToPath(import.meta.url));
-  return currentDir.includes(`${path.sep}dist`);
-}
-
-function getRepoRootFromDev(): string {
-  const currentDir = path.dirname(fileURLToPath(import.meta.url));
-  // currentDir is apps/cli/src/templates
-  return path.resolve(currentDir, '..', '..', '..', '..');
 }
 
 function readTemplatesRecursively(dir: string, relativePath: string): Template[] {

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -1,13 +1,6 @@
-import { cpSync, existsSync, mkdirSync } from 'node:fs';
+import { cpSync } from 'node:fs';
 import path from 'node:path';
 import { defineConfig } from 'tsup';
-
-const SKILLS_TO_INCLUDE = [
-  'agentv-chat-to-eval',
-  'agentv-eval-builder',
-  'agentv-eval-orchestrator',
-  'agentv-prompt-optimizer',
-];
 
 export default defineConfig({
   entry: ['src/index.ts', 'src/cli.ts'],
@@ -37,9 +30,6 @@ export default defineConfig({
     const srcTemplatesDir = path.join('src', 'templates');
     const distTemplatesDir = path.join('dist', 'templates');
 
-    const repoRootDir = path.resolve('..', '..');
-    const rootSkillsDir = path.join(repoRootDir, 'plugins', 'agentv-dev', 'skills');
-
     // Copy entire templates directory structure recursively
     cpSync(srcTemplatesDir, distTemplatesDir, {
       recursive: true,
@@ -48,16 +38,6 @@ export default defineConfig({
         return !src.endsWith('.ts');
       },
     });
-
-    // Also copy agentv skills from repo root (source of truth)
-    const distSkillsDir = path.join(distTemplatesDir, '.agents', 'skills');
-    for (const skill of SKILLS_TO_INCLUDE) {
-      const source = path.join(rootSkillsDir, skill);
-      const target = path.join(distSkillsDir, skill);
-      if (!existsSync(source)) continue;
-      mkdirSync(path.dirname(target), { recursive: true });
-      cpSync(source, target, { recursive: true });
-    }
 
     console.log('✓ Template files copied to dist/templates');
   },


### PR DESCRIPTION
## Summary
- Removed skill-copying logic from `tsup.config.ts` (skills are now installed via the `agentv-dev` plugin)
- Removed unused `getAgentsTemplates()`, `isDistRuntime()`, and `getRepoRootFromDev()` from `templates/index.ts`
- Eliminates ~58 lines of dead code and prevents obsolete `.agents/skills`, `.claude/skills`, and `.github/prompts` files from being published in the CLI package

## Test plan
- [x] All pre-push checks pass (build, typecheck, lint, tests)
- [x] Verified `dist/templates/` only contains `.agentv/` config files after clean rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)