### PR TITLE
fix(vscode-eval): remove file-change reporting instructions from response templates

### DIFF
--- a/packages/core/src/evaluation/providers/vscode-templates.ts
+++ b/packages/core/src/evaluation/providers/vscode-templates.ts
@@ -11,8 +11,6 @@ export const AGENTV_REQUEST_TEMPLATE = `[[ ## task ## ]]
 
 **IMPORTANT**: Follow these exact steps:
 1. Create and write your complete response to: {{responseFileTmp}}
-    - All intended file outputs/changes MUST be written in your response file.
-    - For each intended file, include the repo name, relative path and unified git diff following the convention \`diff --git ...\`.
 2. When completely finished, run these PowerShell commands to signal completion:
 \`\`\`
 Move-Item -LiteralPath '{{responseFileTmp}}' -Destination '{{responseFileFinal}}'
@@ -30,8 +28,6 @@ export const AGENTV_BATCH_REQUEST_TEMPLATE = `[[ ## task ## ]]
 
 **IMPORTANT**: Follow these exact steps:
 1. Create and write your complete response to: {{responseFileTmp}}
-    - All intended file outputs/changes MUST be written in your response file.
-    - For each intended file, include the repo name, relative path and unified git diff following the convention \`diff --git ...\`.
 2. When completely finished and the response is stable, rename it to: {{responseFileFinal}}
 3. Do not unlock the workspace from this request; batch orchestration will handle unlocking after all responses are ready.
 `;


### PR DESCRIPTION
## Summary
- Remove sub-bullets from `AGENTV_REQUEST_TEMPLATE` and `AGENTV_BATCH_REQUEST_TEMPLATE` that asked subagents to list file outputs/changes and inline unified diffs in the response file
- AgentV already captures workspace diffs into `file_changes` automatically — these instructions were redundant, encouraged oversized responses, and increased timeout risk
- Add regression tests covering all 4 template exports (both `vscode-templates.ts` and `vscode/dispatch/templates.ts`)

Closes #473

## Test plan
- [x] Unit tests assert no `file_changes` or `diff --git` instructions in any template
- [x] All pre-push hooks pass (build, typecheck, lint, test)
- [ ] Red/green team e2e manual validation with VS Code eval

🤖 Generated with [Claude Code](https://claude.com/claude-code)