### PR TITLE
feat(cli): autoupdate prompt when new version detected

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,7 +1,6 @@
 import { binary, run, subcommands } from 'cmd-ts';
 
 import packageJson from '../package.json' with { type: 'json' };
-import { getUpdateNotice } from './update-check.js';
 import { compareCommand } from './commands/compare/index.js';
 import { convertCommand } from './commands/convert/index.js';
 import { createCommand } from './commands/create/index.js';
@@ -13,6 +12,7 @@ import { selfCommand } from './commands/self/index.js';
 import { traceCommand } from './commands/trace/index.js';
 import { trimCommand } from './commands/trim/index.js';
 import { validateCommand } from './commands/validate/index.js';
+import { getUpdateNotice } from './update-check.js';
 
 export const app = subcommands({
   name: 'agentv',

--- a/apps/cli/src/update-check.ts
+++ b/apps/cli/src/update-check.ts
@@ -1,7 +1,7 @@
+import { spawn } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { spawn } from 'node:child_process';
 
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const AGENTV_DIR = join(homedir(), '.agentv');
@@ -9,64 +9,56 @@ const CACHE_FILE = 'version-check.json';
 const NPM_REGISTRY_URL = 'https://registry.npmjs.org/agentv/latest';
 
 export interface UpdateCache {
-	latestVersion: string;
-	lastCheckedAt: string; // ISO 8601
+  latestVersion: string;
+  lastCheckedAt: string; // ISO 8601
 }
 
 /**
  * Read the cached update info from disk. Returns null if missing or malformed.
  */
-export async function getCachedUpdateInfo(
-	path?: string,
-): Promise<UpdateCache | null> {
-	const filePath = path ?? join(AGENTV_DIR, CACHE_FILE);
-	try {
-		const raw = await readFile(filePath, 'utf-8');
-		const data = JSON.parse(raw);
-		if (
-			typeof data.latestVersion === 'string' &&
-			typeof data.lastCheckedAt === 'string'
-		) {
-			return data as UpdateCache;
-		}
-		return null;
-	} catch {
-		return null;
-	}
+export async function getCachedUpdateInfo(path?: string): Promise<UpdateCache | null> {
+  const filePath = path ?? join(AGENTV_DIR, CACHE_FILE);
+  try {
+    const raw = await readFile(filePath, 'utf-8');
+    const data = JSON.parse(raw);
+    if (typeof data.latestVersion === 'string' && typeof data.lastCheckedAt === 'string') {
+      return data as UpdateCache;
+    }
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 /**
  * Decide whether a fresh check is needed based on the cache.
  */
 export function shouldCheck(cache: UpdateCache | null): boolean {
-	if (!cache) return true;
-	const elapsed = Date.now() - new Date(cache.lastCheckedAt).getTime();
-	return elapsed > CHECK_INTERVAL_MS;
+  if (!cache) return true;
+  const elapsed = Date.now() - new Date(cache.lastCheckedAt).getTime();
+  return elapsed > CHECK_INTERVAL_MS;
 }
 
 /**
  * Compare two semver strings. Returns true if a > b.
  */
 function isNewer(a: string, b: string): boolean {
-	const pa = a.split('.').map((s) => Number(s.replace(/-.*$/, '')));
-	const pb = b.split('.').map((s) => Number(s.replace(/-.*$/, '')));
-	for (let i = 0; i < 3; i++) {
-		if ((pa[i] ?? 0) > (pb[i] ?? 0)) return true;
-		if ((pa[i] ?? 0) < (pb[i] ?? 0)) return false;
-	}
-	return false;
+  const pa = a.split('.').map((s) => Number(s.replace(/-.*$/, '')));
+  const pb = b.split('.').map((s) => Number(s.replace(/-.*$/, '')));
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] ?? 0) > (pb[i] ?? 0)) return true;
+    if ((pa[i] ?? 0) < (pb[i] ?? 0)) return false;
+  }
+  return false;
 }
 
 /**
  * Build a human-readable update notice, or null if no update available.
  */
-export function buildNotice(
-	currentVersion: string,
-	latestVersion: string | null,
-): string | null {
-	if (!latestVersion) return null;
-	if (!isNewer(latestVersion, currentVersion)) return null;
-	return `  Update available: ${currentVersion} → ${latestVersion}\n  Run \`agentv self update\` to upgrade.`;
+export function buildNotice(currentVersion: string, latestVersion: string | null): string | null {
+  if (!latestVersion) return null;
+  if (!isNewer(latestVersion, currentVersion)) return null;
+  return `  Update available: ${currentVersion} → ${latestVersion}\n  Run \`agentv self update\` to upgrade.`;
 }
 
 /**
@@ -75,10 +67,10 @@ export function buildNotice(
  * survives even if the parent calls process.exit().
  */
 export function backgroundUpdateCheck(): void {
-	const dir = AGENTV_DIR;
-	const filePath = join(dir, CACHE_FILE);
+  const dir = AGENTV_DIR;
+  const filePath = join(dir, CACHE_FILE);
 
-	const script = `
+  const script = `
     const https = require('https');
     const fs = require('fs');
     const dir = ${JSON.stringify(dir)};
@@ -100,29 +92,27 @@ export function backgroundUpdateCheck(): void {
     }).on('error', () => process.exit()).on('timeout', function() { this.destroy(); process.exit(); });
   `;
 
-	try {
-		const child = spawn(process.execPath, ['-e', script], {
-			detached: true,
-			stdio: 'ignore',
-			windowsHide: true,
-		});
-		child.unref();
-	} catch {}
+  try {
+    const child = spawn(process.execPath, ['-e', script], {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    child.unref();
+  } catch {}
 }
 
 /**
  * Get the update notice to display, or null. Kicks off a background
  * refresh if the cache is stale. Never blocks startup.
  */
-export async function getUpdateNotice(
-	currentVersion: string,
-): Promise<string | null> {
-	if (process.env.AGENTV_NO_UPDATE_CHECK === '1' || process.env.CI === 'true') {
-		return null;
-	}
-	const cache = await getCachedUpdateInfo();
-	if (shouldCheck(cache)) {
-		backgroundUpdateCheck();
-	}
-	return buildNotice(currentVersion, cache?.latestVersion ?? null);
+export async function getUpdateNotice(currentVersion: string): Promise<string | null> {
+  if (process.env.AGENTV_NO_UPDATE_CHECK === '1' || process.env.CI === 'true') {
+    return null;
+  }
+  const cache = await getCachedUpdateInfo();
+  if (shouldCheck(cache)) {
+    backgroundUpdateCheck();
+  }
+  return buildNotice(currentVersion, cache?.latestVersion ?? null);
 }

--- a/apps/cli/test/unit/update-check.test.ts
+++ b/apps/cli/test/unit/update-check.test.ts
@@ -1,76 +1,72 @@
-import { describe, it, expect, afterEach } from 'bun:test';
-import { writeFile, unlink } from 'node:fs/promises';
-import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'bun:test';
+import { unlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import {
-	getCachedUpdateInfo,
-	shouldCheck,
-	buildNotice,
-} from '../../src/update-check.js';
+import { join } from 'node:path';
+import { buildNotice, getCachedUpdateInfo, shouldCheck } from '../../src/update-check.js';
 
 describe('update-check', () => {
-	describe('shouldCheck', () => {
-		it('returns true when cache is null', () => {
-			expect(shouldCheck(null)).toBe(true);
-		});
+  describe('shouldCheck', () => {
+    it('returns true when cache is null', () => {
+      expect(shouldCheck(null)).toBe(true);
+    });
 
-		it('returns true when lastCheckedAt is older than 24 hours', () => {
-			const old = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
-			expect(shouldCheck({ latestVersion: '1.0.0', lastCheckedAt: old })).toBe(true);
-		});
+    it('returns true when lastCheckedAt is older than 24 hours', () => {
+      const old = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+      expect(shouldCheck({ latestVersion: '1.0.0', lastCheckedAt: old })).toBe(true);
+    });
 
-		it('returns false when lastCheckedAt is within 24 hours', () => {
-			const recent = new Date().toISOString();
-			expect(shouldCheck({ latestVersion: '1.0.0', lastCheckedAt: recent })).toBe(false);
-		});
-	});
+    it('returns false when lastCheckedAt is within 24 hours', () => {
+      const recent = new Date().toISOString();
+      expect(shouldCheck({ latestVersion: '1.0.0', lastCheckedAt: recent })).toBe(false);
+    });
+  });
 
-	describe('buildNotice', () => {
-		it('returns a notice string when latest > current', () => {
-			const notice = buildNotice('2.10.0', '2.11.0');
-			expect(notice).toContain('2.10.0');
-			expect(notice).toContain('2.11.0');
-			expect(notice).toContain('agentv self update');
-		});
+  describe('buildNotice', () => {
+    it('returns a notice string when latest > current', () => {
+      const notice = buildNotice('2.10.0', '2.11.0');
+      expect(notice).toContain('2.10.0');
+      expect(notice).toContain('2.11.0');
+      expect(notice).toContain('agentv self update');
+    });
 
-		it('returns null when versions are equal', () => {
-			expect(buildNotice('2.10.0', '2.10.0')).toBeNull();
-		});
+    it('returns null when versions are equal', () => {
+      expect(buildNotice('2.10.0', '2.10.0')).toBeNull();
+    });
 
-		it('returns null when current > latest', () => {
-			expect(buildNotice('2.11.0', '2.10.0')).toBeNull();
-		});
+    it('returns null when current > latest', () => {
+      expect(buildNotice('2.11.0', '2.10.0')).toBeNull();
+    });
 
-		it('returns null when latest is null', () => {
-			expect(buildNotice('2.10.0', null)).toBeNull();
-		});
-	});
+    it('returns null when latest is null', () => {
+      expect(buildNotice('2.10.0', null)).toBeNull();
+    });
+  });
 
-	describe('getCachedUpdateInfo', () => {
-		const tmpPath = join(tmpdir(), `update-check-test-${process.pid}.json`);
+  describe('getCachedUpdateInfo', () => {
+    const tmpPath = join(tmpdir(), `update-check-test-${process.pid}.json`);
 
-		afterEach(async () => {
-			try {
-				await unlink(tmpPath);
-			} catch {}
-		});
+    afterEach(async () => {
+      try {
+        await unlink(tmpPath);
+      } catch {}
+    });
 
-		it('returns null for a nonexistent file', async () => {
-			const result = await getCachedUpdateInfo('/tmp/does-not-exist.json');
-			expect(result).toBeNull();
-		});
+    it('returns null for a nonexistent file', async () => {
+      const result = await getCachedUpdateInfo('/tmp/does-not-exist.json');
+      expect(result).toBeNull();
+    });
 
-		it('reads back a valid JSON cache file', async () => {
-			const cache = { latestVersion: '1.2.3', lastCheckedAt: '2025-01-01T00:00:00.000Z' };
-			await writeFile(tmpPath, JSON.stringify(cache));
-			const result = await getCachedUpdateInfo(tmpPath);
-			expect(result).toEqual(cache);
-		});
+    it('reads back a valid JSON cache file', async () => {
+      const cache = { latestVersion: '1.2.3', lastCheckedAt: '2025-01-01T00:00:00.000Z' };
+      await writeFile(tmpPath, JSON.stringify(cache));
+      const result = await getCachedUpdateInfo(tmpPath);
+      expect(result).toEqual(cache);
+    });
 
-		it('returns null for malformed JSON', async () => {
-			await writeFile(tmpPath, '{not valid json!!!');
-			const result = await getCachedUpdateInfo(tmpPath);
-			expect(result).toBeNull();
-		});
-	});
+    it('returns null for malformed JSON', async () => {
+      await writeFile(tmpPath, '{not valid json!!!');
+      const result = await getCachedUpdateInfo(tmpPath);
+      expect(result).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Add non-blocking version check on CLI startup that notifies users when a new version is available
- Reads cached version from `~/.agentv/version-check.json` (24-hour TTL), spawns a detached background process to refresh from npm registry when stale
- Prints banner to stderr after command output: `Update available: X.Y.Z → A.B.C`
- Disabled via `AGENTV_NO_UPDATE_CHECK=1` or `CI=true`

Ported from the allagents CLI implementation.

Closes #401

## Test plan
- [x] Unit tests for `shouldCheck`, `buildNotice`, `getCachedUpdateInfo` (10 tests)
- [x] Manual: run `agentv eval --help` and verify no banner on first run (cache empty, background fetch fires)
- [x] Manual: run again after cache is populated and verify banner appears if version is outdated
- [x] Manual: verify `AGENTV_NO_UPDATE_CHECK=1 agentv eval --help` suppresses the banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)