### PR TITLE
fix(core): improve windows workspace setup reliability and diagnostics

### DIFF
--- a/examples/features/workspace-setup-script/README.md
+++ b/examples/features/workspace-setup-script/README.md
@@ -60,4 +60,11 @@ workspace:
 
 ## Cross-platform
 
-The script handles Windows by using `npx.cmd` instead of `npx`. Each command is spawned directly via `spawnSync` (no shell assumption).
+The script handles Windows by using `npx.cmd` instead of `npx`.
+
+Because the script first reads AgentV payload from stdin, it then launches `npx` with:
+
+- `stdio: ['ignore', 'inherit', 'inherit']`
+- `shell: process.platform === 'win32'`
+
+This avoids a Windows-specific `spawnSync npx.cmd EINVAL` failure seen when stdin is inherited after being consumed in `before_all` hooks.

--- a/examples/features/workspace-setup-script/scripts/workspace-setup.mjs
+++ b/examples/features/workspace-setup-script/scripts/workspace-setup.mjs
@@ -42,6 +42,12 @@ const npx = process.platform === 'win32' ? 'npx.cmd' : 'npx';
 const result = spawnSync(
   npx,
   ['--yes', 'allagents', 'workspace', 'init', workspace_path, '--from', templatePath],
-  { stdio: 'inherit' },
+  {
+    // This script reads AgentV stdin first, so don't pass fd 0 through.
+    // On Windows, inheriting stdin into `npx.cmd` can raise EINVAL.
+    // shell=true ensures `.cmd` is launched reliably.
+    stdio: ['ignore', 'inherit', 'inherit'],
+    shell: process.platform === 'win32',
+  },
 );
 process.exit(result.status ?? 1);

