### PR TITLE
docs(skill): update rubric evaluator reference to use type: rubrics syntax

### DIFF
--- a/plugins/agentv-dev/skills/agentv-eval-builder/references/rubric-evaluator.md
+++ b/plugins/agentv-dev/skills/agentv-eval-builder/references/rubric-evaluator.md
@@ -1,6 +1,16 @@
 # Rubric Evaluator
 
+Rubrics are defined as `assert` entries with `type: rubrics`. They support binary checklist grading and score-range analytic grading.
+
 ## Field Reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `type` | string | required | Must be `rubrics` |
+| `criteria` | array | required | List of criterion strings or objects |
+| `required` | boolean or number | - | Gate: `true` requires score >= 0.8; a number (0–1) sets a custom threshold |
+
+### Criterion Object Fields
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -14,16 +24,18 @@
 ## Checklist Mode
 
 ```yaml
-rubrics:
-  - Mentions divide-and-conquer approach
-  - id: complexity
-    outcome: States time complexity correctly
-    weight: 2.0
-    required: true
-  - id: examples
-    outcome: Includes code examples
-    weight: 1.0
-    required: false
+assert:
+  - type: rubrics
+    criteria:
+      - Mentions divide-and-conquer approach
+      - id: complexity
+        outcome: States time complexity correctly
+        weight: 2.0
+        required: true
+      - id: examples
+        outcome: Includes code examples
+        weight: 1.0
+        required: false
 ```
 
 ## Score-Range Mode
@@ -31,15 +43,17 @@ rubrics:
 Shorthand map format (recommended):
 
 ```yaml
-rubrics:
-  - id: correctness
-    weight: 2.0
-    required_min_score: 7
-    score_ranges:
-      0: Critical bugs
-      3: Minor bugs
-      6: Correct with minor issues
-      9: Fully correct
+assert:
+  - type: rubrics
+    criteria:
+      - id: correctness
+        weight: 2.0
+        required_min_score: 7
+        score_ranges:
+          0: Critical bugs
+          3: Minor bugs
+          6: Correct with minor issues
+          9: Fully correct
 ```
 
 Map keys are lower bounds (0-10). Each range extends from its key to (next key - 1), with the last extending to 10. Must start at 0.


### PR DESCRIPTION
## Summary
- Updated `rubric-evaluator.md` skill reference to use the canonical `assert: - type: rubrics` with `criteria:` syntax instead of the old bare `rubrics:` top-level format
- Added top-level field reference table documenting `type`, `criteria`, and `required` fields
- Separated criterion object fields into their own subsection for clarity

## Notes
- The docs site pages (`rubrics.mdx`, `eval-cases.mdx`, etc.) were already using the correct `type: rubrics` syntax — no changes needed there
- This brings the AI-facing skill reference card in line with the current YAML schema

## Test plan
- [x] Verified docs site (`rubrics.mdx`, `eval-cases.mdx`, `agent-eval-layers.mdx`) already uses correct syntax
- [x] Verified examples (`examples/features/rubric/`) already use correct syntax
- [x] Pre-push hooks pass (build, typecheck, lint, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)