### PR TITLE
fix: log LLM judge failures as stderr warnings

### DIFF
--- a/packages/core/src/evaluation/evaluators/llm-judge.ts
+++ b/packages/core/src/evaluation/evaluators/llm-judge.ts
@@ -180,6 +180,8 @@ export class LlmJudgeEvaluator implements Evaluator {
       // Judge parse failure → skip (not silent zero).
       // Signals infrastructure error to downstream consumers, excluded from score averages.
       const message = e instanceof Error ? e.message : String(e);
+      const evalName = context.evaluator?.name ?? 'llm-judge';
+      console.warn(`⚠ LLM judge "${evalName}" failed after 3 attempts (${message}) — skipped`);
       return {
         score: 0,
         verdict: 'skip' as const,
@@ -242,6 +244,8 @@ export class LlmJudgeEvaluator implements Evaluator {
       };
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
+      const evalName = context.evaluator?.name ?? 'llm-judge';
+      console.warn(`⚠ LLM judge "${evalName}" failed after 3 attempts (${message}) — skipped`);
       return {
         score: 0,
         verdict: 'skip' as const,
@@ -296,6 +300,8 @@ export class LlmJudgeEvaluator implements Evaluator {
       };
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
+      const evalName = context.evaluator?.name ?? 'llm-judge';
+      console.warn(`⚠ LLM judge "${evalName}" failed after 3 attempts (${message}) — skipped`);
       return {
         score: 0,
         verdict: 'skip' as const,

--- a/packages/core/test/evaluation/evaluators.test.ts
+++ b/packages/core/test/evaluation/evaluators.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, spyOn } from 'bun:test';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -501,6 +501,61 @@ describe('LlmJudgeEvaluator', () => {
     expect(result.verdict).toBe('skip');
     expect(result.misses.length).toBeGreaterThan(0);
     expect(result.misses[0]).toContain('Judge parse failure');
+  });
+
+  it('emits stderr warning on judge parse failure', async () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+
+    const judgeProvider = new StubProvider(textResponse('not valid json at all'));
+
+    const evaluator = new LlmJudgeEvaluator({
+      resolveJudgeProvider: async () => judgeProvider,
+    });
+
+    await evaluator.evaluate({
+      evalCase: { ...baseTestCase, evaluator: 'llm-judge' },
+      candidate: 'Answer',
+      target: baseTarget,
+      provider: judgeProvider,
+      attempt: 0,
+      promptInputs: { question: '', guidelines: '' },
+      now: new Date(),
+      evaluator: {
+        name: 'my-custom-judge',
+        type: 'llm-judge',
+      },
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('LLM judge');
+    expect(warnSpy.mock.calls[0][0]).toContain('my-custom-judge');
+    expect(warnSpy.mock.calls[0][0]).toContain('skipped');
+    warnSpy.mockRestore();
+  });
+
+  it('emits stderr warning with default name when evaluator name is not set', async () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+
+    const judgeProvider = new StubProvider(textResponse('garbage'));
+
+    const evaluator = new LlmJudgeEvaluator({
+      resolveJudgeProvider: async () => judgeProvider,
+    });
+
+    await evaluator.evaluate({
+      evalCase: { ...baseTestCase, evaluator: 'llm-judge' },
+      candidate: 'Answer',
+      target: baseTarget,
+      provider: judgeProvider,
+      attempt: 0,
+      promptInputs: { question: '', guidelines: '' },
+      now: new Date(),
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('llm-judge');
+    expect(warnSpy.mock.calls[0][0]).toContain('skipped');
+    warnSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary

- Add `console.warn` in all 3 catch blocks of `llm-judge.ts` that produce skip verdicts
- Warning format: `⚠ LLM judge "<name>" failed after 3 attempts (<reason>) — skipped`
- Includes evaluator name (from `context.evaluator?.name`, falls back to `'llm-judge'`)

Fixes #485

## Red-green verification

**RED (main):** LLM judge parse failure produces `verdict: 'skip'` silently — no stderr output
**GREEN (fix):** Warning emitted to stderr with evaluator name and reason

## Test plan

- [x] 2 new tests added (custom evaluator name in warning, default name fallback)
- [x] All 41 tests pass (39 existing + 2 new)
- [x] CI passes (build, typecheck, lint, test)
- [ ] Manual verification: run eval with a judge that returns malformed JSON, confirm warning appears in terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>