### PR TITLE
docs: document default judge path when no assert is present

### DIFF
--- a/plugins/agentv-dev/skills/agentv-eval-builder/SKILL.md
+++ b/plugins/agentv-dev/skills/agentv-eval-builder/SKILL.md
@@ -131,6 +131,31 @@ tests:
 
 `execution.evaluators` is deprecated. When both `assert` and `execution.evaluators` are present, `assert` takes precedence.
 
+## Default Evaluation (no assert)
+
+When a test has **no `assert` field**, a default `llm-judge` evaluator runs automatically against the `criteria` field. This is the zero-config path for simple evaluations:
+
+```yaml
+tests:
+  - id: simple-eval
+    criteria: Assistant correctly explains the bug and proposes a fix
+    input: "Debug this function..."
+    # No assert → default llm-judge evaluates against criteria
+```
+
+When `assert` **is** present, only the declared evaluators run — no default judge is added. If you want an LLM judge alongside deterministic checks, declare it explicitly:
+
+```yaml
+tests:
+  - id: mixed-eval
+    criteria: Response is helpful and mentions the fix
+    input: "Debug this function..."
+    assert:
+      - type: llm-judge        # must be explicit when assert is present
+      - type: contains
+        value: "fix"
+```
+
 ## Required Gates
 
 Any evaluator can be marked `required` to enforce a minimum score:


### PR DESCRIPTION
## Summary
- Added "Default Evaluation (no assert)" section to `agentv-eval-builder` skill doc
- Documents that tests without `assert` get an implicit `llm-judge` against `criteria`
- Shows that when `assert` IS present, `llm-judge` must be declared explicitly
- Follows from the #447→#448→#452→#453 design decision

## Context
The skill doc explains the `assert` field and all evaluator types but never mentioned what happens when `assert` is absent. Users writing simple evals (criteria + input, no assert) rely on the default judge path but had no documentation for this behavior.

## Test plan
- [x] Docs-only change — no code modified
- [x] Verified behavior with `bun apps/cli/src/cli.ts eval examples/features/basic/evals/dataset.eval.yaml --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)