### PR TITLE
feat(config): add required_version to .agentv/config.yaml

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -39,10 +39,12 @@
     "fast-glob": "^3.3.3",
     "json5": "^2.2.3",
     "micromatch": "^4.0.8",
+    "semver": "^7.7.4",
     "yaml": "^2.6.1"
   },
   "devDependencies": {
     "@agentv/core": "workspace:*",
+    "@types/semver": "^7.7.1",
     "execa": "^9.3.0"
   }
 }

--- a/apps/cli/src/commands/eval/commands/run.ts
+++ b/apps/cli/src/commands/eval/commands/run.ts
@@ -147,6 +147,10 @@ export const evalRunCommand = command({
       long: 'retry-errors',
       description: 'Path to previous output JSONL — re-run only execution_error test cases',
     }),
+    strict: flag({
+      long: 'strict',
+      description: 'Exit with error on version mismatch (instead of warning)',
+    }),
   },
   handler: async (args) => {
     // Launch interactive wizard when no eval paths and stdin is a TTY
@@ -184,6 +188,7 @@ export const evalRunCommand = command({
       otelCaptureContent: args.otelCaptureContent,
       otelGroupTurns: args.otelGroupTurns,
       retryErrors: args.retryErrors,
+      strict: args.strict,
     };
     await runEvalCommand({ testFiles: resolvedPaths, rawOptions });
   },

--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -25,6 +25,7 @@ import {
   subscribeToPiLogEntries,
 } from '@agentv/core';
 
+import { enforceRequiredVersion } from '../../version-check.js';
 import { loadEnvFromHierarchy } from './env.js';
 import {
   type OutputFormat,
@@ -642,6 +643,13 @@ export async function runEvalCommand(input: RunEvalCommandInput): Promise<void> 
   // loadConfig expects an eval file path and walks up from its directory.
   // Pass a dummy file in cwd so the search starts from the working directory.
   const yamlConfig = await loadConfig(path.join(cwd, '_'), repoRoot);
+
+  // Check required_version before proceeding with eval
+  if (yamlConfig?.required_version) {
+    await enforceRequiredVersion(yamlConfig.required_version, {
+      strict: normalizeBoolean(input.rawOptions.strict),
+    });
+  }
 
   let options = normalizeOptions(input.rawOptions, config, yamlConfig?.execution);
 

--- a/apps/cli/src/version-check.ts
+++ b/apps/cli/src/version-check.ts
@@ -1,0 +1,86 @@
+import { satisfies, validRange } from 'semver';
+
+import packageJson from '../package.json' with { type: 'json' };
+
+const ANSI_YELLOW = '\u001b[33m';
+const ANSI_RED = '\u001b[31m';
+const ANSI_RESET = '\u001b[0m';
+
+export interface VersionCheckResult {
+  readonly satisfied: boolean;
+  readonly currentVersion: string;
+  readonly requiredRange: string;
+}
+
+/**
+ * Validate and check the installed version against a required semver range.
+ * Throws on malformed range strings.
+ */
+export function checkVersion(requiredVersion: string): VersionCheckResult {
+  const currentVersion = packageJson.version;
+
+  if (!requiredVersion.trim() || !validRange(requiredVersion)) {
+    throw new Error(
+      `Invalid required_version "${requiredVersion}" in .agentv/config.yaml. Must be a valid semver range (e.g., ">=2.11.0", "^2.11.0").`,
+    );
+  }
+
+  return {
+    satisfied: satisfies(currentVersion, requiredVersion),
+    currentVersion,
+    requiredRange: requiredVersion,
+  };
+}
+
+/**
+ * Run the version compatibility check and handle user interaction.
+ *
+ * - If the version satisfies the range, returns silently.
+ * - If the range is malformed, prints an error and exits with code 1.
+ * - If the version is below the range:
+ *   - Interactive (TTY): warns and prompts to continue or abort.
+ *   - Non-interactive: warns to stderr, continues (unless strict).
+ *   - Strict mode: warns and exits with code 1.
+ */
+export async function enforceRequiredVersion(
+  requiredVersion: string,
+  options?: { strict?: boolean },
+): Promise<void> {
+  let result: VersionCheckResult;
+  try {
+    result = checkVersion(requiredVersion);
+  } catch (err) {
+    console.error(`${ANSI_RED}Error: ${(err as Error).message}${ANSI_RESET}`);
+    process.exit(1);
+  }
+
+  if (result.satisfied) {
+    return;
+  }
+
+  const warning = `${ANSI_YELLOW}Warning: This project requires agentv ${result.requiredRange} but you have ${result.currentVersion}.${ANSI_RESET}\n  Run \`agentv self update\` to upgrade.`;
+
+  if (options?.strict) {
+    console.error(warning);
+    console.error(
+      `${ANSI_RED}Aborting: --strict mode requires the installed version to satisfy the required range.${ANSI_RESET}`,
+    );
+    process.exit(1);
+  }
+
+  if (process.stdin.isTTY && process.stdout.isTTY) {
+    console.warn(warning);
+    const shouldContinue = await promptContinue();
+    if (!shouldContinue) {
+      process.exit(1);
+    }
+  } else {
+    // Non-interactive: warn to stderr and continue
+    process.stderr.write(`${warning}\n`);
+  }
+}
+
+async function promptContinue(): Promise<boolean> {
+  const { confirm } = await import('@inquirer/prompts');
+  return confirm({ message: 'Continue anyway?', default: false });
+}

--- a/apps/cli/test/version-check.test.ts
+++ b/apps/cli/test/version-check.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import { checkVersion } from '../src/version-check.js';
+
+describe('checkVersion', () => {
+  // Note: checkVersion uses the actual package.json version (currently 2.12.0).
+  // Tests are written relative to that.
+
+  test('satisfies range when current version is within range', () => {
+    const result = checkVersion('>=2.0.0');
+    expect(result.satisfied).toBe(true);
+    expect(result.requiredRange).toBe('>=2.0.0');
+  });
+
+  test('does not satisfy range when current version is below', () => {
+    const result = checkVersion('>=99.0.0');
+    expect(result.satisfied).toBe(false);
+    expect(result.requiredRange).toBe('>=99.0.0');
+  });
+
+  test('supports caret ranges', () => {
+    const result = checkVersion('^2.0.0');
+    expect(result.satisfied).toBe(true);
+  });
+
+  test('supports tilde ranges', () => {
+    const result = checkVersion('~2.12.0');
+    expect(result.satisfied).toBe(true);
+  });
+
+  test('supports range intersections', () => {
+    const result = checkVersion('>=2.0.0 <3.0.0');
+    expect(result.satisfied).toBe(true);
+  });
+
+  test('fails range intersection when current version is outside', () => {
+    const result = checkVersion('>=3.0.0 <4.0.0');
+    expect(result.satisfied).toBe(false);
+  });
+
+  test('throws on malformed semver range', () => {
+    expect(() => checkVersion('not-a-range')).toThrow(/Invalid required_version/);
+  });
+
+  test('throws on empty string', () => {
+    expect(() => checkVersion('')).toThrow(/Invalid required_version/);
+  });
+
+  test('returns the current version from package.json', () => {
+    const result = checkVersion('>=1.0.0');
+    expect(result.currentVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/apps/web/src/content/docs/evaluation/running-evals.mdx
+++ b/apps/web/src/content/docs/evaluation/running-evals.mdx
@@ -163,6 +163,30 @@ Runs code judges deterministically and returns LLM judge prompts for the agent t
 | Have API keys, want end-to-end automation | `agentv eval` |
 | No API keys, agent can act as the LLM | `agentv prompt` |
 
+## Version Requirements
+
+Declare the minimum AgentV version needed by your eval project in `.agentv/config.yaml`:
+
+```yaml
+required_version: ">=2.12.0"
+```
+
+The value is a **semver range** using standard npm syntax (e.g., `>=2.12.0`, `^2.12.0`, `~2.12`, `>=2.12.0 <3.0.0`).
+
+| Condition | Interactive (TTY) | Non-interactive (CI) |
+|-----------|-------------------|---------------------|
+| Version satisfies range | Runs silently | Runs silently |
+| Version below range | Warns + prompts to continue | Warns to stderr, continues |
+| `--strict` flag + mismatch | Warns + exits 1 | Warns + exits 1 |
+| No `required_version` set | Runs silently | Runs silently |
+| Malformed semver range | Error + exits 1 | Error + exits 1 |
+
+Use `--strict` in CI pipelines to enforce version requirements:
+
+```bash
+agentv eval --strict evals/my-eval.yaml
+```
+
 ## Config File Defaults
 
 Set default execution options so you don't have to pass them on every CLI invocation. Both `.agentv/config.yaml` and `agentv.config.ts` are supported.

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "apps/cli": {
       "name": "agentv",
-      "version": "2.7.1-next.6",
+      "version": "2.12.0",
       "bin": {
         "agentv": "./dist/cli.js",
       },
@@ -40,10 +40,12 @@
         "fast-glob": "^3.3.3",
         "json5": "^2.2.3",
         "micromatch": "^4.0.8",
+        "semver": "^7.7.4",
         "yaml": "^2.6.1",
       },
       "devDependencies": {
         "@agentv/core": "workspace:*",
+        "@types/semver": "^7.7.1",
         "execa": "^9.3.0",
       },
     },
@@ -59,7 +61,7 @@
     },
     "packages/core": {
       "name": "@agentv/core",
-      "version": "2.7.1-next.6",
+      "version": "2.12.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",
         "@agentv/eval": "workspace:*",
@@ -93,7 +95,7 @@
     },
     "packages/eval": {
       "name": "@agentv/eval",
-      "version": "2.7.1-next.6",
+      "version": "2.12.0",
       "dependencies": {
         "zod": "^3.23.8",
       },
@@ -735,6 +737,8 @@
     "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
     "@types/sax": ["@types/sax@1.2.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A=="],
+
+    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -1558,7 +1562,7 @@
 
     "sax": ["sax@1.4.4", "", {}, "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw=="],
 
-    "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "sharp": ["sharp@0.33.5", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.6.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.33.5", "@img/sharp-darwin-x64": "0.33.5", "@img/sharp-libvips-darwin-arm64": "1.0.4", "@img/sharp-libvips-darwin-x64": "1.0.4", "@img/sharp-libvips-linux-arm": "1.0.5", "@img/sharp-libvips-linux-arm64": "1.0.4", "@img/sharp-libvips-linux-s390x": "1.0.4", "@img/sharp-libvips-linux-x64": "1.0.4", "@img/sharp-libvips-linuxmusl-arm64": "1.0.4", "@img/sharp-libvips-linuxmusl-x64": "1.0.4", "@img/sharp-linux-arm": "0.33.5", "@img/sharp-linux-arm64": "0.33.5", "@img/sharp-linux-s390x": "0.33.5", "@img/sharp-linux-x64": "0.33.5", "@img/sharp-linuxmusl-arm64": "0.33.5", "@img/sharp-linuxmusl-x64": "0.33.5", "@img/sharp-wasm32": "0.33.5", "@img/sharp-win32-ia32": "0.33.5", "@img/sharp-win32-x64": "0.33.5" } }, "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw=="],
 
@@ -2002,6 +2006,8 @@
 
     "astro/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
+    "astro/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
     "astro/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "astro/tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
@@ -2047,6 +2053,8 @@
     "sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw=="],
 
     "sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
+
+    "sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "sitemap/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
 

--- a/packages/core/src/evaluation/loaders/config-loader.ts
+++ b/packages/core/src/evaluation/loaders/config-loader.ts
@@ -23,6 +23,7 @@ export type ExecutionDefaults = {
 };
 
 export type AgentVConfig = {
+  readonly required_version?: string;
   readonly guideline_patterns?: readonly string[];
   readonly eval_patterns?: readonly string[];
   readonly execution?: ExecutionDefaults;
@@ -56,6 +57,12 @@ export async function loadConfig(
 
       const config = parsed as AgentVConfig;
 
+      const requiredVersion = (parsed as Record<string, unknown>).required_version;
+      if (requiredVersion !== undefined && typeof requiredVersion !== 'string') {
+        logWarning(`Invalid required_version in ${configPath}, expected string`);
+        continue;
+      }
+
       const guidelinePatterns = config.guideline_patterns;
       if (guidelinePatterns !== undefined && !Array.isArray(guidelinePatterns)) {
         logWarning(`Invalid guideline_patterns in ${configPath}, expected array`);
@@ -87,6 +94,7 @@ export async function loadConfig(
       );
 
       return {
+        required_version: requiredVersion as string | undefined,
         guideline_patterns: guidelinePatterns as readonly string[] | undefined,
         eval_patterns: evalPatterns as readonly string[] | undefined,
         execution: executionDefaults,

--- a/plugins/agentv-dev/skills/agentv-eval-builder/references/config-schema.json
+++ b/plugins/agentv-dev/skills/agentv-eval-builder/references/config-schema.json
@@ -9,6 +9,11 @@
       "description": "Schema identifier",
       "enum": ["agentv-config-v2"]
     },
+    "required_version": {
+      "type": "string",
+      "description": "Minimum AgentV version required to run this project's evals. Uses semver range syntax (e.g., '>=2.11.0', '^2.11.0'). When the installed version is below the range, AgentV warns and prompts to update.",
+      "examples": [">=2.11.0", "^2.12.0", ">=2.11.0 <3.0.0"]
+    },
     "guideline_patterns": {
       "type": "array",
       "description": "Glob patterns for identifying guideline files (instructions, prompts). Files matching these patterns are treated as guidelines, while non-matching files are treated as regular file content.",


### PR DESCRIPTION
## Summary

- Adds `required_version` field to `.agentv/config.yaml` for declaring minimum AgentV version via semver range
- When installed version is below range: warns interactively (with prompt) or to stderr in CI
- `--strict` flag on `agentv eval` exits non-zero on version mismatch for CI enforcement
- Malformed semver ranges produce a clear error and exit 1

## Behavior

| Condition | Interactive (TTY) | Non-interactive (CI) |
|-----------|-------------------|---------------------|
| Version satisfies range | Runs silently | Runs silently |
| Version below range | Warns + prompts "Continue anyway?" | Warns to stderr, continues |
| `--strict` + mismatch | Warns + exits 1 | Warns + exits 1 |
| No `required_version` set | No-op | No-op |
| Malformed semver range | Error + exits 1 | Error + exits 1 |

## Test plan

- [x] Unit tests for `checkVersion()` — semver range parsing, satisfaction, edge cases (9 tests)
- [x] All existing tests pass (1088 tests, 0 failures)
- [x] Build, typecheck, lint pass
- [x] Manual e2e: no `required_version` (no-op)
- [x] Manual e2e: satisfied version (runs silently)
- [x] Manual e2e: unsatisfied version non-interactive (warns, continues)
- [x] Manual e2e: `--strict` + unsatisfied version (exits 1)
- [x] Manual e2e: malformed range (error + exits 1)

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)