### PR TITLE
docs: document criteria and assert interaction behavior

### DIFF
--- a/apps/web/src/content/docs/evaluation/eval-cases.mdx
+++ b/apps/web/src/content/docs/evaluation/eval-cases.mdx
@@ -245,6 +245,47 @@ Required gates are evaluated after all evaluators run. If any required evaluator
 - Suite-level `assert` evaluators are appended automatically.
 - Set `execution.skip_defaults: true` on a test to skip suite-level defaults.
 
+## How `criteria` and `assert` Interact
+
+The `criteria` field is a **data field** that describes what the response should accomplish. It is not an evaluator itself — how it gets used depends on whether `assert` is present.
+
+### No `assert` — implicit LLM judge
+
+When a test has no `assert` field, a default `llm-judge` evaluator runs automatically and uses `criteria` as the evaluation prompt:
+
+```yaml
+tests:
+  - id: simple-eval
+    criteria: Assistant correctly explains the bug and proposes a fix
+    input: "Debug this function..."
+    # No assert → default llm-judge evaluates against criteria
+```
+
+### `assert` present — explicit evaluators only
+
+When `assert` is defined, only the declared evaluators run. No implicit judge is added. Judges that are declared (such as `llm-judge`, `code-judge`, `agent-judge`, or `rubrics`) receive `criteria` as input automatically.
+
+If `assert` contains only deterministic evaluators (like `contains` or `regex`), the `criteria` field is not evaluated and a warning is emitted:
+
+```
+Warning: Test 'my-test': criteria is defined but no evaluator in assert
+will evaluate it. Add 'type: llm-judge' to assert, or remove criteria
+if it is documentation-only.
+```
+
+To use `criteria` alongside deterministic checks, add a judge explicitly:
+
+```yaml
+tests:
+  - id: mixed-eval
+    criteria: Response is helpful and mentions the fix
+    input: "Debug this function..."
+    assert:
+      - type: llm-judge        # explicit — receives criteria automatically
+      - type: contains
+        value: "fix"
+```
+
 ## Sidecar Metadata
 
 Pass additional context to evaluators via the `sidecar` field:

--- a/apps/web/src/content/docs/evaluators/llm-judges.mdx
+++ b/apps/web/src/content/docs/evaluators/llm-judges.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 LLM judges use a language model to evaluate agent responses against custom criteria defined in a prompt file.
 
+## Default Judge
+
+When a test defines `criteria` but has **no `assert` field**, a default `llm-judge` runs automatically. The built-in prompt evaluates the response against your `criteria` and `expected_output`:
+
+```yaml
+tests:
+  - id: simple-eval
+    criteria: Correctly explains the bug and proposes a fix
+    input: "Debug this function..."
+    # No assert needed — default llm-judge evaluates against criteria
+```
+
+When `assert` **is** present, no default judge is added. To use an LLM judge alongside other evaluators, declare it explicitly. See [How criteria and assert interact](/evaluation/eval-cases/#how-criteria-and-assert-interact).
+
 ## Configuration
 
 Reference an LLM judge in your eval file:

--- a/plugins/agentv-dev/skills/agentv-eval-builder/SKILL.md
+++ b/plugins/agentv-dev/skills/agentv-eval-builder/SKILL.md
@@ -131,9 +131,19 @@ tests:
 
 `execution.evaluators` is deprecated. When both `assert` and `execution.evaluators` are present, `assert` takes precedence.
 
-## Default Evaluation (no assert)
+## How `criteria` and `assert` Interact
 
-When a test has **no `assert` field**, a default `llm-judge` evaluator runs automatically against the `criteria` field. This is the zero-config path for simple evaluations:
+`criteria` is a **data field** — it describes what the response should accomplish. It is **not** an evaluator. How it gets evaluated depends on whether `assert` is present:
+
+| Scenario | What happens | Warning? |
+|----------|-------------|----------|
+| `criteria` + **no `assert`** | Implicit `llm-judge` runs automatically against `criteria` | No |
+| `criteria` + **`assert` with only deterministic evaluators** (contains, regex, etc.) | Only declared evaluators run. `criteria` is **not evaluated**. | Yes — warns that no evaluator will consume criteria |
+| `criteria` + **`assert` with a judge** (llm-judge, code-judge, agent-judge, rubrics) | Declared evaluators run. Judges receive `criteria` as input. | No |
+
+### No assert → implicit llm-judge
+
+The simplest path. `criteria` is automatically evaluated by the default `llm-judge`:
 
 ```yaml
 tests:
@@ -143,7 +153,9 @@ tests:
     # No assert → default llm-judge evaluates against criteria
 ```
 
-When `assert` **is** present, only the declared evaluators run — no default judge is added. If you want an LLM judge alongside deterministic checks, declare it explicitly:
+### assert present → no implicit judge
+
+When `assert` is defined, **only the declared evaluators run**. If you want an LLM judge alongside deterministic checks, declare it explicitly:
 
 ```yaml
 tests:
@@ -154,6 +166,19 @@ tests:
       - type: llm-judge        # must be explicit when assert is present
       - type: contains
         value: "fix"
+```
+
+**Common mistake:** defining `criteria` with only deterministic evaluators. The criteria will be ignored and a warning is emitted:
+
+```yaml
+tests:
+  - id: bad-example
+    criteria: Gives a thoughtful answer    # ⚠ NOT evaluated — no judge in assert
+    input: "What is 2+2?"
+    assert:
+      - type: contains
+        value: "4"
+    # Warning: criteria is defined but no evaluator in assert will evaluate it.
 ```
 
 ## Required Gates


### PR DESCRIPTION
## Summary

- Documents the three scenarios for how `criteria` interacts with `assert` in eval files
- Updates the AI skill reference (SKILL.md) with a behavior table and common mistake example
- Adds a "How criteria and assert interact" section to the eval-cases docs page
- Adds a "Default Judge" section to the llm-judges docs page

## Context

E2E testing confirmed the current behavior:

| Scenario | What happens | Warning? |
|----------|-------------|----------|
| `criteria` + no `assert` | Implicit `llm-judge` runs against criteria | No |
| `criteria` + deterministic `assert` only | Only declared evaluators run, criteria ignored | Yes |
| `criteria` + judge in `assert` | Declared judges receive criteria as input | No |

This behavior was established in #453 but wasn't fully documented.

## Test plan

- [x] Build passes
- [x] Typecheck passes
- [x] Lint passes
- [x] All tests pass
- [ ] Review docs site rendering at preview URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)