### PR TITLE
fix(test): resolve defineCodeJudge fixture import for worktree compatibility

### DIFF
--- a/packages/core/test/fixtures/test-define-judge.ts
+++ b/packages/core/test/fixtures/test-define-judge.ts
@@ -2,7 +2,7 @@
 /**
  * Test fixture for defineCodeJudge integration test.
  */
-import { defineCodeJudge } from '@agentv/eval';
+import { defineCodeJudge } from '../../../eval/src/index.js';
 
 export default defineCodeJudge(({ answer, criteria }) => {
   const hits: string[] = [];


### PR DESCRIPTION
## Summary
- Use relative import path in `test-define-judge.ts` fixture instead of `@agentv/eval` workspace package, which fails to resolve in git worktrees where `node_modules` symlinks may not be set up

Note: The tilde range test fix (issue item #1) was already addressed in commit 90561eb.

## Test plan
- [x] All 37 evaluator tests pass
- [x] All 9 version-check tests pass
- [x] Pre-push hooks pass (build, typecheck, lint, test)

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)