### PR TITLE
fix(cli): subscribe to copilot-cli log entries in CLI progress display

### DIFF
--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -17,6 +17,7 @@ import {
   shouldEnableCache,
   shouldSkipCacheForTemperature,
   subscribeToCodexLogEntries,
+  subscribeToCopilotCliLogEntries,
   subscribeToCopilotSdkLogEntries,
   subscribeToPiLogEntries,
 } from '@agentv/core';
@@ -798,7 +799,14 @@ export async function runEvalCommand(input: RunEvalCommandInput): Promise<void> 
     progressReporter.addLogPaths([entry.filePath], 'pi');
   });
   const seenCopilotLogPaths = new Set<string>();
-  const unsubscribeCopilotLogs = subscribeToCopilotSdkLogEntries((entry) => {
+  const unsubscribeCopilotSdkLogs = subscribeToCopilotSdkLogEntries((entry) => {
+    if (!entry.filePath || seenCopilotLogPaths.has(entry.filePath)) {
+      return;
+    }
+    seenCopilotLogPaths.add(entry.filePath);
+    progressReporter.addLogPaths([entry.filePath], 'copilot');
+  });
+  const unsubscribeCopilotCliLogs = subscribeToCopilotCliLogEntries((entry) => {
     if (!entry.filePath || seenCopilotLogPaths.has(entry.filePath)) {
       return;
     }
@@ -908,7 +916,8 @@ export async function runEvalCommand(input: RunEvalCommandInput): Promise<void> 
   } finally {
     unsubscribeCodexLogs();
     unsubscribePiLogs();
-    unsubscribeCopilotLogs();
+    unsubscribeCopilotSdkLogs();
+    unsubscribeCopilotCliLogs();
     await outputWriter.close().catch(() => undefined);
     if (otelExporter) {
       try {


### PR DESCRIPTION
## Summary

- Subscribe to `subscribeToCopilotCliLogEntries` alongside the existing `subscribeToCopilotSdkLogEntries` in the CLI progress display
- Rename `unsubscribeCopilotLogs` → `unsubscribeCopilotSdkLogs` + `unsubscribeCopilotCliLogs` for clarity
- Both subscriptions share `seenCopilotLogPaths` to deduplicate across copilot providers

Closes #414

## Copilot CLI vs Copilot SDK log quality

Both log trackers (`copilot-cli-log-tracker.ts` and `copilot-sdk-log-tracker.ts`) are **structurally identical** — same `LogEntry` type shape (`filePath`, `evalCaseId`, `targetName`, `attempt`), same pub/sub pattern, same global symbol-based stores. The only difference is the namespace (Symbol keys and type names). Both providers record entries at the same point in their respective flows (after creating a `CopilotStreamLogger`), so log quality is equivalent between the two.

## Manual e2e verification

### 1. copilot-sdk target (existing, confirming no regression)

```
$ bun agentv eval examples/features/matrix-evaluation/evals/dataset.eval.yaml \
    --test-id general-greeting --target copilot
```

```
Output path: .../.agentv/results/eval_2026-03-05T02-50-37-791Z.jsonl
Using target: copilot [provider=copilot-sdk]
0/1   🔄 general-greeting | copilot [provider=copilot-sdk]

Copilot CLI logs:
1. .../.agentv/logs/copilot-sdk/2026-03-05T02-50-40-339Z_copilot_general-greeting_attempt-1_c11cce42.log
1/1   ✅ general-greeting | copilot [provider=copilot-sdk]

EVALUATION SUMMARY
Total tests: 1 | Mean score: 1.000
```

### 2. copilot-cli target (the fix — previously no logs shown)

```
$ bun agentv eval examples/features/file-changes-judges/evals/dataset.eval.yaml \
    --test-id verify-file-changes-judges
```

```
Output path: .../.agentv/results/eval_2026-03-05T02-51-41-931Z.jsonl
Using target: mock_agent [provider=cli]
Warning: Shared workspace requires sequential execution. Overriding workers from 3 to 1.
0/1   🔄 verify-file-changes-judges | mock_agent [provider=cli]

Copilot CLI logs:
1. .../.agentv/logs/copilot-cli/2026-03-05T02-51-47-380Z_copilot_judge_verify-file-changes-judges_attempt-1_07a216fb.log
1/1   ✅ verify-file-changes-judges | mock_agent [provider=cli]

EVALUATION SUMMARY
Total tests: 1 | Mean score: 1.000
```

**Key evidence:** The `Copilot CLI logs:` section with the `copilot-cli/` log path now appears in terminal output. Before this fix, copilot-cli log entries were recorded but never displayed because the CLI didn't subscribe to them.

### 3. Build / typecheck / lint / tests

```
$ bun run build       # ✅ Build success
$ bun run typecheck   # ✅ 0 errors
$ bun run lint        # ✅ 361 files, no issues
$ bun run test        # ✅ 1003 tests pass (801 core + 57 eval + 145 cli)
```

## Test plan

- [x] Verify `copilot-sdk` logs still appear (no regression)
- [x] Verify `copilot-cli` logs now appear in terminal during eval
- [x] Build passes
- [x] Typecheck passes
- [x] Lint passes
- [x] All 1003 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)