### PR TITLE
refactor(core): remove on_reuse/on_finish hooks and rename lifecycle hooks

### DIFF
--- a/apps/web/src/content/docs/evaluation/eval-cases.mdx
+++ b/apps/web/src/content/docs/evaluation/eval-cases.mdx
@@ -120,7 +120,7 @@ Override the suite-level workspace config for individual tests. Test-level field
 ```yaml
 workspace:
   hooks:
-    before_all_tests:
+    before_all:
       command: ["bun", "run", "default-setup.ts"]
 
 tests:
@@ -129,13 +129,13 @@ tests:
     input: Do something
     workspace:
       hooks:
-        before_all_tests:
+        before_all:
           command: ["bun", "run", "custom-setup.ts"]
 
   - id: case-2
     criteria: Should also work
     input: Do something else
-    # Inherits suite-level hooks.before_all_tests
+    # Inherits suite-level hooks.before_all
 ```
 
 See [Workspace Lifecycle Hooks](/targets/configuration/#workspace-lifecycle-hooks) for the full workspace config reference.
@@ -154,7 +154,7 @@ tests:
       base_commit: "abc123def"
     workspace:
       hooks:
-        before_all_tests:
+        before_all:
           command: ["python", "checkout_repo.py"]
 ```
 

--- a/apps/web/src/content/docs/evaluation/running-evals.mdx
+++ b/apps/web/src/content/docs/evaluation/running-evals.mdx
@@ -98,19 +98,14 @@ workspace:
   mode: pooled           # pooled | ephemeral | static
   static_path: null      # required when mode=static
   hooks:
-    on_reuse:
+    after_each:
       reset: fast        # none | fast | strict
-    after_each_test:
-      reset: fast        # none | fast | strict
-    on_finish:
-      clean: on_success  # always | on_success | on_failure | never
 ```
 
 Notes:
 - Pooling is default for shared workspaces with repos when mode is not specified.
 - `mode: static` (or `--workspace-mode static`) requires `static_path` / `--workspace-path`.
 - Static mode is incompatible with `isolation: per_test`.
-- `hooks.on_finish.clean` controls temp eval-run workspace cleanup under `~/.agentv/workspaces/...`.
 - Pool slots are managed separately (`agentv workspace list|clean`).
 
 ### Retry Execution Errors

--- a/apps/web/src/content/docs/guides/workspace-pool.mdx
+++ b/apps/web/src/content/docs/guides/workspace-pool.mdx
@@ -59,18 +59,10 @@ workspace:
 
 By default, pool reset uses `git clean -fd` which **preserves `.gitignore`d files** like `node_modules/`, `build/`, and compiled binaries. This means `before_all` build steps survive across reuse cycles.
 
-For strict reset that also removes `.gitignore`d files, set `workspace.hooks.on_reuse.reset: strict`:
+For strict reset that also removes `.gitignore`d files, use the `--workspace-clean full` CLI flag:
 
-```yaml
-workspace:
-  hooks:
-    on_reuse:
-      reset: strict
-  repos:
-    - path: ./my-repo
-      source:
-        type: git
-        url: https://github.com/org/my-repo.git
+```bash
+agentv eval evals/my-eval.yaml --workspace-clean full
 ```
 
 | Mode | Git command | `.gitignore`d files | Use case |
@@ -109,7 +101,7 @@ repos:
     checkout:
       ref: main
 hooks:
-  after_each_test:
+  after_each:
     reset: fast
 ```
 
@@ -188,7 +180,7 @@ This bypasses clone, copy, and pool entirely. AgentV never deletes a user-provid
 
 ## Interaction with keep/cleanup flags
 
-`workspace.hooks.on_finish.clean` (or CLI `--retain-on-success` / `--retain-on-failure`) controls temporary eval-run workspaces under `~/.agentv/workspaces/...` (non-pooled paths).
+CLI flags `--retain-on-success` / `--retain-on-failure` control temporary eval-run workspaces under `~/.agentv/workspaces/...` (non-pooled paths).
 
 - In pooled mode, pool slots are retained for reuse regardless of retention settings.
 - Retention settings do not remove pool entries; use `agentv workspace clean` for pool cleanup.

--- a/apps/web/src/content/docs/targets/configuration.mdx
+++ b/apps/web/src/content/docs/targets/configuration.mdx
@@ -101,7 +101,7 @@ targets:
 When `workspace_template` is set:
 - The template directory is copied to `~/.agentv/workspaces/<eval-run-id>/shared/`
 - The `.git` directory is skipped during copy
-- Tests share the workspace; use `hooks.after_each_test` to reset state between tests
+- Tests share the workspace; use `hooks.after_each` to reset state between tests
 
 ### Workspace Lifecycle Hooks
 
@@ -111,32 +111,26 @@ Run commands and reset/cleanup policies at different lifecycle points using `wor
 workspace:
   template: ./workspace-templates/my-project
   hooks:
-    before_all_tests:
+    before_all:
       command: ["bun", "run", "setup.ts"]
       timeout_ms: 120000
       cwd: ./scripts
-    after_each_test:
+    after_each:
       command: ["bun", "run", "reset.ts"]
       timeout_ms: 5000
       reset: fast
-    after_all_tests:
+    after_all:
       command: ["bun", "run", "cleanup.ts"]
       timeout_ms: 30000
-    on_reuse:
-      reset: fast
-    on_finish:
-      clean: on_success
 ```
 
 | Field | Description |
 |-------|-------------|
 | `template` | Directory to copy as workspace (alternative to target-level `workspace_template`) |
-| `hooks.before_all_tests` | Runs once after workspace creation, before the first test |
-| `hooks.after_all_tests` | Runs once after the last test, before cleanup |
-| `hooks.before_each_test` | Runs before each test |
-| `hooks.after_each_test` | Runs after each test (supports both `command` and `reset`) |
-| `hooks.on_reuse` | Runs when a pooled workspace slot is reused |
-| `hooks.on_finish` | Controls final cleanup behavior |
+| `hooks.before_all` | Runs once after workspace creation, before the first test |
+| `hooks.after_all` | Runs once after the last test, before cleanup |
+| `hooks.before_each` | Runs before each test |
+| `hooks.after_each` | Runs after each test (supports both `command` and `reset`) |
 
 Each hook config accepts:
 
@@ -148,13 +142,13 @@ Each hook config accepts:
 | `timeout_ms` | Timeout in milliseconds (default: 60000 for setup hooks, 30000 for teardown hooks) |
 | `cwd` | Working directory (relative paths resolved against eval file directory) |
 
-**Lifecycle order:** template copy → `hooks.before_all_tests` → git baseline → (`hooks.before_each_test` → agent runs → file changes captured → `hooks.after_each_test`) × N tests → `hooks.after_all_tests` → cleanup
+**Lifecycle order:** template copy → `hooks.before_all` → git baseline → (`hooks.before_each` → agent runs → file changes captured → `hooks.after_each`) × N tests → `hooks.after_all` → cleanup
 
-**Shared workspace:** The workspace is created once and shared across all tests in a suite. Use `hooks.after_each_test.reset` to reset state between tests (e.g., `fast`/`strict`).
+**Shared workspace:** The workspace is created once and shared across all tests in a suite. Use `hooks.after_each.reset` to reset state between tests (e.g., `fast`/`strict`).
 
 **Error handling:**
-- `hooks.before_all_tests` / `hooks.before_each_test` command failure aborts the test with an error result
-- `hooks.after_all_tests` / `hooks.after_each_test` command failure is non-fatal (warning only)
+- `hooks.before_all` / `hooks.before_each` command failure aborts the test with an error result
+- `hooks.after_all` / `hooks.after_each` command failure is non-fatal (warning only)
 
 **Script context:** All scripts receive a JSON object on stdin with case context:
 
@@ -191,12 +185,8 @@ workspace:
         type: local
         path: /home/user/projects/my-project
   hooks:
-    after_each_test:
+    after_each:
       reset: fast             # none | fast | strict
-    on_reuse:
-      reset: fast             # none | fast | strict
-    on_finish:
-      clean: on_success       # always | on_success | on_failure | never
   isolation: shared           # shared (default) | per_test
   mode: pooled                # pooled | ephemeral | static
   static_path: /tmp/my-ws     # required when mode=static
@@ -212,12 +202,10 @@ workspace:
 | `repos[].clone.depth` | Shallow clone depth |
 | `repos[].clone.filter` | Partial clone filter (e.g., `blob:none`) |
 | `repos[].clone.sparse` | Sparse checkout paths |
-| `hooks.after_each_test.reset` | Reset policy after each test: `none`, `fast`, `strict` |
+| `hooks.after_each.reset` | Reset policy after each test: `none`, `fast`, `strict` |
 | `isolation` | `shared` reuses one workspace; `per_test` creates a fresh copy per test |
 | `mode` | Workspace mode: `pooled`, `ephemeral`, `static` |
 | `static_path` | Existing workspace path used when `mode=static` |
-| `hooks.on_reuse.reset` | Pooled workspace slot reset policy on reuse: `none`, `fast` (`git clean -fd`), `strict` (`git clean -fdx`) |
-| `hooks.on_finish.clean` | Temp workspace cleanup policy: `always`, `on_success`, `on_failure`, `never` |
 
 **Pooling:** `mode: pooled` (or default shared repo mode) reuses pool slots between runs. Use `mode: ephemeral` to disable pooling for fresh clone/checkouts each run.
 
@@ -248,7 +236,7 @@ workspace:
     - path: ./backend
       source: { type: git, url: https://github.com/org/backend.git }
   hooks:
-    after_each_test:
+    after_each:
       reset: fast
 ```
 
@@ -257,9 +245,6 @@ workspace:
 Default finish behavior:
 - **Success**: cleanup
 - **Failure**: keep
-
-Override with workspace finish policy:
-- `hooks.on_finish.clean: always|on_success|on_failure|never`
 
 CLI overrides:
 - `--retain-on-success keep|cleanup`

--- a/examples/features/repo-lifecycle/evals/pool-e2e.eval.yaml
+++ b/examples/features/repo-lifecycle/evals/pool-e2e.eval.yaml
@@ -4,9 +4,6 @@ description: >-
 
 workspace:
   mode: pooled
-  hooks:
-    on_reuse:
-      reset: fast
   repos:
     - path: ./repo
       source:

--- a/examples/features/workspace-multi-repo/evals/dataset.eval.yaml
+++ b/examples/features/workspace-multi-repo/evals/dataset.eval.yaml
@@ -6,7 +6,7 @@ description: >-
 workspace:
   template: ../workspace-template
   hooks:
-    after_each_test:
+    after_each:
       reset: fast
   repos:
     - path: ./agentv

--- a/examples/features/workspace-setup-script/README.md
+++ b/examples/features/workspace-setup-script/README.md
@@ -49,7 +49,7 @@ The template path is passed as an argument. Use `--require` to validate that exp
 workspace:
   template: ./workspace-template
   hooks:
-    before_all_tests:
+    before_all:
       command:
         - node
         - ../scripts/workspace-setup.mjs

--- a/examples/features/workspace-setup-script/evals/dataset-vscode.eval.yaml
+++ b/examples/features/workspace-setup-script/evals/dataset-vscode.eval.yaml
@@ -5,13 +5,13 @@ description: >-
 workspace:
   template: ../workspace-template
   hooks:
-    before_all_tests:
+    before_all:
       command:
         - node
         - ../scripts/workspace-setup.mjs
         - --from
         - ../workspace-template/.allagents/workspace.yaml
-    after_each_test:
+    after_each:
       reset: fast
   repos:
     - path: ./my-repo

--- a/examples/features/workspace-setup-script/evals/dataset.eval.yaml
+++ b/examples/features/workspace-setup-script/evals/dataset.eval.yaml
@@ -5,7 +5,7 @@ description: >-
 workspace:
   template: ../workspace-template
   hooks:
-    before_all_tests:
+    before_all:
       command:
         - node
         - ../scripts/workspace-setup.mjs

--- a/examples/features/workspace-setup-script/scripts/workspace-setup.mjs
+++ b/examples/features/workspace-setup-script/scripts/workspace-setup.mjs
@@ -9,7 +9,7 @@
 // Usage in eval YAML:
 //   workspace:
 //     hooks:
-//       before_all_tests:
+//       before_all:
 //         command:
 //           - node
 //           - ../scripts/workspace-setup.mjs

--- a/examples/features/workspace-shared-config/workspace.yaml
+++ b/examples/features/workspace-shared-config/workspace.yaml
@@ -1,9 +1,7 @@
 template: ./workspace-template
 mode: pooled
 hooks:
-  on_reuse:
-    reset: fast
-  after_each_test:
+  after_each:
     reset: fast
 repos:
   - path: ./agentv

--- a/examples/showcase/cross-repo-sync/evals/dataset.eval.yaml
+++ b/examples/showcase/cross-repo-sync/evals/dataset.eval.yaml
@@ -6,11 +6,11 @@ tags: [showcase, workspace, cross-repo]
 workspace:
   template: ../workspace-template
   hooks:
-    before_each_test:
+    before_each:
       command: ["bash", "../scripts/run-ts.sh", "../scripts/setup.ts"]
       timeout_ms: 900000
       cwd: .
-    after_each_test:
+    after_each:
       command: ["bash", "../scripts/run-ts.sh", "../scripts/reset.ts"]
       timeout_ms: 5000
       cwd: .

--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -478,23 +478,8 @@ export async function runEvaluation(
     !isPerTestIsolation &&
     !useStaticWorkspace;
 
-  const finishCleanPolicy = suiteWorkspace?.hooks?.on_finish?.clean;
-  const resolvedRetainOnSuccess =
-    (finishCleanPolicy === 'always' || finishCleanPolicy === 'on_success'
-      ? 'cleanup'
-      : finishCleanPolicy === 'on_failure' || finishCleanPolicy === 'never'
-        ? 'keep'
-        : undefined) ??
-    retainOnSuccess ??
-    (keepWorkspaces ? 'keep' : 'cleanup');
-  const resolvedRetainOnFailure =
-    (finishCleanPolicy === 'always' || finishCleanPolicy === 'on_failure'
-      ? 'cleanup'
-      : finishCleanPolicy === 'on_success' || finishCleanPolicy === 'never'
-        ? 'keep'
-        : undefined) ??
-    retainOnFailure ??
-    (cleanupWorkspaces ? 'cleanup' : 'keep');
+  const resolvedRetainOnSuccess = retainOnSuccess ?? (keepWorkspaces ? 'keep' : 'cleanup');
+  const resolvedRetainOnFailure = retainOnFailure ?? (cleanupWorkspaces ? 'cleanup' : 'keep');
 
   const requestedWorkers = options.maxConcurrency ?? target.workers ?? 1;
   // Pool-enabled workspaces support concurrent workers (each worker gets its own slot).
@@ -543,7 +528,6 @@ export async function runEvaluation(
         repoManager: poolRepoManager,
         poolReset:
           (workspaceClean === 'full' ? 'strict' : workspaceClean === 'standard' ? 'fast' : null) ??
-          suiteWorkspace.hooks?.on_reuse?.reset ??
           'fast',
       });
       poolSlots.push(slot);
@@ -610,7 +594,7 @@ export async function runEvaluation(
     }
 
     // Execute before_all (runs ONCE before first test per workspace)
-    const suiteBeforeAllHook = suiteWorkspace?.hooks?.before_all_tests;
+    const suiteBeforeAllHook = suiteWorkspace?.hooks?.before_all;
     if (sharedWorkspacePath && hasHookCommand(suiteBeforeAllHook)) {
       const beforeAllHook = suiteBeforeAllHook;
       const beforeAllCommand = (beforeAllHook.command ?? beforeAllHook.script ?? []).join(' ');
@@ -625,7 +609,7 @@ export async function runEvaluation(
       };
       try {
         beforeAllOutput = await executeWorkspaceScript(
-          toScriptConfig(beforeAllHook, 'before_all_tests', 'suite workspace'),
+          toScriptConfig(beforeAllHook, 'before_all', 'suite workspace'),
           scriptContext,
         );
         setupLog('shared before_all completed');
@@ -651,7 +635,7 @@ export async function runEvaluation(
         };
         try {
           const output = await executeWorkspaceScript(
-            toScriptConfig(beforeAllHook, 'before_all_tests', 'suite workspace'),
+            toScriptConfig(beforeAllHook, 'before_all', 'suite workspace'),
             scriptContext,
           );
           // Capture first slot's output for result attachment
@@ -933,7 +917,7 @@ export async function runEvaluation(
           ? [sharedWorkspacePath]
           : [];
 
-    const suiteAfterAllHook = suiteWorkspace?.hooks?.after_all_tests;
+    const suiteAfterAllHook = suiteWorkspace?.hooks?.after_all;
     if (afterAllWorkspaces.length > 0 && hasHookCommand(suiteAfterAllHook)) {
       const afterAllHook = suiteAfterAllHook;
       for (const wsPath of afterAllWorkspaces) {
@@ -945,7 +929,7 @@ export async function runEvaluation(
         };
         try {
           const afterAllOutput = await executeWorkspaceScript(
-            toScriptConfig(afterAllHook, 'after_all_tests', 'suite workspace'),
+            toScriptConfig(afterAllHook, 'after_all', 'suite workspace'),
             scriptContext,
             'warn',
           );
@@ -1312,7 +1296,7 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
     }
 
     // Execute per-case before_all (only when not using shared workspace)
-    const caseBeforeAllHook = evalCase.workspace?.hooks?.before_all_tests;
+    const caseBeforeAllHook = evalCase.workspace?.hooks?.before_all;
     if (workspacePath && hasHookCommand(caseBeforeAllHook)) {
       const beforeAllHook = caseBeforeAllHook;
       const beforeAllCommand = (beforeAllHook.command ?? beforeAllHook.script ?? []).join(' ');
@@ -1331,7 +1315,7 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
       };
       try {
         beforeAllOutput = await executeWorkspaceScript(
-          toScriptConfig(beforeAllHook, 'before_all_tests', `test '${evalCase.id}'`),
+          toScriptConfig(beforeAllHook, 'before_all', `test '${evalCase.id}'`),
           scriptContext,
         );
         if (setupDebug) {
@@ -1357,7 +1341,7 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
   }
 
   // Execute before_each hook (runs before each test for any workspace)
-  const caseBeforeEachHook = evalCase.workspace?.hooks?.before_each_test;
+  const caseBeforeEachHook = evalCase.workspace?.hooks?.before_each;
   if (workspacePath && hasHookCommand(caseBeforeEachHook)) {
     const beforeEachHook = caseBeforeEachHook;
     const scriptContext: ScriptExecutionContext = {
@@ -1370,7 +1354,7 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
     };
     try {
       beforeEachOutput = await executeWorkspaceScript(
-        toScriptConfig(beforeEachHook, 'before_each_test', `test '${evalCase.id}'`),
+        toScriptConfig(beforeEachHook, 'before_each', `test '${evalCase.id}'`),
         scriptContext,
       );
     } catch (error) {
@@ -1519,15 +1503,15 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
   if (
     repoManager &&
     workspacePath &&
-    evalCase.workspace?.hooks?.after_each_test?.reset &&
-    evalCase.workspace.hooks.after_each_test.reset !== 'none' &&
+    evalCase.workspace?.hooks?.after_each?.reset &&
+    evalCase.workspace.hooks.after_each.reset !== 'none' &&
     evalCase.workspace.repos
   ) {
     try {
       await repoManager.reset(
         evalCase.workspace.repos,
         workspacePath,
-        evalCase.workspace.hooks.after_each_test.reset,
+        evalCase.workspace.hooks.after_each.reset,
       );
     } catch {
       // Reset failures are non-fatal (like after_each)
@@ -1535,7 +1519,7 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
   }
 
   // Execute after_each hook (runs after evaluation, before cleanup)
-  const caseAfterEachHook = evalCase.workspace?.hooks?.after_each_test;
+  const caseAfterEachHook = evalCase.workspace?.hooks?.after_each;
   if (workspacePath && hasHookCommand(caseAfterEachHook)) {
     const afterEachHook = caseAfterEachHook;
     const scriptContext: ScriptExecutionContext = {
@@ -1548,7 +1532,7 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
     };
     try {
       afterEachOutput = await executeWorkspaceScript(
-        toScriptConfig(afterEachHook, 'after_each_test', `test '${evalCase.id}'`),
+        toScriptConfig(afterEachHook, 'after_each', `test '${evalCase.id}'`),
         scriptContext,
         'warn',
       );

--- a/packages/core/src/evaluation/types.ts
+++ b/packages/core/src/evaluation/types.ts
@@ -253,23 +253,17 @@ export type WorkspaceHookConfig = {
   readonly cwd?: string;
   /** Optional reset policy for this hook */
   readonly reset?: 'none' | 'fast' | 'strict';
-  /** Optional cleanup policy for this hook */
-  readonly clean?: 'always' | 'on_success' | 'on_failure' | 'never';
 };
 
 export type WorkspaceHooksConfig = {
   /** Runs once before first test in the workspace lifecycle */
-  readonly before_all_tests?: WorkspaceHookConfig;
+  readonly before_all?: WorkspaceHookConfig;
   /** Runs before each test case */
-  readonly before_each_test?: WorkspaceHookConfig;
+  readonly before_each?: WorkspaceHookConfig;
   /** Runs after each test case */
-  readonly after_each_test?: WorkspaceHookConfig;
+  readonly after_each?: WorkspaceHookConfig;
   /** Runs once after final test in the workspace lifecycle */
-  readonly after_all_tests?: WorkspaceHookConfig;
-  /** Runs when reusing a pooled workspace slot */
-  readonly on_reuse?: WorkspaceHookConfig;
-  /** Runs/controls behavior when workspace lifecycle finishes */
-  readonly on_finish?: WorkspaceHookConfig;
+  readonly after_all?: WorkspaceHookConfig;
 };
 
 export type WorkspaceConfig = {

--- a/packages/core/src/evaluation/validation/eval-file.schema.ts
+++ b/packages/core/src/evaluation/validation/eval-file.schema.ts
@@ -285,16 +285,13 @@ const WorkspaceHookSchema = z.object({
   timeoutMs: z.number().optional(),
   cwd: z.string().optional(),
   reset: z.enum(['none', 'fast', 'strict']).optional(),
-  clean: z.enum(['always', 'on_success', 'on_failure', 'never']).optional(),
 });
 
 const WorkspaceHooksSchema = z.object({
-  before_all_tests: WorkspaceHookSchema.optional(),
-  before_each_test: WorkspaceHookSchema.optional(),
-  after_each_test: WorkspaceHookSchema.optional(),
-  after_all_tests: WorkspaceHookSchema.optional(),
-  on_reuse: WorkspaceHookSchema.optional(),
-  on_finish: WorkspaceHookSchema.optional(),
+  before_all: WorkspaceHookSchema.optional(),
+  before_each: WorkspaceHookSchema.optional(),
+  after_each: WorkspaceHookSchema.optional(),
+  after_all: WorkspaceHookSchema.optional(),
 });
 
 const WorkspaceSchema = z.object({

--- a/packages/core/src/evaluation/validation/eval-validator.ts
+++ b/packages/core/src/evaluation/validation/eval-validator.ts
@@ -271,7 +271,7 @@ function validateWorkspaceRepoConfig(
 ): void {
   const repos = workspace.repos;
   const hooks = workspace.hooks;
-  const afterEachHook = isObject(hooks) ? hooks.after_each_test : undefined;
+  const afterEachHook = isObject(hooks) ? hooks.after_each : undefined;
   const isolation = workspace.isolation;
 
   // Depth vs ancestor warning
@@ -303,20 +303,20 @@ function validateWorkspaceRepoConfig(
       errors.push({
         severity: 'warning',
         filePath,
-        location: 'workspace.hooks.after_each_test',
-        message: `hooks.after_each_test.reset '${afterEachHook.reset}' has no effect without repos.`,
+        location: 'workspace.hooks.after_each',
+        message: `hooks.after_each.reset '${afterEachHook.reset}' has no effect without repos.`,
       });
     }
   }
 
-  // after_each_test reset with per_test isolation warning
+  // after_each reset with per_test isolation warning
   if (isObject(afterEachHook) && afterEachHook.reset && isolation === 'per_test') {
     errors.push({
       severity: 'warning',
       filePath,
-      location: 'workspace.hooks.after_each_test',
+      location: 'workspace.hooks.after_each',
       message:
-        'hooks.after_each_test.reset is redundant with isolation: per_test (each test gets a fresh workspace).',
+        'hooks.after_each.reset is redundant with isolation: per_test (each test gets a fresh workspace).',
     });
   }
 }

--- a/packages/core/src/evaluation/yaml-parser.ts
+++ b/packages/core/src/evaluation/yaml-parser.ts
@@ -607,18 +607,10 @@ function parseWorkspaceHookConfig(
   const obj = raw as Record<string, unknown>;
   const reset =
     obj.reset === 'none' || obj.reset === 'fast' || obj.reset === 'strict' ? obj.reset : undefined;
-  const clean =
-    obj.clean === 'always' ||
-    obj.clean === 'on_success' ||
-    obj.clean === 'on_failure' ||
-    obj.clean === 'never'
-      ? obj.clean
-      : undefined;
-  if (!script && !reset && !clean) return undefined;
+  if (!script && !reset) return undefined;
   return {
     ...(script ?? {}),
     ...(reset !== undefined && { reset }),
-    ...(clean !== undefined && { clean }),
   };
 }
 
@@ -628,19 +620,15 @@ function parseWorkspaceHooksConfig(
 ): WorkspaceHooksConfig | undefined {
   if (!isJsonObject(raw)) return undefined;
   const obj = raw as Record<string, unknown>;
-  const beforeAllTests = parseWorkspaceHookConfig(obj.before_all_tests, evalFileDir);
-  const beforeEachTest = parseWorkspaceHookConfig(obj.before_each_test, evalFileDir);
-  const afterEachTest = parseWorkspaceHookConfig(obj.after_each_test, evalFileDir);
-  const afterAllTests = parseWorkspaceHookConfig(obj.after_all_tests, evalFileDir);
-  const onReuse = parseWorkspaceHookConfig(obj.on_reuse, evalFileDir);
-  const onFinish = parseWorkspaceHookConfig(obj.on_finish, evalFileDir);
+  const beforeAll = parseWorkspaceHookConfig(obj.before_all, evalFileDir);
+  const beforeEach = parseWorkspaceHookConfig(obj.before_each, evalFileDir);
+  const afterEach = parseWorkspaceHookConfig(obj.after_each, evalFileDir);
+  const afterAll = parseWorkspaceHookConfig(obj.after_all, evalFileDir);
   const hooks: WorkspaceHooksConfig = {
-    ...(beforeAllTests !== undefined && { before_all_tests: beforeAllTests }),
-    ...(beforeEachTest !== undefined && { before_each_test: beforeEachTest }),
-    ...(afterEachTest !== undefined && { after_each_test: afterEachTest }),
-    ...(afterAllTests !== undefined && { after_all_tests: afterAllTests }),
-    ...(onReuse !== undefined && { on_reuse: onReuse }),
-    ...(onFinish !== undefined && { on_finish: onFinish }),
+    ...(beforeAll !== undefined && { before_all: beforeAll }),
+    ...(beforeEach !== undefined && { before_each: beforeEach }),
+    ...(afterEach !== undefined && { after_each: afterEach }),
+    ...(afterAll !== undefined && { after_all: afterAll }),
   };
   return Object.keys(hooks).length > 0 ? hooks : undefined;
 }
@@ -744,18 +732,10 @@ function mergeWorkspaceConfigs(
     };
   };
   const mergedHooks = {
-    before_all_tests: mergeHook(
-      suiteLevel.hooks?.before_all_tests,
-      caseLevel.hooks?.before_all_tests,
-    ),
-    before_each_test: mergeHook(
-      suiteLevel.hooks?.before_each_test,
-      caseLevel.hooks?.before_each_test,
-    ),
-    after_each_test: mergeHook(suiteLevel.hooks?.after_each_test, caseLevel.hooks?.after_each_test),
-    after_all_tests: mergeHook(suiteLevel.hooks?.after_all_tests, caseLevel.hooks?.after_all_tests),
-    on_reuse: mergeHook(suiteLevel.hooks?.on_reuse, caseLevel.hooks?.on_reuse),
-    on_finish: mergeHook(suiteLevel.hooks?.on_finish, caseLevel.hooks?.on_finish),
+    before_all: mergeHook(suiteLevel.hooks?.before_all, caseLevel.hooks?.before_all),
+    before_each: mergeHook(suiteLevel.hooks?.before_each, caseLevel.hooks?.before_each),
+    after_each: mergeHook(suiteLevel.hooks?.after_each, caseLevel.hooks?.after_each),
+    after_all: mergeHook(suiteLevel.hooks?.after_all, caseLevel.hooks?.after_all),
   };
   const hasHooks = Object.values(mergedHooks).some((hook) => hook !== undefined);
 

--- a/packages/core/test/evaluation/orchestrator.test.ts
+++ b/packages/core/test/evaluation/orchestrator.test.ts
@@ -1417,7 +1417,7 @@ rl.on('close', () => {
       workspace: {
         template: templateDir,
         hooks: {
-          before_all_tests: {
+          before_all: {
             command: ['node', setupScript],
             timeout_ms: 10000,
           },
@@ -1460,7 +1460,7 @@ rl.on('close', () => {
       workspace: {
         template: templateDir,
         hooks: {
-          before_all_tests: {
+          before_all: {
             command: ['node', failingScript],
             timeout_ms: 5000,
           },
@@ -1523,7 +1523,7 @@ rl.on('close', () => {
       workspace: {
         template: templateDir,
         hooks: {
-          after_each_test: {
+          after_each: {
             command: ['node', teardownScript],
             timeout_ms: 10000,
           },
@@ -1565,7 +1565,7 @@ rl.on('close', () => {
       workspace: {
         template: templateDir,
         hooks: {
-          before_each_test: {
+          before_each: {
             reset: 'fast',
           },
         },
@@ -2557,7 +2557,7 @@ describe('--workspace flag', () => {
     const evalCase: EvalTest = {
       ...baseTestCase,
       workspace: {
-        hooks: { before_all_tests: { command: ['false'] } },
+        hooks: { before_all: { command: ['false'] } },
       },
     };
 
@@ -2590,7 +2590,7 @@ describe('--workspace flag', () => {
     const evalCase: EvalTest = {
       ...baseTestCase,
       workspace: {
-        hooks: { before_each_test: { command: ['echo', 'setup-done'] } },
+        hooks: { before_each: { command: ['echo', 'setup-done'] } },
       },
     };
 

--- a/packages/core/test/evaluation/repo-schema-validation.test.ts
+++ b/packages/core/test/evaluation/repo-schema-validation.test.ts
@@ -59,7 +59,7 @@ describe('repo lifecycle schema validation', () => {
     expect(result.success).toBe(true);
   });
 
-  it('accepts workspace with hooks after_each_test reset config', () => {
+  it('accepts workspace with hooks after_each reset config', () => {
     const result = EvalFileSchema.safeParse({
       ...baseEval,
       workspace: {
@@ -69,7 +69,7 @@ describe('repo lifecycle schema validation', () => {
             source: { type: 'git', url: 'https://github.com/org/repo.git' },
           },
         ],
-        hooks: { after_each_test: { reset: 'fast' } },
+        hooks: { after_each: { reset: 'fast' } },
       },
     });
     expect(result.success).toBe(true);
@@ -106,11 +106,11 @@ describe('repo lifecycle schema validation', () => {
     expect(result.success).toBe(false);
   });
 
-  it('rejects invalid hooks after_each_test reset mode', () => {
+  it('rejects invalid hooks after_each reset mode', () => {
     const result = EvalFileSchema.safeParse({
       ...baseEval,
       workspace: {
-        hooks: { after_each_test: { reset: 'invalid' } },
+        hooks: { after_each: { reset: 'invalid' } },
       },
     });
     expect(result.success).toBe(false);
@@ -154,8 +154,8 @@ describe('repo lifecycle schema validation', () => {
       workspace: {
         template: './fixtures',
         hooks: {
-          before_all_tests: { command: ['bash', 'setup.sh'] },
-          after_each_test: { reset: 'fast' },
+          before_all: { command: ['bash', 'setup.sh'] },
+          after_each: { reset: 'fast' },
         },
         repos: [
           {

--- a/packages/core/test/evaluation/workspace-config-parsing.test.ts
+++ b/packages/core/test/evaluation/workspace-config-parsing.test.ts
@@ -17,7 +17,7 @@ describe('Workspace config parsing', () => {
     await rm(testDir, { recursive: true, force: true });
   });
 
-  it('should parse per-case workspace config with before_all_tests and after_each_test hooks', async () => {
+  it('should parse per-case workspace config with before_all and after_each hooks', async () => {
     const evalFile = path.join(testDir, 'workspace-case.yaml');
     await writeFile(
       evalFile,
@@ -28,10 +28,10 @@ tests:
     criteria: "Should do the thing"
     workspace:
       hooks:
-        before_all_tests:
+        before_all:
           script: ["bun", "run", "setup.ts"]
           timeout_ms: 120000
-        after_each_test:
+        after_each:
           script: ["bun", "run", "teardown.ts"]
           timeout_ms: 30000
 `,
@@ -40,11 +40,11 @@ tests:
     const cases = await loadTests(evalFile, testDir);
     expect(cases).toHaveLength(1);
     expect(cases[0].workspace).toBeDefined();
-    expect(cases[0].workspace?.hooks?.before_all_tests).toEqual({
+    expect(cases[0].workspace?.hooks?.before_all).toEqual({
       command: ['bun', 'run', 'setup.ts'],
       timeout_ms: 120000,
     });
-    expect(cases[0].workspace?.hooks?.after_each_test).toEqual({
+    expect(cases[0].workspace?.hooks?.after_each).toEqual({
       command: ['bun', 'run', 'teardown.ts'],
       timeout_ms: 30000,
     });
@@ -80,7 +80,7 @@ tests:
       `
 workspace:
   hooks:
-    before_all_tests:
+    before_all:
       script: ["bun", "run", "default-setup.ts"]
 
 tests:
@@ -96,10 +96,10 @@ tests:
     const cases = await loadTests(evalFile, testDir);
     expect(cases).toHaveLength(2);
     // Both cases should inherit suite-level workspace
-    expect(cases[0].workspace?.hooks?.before_all_tests).toEqual({
+    expect(cases[0].workspace?.hooks?.before_all).toEqual({
       command: ['bun', 'run', 'default-setup.ts'],
     });
-    expect(cases[1].workspace?.hooks?.before_all_tests).toEqual({
+    expect(cases[1].workspace?.hooks?.before_all).toEqual({
       command: ['bun', 'run', 'default-setup.ts'],
     });
   });
@@ -111,7 +111,7 @@ tests:
       `
 workspace:
   hooks:
-    before_all_tests:
+    before_all:
       script: ["bun", "run", "default-setup.ts"]
 
 tests:
@@ -120,7 +120,7 @@ tests:
     criteria: "Should work"
     workspace:
       hooks:
-        before_all_tests:
+        before_all:
           script: ["bun", "run", "custom-setup.ts"]
   - id: case-default
     input: "Do something else"
@@ -134,137 +134,19 @@ tests:
     // case-override: before_all replaced
     const overrideCase = cases.find((c) => c.id === 'case-override');
     expect(overrideCase).toBeDefined();
-    expect(overrideCase.workspace?.hooks?.before_all_tests).toEqual({
+    expect(overrideCase.workspace?.hooks?.before_all).toEqual({
       command: ['bun', 'run', 'custom-setup.ts'],
     });
 
     // case-default: inherits suite-level workspace entirely
     const defaultCase = cases.find((c) => c.id === 'case-default');
     expect(defaultCase).toBeDefined();
-    expect(defaultCase.workspace?.hooks?.before_all_tests).toEqual({
+    expect(defaultCase.workspace?.hooks?.before_all).toEqual({
       command: ['bun', 'run', 'default-setup.ts'],
     });
   });
 
-  it('should inherit on_reuse reset settings from suite-level workspace when case-level workspace is present', async () => {
-    const evalFile = path.join(testDir, 'workspace-pool-inherit.yaml');
-    await writeFile(
-      evalFile,
-      `
-workspace:
-  pool: false
-  hooks:
-    on_reuse:
-      reset: strict
-  repos:
-    - path: ./repo
-      source:
-        type: git
-        url: https://github.com/org/repo.git
-
-tests:
-  - id: case-override-script
-    input: "Do something"
-    criteria: "Should work"
-    workspace:
-      hooks:
-        before_all_tests:
-          script: ["bun", "run", "custom-setup.ts"]
-  - id: case-default
-    input: "Do something else"
-    criteria: "Should also work"
-`,
-    );
-
-    const cases = await loadTests(evalFile, testDir);
-    expect(cases).toHaveLength(2);
-
-    const overrideCase = cases.find((c) => c.id === 'case-override-script');
-    expect(overrideCase).toBeDefined();
-    expect(overrideCase.workspace?.pool).toBe(false);
-    expect(overrideCase.workspace?.hooks?.on_reuse?.reset).toBe('strict');
-    expect(overrideCase.workspace?.repos).toHaveLength(1);
-    expect(overrideCase.workspace?.hooks?.before_all_tests).toEqual({
-      command: ['bun', 'run', 'custom-setup.ts'],
-    });
-
-    const defaultCase = cases.find((c) => c.id === 'case-default');
-    expect(defaultCase).toBeDefined();
-    expect(defaultCase.workspace?.pool).toBe(false);
-    expect(defaultCase.workspace?.hooks?.on_reuse?.reset).toBe('strict');
-  });
-
-  it('should allow case-level workspace to override suite-level on_reuse reset settings', async () => {
-    const evalFile = path.join(testDir, 'workspace-pool-override.yaml');
-    await writeFile(
-      evalFile,
-      `
-workspace:
-  pool: true
-  hooks:
-    on_reuse:
-      reset: fast
-
-tests:
-  - id: case-disable-pool
-    input: "Do something"
-    criteria: "Should work"
-    workspace:
-      pool: false
-      hooks:
-        on_reuse:
-          reset: strict
-`,
-    );
-
-    const cases = await loadTests(evalFile, testDir);
-    expect(cases).toHaveLength(1);
-    expect(cases[0].workspace?.pool).toBe(false);
-    expect(cases[0].workspace?.hooks?.on_reuse?.reset).toBe('strict');
-  });
-
-  it('should parse and merge workspace mode and on_finish settings', async () => {
-    const evalFile = path.join(testDir, 'workspace-mode-retention.yaml');
-    await writeFile(
-      evalFile,
-      `
-workspace:
-  mode: pooled
-  hooks:
-    on_reuse:
-      reset: strict
-    on_finish:
-      clean: on_success
-
-tests:
-  - id: case-retain-override
-    input: "Do something"
-    criteria: "Should work"
-    workspace:
-      hooks:
-        on_finish:
-          clean: always
-  - id: case-default
-    input: "Do something else"
-    criteria: "Should also work"
-`,
-    );
-
-    const cases = await loadTests(evalFile, testDir);
-    expect(cases).toHaveLength(2);
-
-    const overrideCase = cases.find((c) => c.id === 'case-retain-override');
-    expect(overrideCase?.workspace?.mode).toBe('pooled');
-    expect(overrideCase?.workspace?.hooks?.on_reuse?.reset).toBe('strict');
-    expect(overrideCase?.workspace?.hooks?.on_finish?.clean).toBe('always');
-
-    const defaultCase = cases.find((c) => c.id === 'case-default');
-    expect(defaultCase?.workspace?.mode).toBe('pooled');
-    expect(defaultCase?.workspace?.hooks?.on_reuse?.reset).toBe('strict');
-    expect(defaultCase?.workspace?.hooks?.on_finish?.clean).toBe('on_success');
-  });
-
-  it('should resolve before_all_tests cwd relative to eval file directory', async () => {
+  it('should resolve before_all cwd relative to eval file directory', async () => {
     const evalFile = path.join(testDir, 'workspace-cwd.yaml');
     await writeFile(
       evalFile,
@@ -275,7 +157,7 @@ tests:
     criteria: "Should work"
     workspace:
       hooks:
-        before_all_tests:
+        before_all:
           script: ["bun", "run", "setup.ts"]
           cwd: ./scripts
 `,
@@ -283,7 +165,7 @@ tests:
 
     const cases = await loadTests(evalFile, testDir);
     expect(cases).toHaveLength(1);
-    expect(cases[0].workspace?.hooks?.before_all_tests?.cwd).toBe(path.join(testDir, 'scripts'));
+    expect(cases[0].workspace?.hooks?.before_all?.cwd).toBe(path.join(testDir, 'scripts'));
   });
 
   it('should parse workspace template path', async () => {
@@ -350,7 +232,7 @@ tests:
     expect(workspace?.repos?.[0].clone?.sparse).toEqual(['src/**']);
   });
 
-  it('parses workspace hooks after_each_test reset config', async () => {
+  it('parses workspace hooks after_each reset config', async () => {
     const evalFile = path.join(testDir, 'workspace-reset.yaml');
     await writeFile(
       evalFile,
@@ -358,7 +240,7 @@ tests:
 description: test
 workspace:
   hooks:
-    after_each_test:
+    after_each:
       reset: fast
 tests:
   - id: test-1
@@ -368,7 +250,7 @@ tests:
     );
 
     const cases = await loadTests(evalFile, testDir);
-    expect(cases[0].workspace?.hooks?.after_each_test?.reset).toBe('fast');
+    expect(cases[0].workspace?.hooks?.after_each?.reset).toBe('fast');
   });
 
   it('parses workspace isolation field', async () => {
@@ -431,7 +313,7 @@ repos:
       ref: main
       resolve: remote
 hooks:
-  after_each_test:
+  after_each:
     reset: fast
 `,
       );
@@ -466,7 +348,7 @@ tests:
           url: 'https://github.com/org/repo.git',
         });
         expect(c.workspace?.repos?.[0].checkout?.ref).toBe('main');
-        expect(c.workspace?.hooks?.after_each_test?.reset).toBe('fast');
+        expect(c.workspace?.hooks?.after_each?.reset).toBe('fast');
       }
     });
 
@@ -480,7 +362,7 @@ tests:
         `
 template: ./my-template
 hooks:
-  before_all_tests:
+  before_all:
     command: ["node", "setup.mjs"]
     cwd: ./scripts
 `,
@@ -504,7 +386,7 @@ tests:
       // template resolved relative to workspace file dir (nested/config/)
       expect(cases[0].workspace?.template).toBe(path.join(wsDir, 'my-template'));
       // cwd resolved relative to workspace file dir
-      expect(cases[0].workspace?.hooks?.before_all_tests?.cwd).toBe(path.join(wsDir, 'scripts'));
+      expect(cases[0].workspace?.hooks?.before_all?.cwd).toBe(path.join(wsDir, 'scripts'));
     });
 
     it('should throw a clear error when workspace file is not found', async () => {
@@ -536,9 +418,9 @@ tests:
         `
 template: ./base-template
 hooks:
-  before_all_tests:
+  before_all:
     command: ["node", "base-setup.mjs"]
-  after_each_test:
+  after_each:
     reset: fast
 `,
       );
@@ -558,7 +440,7 @@ tests:
     criteria: "Should work"
     workspace:
       hooks:
-        before_all_tests:
+        before_all:
           command: ["node", "custom-setup.mjs"]
 `,
       );
@@ -568,21 +450,21 @@ tests:
 
       // default-case inherits external workspace
       const defaultCase = cases.find((c) => c.id === 'default-case');
-      expect(defaultCase?.workspace?.hooks?.before_all_tests?.command).toEqual([
+      expect(defaultCase?.workspace?.hooks?.before_all?.command).toEqual([
         'node',
         'base-setup.mjs',
       ]);
       expect(defaultCase?.workspace?.template).toBe(path.join(wsDir, 'base-template'));
-      expect(defaultCase?.workspace?.hooks?.after_each_test?.reset).toBe('fast');
+      expect(defaultCase?.workspace?.hooks?.after_each?.reset).toBe('fast');
 
-      // override-case: before_all_tests replaced, template and after_each_test inherited
+      // override-case: before_all replaced, template and after_each inherited
       const overrideCase = cases.find((c) => c.id === 'override-case');
-      expect(overrideCase?.workspace?.hooks?.before_all_tests?.command).toEqual([
+      expect(overrideCase?.workspace?.hooks?.before_all?.command).toEqual([
         'node',
         'custom-setup.mjs',
       ]);
       expect(overrideCase?.workspace?.template).toBe(path.join(wsDir, 'base-template'));
-      expect(overrideCase?.workspace?.hooks?.after_each_test?.reset).toBe('fast');
+      expect(overrideCase?.workspace?.hooks?.after_each?.reset).toBe('fast');
     });
   });
 });

--- a/plugins/agentv-dev/skills/agentv-eval-builder/SKILL.md
+++ b/plugins/agentv-dev/skills/agentv-eval-builder/SKILL.md
@@ -247,12 +247,8 @@ workspace:
       clone:
         depth: 10
   hooks:
-    after_each_test:
+    after_each:
       reset: fast          # none | fast | strict
-    on_reuse:
-      reset: fast          # none | fast | strict (pooled slot reuse reset mode)
-    on_finish:
-      clean: on_success    # always | on_success | on_failure | never
   isolation: shared        # shared | per_test
   mode: pooled             # pooled | ephemeral | static
 ```
@@ -264,8 +260,7 @@ workspace:
 - `clone.sparse`: sparse checkout paths array
 - `mode`: `pooled` (default for shared repos), `ephemeral`, or `static`
 - `static_path`: required when `mode: static`
-- `hooks.on_reuse.reset: strict` uses `git clean -fdx` on pooled slot reuse (`fast` uses `-fd`)
-- `hooks.on_finish.clean` controls temp workspace cleanup behavior
+- Pool reset defaults to `fast` (`git clean -fd`); use `--workspace-clean full` for strict reset (`git clean -fdx`)
 - Pool entries are managed separately via `agentv workspace list` and `agentv workspace clean`
 
 See https://agentv.dev/targets/configuration/#repository-lifecycle

--- a/plugins/agentv-dev/skills/agentv-eval-builder/references/eval-schema.json
+++ b/plugins/agentv-dev/skills/agentv-eval-builder/references/eval-schema.json
@@ -4618,7 +4618,7 @@
                       "hooks": {
                         "type": "object",
                         "properties": {
-                          "before_all_tests": {
+                          "before_all": {
                             "type": "object",
                             "properties": {
                               "command": {
@@ -4645,15 +4645,11 @@
                               "reset": {
                                 "type": "string",
                                 "enum": ["none", "fast", "strict"]
-                              },
-                              "clean": {
-                                "type": "string",
-                                "enum": ["always", "on_success", "on_failure", "never"]
                               }
                             },
                             "additionalProperties": false
                           },
-                          "before_each_test": {
+                          "before_each": {
                             "type": "object",
                             "properties": {
                               "command": {
@@ -4680,15 +4676,11 @@
                               "reset": {
                                 "type": "string",
                                 "enum": ["none", "fast", "strict"]
-                              },
-                              "clean": {
-                                "type": "string",
-                                "enum": ["always", "on_success", "on_failure", "never"]
                               }
                             },
                             "additionalProperties": false
                           },
-                          "after_each_test": {
+                          "after_each": {
                             "type": "object",
                             "properties": {
                               "command": {
@@ -4715,15 +4707,11 @@
                               "reset": {
                                 "type": "string",
                                 "enum": ["none", "fast", "strict"]
-                              },
-                              "clean": {
-                                "type": "string",
-                                "enum": ["always", "on_success", "on_failure", "never"]
                               }
                             },
                             "additionalProperties": false
                           },
-                          "after_all_tests": {
+                          "after_all": {
                             "type": "object",
                             "properties": {
                               "command": {
@@ -4750,80 +4738,6 @@
                               "reset": {
                                 "type": "string",
                                 "enum": ["none", "fast", "strict"]
-                              },
-                              "clean": {
-                                "type": "string",
-                                "enum": ["always", "on_success", "on_failure", "never"]
-                              }
-                            },
-                            "additionalProperties": false
-                          },
-                          "on_reuse": {
-                            "type": "object",
-                            "properties": {
-                              "command": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "script": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "timeout_ms": {
-                                "type": "number"
-                              },
-                              "timeoutMs": {
-                                "type": "number"
-                              },
-                              "cwd": {
-                                "type": "string"
-                              },
-                              "reset": {
-                                "type": "string",
-                                "enum": ["none", "fast", "strict"]
-                              },
-                              "clean": {
-                                "type": "string",
-                                "enum": ["always", "on_success", "on_failure", "never"]
-                              }
-                            },
-                            "additionalProperties": false
-                          },
-                          "on_finish": {
-                            "type": "object",
-                            "properties": {
-                              "command": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "script": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "timeout_ms": {
-                                "type": "number"
-                              },
-                              "timeoutMs": {
-                                "type": "number"
-                              },
-                              "cwd": {
-                                "type": "string"
-                              },
-                              "reset": {
-                                "type": "string",
-                                "enum": ["none", "fast", "strict"]
-                              },
-                              "clean": {
-                                "type": "string",
-                                "enum": ["always", "on_success", "on_failure", "never"]
                               }
                             },
                             "additionalProperties": false
@@ -9399,7 +9313,7 @@
                       "hooks": {
                         "type": "object",
                         "properties": {
-                          "before_all_tests": {
+                          "before_all": {
                             "type": "object",
                             "properties": {
                               "command": {
@@ -9426,15 +9340,11 @@
                               "reset": {
                                 "type": "string",
                                 "enum": ["none", "fast", "strict"]
-                              },
-                              "clean": {
-                                "type": "string",
-                                "enum": ["always", "on_success", "on_failure", "never"]
                               }
                             },
                             "additionalProperties": false
                           },
-                          "before_each_test": {
+                          "before_each": {
                             "type": "object",
                             "properties": {
                               "command": {
@@ -9461,15 +9371,11 @@
                               "reset": {
                                 "type": "string",
                                 "enum": ["none", "fast", "strict"]
-                              },
-                              "clean": {
-                                "type": "string",
-                                "enum": ["always", "on_success", "on_failure", "never"]
                               }
                             },
                             "additionalProperties": false
                           },
-                          "after_each_test": {
+                          "after_each": {
                             "type": "object",
                             "properties": {
                               "command": {
@@ -9496,15 +9402,11 @@
                               "reset": {
                                 "type": "string",
                                 "enum": ["none", "fast", "strict"]
-                              },
-                              "clean": {
-                                "type": "string",
-                                "enum": ["always", "on_success", "on_failure", "never"]
                               }
                             },
                             "additionalProperties": false
                           },
-                          "after_all_tests": {
+                          "after_all": {
                             "type": "object",
                             "properties": {
                               "command": {
@@ -9531,80 +9433,6 @@
                               "reset": {
                                 "type": "string",
                                 "enum": ["none", "fast", "strict"]
-                              },
-                              "clean": {
-                                "type": "string",
-                                "enum": ["always", "on_success", "on_failure", "never"]
-                              }
-                            },
-                            "additionalProperties": false
-                          },
-                          "on_reuse": {
-                            "type": "object",
-                            "properties": {
-                              "command": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "script": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "timeout_ms": {
-                                "type": "number"
-                              },
-                              "timeoutMs": {
-                                "type": "number"
-                              },
-                              "cwd": {
-                                "type": "string"
-                              },
-                              "reset": {
-                                "type": "string",
-                                "enum": ["none", "fast", "strict"]
-                              },
-                              "clean": {
-                                "type": "string",
-                                "enum": ["always", "on_success", "on_failure", "never"]
-                              }
-                            },
-                            "additionalProperties": false
-                          },
-                          "on_finish": {
-                            "type": "object",
-                            "properties": {
-                              "command": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "script": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "timeout_ms": {
-                                "type": "number"
-                              },
-                              "timeoutMs": {
-                                "type": "number"
-                              },
-                              "cwd": {
-                                "type": "string"
-                              },
-                              "reset": {
-                                "type": "string",
-                                "enum": ["none", "fast", "strict"]
-                              },
-                              "clean": {
-                                "type": "string",
-                                "enum": ["always", "on_success", "on_failure", "never"]
                               }
                             },
                             "additionalProperties": false
@@ -13007,7 +12835,7 @@
                 "hooks": {
                   "type": "object",
                   "properties": {
-                    "before_all_tests": {
+                    "before_all": {
                       "type": "object",
                       "properties": {
                         "command": {
@@ -13034,15 +12862,11 @@
                         "reset": {
                           "type": "string",
                           "enum": ["none", "fast", "strict"]
-                        },
-                        "clean": {
-                          "type": "string",
-                          "enum": ["always", "on_success", "on_failure", "never"]
                         }
                       },
                       "additionalProperties": false
                     },
-                    "before_each_test": {
+                    "before_each": {
                       "type": "object",
                       "properties": {
                         "command": {
@@ -13069,15 +12893,11 @@
                         "reset": {
                           "type": "string",
                           "enum": ["none", "fast", "strict"]
-                        },
-                        "clean": {
-                          "type": "string",
-                          "enum": ["always", "on_success", "on_failure", "never"]
                         }
                       },
                       "additionalProperties": false
                     },
-                    "after_each_test": {
+                    "after_each": {
                       "type": "object",
                       "properties": {
                         "command": {
@@ -13104,15 +12924,11 @@
                         "reset": {
                           "type": "string",
                           "enum": ["none", "fast", "strict"]
-                        },
-                        "clean": {
-                          "type": "string",
-                          "enum": ["always", "on_success", "on_failure", "never"]
                         }
                       },
                       "additionalProperties": false
                     },
-                    "after_all_tests": {
+                    "after_all": {
                       "type": "object",
                       "properties": {
                         "command": {
@@ -13139,80 +12955,6 @@
                         "reset": {
                           "type": "string",
                           "enum": ["none", "fast", "strict"]
-                        },
-                        "clean": {
-                          "type": "string",
-                          "enum": ["always", "on_success", "on_failure", "never"]
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    "on_reuse": {
-                      "type": "object",
-                      "properties": {
-                        "command": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "script": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "timeout_ms": {
-                          "type": "number"
-                        },
-                        "timeoutMs": {
-                          "type": "number"
-                        },
-                        "cwd": {
-                          "type": "string"
-                        },
-                        "reset": {
-                          "type": "string",
-                          "enum": ["none", "fast", "strict"]
-                        },
-                        "clean": {
-                          "type": "string",
-                          "enum": ["always", "on_success", "on_failure", "never"]
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    "on_finish": {
-                      "type": "object",
-                      "properties": {
-                        "command": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "script": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "timeout_ms": {
-                          "type": "number"
-                        },
-                        "timeoutMs": {
-                          "type": "number"
-                        },
-                        "cwd": {
-                          "type": "string"
-                        },
-                        "reset": {
-                          "type": "string",
-                          "enum": ["none", "fast", "strict"]
-                        },
-                        "clean": {
-                          "type": "string",
-                          "enum": ["always", "on_success", "on_failure", "never"]
                         }
                       },
                       "additionalProperties": false


### PR DESCRIPTION
## Summary

- **Rename** workspace lifecycle hooks to shorter names matching test framework conventions (Jest, Vitest):
  - `before_all_tests` → `before_all`
  - `before_each_test` → `before_each`
  - `after_each_test` → `after_each`
  - `after_all_tests` → `after_all`
- **Remove** `on_reuse` hook — redundant (pool defaults to `reset: fast`, strict available via `--workspace-clean full`)
- **Remove** `on_finish` hook — redundant (cleanup controlled by CLI flags `--retain-on-success` / `--retain-on-failure`)
- **Remove** `clean` field from `WorkspaceHookConfig` (was only used by `on_finish`)

## Test plan

- [x] All 925 core tests pass
- [x] Typecheck passes
- [x] Lint passes
- [x] No remaining references to old hook names in codebase

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)