### PR TITLE
feat: implicit judge when criteria defined with assert (#447)

### DIFF
--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -1627,9 +1627,19 @@ async function runEvaluatorsForCase(options: {
   } = options;
 
   if (evalCase.evaluators && evalCase.evaluators.length > 0) {
+    // #447: If criteria is non-empty and target has a judge, prepend an implicit
+    // llm_judge so criteria are always evaluated qualitatively. Assert is additive.
+    const hasCriteria = evalCase.criteria?.trim().length > 0;
+    const hasJudge = Boolean(target.judgeTarget);
+
+    const evaluatorsWithImplicitJudge =
+      hasCriteria && hasJudge
+        ? [{ name: 'implicit_judge', type: 'llm_judge' as const }, ...evalCase.evaluators]
+        : evalCase.evaluators;
+
     return runEvaluatorList({
       evalCase,
-      evaluators: evalCase.evaluators,
+      evaluators: evaluatorsWithImplicitJudge,
       candidate,
       target,
       provider,

--- a/packages/core/test/evaluation/orchestrator.test.ts
+++ b/packages/core/test/evaluation/orchestrator.test.ts
@@ -1717,6 +1717,175 @@ describe('deterministic assertion evaluators in orchestrator', () => {
   });
 });
 
+describe('implicit judge when criteria defined with assert (#447)', () => {
+  const criteriaTestCase: EvalTest = {
+    id: 'implicit-judge-1',
+    dataset: 'test-dataset',
+    question: 'Test question',
+    input: [{ role: 'user', content: 'Test question' }],
+    input_segments: [{ type: 'text', value: 'Test question' }],
+    expected_output: [],
+    reference_answer: '',
+    guideline_paths: [],
+    file_paths: [],
+    criteria: 'Response should be polite',
+  };
+
+  it('prepends implicit llm_judge when criteria is non-empty and target has judgeTarget', async () => {
+    const provider = new SequenceProvider('mock', {
+      responses: [{ output: [{ role: 'assistant', content: 'hello world' }] }],
+    });
+
+    const targetWithJudge: ResolvedTarget = {
+      ...baseTarget,
+      judgeTarget: 'judge-target',
+    };
+
+    const result = await runEvalCase({
+      evalCase: {
+        ...criteriaTestCase,
+        criteria: 'Response should be polite',
+        evaluators: [{ name: 'has-hello', type: 'contains' as const, value: 'hello' }],
+      },
+      provider,
+      target: targetWithJudge,
+      evaluators: evaluatorRegistry,
+    });
+
+    // Should have 2 scores: implicit llm_judge + contains assertion
+    expect(result.scores).toHaveLength(2);
+    expect(result.scores?.[0].type).toBe('llm_judge');
+    expect(result.scores?.[1].type).toBe('contains');
+  });
+
+  it('does NOT add implicit judge when criteria is empty', async () => {
+    const provider = new SequenceProvider('mock', {
+      responses: [{ output: [{ role: 'assistant', content: 'hello world' }] }],
+    });
+
+    const targetWithJudge: ResolvedTarget = {
+      ...baseTarget,
+      judgeTarget: 'judge-target',
+    };
+
+    const result = await runEvalCase({
+      evalCase: {
+        ...criteriaTestCase,
+        criteria: '',
+        evaluators: [{ name: 'has-hello', type: 'contains' as const, value: 'hello' }],
+      },
+      provider,
+      target: targetWithJudge,
+      evaluators: evaluatorRegistry,
+    });
+
+    // Only the contains assertion — no implicit judge
+    expect(result.scores).toHaveLength(1);
+    expect(result.scores?.[0].type).toBe('contains');
+  });
+
+  it('does NOT add implicit judge when target lacks judgeTarget', async () => {
+    const provider = new SequenceProvider('mock', {
+      responses: [{ output: [{ role: 'assistant', content: 'hello world' }] }],
+    });
+
+    const result = await runEvalCase({
+      evalCase: {
+        ...criteriaTestCase,
+        criteria: 'Response should be polite',
+        evaluators: [{ name: 'has-hello', type: 'contains' as const, value: 'hello' }],
+      },
+      provider,
+      target: baseTarget, // no judgeTarget
+      evaluators: evaluatorRegistry,
+    });
+
+    // Only the contains assertion — no implicit judge
+    expect(result.scores).toHaveLength(1);
+    expect(result.scores?.[0].type).toBe('contains');
+  });
+
+  it('does NOT add implicit judge when only expected_output is defined (no criteria)', async () => {
+    const provider = new SequenceProvider('mock', {
+      responses: [{ output: [{ role: 'assistant', content: 'hello world' }] }],
+    });
+
+    const targetWithJudge: ResolvedTarget = {
+      ...baseTarget,
+      judgeTarget: 'judge-target',
+    };
+
+    const result = await runEvalCase({
+      evalCase: {
+        ...criteriaTestCase,
+        criteria: '',
+        expected_output: [{ answer: 'hello world' }],
+        evaluators: [{ name: 'has-hello', type: 'contains' as const, value: 'hello' }],
+      },
+      provider,
+      target: targetWithJudge,
+      evaluators: evaluatorRegistry,
+    });
+
+    // Only the contains assertion — expected_output alone does not trigger implicit judge
+    expect(result.scores).toHaveLength(1);
+    expect(result.scores?.[0].type).toBe('contains');
+  });
+
+  it('implicit judge score is weighted equally with assert evaluators', async () => {
+    const provider = new SequenceProvider('mock', {
+      responses: [{ output: [{ role: 'assistant', content: 'hello world' }] }],
+    });
+
+    const targetWithJudge: ResolvedTarget = {
+      ...baseTarget,
+      judgeTarget: 'judge-target',
+    };
+
+    const result = await runEvalCase({
+      evalCase: {
+        ...criteriaTestCase,
+        criteria: 'Response should be polite',
+        evaluators: [{ name: 'has-hello', type: 'contains' as const, value: 'hello' }],
+      },
+      provider,
+      target: targetWithJudge,
+      evaluators: evaluatorRegistry,
+    });
+
+    // llm_judge mock returns 0.8, contains returns 1.0
+    // Weighted average: (0.8 + 1.0) / 2 = 0.9
+    expect(result.score).toBeCloseTo(0.9);
+    expect(result.scores?.[0].weight).toBe(1);
+    expect(result.scores?.[1].weight).toBe(1);
+  });
+
+  it('does NOT add implicit judge when criteria is whitespace-only', async () => {
+    const provider = new SequenceProvider('mock', {
+      responses: [{ output: [{ role: 'assistant', content: 'hello world' }] }],
+    });
+
+    const targetWithJudge: ResolvedTarget = {
+      ...baseTarget,
+      judgeTarget: 'judge-target',
+    };
+
+    const result = await runEvalCase({
+      evalCase: {
+        ...criteriaTestCase,
+        criteria: '   ',
+        evaluators: [{ name: 'has-hello', type: 'contains' as const, value: 'hello' }],
+      },
+      provider,
+      target: targetWithJudge,
+      evaluators: evaluatorRegistry,
+    });
+
+    expect(result.scores).toHaveLength(1);
+    expect(result.scores?.[0].type).toBe('contains');
+  });
+});
+
 describe('required gates', () => {
   const assertionTestCase: EvalTest = {
     id: 'required-gate-1',


### PR DESCRIPTION
## Summary

- When a test has non-empty `criteria`, an `assert` block, and the target has `judge_target` configured, an implicit `llm_judge` evaluator is prepended to the assert list
- `assert` becomes additive — criteria are always evaluated qualitatively instead of being silently ignored
- `expected_output` alone does NOT trigger the implicit judge — it's a structural field consumed by deterministic assertions and code judges

## Changes

- `packages/core/src/evaluation/orchestrator.ts` — 10 lines added to `runEvaluatorsForCase()` at the evaluators-present branch
- `packages/core/test/evaluation/orchestrator.test.ts` — 6 new tests covering: positive case, empty criteria, no judgeTarget, expected_output-only, equal weighting, whitespace-only criteria

## Test plan

- [x] 6 new tests pass (TDD: confirmed failing before implementation, passing after)
- [x] 875 core tests pass, 0 fail
- [x] Biome lint clean
- [x] Existing assertion/weighted/required-gate tests unaffected (use `criteria: ''` and targets without `judgeTarget`)

Closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)