--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -379,6 +379,11 @@ export async function runEvaluation(
   const resolvedTemplate = await resolveWorkspaceTemplate(rawTemplate);
   const workspaceTemplate = resolvedTemplate?.dir;
   let suiteWorkspaceFile = resolvedTemplate?.workspaceFile;
+  const setupLog = (message: string): void => {
+    if (verbose) {
+      console.log(`[setup] ${message}`);
+    }
+  };
 
   // Resolve worker count: CLI option > target setting > default (1)
   // Force workers=1 when shared workspace is used to prevent data corruption
@@ -390,6 +395,9 @@ export async function runEvaluation(
   );
   const requestedWorkers = options.maxConcurrency ?? target.workers ?? 1;
   const workers = hasSharedWorkspace ? 1 : requestedWorkers;
+  setupLog(
+    `sharedWorkspace=${hasSharedWorkspace} perTestIsolation=${isPerTestIsolation} requestedWorkers=${requestedWorkers} effectiveWorkers=${workers}`,
+  );
   if (hasSharedWorkspace && requestedWorkers > 1) {
     console.warn(
       `Warning: Shared workspace requires sequential execution. Overriding workers from ${requestedWorkers} to 1.`,
@@ -401,8 +409,10 @@ export async function runEvaluation(
   let beforeAllOutput: string | undefined;
 
   if (workspaceTemplate) {
+    setupLog(`creating shared workspace from template: ${workspaceTemplate}`);
     try {
       sharedWorkspacePath = await createTempWorkspace(workspaceTemplate, evalRunId, 'shared');
+      setupLog(`shared workspace created at: ${sharedWorkspacePath}`);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to create shared workspace: ${message}`);
@@ -423,13 +433,16 @@ export async function runEvaluation(
     // No template but before_all or repos is configured: create empty workspace
     sharedWorkspacePath = getWorkspacePath(evalRunId, 'shared');
     await mkdir(sharedWorkspacePath, { recursive: true });
+    setupLog(`created empty shared workspace at: ${sharedWorkspacePath}`);
   }
 
   // Materialize repos into shared workspace (skip for per_test — repos are materialized per case)
-  const repoManager = suiteWorkspace?.repos?.length ? new RepoManager() : undefined;
+  const repoManager = suiteWorkspace?.repos?.length ? new RepoManager(undefined, verbose) : undefined;
   if (repoManager && sharedWorkspacePath && suiteWorkspace?.repos && !isPerTestIsolation) {
+    setupLog(`materializing ${suiteWorkspace.repos.length} shared repo(s) into ${sharedWorkspacePath}`);
     try {
       await repoManager.materializeAll(suiteWorkspace.repos, sharedWorkspacePath);
+      setupLog('shared repo materialization complete');
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (sharedWorkspacePath) {
@@ -441,6 +454,10 @@ export async function runEvaluation(
 
   // Execute before_all (runs ONCE before first test)
   if (sharedWorkspacePath && suiteWorkspace?.before_all) {
+    const beforeAllCommand = (suiteWorkspace.before_all.command ?? suiteWorkspace.before_all.script ?? []).join(' ');
+    setupLog(
+      `running shared before_all in cwd=${suiteWorkspace.before_all.cwd ?? evalDir} command=${beforeAllCommand}`,
+    );
     const scriptContext: ScriptExecutionContext = {
       workspacePath: sharedWorkspacePath,
       testId: '__before_all__',
@@ -449,6 +466,7 @@ export async function runEvaluation(
     };
     try {
       beforeAllOutput = await executeWorkspaceScript(suiteWorkspace.before_all, scriptContext);
+      setupLog('shared before_all completed');
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (sharedWorkspacePath) {
@@ -462,8 +480,10 @@ export async function runEvaluation(
   if (sharedWorkspacePath) {
     try {
       sharedBaselineCommit = await initializeBaseline(sharedWorkspacePath);
+      setupLog(`shared baseline initialized: ${sharedBaselineCommit}`);
     } catch {
       // Non-fatal: file change tracking is best-effort
+      setupLog('shared baseline initialization skipped (non-fatal)');
     }
   }
 
@@ -952,6 +972,7 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
     repoManager,
     evalDir,
   } = options;
+  const setupDebug = process.env.AGENTV_SETUP_DEBUG === '1';
 
   const formattingMode = usesFileReferencePrompt(provider) ? 'agent' : 'lm';
   const promptInputs = await buildPromptInputs(evalCase, formattingMode);
@@ -1021,9 +1042,17 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
 
     // Materialize repos into per-case workspace
     if (evalCase.workspace?.repos?.length && workspacePath) {
-      const perCaseRepoManager = new RepoManager();
+      const perCaseRepoManager = new RepoManager(undefined, setupDebug);
       try {
+        if (setupDebug) {
+          console.log(
+            `[setup] test=${evalCase.id} materializing ${evalCase.workspace.repos.length} per-test repo(s) into ${workspacePath}`,
+          );
+        }
         await perCaseRepoManager.materializeAll(evalCase.workspace.repos, workspacePath);
+        if (setupDebug) {
+          console.log(`[setup] test=${evalCase.id} per-test repo materialization complete`);
+        }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         return buildErrorResult(
@@ -1041,6 +1070,12 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
 
     // Execute per-case before_all (only when not using shared workspace)
     if (workspacePath && evalCase.workspace?.before_all) {
+      const beforeAllCommand = (evalCase.workspace.before_all.command ?? evalCase.workspace.before_all.script ?? []).join(' ');
+      if (setupDebug) {
+        console.log(
+          `[setup] test=${evalCase.id} running before_all in cwd=${evalCase.workspace.before_all.cwd ?? evalDir} command=${beforeAllCommand}`,
+        );
+      }
       const scriptContext: ScriptExecutionContext = {
         workspacePath,
         testId: evalCase.id,
@@ -1054,6 +1089,9 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
           evalCase.workspace.before_all,
           scriptContext,
         );
+        if (setupDebug) {
+          console.log(`[setup] test=${evalCase.id} before_all completed`);
+        }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         if (forceCleanup && workspacePath) {

--- a/packages/core/src/evaluation/providers/vscode/dispatch/vscodeProcess.ts
+++ b/packages/core/src/evaluation/providers/vscode/dispatch/vscodeProcess.ts
@@ -27,15 +27,21 @@ model: Grok Code Fast 1 (copilot)
 function spawnVsCode(
   vscodeCmd: string,
   args: string[],
-  options?: { shell?: boolean },
+  options?: { shell?: boolean; label?: string },
 ): ChildProcess {
-  const child = spawn(vscodeCmd, args, {
+  const useShell = options?.shell ?? true;
+  const command = useShell ? shellQuote(vscodeCmd) : vscodeCmd;
+  const child = spawn(command, args, {
     windowsHide: true,
-    shell: options?.shell ?? true,
+    shell: useShell,
     detached: false,
   });
-  child.on('error', () => {
-    // Handled by raceSpawnError when used, or silently ignored for fire-and-forget calls
+  child.on('error', (error) => {
+    const label = options?.label ?? 'spawn';
+    const renderedArgs = args.map((value) => JSON.stringify(value)).join(' ');
+    console.error(
+      `[vscode] ${label} failed: command=${JSON.stringify(vscodeCmd)} args=${renderedArgs} error=${error.message}`,
+    );
   });
   return child;
 }
@@ -93,7 +99,8 @@ export async function ensureWorkspaceFocused(
   const alreadyOpen = await checkWorkspaceOpened(workspaceName, vscodeCmd);
 
   if (alreadyOpen) {
-    spawnVsCode(shellQuote(vscodeCmd), [workspacePath]);
+    const child = spawnVsCode(vscodeCmd, [workspacePath], { label: 'focus-existing-workspace' });
+    await raceSpawnError(child);
     return true;
   }
 
@@ -105,7 +112,10 @@ export async function ensureWorkspaceFocused(
   const wakeupDst = path.join(githubAgentsDir, 'wakeup.md');
   await writeFile(wakeupDst, DEFAULT_WAKEUP_CONTENT, 'utf8');
 
-  spawnVsCode(shellQuote(vscodeCmd), [workspacePath]);
+  const workspaceChild = spawnVsCode(vscodeCmd, [workspacePath], {
+    label: 'open-workspace',
+  });
+  await raceSpawnError(workspaceChild);
   await sleep(100);
 
   const wakeupChatId = 'wakeup';
@@ -116,7 +126,8 @@ export async function ensureWorkspaceFocused(
     wakeupChatId,
     `create a file named .alive in the ${path.basename(subagentDir)} folder`,
   ];
-  spawnVsCode(shellQuote(vscodeCmd), chatArgs);
+  const wakeupChild = spawnVsCode(vscodeCmd, chatArgs, { label: 'send-wakeup-chat' });
+  await raceSpawnError(wakeupChild);
 
   const start = Date.now();
   while (!(await pathExists(aliveFile))) {
@@ -166,7 +177,7 @@ export async function launchVsCodeWithChat(
   }
 
   await sleep(500);
-  const child = spawnVsCode(shellQuote(vscodeCmd), chatArgs);
+  const child = spawnVsCode(vscodeCmd, chatArgs, { label: 'send-chat' });
   await raceSpawnError(child);
 }
 
@@ -200,6 +211,6 @@ export async function launchVsCodeWithBatchChat(
   }
 
   await sleep(500);
-  const child = spawnVsCode(shellQuote(vscodeCmd), chatArgs);
+  const child = spawnVsCode(vscodeCmd, chatArgs, { label: 'send-batch-chat' });
   await raceSpawnError(child);
 }

--- a/packages/core/src/evaluation/workspace/repo-manager.ts
+++ b/packages/core/src/evaluation/workspace/repo-manager.ts
@@ -80,9 +80,41 @@ async function releaseLock(lockPath: string): Promise<void> {
 
 export class RepoManager {
   private readonly cacheDir: string;
+  private readonly verbose: boolean;
 
-  constructor(cacheDir?: string) {
+  constructor(cacheDir?: string, verbose = false) {
     this.cacheDir = cacheDir ?? getGitCacheRoot();
+    this.verbose = verbose;
+  }
+
+  private async runGit(
+    args: string[],
+    opts?: { cwd?: string; timeout?: number },
+  ): Promise<string> {
+    const startedAt = Date.now();
+    if (this.verbose) {
+      console.log(
+        `[repo] git start cwd=${opts?.cwd ?? process.cwd()} args=${args.join(' ')}`,
+      );
+    }
+
+    try {
+      const output = await git(args, opts);
+      if (this.verbose) {
+        console.log(
+          `[repo] git ok durationMs=${Date.now() - startedAt} args=${args.join(' ')}`,
+        );
+      }
+      return output;
+    } catch (error) {
+      if (this.verbose) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.log(
+          `[repo] git fail durationMs=${Date.now() - startedAt} args=${args.join(' ')} error=${message}`,
+        );
+      }
+      throw error;
+    }
   }
 
   /**
@@ -100,9 +132,18 @@ export class RepoManager {
     const lockPath = `${cachePath}.lock`;
     const cacheExists = existsSync(path.join(cachePath, 'HEAD'));
 
+    if (this.verbose) {
+      console.log(
+        `[repo] ensureCache source=${getSourceUrl(source)} resolve=${resolve ?? 'remote'} cache=${cachePath}`,
+      );
+    }
+
     // Local resolve: use existing cache as-is, no remote operations
     if (resolve === 'local') {
       if (cacheExists) {
+        if (this.verbose) {
+          console.log(`[repo] using existing local cache ${cachePath}`);
+        }
         return cachePath;
       }
       const url = getSourceUrl(source);
@@ -112,17 +153,29 @@ export class RepoManager {
     }
 
     await mkdir(this.cacheDir, { recursive: true });
+    const lockStartedAt = Date.now();
     await acquireLock(lockPath);
+    if (this.verbose) {
+      console.log(
+        `[repo] lock acquired path=${lockPath} waitedMs=${Date.now() - lockStartedAt}`,
+      );
+    }
 
     try {
       if (cacheExists) {
+        if (this.verbose) {
+          console.log(`[repo] refreshing existing cache ${cachePath}`);
+        }
         // Cache exists — fetch updates
         const fetchArgs = ['fetch', '--prune'];
         if (depth) {
           fetchArgs.push('--depth', String(depth));
         }
-        await git(fetchArgs, { cwd: cachePath });
+        await this.runGit(fetchArgs, { cwd: cachePath });
       } else {
+        if (this.verbose) {
+          console.log(`[repo] creating new cache ${cachePath}`);
+        }
         // Clone as bare mirror
         const cloneArgs = ['clone', '--mirror', '--bare'];
         if (depth) {
@@ -132,10 +185,13 @@ export class RepoManager {
         const sourceUrl = getSourceUrl(source);
         const cloneUrl = depth && source.type === 'local' ? `file://${sourceUrl}` : sourceUrl;
         cloneArgs.push(cloneUrl, cachePath);
-        await git(cloneArgs);
+        await this.runGit(cloneArgs);
       }
     } finally {
       await releaseLock(lockPath);
+      if (this.verbose) {
+        console.log(`[repo] lock released path=${lockPath}`);
+      }
     }
 
     return cachePath;
@@ -147,6 +203,12 @@ export class RepoManager {
    */
   async materialize(repo: RepoConfig, workspacePath: string): Promise<void> {
     const targetDir = path.join(workspacePath, repo.path);
+    const startedAt = Date.now();
+    if (this.verbose) {
+      console.log(
+        `[repo] materialize start path=${repo.path} source=${getSourceUrl(repo.source)} workspace=${workspacePath}`,
+      );
+    }
     const cachePath = await this.ensureCache(
       repo.source,
       repo.clone?.depth,
@@ -169,12 +231,12 @@ export class RepoManager {
     const cloneUrl = repo.clone?.depth || repo.clone?.filter ? `file://${cachePath}` : cachePath;
     cloneArgs.push(cloneUrl, targetDir);
 
-    await git(cloneArgs);
+    await this.runGit(cloneArgs);
 
     // Sparse checkout setup (before actual checkout)
     if (repo.clone?.sparse?.length) {
-      await git(['sparse-checkout', 'init', '--cone'], { cwd: targetDir });
-      await git(['sparse-checkout', 'set', ...repo.clone.sparse], { cwd: targetDir });
+      await this.runGit(['sparse-checkout', 'init', '--cone'], { cwd: targetDir });
+      await this.runGit(['sparse-checkout', 'set', ...repo.clone.sparse], { cwd: targetDir });
     }
 
     // Resolve ref
@@ -186,7 +248,7 @@ export class RepoManager {
       // Resolve via ls-remote for remote refs
       const url = getSourceUrl(repo.source);
       try {
-        const lsOutput = await git(['ls-remote', url, ref]);
+      const lsOutput = await this.runGit(['ls-remote', url, ref]);
         const match = lsOutput.split('\t')[0];
         if (!match) {
           throw new Error(`Ref '${ref}' not found on remote ${url}`);
@@ -203,20 +265,29 @@ export class RepoManager {
     }
 
     // Checkout
-    await git(['checkout', resolvedSha], { cwd: targetDir });
+    if (this.verbose) {
+      console.log(
+        `[repo] checkout path=${repo.path} ref=${ref} resolved=${resolvedSha} resolve=${resolve}`,
+      );
+    }
+    await this.runGit(['checkout', resolvedSha], { cwd: targetDir });
 
     // Walk ancestors if requested
     const ancestor = repo.checkout?.ancestor ?? 0;
     if (ancestor > 0) {
       try {
-        const ancestorSha = await git(['rev-parse', `HEAD~${ancestor}`], { cwd: targetDir });
-        await git(['checkout', ancestorSha], { cwd: targetDir });
+        const ancestorSha = await this.runGit(['rev-parse', `HEAD~${ancestor}`], {
+          cwd: targetDir,
+        });
+        await this.runGit(['checkout', ancestorSha], { cwd: targetDir });
       } catch {
         // Try to deepen if shallow
         if (repo.clone?.depth) {
-          await git(['fetch', '--deepen', String(ancestor)], { cwd: targetDir });
-          const ancestorSha = await git(['rev-parse', `HEAD~${ancestor}`], { cwd: targetDir });
-          await git(['checkout', ancestorSha], { cwd: targetDir });
+          await this.runGit(['fetch', '--deepen', String(ancestor)], { cwd: targetDir });
+          const ancestorSha = await this.runGit(['rev-parse', `HEAD~${ancestor}`], {
+            cwd: targetDir,
+          });
+          await this.runGit(['checkout', ancestorSha], { cwd: targetDir });
         } else {
           throw new Error(
             `Cannot resolve ancestor ${ancestor} of ref '${ref}'. ` +
@@ -225,12 +296,24 @@ export class RepoManager {
         }
       }
     }
+
+    if (this.verbose) {
+      console.log(
+        `[repo] materialize done path=${repo.path} target=${targetDir} durationMs=${Date.now() - startedAt}`,
+      );
+    }
   }
 
   /** Materialize all repos into the workspace. */
   async materializeAll(repos: readonly RepoConfig[], workspacePath: string): Promise<void> {
+    if (this.verbose) {
+      console.log(`[repo] materializeAll count=${repos.length} workspace=${workspacePath}`);
+    }
     for (const repo of repos) {
       await this.materialize(repo, workspacePath);
+    }
+    if (this.verbose) {
+      console.log('[repo] materializeAll complete');
     }
   }
 
@@ -253,8 +336,8 @@ export class RepoManager {
     // strategy === 'hard'
     for (const repo of repos) {
       const targetDir = path.join(workspacePath, repo.path);
-      await git(['reset', '--hard', 'HEAD'], { cwd: targetDir });
-      await git(['clean', '-fd'], { cwd: targetDir });
+      await this.runGit(['reset', '--hard', 'HEAD'], { cwd: targetDir });
+      await this.runGit(['clean', '-fd'], { cwd: targetDir });
     }
   }
 


### PR DESCRIPTION
## Why this change was needed
Windows eval runs were failing or appearing stuck during setup for workspace-based evaluations (especially with `before_all` and large local repo materialization).

Observed issues:
- `before_all` setup could fail on Windows with `spawnSync npx.cmd EINVAL` after stdin had already been consumed.
- Setup-stage failures/slowdowns were difficult to pinpoint.
- VS Code spawn failures were not surfaced clearly enough to explain startup failures.

## What changed
- `packages/core/src/evaluation/workspace/repo-manager.ts`
  - Added verbose repo lifecycle diagnostics (cache/lock/clone/fetch/checkout/materialize timing).
  - Added a `verbose` constructor flag and centralized git execution logging.
  - Preserved existing `AGENTV_HOME`-aware cache root behavior.
- `packages/core/src/evaluation/orchestrator.ts`
  - Added setup-phase logging for shared/per-test workspace creation, repo materialization, `before_all`, and baseline init.
  - Wired debug/verbose flags into repo materialization paths.
- `packages/core/src/evaluation/providers/vscode/dispatch/vscodeProcess.ts`
  - Added labeled spawn error logging with command+args context.
  - Fail-fast on immediate VS Code spawn errors in focus/open/chat launch paths.
- `examples/features/workspace-setup-script/scripts/workspace-setup.mjs`
  - Updated Windows spawn settings to avoid inherited-stdin `EINVAL`:
    - `stdio: ['ignore', 'inherit', 'inherit']`
    - `shell: process.platform === 'win32'`
- `examples/features/workspace-setup-script/README.md`
  - Documented the Windows-specific stdin/spawn behavior and rationale.

## Validation
- `bun --filter @agentv/core typecheck` ✅
- Focused run confirms the previous path-regression is fixed.
- Full `@agentv/core` tests on this Windows runner still include an existing OS-specific failure in `repo-manager.test.ts` due to use of `execSync('ls')` (not introduced by this PR).

## Notes
This PR is intentionally scoped to setup reliability + diagnostics and does not alter evaluator semantics.