### PR TITLE
feat(providers): rename copilot to copilot-sdk, make copilot alias copilot-cli

### DIFF
--- a/examples/features/.agentv/targets.yaml
+++ b/examples/features/.agentv/targets.yaml
@@ -69,9 +69,9 @@ targets:
     log_format: json  # 'summary' (default) or 'json' for raw event logs
     # system_prompt: optional override (default instructs agent to include code in response)
 
-  # GitHub Copilot (uses @github/copilot-sdk)
+  # GitHub Copilot SDK (uses @github/copilot-sdk)
   - name: copilot
-    provider: copilot
+    provider: copilot-sdk
     judge_target: azure_base
     model: gpt-5-mini
     # cli_path: /path/to/copilot  # Optional: defaults to bundled @github/copilot binary

--- a/packages/core/src/evaluation/providers/copilot-sdk.ts
+++ b/packages/core/src/evaluation/providers/copilot-sdk.ts
@@ -64,7 +64,7 @@ interface ToolCallInProgress {
  */
 export class CopilotSdkProvider implements Provider {
   readonly id: string;
-  readonly kind = 'copilot' as const;
+  readonly kind = 'copilot-sdk' as const;
   readonly targetName: string;
   readonly supportsBatch = false;
 
@@ -73,7 +73,7 @@ export class CopilotSdkProvider implements Provider {
   private client: any = null;
 
   constructor(targetName: string, config: CopilotSdkResolvedConfig) {
-    this.id = `copilot:${targetName}`;
+    this.id = `copilot-sdk:${targetName}`;
     this.targetName = targetName;
     this.config = config;
   }

--- a/packages/core/src/evaluation/providers/index.ts
+++ b/packages/core/src/evaluation/providers/index.ts
@@ -83,7 +83,7 @@ export function createBuiltinProviderRegistry(): ProviderRegistry {
     .register('gemini', (t) => new GeminiProvider(t.name, t.config as never))
     .register('cli', (t) => new CliProvider(t.name, t.config as never))
     .register('codex', (t) => new CodexProvider(t.name, t.config as never))
-    .register('copilot', (t) => new CopilotSdkProvider(t.name, t.config as never))
+    .register('copilot-sdk', (t) => new CopilotSdkProvider(t.name, t.config as never))
     .register('copilot-cli', (t) => new CopilotCliProvider(t.name, t.config as never))
     .register('pi-coding-agent', (t) => new PiCodingAgentProvider(t.name, t.config as never))
     .register('pi-agent-sdk', (t) => new PiAgentSdkProvider(t.name, t.config as never))

--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -557,7 +557,7 @@ export type ResolvedTarget =
       readonly config: CodexResolvedConfig;
     }
   | {
-      readonly kind: 'copilot';
+      readonly kind: 'copilot-sdk';
       readonly name: string;
       readonly judgeTarget?: string;
       readonly workers?: number;
@@ -742,17 +742,17 @@ export function resolveTargetDefinition(
         providerBatching,
         config: resolveCodexConfig(parsed, env, evalFilePath),
       };
-    case 'copilot':
     case 'copilot-sdk':
     case 'copilot_sdk':
       return {
-        kind: 'copilot',
+        kind: 'copilot-sdk',
         name: parsed.name,
         judgeTarget: parsed.judge_target,
         workers: parsed.workers,
         providerBatching,
         config: resolveCopilotSdkConfig(parsed, env, evalFilePath),
       };
+    case 'copilot':
     case 'copilot-cli':
       return {
         kind: 'copilot-cli',

--- a/packages/core/src/evaluation/providers/types.ts
+++ b/packages/core/src/evaluation/providers/types.ts
@@ -15,7 +15,7 @@ export type ProviderKind =
   | 'anthropic'
   | 'gemini'
   | 'codex'
-  | 'copilot'
+  | 'copilot-sdk'
   | 'copilot-cli'
   | 'pi-coding-agent'
   | 'pi-agent-sdk'
@@ -31,7 +31,7 @@ export type ProviderKind =
  */
 export const AGENT_PROVIDER_KINDS: readonly ProviderKind[] = [
   'codex',
-  'copilot',
+  'copilot-sdk',
   'copilot-cli',
   'pi-coding-agent',
   'claude',
@@ -48,7 +48,7 @@ export const KNOWN_PROVIDERS: readonly ProviderKind[] = [
   'anthropic',
   'gemini',
   'codex',
-  'copilot',
+  'copilot-sdk',
   'copilot-cli',
   'pi-coding-agent',
   'pi-agent-sdk',
@@ -68,8 +68,8 @@ export const PROVIDER_ALIASES: readonly string[] = [
   'google', // alias for "gemini"
   'google-gemini', // alias for "gemini"
   'codex-cli', // alias for "codex"
-  'copilot-sdk', // alias for "copilot"
-  'copilot_sdk', // alias for "copilot" (underscore variant)
+  'copilot', // alias for "copilot-cli" (default copilot experience)
+  'copilot_sdk', // alias for "copilot-sdk" (underscore variant)
 
   'pi', // alias for "pi-coding-agent"
   'claude-code', // alias for "claude" (legacy)

--- a/packages/core/src/evaluation/validation/targets-validator.ts
+++ b/packages/core/src/evaluation/validation/targets-validator.ts
@@ -123,6 +123,27 @@ const COPILOT_SDK_SETTINGS = new Set([
   'workspaceTemplate',
 ]);
 
+const COPILOT_CLI_SETTINGS = new Set([
+  ...COMMON_SETTINGS,
+  'executable',
+  'command',
+  'binary',
+  'args',
+  'arguments',
+  'model',
+  'cwd',
+  'timeout_seconds',
+  'timeoutSeconds',
+  'log_dir',
+  'logDir',
+  'log_format',
+  'logFormat',
+  'system_prompt',
+  'systemPrompt',
+  'workspace_template',
+  'workspaceTemplate',
+]);
+
 const VSCODE_SETTINGS = new Set([
   ...COMMON_SETTINGS,
   'executable',
@@ -188,11 +209,12 @@ function getKnownSettings(provider: string): Set<string> | null {
     case 'codex':
     case 'codex-cli':
       return CODEX_SETTINGS;
-    case 'copilot':
     case 'copilot-sdk':
     case 'copilot_sdk':
-    case 'copilot-cli':
       return COPILOT_SDK_SETTINGS;
+    case 'copilot':
+    case 'copilot-cli':
+      return COPILOT_CLI_SETTINGS;
     case 'claude':
     case 'claude-code':
     case 'claude-sdk':

--- a/packages/core/test/evaluation/providers/targets.test.ts
+++ b/packages/core/test/evaluation/providers/targets.test.ts
@@ -611,36 +611,48 @@ describe('resolveTargetDefinition', () => {
     ).toThrow(/mutually exclusive/i);
   });
 
-  it('resolves copilot workspace_template', () => {
+  it('resolves copilot-sdk workspace_template', () => {
     const target = resolveTargetDefinition(
       {
         name: 'copilot-with-template',
-        provider: 'copilot',
+        provider: 'copilot-sdk',
         workspace_template: '/templates/copilot-workspace',
       },
       {},
     );
 
-    expect(target.kind).toBe('copilot');
-    if (target.kind !== 'copilot') {
-      throw new Error('expected copilot target');
+    expect(target.kind).toBe('copilot-sdk');
+    if (target.kind !== 'copilot-sdk') {
+      throw new Error('expected copilot-sdk target');
     }
 
     expect(target.config.workspaceTemplate).toBe('/templates/copilot-workspace');
   });
 
-  it('throws when both cwd and workspace_template are specified for copilot', () => {
+  it('throws when both cwd and workspace_template are specified for copilot-sdk', () => {
     expect(() =>
       resolveTargetDefinition(
         {
           name: 'copilot-both',
-          provider: 'copilot',
+          provider: 'copilot-sdk',
           cwd: '/some/path',
           workspace_template: '/templates/workspace',
         },
         {},
       ),
     ).toThrow(/mutually exclusive/i);
+  });
+
+  it('resolves copilot alias to copilot-cli', () => {
+    const target = resolveTargetDefinition(
+      {
+        name: 'copilot-alias',
+        provider: 'copilot',
+      },
+      {},
+    );
+
+    expect(target.kind).toBe('copilot-cli');
   });
 
   it('resolves copilot-cli as its own provider kind', () => {


### PR DESCRIPTION
## Summary

- **Renames** the canonical provider kind `copilot` → `copilot-sdk` for the `@github/copilot-sdk` based provider
- **Makes** `copilot` an alias for `copilot-cli`, which is the better default for autonomous evaluation (no 60s idle timeout, auto-approves permissions)
- **Adds** separate `COPILOT_CLI_SETTINGS` validation set for copilot-cli specific fields (`executable`, `args`, etc.)

**Breaking change:** Users with `provider: copilot` in their configs will now get CopilotCliProvider instead of CopilotSdkProvider. To keep the SDK provider, change to `provider: copilot-sdk`.

Closes #411

## Test plan

- [x] All 1003 existing tests pass
- [x] New test verifies `copilot` alias resolves to `copilot-cli`
- [x] Updated tests verify `copilot-sdk` resolves to the SDK provider
- [x] Build, typecheck, lint all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)