### PR TITLE
docs(claude): require worktree .env preflight for eval/e2e

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,10 +131,19 @@ Use `agent-browser` for visual verification of docs site changes. Environment-sp
 
 Unit tests alone are insufficient for evaluator changes. After implementing or modifying evaluators:
 
+0. **Preflight (MUST pass before any eval/e2e run):** if you are in a git worktree, ensure a `.env` file exists in the current worktree root.
+   - Linux/macOS check: `test -f .env`
+   - Windows PowerShell check: `Test-Path .env`
+   - If missing, copy it from the main repo before running evals.
+
 1. **Copy `.env` to the worktree** if running in a git worktree (e2e tests need environment variables):
    ```bash
    cp /path/to/main/.env .env
    ```
+   ```powershell
+   Copy-Item D:/path/to/main/.env .env
+   ```
+   Do not claim e2e or evaluator verification results unless this preflight has passed.
 
 2. **Run an actual eval** with a real example file:
    ```bash


### PR DESCRIPTION
## Summary
Clarifies evaluator verification instructions so AI agents and contributors do not miss `.env` setup in worktrees.

## Changes
- Added **Step 0 preflight** in `Verifying Evaluator Changes` requiring `.env` presence before any eval/e2e run.
- Added explicit Linux/macOS and Windows checks:
  - `test -f .env`
  - `Test-Path .env`
- Added Windows copy command alongside existing `cp` example.
- Added explicit guidance: do not claim e2e/evaluator verification unless preflight passes.

## Why
Recent evaluator runs failed in worktrees with `GOOGLE_GENERATIVE_AI_API_KEY ... is not set` despite valid keys in the main repo `.env`, because `.env` had not been copied into the worktree.