### PR TITLE
fix(core): handle malformed JSON in all LLM judge modes

### DIFF
--- a/packages/core/src/evaluation/evaluators/llm-judge.ts
+++ b/packages/core/src/evaluation/evaluators/llm-judge.ts
@@ -219,26 +219,39 @@ export class LlmJudgeEvaluator implements Evaluator {
       target: judgeProvider.targetName,
     };
 
-    const { data, tokenUsage } = await this.runWithRetry({
-      context,
-      judgeProvider,
-      systemPrompt,
-      userPrompt: prompt,
-      schema: rubricEvaluationSchema,
-    });
+    try {
+      const { data, tokenUsage } = await this.runWithRetry({
+        context,
+        judgeProvider,
+        systemPrompt,
+        userPrompt: prompt,
+        schema: rubricEvaluationSchema,
+      });
 
-    const { score, verdict, hits, misses } = calculateRubricScore(data, rubrics);
+      const { score, verdict, hits, misses } = calculateRubricScore(data, rubrics);
 
-    return {
-      score,
-      verdict,
-      hits,
-      misses,
-      expectedAspectCount: rubrics.length,
-      reasoning: data.overall_reasoning,
-      evaluatorRawRequest,
-      tokenUsage,
-    };
+      return {
+        score,
+        verdict,
+        hits,
+        misses,
+        expectedAspectCount: rubrics.length,
+        reasoning: data.overall_reasoning,
+        evaluatorRawRequest,
+        tokenUsage,
+      };
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      return {
+        score: 0,
+        verdict: 'skip' as const,
+        hits: [],
+        misses: [`Judge parse failure after 3 attempts: ${message}`],
+        expectedAspectCount: rubrics.length,
+        reasoning: `Judge parse failure after 3 attempts: ${message}`,
+        evaluatorRawRequest,
+      };
+    }
   }
 
   /**
@@ -259,27 +272,40 @@ export class LlmJudgeEvaluator implements Evaluator {
       target: judgeProvider.targetName,
     };
 
-    const { data, tokenUsage } = await this.runWithRetry({
-      context,
-      judgeProvider,
-      systemPrompt,
-      userPrompt: prompt,
-      schema: scoreRangeEvaluationSchema,
-    });
+    try {
+      const { data, tokenUsage } = await this.runWithRetry({
+        context,
+        judgeProvider,
+        systemPrompt,
+        userPrompt: prompt,
+        schema: scoreRangeEvaluationSchema,
+      });
 
-    const { score, verdict, hits, misses, details } = calculateScoreRangeResult(data, rubrics);
+      const { score, verdict, hits, misses, details } = calculateScoreRangeResult(data, rubrics);
 
-    return {
-      score,
-      verdict,
-      hits,
-      misses,
-      expectedAspectCount: rubrics.length,
-      reasoning: data.overall_reasoning,
-      evaluatorRawRequest,
-      details,
-      tokenUsage,
-    };
+      return {
+        score,
+        verdict,
+        hits,
+        misses,
+        expectedAspectCount: rubrics.length,
+        reasoning: data.overall_reasoning,
+        evaluatorRawRequest,
+        details,
+        tokenUsage,
+      };
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      return {
+        score: 0,
+        verdict: 'skip' as const,
+        hits: [],
+        misses: [`Judge parse failure after 3 attempts: ${message}`],
+        expectedAspectCount: rubrics.length,
+        reasoning: `Judge parse failure after 3 attempts: ${message}`,
+        evaluatorRawRequest,
+      };
+    }
   }
 
   /**

--- a/packages/core/test/evaluation/evaluators.test.ts
+++ b/packages/core/test/evaluation/evaluators.test.ts
@@ -435,6 +435,73 @@ describe('LlmJudgeEvaluator', () => {
     expect(result.evaluatorRawRequest?.userPrompt).toContain(flatQuestion);
     expect(result.evaluatorRawRequest?.userPrompt).not.toContain('@[User]:');
   });
+
+  it('returns skip verdict when rubric mode receives malformed JSON', async () => {
+    const judgeProvider = new StubProvider(textResponse('not valid json at all'));
+
+    const evaluator = new LlmJudgeEvaluator({
+      resolveJudgeProvider: async () => judgeProvider,
+    });
+
+    const result = await evaluator.evaluate({
+      evalCase: { ...baseTestCase, evaluator: 'llm-judge' },
+      candidate: 'Answer',
+      target: baseTarget,
+      provider: judgeProvider,
+      attempt: 0,
+      promptInputs: { question: '', guidelines: '' },
+      now: new Date(),
+      evaluator: {
+        name: 'rubric',
+        type: 'llm-judge',
+        rubrics: [{ id: 'r1', outcome: 'Mentions logging', weight: 1.0, required: false }],
+      },
+    });
+
+    expect(result.score).toBe(0);
+    expect(result.verdict).toBe('skip');
+    expect(result.misses.length).toBeGreaterThan(0);
+    expect(result.misses[0]).toContain('Judge parse failure');
+  });
+
+  it('returns skip verdict when score-range rubric mode receives malformed JSON', async () => {
+    const judgeProvider = new StubProvider(textResponse('truncated {'));
+
+    const evaluator = new LlmJudgeEvaluator({
+      resolveJudgeProvider: async () => judgeProvider,
+    });
+
+    const result = await evaluator.evaluate({
+      evalCase: { ...baseTestCase, evaluator: 'llm-judge' },
+      candidate: 'Answer',
+      target: baseTarget,
+      provider: judgeProvider,
+      attempt: 0,
+      promptInputs: { question: '', guidelines: '' },
+      now: new Date(),
+      evaluator: {
+        name: 'rubric',
+        type: 'llm-judge',
+        rubrics: [
+          {
+            id: 'r1',
+            outcome: 'Completeness',
+            weight: 1.0,
+            required: false,
+            score_ranges: [
+              { score_range: [0, 3] as [number, number], outcome: 'Poor' },
+              { score_range: [7, 10] as [number, number], outcome: 'Good' },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(result.score).toBe(0);
+    expect(result.verdict).toBe('skip');
+    expect(result.misses.length).toBeGreaterThan(0);
+    expect(result.misses[0]).toContain('Judge parse failure');
+  });
 });
 
 describe('CodeEvaluator', () => {


### PR DESCRIPTION
## Summary

Fixes #480 — LLM judge crashes on malformed JSON responses.

The freeform evaluation path already had graceful error handling (try/catch around `runWithRetry`), but the rubric and score-range paths were missing it. When an LLM returned malformed JSON for rubric-based evaluations, the error propagated up and crashed the entire eval run.

- Added try/catch to `evaluateWithRubrics()` and `evaluateWithScoreRanges()` to match the existing pattern in `evaluateFreeform()`
- All three LLM judge modes now return a graceful `skip` verdict with `score: 0` instead of crashing
- Added 2 tests confirming skip verdict for malformed JSON in both rubric modes

Closes #480

## Test plan

- [x] New test: rubric mode returns skip verdict on malformed JSON
- [x] New test: score-range rubric mode returns skip verdict on malformed JSON
- [x] All 888 existing tests pass
- [x] Pre-push hooks pass (build, typecheck, lint, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)