### PR TITLE
docs: document agent provider prompt format with preread block

### DIFF
--- a/apps/web/src/content/docs/targets/coding-agents.mdx
+++ b/apps/web/src/content/docs/targets/coding-agents.mdx
@@ -7,6 +7,60 @@ sidebar:
 
 Coding agent targets evaluate AI coding assistants and CLI-based agents. These targets require a `judge_target` to run LLM-based evaluators.
 
+## Prompt format
+
+Agent providers receive a structured prompt document with two sections: a **preread block** listing files the agent must read, and the **user query** containing the eval input.
+
+### File handling
+
+When an eval test includes `type: file` inputs, agent providers do **not** receive the file content inline. Instead, they receive:
+
+1. A preread block with `file://` URIs pointing to absolute paths on disk
+2. The user query with `<file: path="...">` reference tags
+
+The agent is expected to read the files itself using its filesystem tools.
+
+This differs from [LLM providers](/targets/llm-providers), which receive file content embedded directly in the prompt as XML:
+
+```xml
+<file path="src/example.ts">
+// file content is inlined here
+</file>
+```
+
+### Example prompt
+
+Given an eval with a guideline file and a file input:
+
+```yaml
+input:
+  - role: user
+    content:
+      - type: file
+        value: ./src/example.ts
+      - type: text
+        value: Review this code
+```
+
+The agent receives a prompt like:
+
+```
+Read all guideline files:
+* [guidelines.md](file:///abs/path/guidelines.md).
+
+Read all input files:
+* [example.ts](file:///abs/path/src/example.ts).
+
+If any file is missing, fail with ERROR: missing-file <filename> and stop.
+Then apply system_instructions on the user query below.
+
+[[ ## user_query ## ]]
+<file: path="./src/example.ts">
+Review this code
+```
+
+The preread block instructs the agent to read both guideline and input files before processing the query. If a `system_prompt` is configured on the target, it is passed separately via the provider SDK (not in the prompt document).
+
 ## Claude
 
 ```yaml

--- a/plugins/agentv-dev/skills/agentv-eval-builder/SKILL.md
+++ b/plugins/agentv-dev/skills/agentv-eval-builder/SKILL.md
@@ -54,6 +54,7 @@ tests:
 **Message format:** `{role, content}` where role is `system`, `user`, `assistant`, or `tool`
 **Content types:** inline text, `{type: "file", value: "./path.md"}`
 **File paths:** relative from eval file dir, or absolute with `/` prefix from repo root
+**File handling by provider type:** LLM providers receive file content inlined in XML tags. Agent providers receive a preread block with `file://` URIs and must read files themselves. See [Coding Agents > Prompt format](https://agentv.dev/targets/coding-agents#prompt-format).
 
 **JSONL format:** One test per line as JSON. Optional `.yaml` sidecar for shared defaults. See `examples/features/basic-jsonl/`.
 


### PR DESCRIPTION
## Summary
- Adds a "Prompt format" section to the [Coding Agents](https://agentv.dev/targets/coding-agents) docs page explaining how agent providers receive a structured prompt document with a preread block and file reference tags
- Documents the difference between agent mode (file references + preread URIs) and LLM mode (inlined content)
- Adds a brief note to the eval-builder skill reference card linking to the new docs section

Closes #422

## Test plan
- [x] Verify the new section renders correctly on agentv.dev
- [x] Confirm the anchor link from the skill file resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)