### PR TITLE
docs: document implicit LLM judge behavior

### DIFF
--- a/apps/web/src/content/docs/evaluation/eval-cases.mdx
+++ b/apps/web/src/content/docs/evaluation/eval-cases.mdx
@@ -237,6 +237,34 @@ assert:
 
 Required gates are evaluated after all evaluators run. If any required evaluator falls below its threshold, the verdict is forced to `fail`.
 
+### Implicit LLM Judge
+
+When a test has all three of these conditions:
+
+1. Non-empty `criteria` field
+2. An `assert` block with one or more evaluators
+3. Target has a `judge_target` configured
+
+AgentV automatically prepends an implicit `llm_judge` evaluator to the assert list. This ensures `criteria` is always evaluated qualitatively, even when explicit assertions are defined — `assert` is additive with criteria-based evaluation, not a replacement.
+
+```yaml
+tests:
+  - id: json-api
+    criteria: Returns a helpful, well-structured JSON response
+    input: Return the system status as JSON
+    assert:
+      - type: is_json
+      - type: contains
+        value: '"status"'
+      # implicit llm_judge is automatically prepended
+      # evaluating criteria via the judge_target
+```
+
+The implicit judge does not apply when:
+- `criteria` is empty or whitespace-only
+- The target does not have a `judge_target` (e.g., LLM provider targets that are their own judge)
+- There is no `assert` block (criteria is evaluated by the default evaluator)
+
 ### Assert Merge Behavior
 
 `assert` can be defined at both suite and test levels:

--- a/apps/web/src/content/docs/evaluators/llm-judges.mdx
+++ b/apps/web/src/content/docs/evaluators/llm-judges.mdx
@@ -83,6 +83,10 @@ Evaluate and provide a score from 0 to 1.`;
 });
 ```
 
+## Implicit LLM Judge
+
+When a test defines both `criteria` and an `assert` block, and the target has a `judge_target` configured, AgentV automatically prepends an implicit `llm_judge` to evaluate the criteria. This means `assert` is additive — explicit assertions don't replace criteria-based evaluation. See [Tests > Implicit LLM Judge](/evaluation/eval-cases/#implicit-llm-judge) for details.
+
 ## How It Works
 
 1. AgentV renders the prompt template with variables from the test

--- a/plugins/agentv-dev/skills/agentv-eval-builder/SKILL.md
+++ b/plugins/agentv-dev/skills/agentv-eval-builder/SKILL.md
@@ -131,6 +131,8 @@ tests:
 
 `execution.evaluators` is deprecated. When both `assert` and `execution.evaluators` are present, `assert` takes precedence.
 
+**Implicit LLM judge:** When a test has non-empty `criteria`, an `assert` block, and the target has `judge_target` configured, an implicit `llm_judge` is automatically prepended. This makes `assert` additive — criteria are always evaluated qualitatively alongside explicit assertions.
+
 ## Required Gates
 
 Any evaluator can be marked `required` to enforce a minimum score:


### PR DESCRIPTION
## Summary

- Documents the implicit `llm_judge` behavior introduced in #448
- Updates eval-cases docs, LLM judges docs, and the eval builder skill reference

## Changes

- **`eval-cases.mdx`** — New "Implicit LLM Judge" subsection explaining the three conditions, YAML example, and when it does not apply
- **`llm-judges.mdx`** — Short section with cross-link to the detailed explanation
- **`SKILL.md`** — One-paragraph note so AI agents are aware of the behavior

## Test plan

- [x] All pre-push checks pass (build, typecheck, lint, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)