### PR TITLE
fix: remove default 120s agent timeout

### DIFF
--- a/packages/core/src/evaluation/config.ts
+++ b/packages/core/src/evaluation/config.ts
@@ -38,7 +38,7 @@ const AgentVConfigSchema = z.object({
       workers: z.number().int().min(1).max(50).optional(),
       /** Maximum retries on failure (default: 2) */
       maxRetries: z.number().int().min(0).optional(),
-      /** Agent timeout in milliseconds (default: 120000) */
+      /** Agent timeout in milliseconds. No timeout if not set. */
       agentTimeoutMs: z.number().int().min(0).optional(),
       /** Enable verbose logging */
       verbose: z.boolean().optional(),

--- a/packages/core/src/evaluation/evaluate.ts
+++ b/packages/core/src/evaluation/evaluate.ts
@@ -113,7 +113,7 @@ export interface EvalConfig {
   readonly workers?: number;
   /** Maximum retries on failure (default: 2) */
   readonly maxRetries?: number;
-  /** Agent timeout in milliseconds (default: 120000) */
+  /** Agent timeout in milliseconds. No timeout if not set. */
   readonly agentTimeoutMs?: number;
   /** Enable response caching */
   readonly cache?: boolean;
@@ -275,7 +275,7 @@ export async function evaluate(config: EvalConfig): Promise<EvalRunResult> {
     repoRoot,
     target: resolvedTarget,
     maxRetries: config.maxRetries ?? 2,
-    agentTimeoutMs: config.agentTimeoutMs ?? 120_000,
+    agentTimeoutMs: config.agentTimeoutMs,
     verbose: config.verbose,
     maxConcurrency: config.workers ?? 3,
     filter: config.filter,

--- a/packages/core/src/evaluation/providers/pi-agent-sdk.ts
+++ b/packages/core/src/evaluation/providers/pi-agent-sdk.ts
@@ -110,17 +110,19 @@ export class PiAgentSdkProvider implements Provider {
     });
 
     try {
-      // Set up timeout if configured
-      const timeoutMs = this.config.timeoutMs ?? 120000;
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(
-          () => reject(new Error(`Pi agent SDK timed out after ${timeoutMs}ms`)),
-          timeoutMs,
-        );
-      });
-
-      // Run the prompt with timeout
-      await Promise.race([agent.prompt(request.question), timeoutPromise]);
+      // Run the prompt, with optional timeout
+      if (this.config.timeoutMs) {
+        const timeoutMs = this.config.timeoutMs;
+        const timeoutPromise = new Promise<never>((_, reject) => {
+          setTimeout(
+            () => reject(new Error(`Pi agent SDK timed out after ${timeoutMs}ms`)),
+            timeoutMs,
+          );
+        });
+        await Promise.race([agent.prompt(request.question), timeoutPromise]);
+      } else {
+        await agent.prompt(request.question);
+      }
 
       // Wait for agent to finish
       await agent.waitForIdle();


### PR DESCRIPTION
## Summary
- Remove the hardcoded 120s (`120_000ms`) default for `agentTimeoutMs` in `evaluate.ts`
- Remove the 120s fallback in `pi-agent-sdk.ts` — timeout is now only applied when explicitly configured
- Update JSDoc comments in `config.ts` and `evaluate.ts` to reflect "no timeout if not set"

## Motivation
The implicit 120s default caused agents to time out unexpectedly when no `timeout_seconds` was configured on the target or `agentTimeoutMs` in `agentv.config.ts`. Users who want a timeout can set it explicitly; those who don't should not be silently capped.

## Risk
Low — the timeout was undocumented and the orchestrator already handles `undefined` correctly (`orchestrator.ts:2316`). Workspace setup timeouts (repo-manager, script-executor) are unaffected.

## Test plan
- [x] All existing tests pass (build, typecheck, lint, test)
- [ ] Verify agent runs without timeout when `timeout_seconds` is not set
- [ ] Verify agent still times out when `timeout_seconds` is explicitly configured