### PR TITLE
refactor: rename evaluators to assertions for internal consistency

### DIFF
--- a/apps/cli/src/commands/eval/commands/prompt/judge.ts
+++ b/apps/cli/src/commands/eval/commands/prompt/judge.ts
@@ -53,7 +53,7 @@ export const evalPromptJudgeCommand = command({
     const candidate = (await readFile(args.answerFile, 'utf8')).trim();
     const promptInputs = await buildPromptInputs(evalCase);
 
-    const evaluators = evalCase.evaluators ?? [];
+    const evaluators = evalCase.assertions ?? [];
     const outputs: EvaluatorOutput[] = [];
 
     for (const config of evaluators) {

--- a/apps/cli/src/commands/eval/commands/prompt/overview.ts
+++ b/apps/cli/src/commands/eval/commands/prompt/overview.ts
@@ -164,7 +164,7 @@ export const evalPromptOverviewCommand = command({
 });
 
 function describeEvaluators(evalCase: EvalTest): string | undefined {
-  const configs = evalCase.evaluators;
+  const configs = evalCase.assertions;
   if (!configs || configs.length === 0) return undefined;
   return configs.map((c) => `${c.name} (${c.type})`).join(', ');
 }

--- a/packages/core/src/evaluation/evaluate.ts
+++ b/packages/core/src/evaluation/evaluate.ts
@@ -262,7 +262,7 @@ export async function evaluate(config: EvalConfig): Promise<EvalRunResult> {
         guideline_paths: [],
         guideline_patterns: [],
         file_paths: [],
-        evaluators: assertConfigs.length > 0 ? assertConfigs : undefined,
+        assertions: assertConfigs.length > 0 ? assertConfigs : undefined,
         metadata: test.metadata,
       };
     });

--- a/packages/core/src/evaluation/evaluators/composite.ts
+++ b/packages/core/src/evaluation/evaluators/composite.ts
@@ -53,7 +53,7 @@ export class CompositeEvaluator implements Evaluator {
   async evaluate(context: EvaluationContext): Promise<EvaluationScore> {
     // 1. Instantiate and run evaluators in parallel
     const memberResults = await Promise.all(
-      this.config.evaluators.map(async (memberConfig) => {
+      this.config.assertions.map(async (memberConfig) => {
         const evaluator = this.evaluatorFactory.create(memberConfig, context);
         return {
           id: memberConfig.name,

--- a/packages/core/src/evaluation/loaders/evaluator-parser.ts
+++ b/packages/core/src/evaluation/loaders/evaluator-parser.ts
@@ -26,6 +26,7 @@ export function normalizeEvaluatorType(type: string): string {
 export async function parseEvaluators(
   rawEvalCase: JsonObject & {
     readonly execution?: JsonValue;
+    readonly assertions?: JsonValue;
     readonly evaluators?: JsonValue;
     readonly assert?: JsonValue;
   },
@@ -36,17 +37,18 @@ export async function parseEvaluators(
   const execution = rawEvalCase.execution;
   const executionObject = isJsonObject(execution) ? execution : undefined;
 
-  // Case-level evaluators priority: assert > execution.evaluators (deprecated) > top-level evaluators (deprecated)
+  // Case-level evaluators priority: assertions > assert > execution.evaluators (deprecated) > top-level evaluators (deprecated)
   const caseEvaluators =
+    rawEvalCase.assertions ??
     rawEvalCase.assert ??
     (executionObject ? executionObject.evaluators : undefined) ?? // deprecated: use assert
     rawEvalCase.evaluators; // deprecated: use assert
 
-  // Root-level (default) evaluators: assert > execution.evaluators (deprecated)
+  // Root-level (default) evaluators: assertions > assert > execution.evaluators (deprecated)
   const skipDefaults = executionObject?.skip_defaults === true;
   const rootEvaluators = skipDefaults
     ? undefined
-    : (globalExecution?.assert ?? globalExecution?.evaluators); // deprecated: use assert
+    : (globalExecution?.assertions ?? globalExecution?.assert ?? globalExecution?.evaluators); // deprecated: use assert
 
   // Parse case-level evaluators
   const parsedCase = await parseEvaluatorList(caseEvaluators, searchRoots, evalId);
@@ -250,8 +252,8 @@ async function parseEvaluatorList(
     }
 
     if (typeValue === 'composite') {
-      // Accept assert as canonical key; evaluators is deprecated
-      const rawMembers = rawEvaluator.assert ?? rawEvaluator.evaluators; // evaluators deprecated
+      // Accept assertions > assert > evaluators (deprecated)
+      const rawMembers = rawEvaluator.assertions ?? rawEvaluator.assert ?? rawEvaluator.evaluators; // evaluators deprecated
       if (!Array.isArray(rawMembers)) {
         logWarning(
           `Skipping composite evaluator '${name}' in '${evalId}': missing evaluators (or assert) array`,
@@ -386,7 +388,7 @@ async function parseEvaluatorList(
       evaluators.push({
         name,
         type: 'composite',
-        evaluators: memberEvaluators,
+        assertions: memberEvaluators,
         aggregator,
         ...(weight !== undefined ? { weight } : {}),
         ...(required !== undefined ? { required } : {}),

--- a/packages/core/src/evaluation/loaders/jsonl-parser.ts
+++ b/packages/core/src/evaluation/loaders/jsonl-parser.ts
@@ -316,7 +316,7 @@ export async function loadTestsFromJsonl(
       file_paths: allFilePaths,
       criteria: outcome ?? '',
       evaluator: evalCaseEvaluatorKind,
-      evaluators,
+      assertions: evaluators,
     };
 
     if (verbose) {

--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -1968,10 +1968,10 @@ async function runEvaluatorsForCase(options: {
     workspacePath,
   } = options;
 
-  if (evalCase.evaluators && evalCase.evaluators.length > 0) {
+  if (evalCase.assertions && evalCase.assertions.length > 0) {
     return runEvaluatorList({
       evalCase,
-      evaluators: evalCase.evaluators,
+      evaluators: evalCase.assertions,
       candidate,
       target,
       provider,

--- a/packages/core/src/evaluation/types.ts
+++ b/packages/core/src/evaluation/types.ts
@@ -392,7 +392,7 @@ export type CompositeAggregatorConfig =
 export type CompositeEvaluatorConfig = {
   readonly name: string;
   readonly type: 'composite';
-  readonly evaluators: readonly EvaluatorConfig[];
+  readonly assertions: readonly EvaluatorConfig[];
   readonly aggregator: CompositeAggregatorConfig;
   readonly weight?: number;
   readonly required?: boolean | number;
@@ -764,7 +764,7 @@ export interface EvalTest {
   readonly file_paths: readonly string[];
   readonly criteria: string;
   readonly evaluator?: EvaluatorKind;
-  readonly evaluators?: readonly EvaluatorConfig[];
+  readonly assertions?: readonly EvaluatorConfig[];
   /** Workspace configuration (merged from suite-level and case-level) */
   readonly workspace?: WorkspaceConfig;
   /** Arbitrary metadata passed to workspace scripts via stdin */

--- a/packages/core/src/evaluation/validation/eval-file.schema.ts
+++ b/packages/core/src/evaluation/validation/eval-file.schema.ts
@@ -114,6 +114,7 @@ const AggregatorSchema = z.discriminatedUnion('type', [
 const CompositeSchema: z.ZodType = z.lazy(() =>
   EvaluatorCommonSchema.extend({
     type: z.literal('composite'),
+    assertions: z.array(EvaluatorSchema).optional(),
     assert: z.array(EvaluatorSchema).optional(),
     evaluators: z.array(EvaluatorSchema).optional(),
     aggregator: AggregatorSchema,
@@ -323,6 +324,7 @@ const FailOnErrorSchema = z.boolean();
 const ExecutionSchema = z.object({
   target: z.string().optional(),
   targets: z.array(z.string()).optional(),
+  assertions: z.array(EvaluatorSchema).optional(),
   assert: z.array(EvaluatorSchema).optional(),
   evaluators: z.array(EvaluatorSchema).optional(),
   skip_defaults: z.boolean().optional(),
@@ -344,6 +346,7 @@ const EvalTestSchema = z.object({
   expected_outcome: z.string().optional(),
   input: InputSchema.optional(),
   expected_output: ExpectedOutputSchema.optional(),
+  assertions: z.array(EvaluatorSchema).optional(),
   assert: z.array(EvaluatorSchema).optional(),
   evaluators: z.array(EvaluatorSchema).optional(),
   execution: ExecutionSchema.optional(),

--- a/packages/core/src/evaluation/yaml-parser.ts
+++ b/packages/core/src/evaluation/yaml-parser.ts
@@ -466,7 +466,7 @@ async function loadTestsFromYaml(
       file_paths: allFilePaths,
       criteria: outcome ?? '',
       evaluator: evalCaseEvaluatorKind,
-      evaluators,
+      assertions: evaluators,
       workspace: mergedWorkspace,
       metadata,
       targets: caseTargets,

--- a/packages/core/test/evaluation/evaluators/composite-threshold.test.ts
+++ b/packages/core/test/evaluation/evaluators/composite-threshold.test.ts
@@ -83,7 +83,7 @@ describe('CompositeEvaluator threshold aggregation', () => {
       config: {
         name: 'gate',
         type: 'composite',
-        evaluators: [
+        assertions: [
           { name: 'a', type: 'latency', threshold: 5000 },
           { name: 'b', type: 'latency', threshold: 5000 },
           { name: 'c', type: 'latency', threshold: 5000 },
@@ -112,7 +112,7 @@ describe('CompositeEvaluator threshold aggregation', () => {
       config: {
         name: 'gate',
         type: 'composite',
-        evaluators: [
+        assertions: [
           { name: 'a', type: 'latency', threshold: 5000 },
           { name: 'b', type: 'latency', threshold: 5000 },
           { name: 'c', type: 'latency', threshold: 5000 },
@@ -140,7 +140,7 @@ describe('CompositeEvaluator threshold aggregation', () => {
       config: {
         name: 'gate',
         type: 'composite',
-        evaluators: [
+        assertions: [
           { name: 'a', type: 'latency', threshold: 5000 },
           { name: 'b', type: 'latency', threshold: 5000 },
           { name: 'c', type: 'latency', threshold: 5000 },
@@ -168,7 +168,7 @@ describe('CompositeEvaluator threshold aggregation', () => {
       config: {
         name: 'gate',
         type: 'composite',
-        evaluators: [
+        assertions: [
           { name: 'a', type: 'latency', threshold: 5000 },
           { name: 'b', type: 'latency', threshold: 5000 },
           { name: 'c', type: 'latency', threshold: 5000 },
@@ -196,7 +196,7 @@ describe('CompositeEvaluator threshold aggregation', () => {
       config: {
         name: 'gate',
         type: 'composite',
-        evaluators: [
+        assertions: [
           { name: 'a', type: 'latency', threshold: 5000 },
           { name: 'b', type: 'latency', threshold: 5000 },
           { name: 'c', type: 'latency', threshold: 5000 },
@@ -224,7 +224,7 @@ describe('CompositeEvaluator threshold aggregation', () => {
       config: {
         name: 'gate',
         type: 'composite',
-        evaluators: [
+        assertions: [
           { name: 'a', type: 'latency', threshold: 5000 },
           { name: 'b', type: 'latency', threshold: 5000 },
           { name: 'c', type: 'latency', threshold: 5000 },
@@ -250,7 +250,7 @@ describe('CompositeEvaluator threshold aggregation', () => {
       config: {
         name: 'gate',
         type: 'composite',
-        evaluators: [
+        assertions: [
           { name: 'a', type: 'latency', threshold: 5000 },
           { name: 'b', type: 'latency', threshold: 5000 },
         ],
@@ -276,7 +276,7 @@ describe('CompositeEvaluator threshold aggregation', () => {
       config: {
         name: 'gate',
         type: 'composite',
-        evaluators: [
+        assertions: [
           { name: 'a', type: 'latency', threshold: 5000 },
           { name: 'b', type: 'latency', threshold: 5000 },
           { name: 'c', type: 'latency', threshold: 5000 },
@@ -302,7 +302,7 @@ describe('CompositeEvaluator threshold aggregation', () => {
       config: {
         name: 'gate',
         type: 'composite',
-        evaluators: [
+        assertions: [
           { name: 'a', type: 'latency', threshold: 5000 },
           { name: 'b', type: 'latency', threshold: 5000 },
         ],
@@ -347,7 +347,7 @@ describe('CompositeEvaluator skip-verdict handling', () => {
       config: {
         name: 'combo',
         type: 'composite',
-        evaluators: [
+        assertions: [
           { name: 'a', type: 'latency', threshold: 5000 },
           { name: 'b', type: 'latency', threshold: 5000 },
           { name: 'c', type: 'latency', threshold: 5000 },
@@ -373,7 +373,7 @@ describe('CompositeEvaluator skip-verdict handling', () => {
       config: {
         name: 'combo',
         type: 'composite',
-        evaluators: [
+        assertions: [
           { name: 'a', type: 'latency', threshold: 5000 },
           { name: 'b', type: 'latency', threshold: 5000 },
         ],
@@ -399,7 +399,7 @@ describe('CompositeEvaluator skip-verdict handling', () => {
       config: {
         name: 'gate',
         type: 'composite',
-        evaluators: [
+        assertions: [
           { name: 'a', type: 'latency', threshold: 5000 },
           { name: 'b', type: 'latency', threshold: 5000 },
           { name: 'c', type: 'latency', threshold: 5000 },
@@ -426,7 +426,7 @@ describe('CompositeEvaluator skip-verdict handling', () => {
       config: {
         name: 'gate',
         type: 'composite',
-        evaluators: [
+        assertions: [
           { name: 'a', type: 'latency', threshold: 5000 },
           { name: 'b', type: 'latency', threshold: 5000 },
         ],
@@ -451,7 +451,7 @@ describe('CompositeEvaluator skip-verdict handling', () => {
       config: {
         name: 'combo',
         type: 'composite',
-        evaluators: [
+        assertions: [
           { name: 'a', type: 'latency', threshold: 5000 },
           { name: 'b', type: 'latency', threshold: 5000 },
         ],

--- a/packages/core/test/evaluation/loaders/evaluator-parser.test.ts
+++ b/packages/core/test/evaluation/loaders/evaluator-parser.test.ts
@@ -1657,7 +1657,7 @@ describe('parseEvaluators - composite assert field', () => {
     expect(evaluators).toHaveLength(1);
     // assert takes precedence - only 1 inner evaluator
     const composite = evaluators?.[0] as CompositeEvaluatorConfig;
-    expect(composite.evaluators).toHaveLength(1);
-    expect(composite.evaluators[0].name).toBe('safety');
+    expect(composite.assertions).toHaveLength(1);
+    expect(composite.assertions[0].name).toBe('safety');
   });
 });

--- a/packages/core/test/evaluation/loaders/jsonl-parser.test.ts
+++ b/packages/core/test/evaluation/loaders/jsonl-parser.test.ts
@@ -179,8 +179,8 @@ describe('loadTestsFromJsonl', () => {
     const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
     expect(cases).toHaveLength(1);
-    expect(cases[0].evaluators).toHaveLength(1);
-    expect(cases[0].evaluators?.[0].name).toBe('rubric-check');
+    expect(cases[0].assertions).toHaveLength(1);
+    expect(cases[0].assertions?.[0].name).toBe('rubric-check');
   });
 
   it('supports inline rubrics field', async () => {
@@ -193,9 +193,9 @@ describe('loadTestsFromJsonl', () => {
     const cases = await loadTestsFromJsonl(jsonlPath, tempDir);
 
     expect(cases).toHaveLength(1);
-    expect(cases[0].evaluators).toHaveLength(1);
-    expect(cases[0].evaluators?.[0].type).toBe('llm-judge');
-    const rubricEvaluator = cases[0].evaluators?.[0] as { type: string; rubrics?: unknown[] };
+    expect(cases[0].assertions).toHaveLength(1);
+    expect(cases[0].assertions?.[0].type).toBe('llm-judge');
+    const rubricEvaluator = cases[0].assertions?.[0] as { type: string; rubrics?: unknown[] };
     expect(rubricEvaluator.rubrics).toHaveLength(2);
   });
 

--- a/packages/core/test/evaluation/orchestrator.test.ts
+++ b/packages/core/test/evaluation/orchestrator.test.ts
@@ -387,7 +387,7 @@ describe('runTestCase', () => {
     const result = await runEvalCase({
       evalCase: {
         ...baseTestCase,
-        evaluators: [{ name: 'semantic', type: 'llm-judge', promptPath }],
+        assertions: [{ name: 'semantic', type: 'llm-judge', promptPath }],
       },
       provider,
       target: baseTarget,
@@ -654,7 +654,7 @@ describe('runEvalCase trace integration', () => {
     const result = await runEvalCase({
       evalCase: {
         ...traceTestCase,
-        evaluators: [
+        assertions: [
           {
             name: 'token-budget',
             type: 'token-usage',
@@ -714,7 +714,7 @@ describe('runEvalCase trace integration', () => {
     const result = await runEvalCase({
       evalCase: {
         ...traceTestCase,
-        evaluators: [
+        assertions: [
           {
             name: 'tool-check',
             type: 'tool-trajectory',
@@ -754,7 +754,7 @@ describe('runEvalCase trace integration', () => {
     const result = await runEvalCase({
       evalCase: {
         ...traceTestCase,
-        evaluators: [
+        assertions: [
           {
             name: 'tool-check',
             type: 'tool-trajectory',
@@ -784,11 +784,11 @@ describe('runEvalCase trace integration', () => {
     const result = await runEvalCase({
       evalCase: {
         ...traceTestCase,
-        evaluators: [
+        assertions: [
           {
             name: 'metrics',
             type: 'composite',
-            evaluators: [
+            assertions: [
               { name: 'latency', type: 'latency', threshold: 1500 },
               { name: 'cost', type: 'cost', budget: 0.1 },
             ],
@@ -859,7 +859,7 @@ describe('runEvalCase trace integration', () => {
       const result = await runEvalCase({
         evalCase: {
           ...baseTestCase,
-          evaluators: [
+          assertions: [
             { name: 'eval1', type: 'llm-judge', weight: 2.0 },
             { name: 'eval2', type: 'llm-judge', weight: 1.0 },
           ],
@@ -891,7 +891,7 @@ describe('runEvalCase trace integration', () => {
       const result = await runEvalCase({
         evalCase: {
           ...baseTestCase,
-          evaluators: [
+          assertions: [
             { name: 'eval1', type: 'llm-judge', weight: 3.0 },
             { name: 'eval2', type: 'llm-judge' }, // no weight specified
           ],
@@ -922,7 +922,7 @@ describe('runEvalCase trace integration', () => {
       const result = await runEvalCase({
         evalCase: {
           ...baseTestCase,
-          evaluators: [
+          assertions: [
             { name: 'eval1', type: 'llm-judge', weight: 0 },
             { name: 'eval2', type: 'llm-judge', weight: 1.0 },
           ],
@@ -953,7 +953,7 @@ describe('runEvalCase trace integration', () => {
       const result = await runEvalCase({
         evalCase: {
           ...baseTestCase,
-          evaluators: [
+          assertions: [
             { name: 'eval1', type: 'llm-judge', weight: 0 },
             { name: 'eval2', type: 'llm-judge', weight: 0 },
           ],
@@ -1016,7 +1016,7 @@ Reference: \${input.reference_answer ?? 'none'}\`);
           ...baseTestCase,
           question: 'What is 2+2?',
           reference_answer: 'The sum is 4',
-          evaluators: [
+          assertions: [
             {
               name: 'ts-prompt-eval',
               type: 'llm-judge',
@@ -1077,7 +1077,7 @@ console.log('Question: ' + input.question + '\\nAnswer: ' + input.answer);
         evalCase: {
           ...baseTestCase,
           question: 'Test question',
-          evaluators: [
+          assertions: [
             {
               name: 'js-prompt-eval',
               type: 'llm-judge',
@@ -1129,7 +1129,7 @@ console.log('Question: ' + input.question + '\\nAnswer: ' + input.answer);
       const result = await runEvalCase({
         evalCase: {
           ...baseTestCase,
-          evaluators: [
+          assertions: [
             {
               name: 'txt-prompt-eval',
               type: 'llm-judge',
@@ -1687,7 +1687,7 @@ describe('deterministic assertion evaluators in orchestrator', () => {
       const result = await runEvalCase({
         evalCase: {
           ...assertionTestCase,
-          evaluators: [evaluator],
+          assertions: [evaluator],
         },
         provider,
         target: baseTarget,
@@ -1724,7 +1724,7 @@ describe('deterministic assertion evaluators in orchestrator', () => {
     const result = await runEvalCase({
       evalCase: {
         ...assertionTestCase,
-        evaluators: [{ name: 'weighted', type: 'contains', value: 'hello', weight: 2.0 }],
+        assertions: [{ name: 'weighted', type: 'contains', value: 'hello', weight: 2.0 }],
       },
       provider,
       target: baseTarget,
@@ -1747,7 +1747,7 @@ describe('deterministic assertion evaluators in orchestrator', () => {
     const result = await runEvalCase({
       evalCase: {
         ...assertionTestCase,
-        evaluators: [
+        assertions: [
           { name: 'has-hello', type: 'contains', value: 'hello' },
           { name: 'has-foo', type: 'contains', value: 'foo' },
         ],
@@ -1791,7 +1791,7 @@ describe('criteria with assert runs only declared evaluators (#452)', () => {
       evalCase: {
         ...criteriaTestCase,
         criteria: 'Response should be polite',
-        evaluators: [{ name: 'has-hello', type: 'contains' as const, value: 'hello' }],
+        assertions: [{ name: 'has-hello', type: 'contains' as const, value: 'hello' }],
       },
       provider,
       target: targetWithJudge,
@@ -1817,7 +1817,7 @@ describe('criteria with assert runs only declared evaluators (#452)', () => {
       evalCase: {
         ...criteriaTestCase,
         criteria: 'Response should be polite',
-        evaluators: [
+        assertions: [
           { name: 'has-hello', type: 'contains' as const, value: 'hello' },
           { name: 'has-world', type: 'contains' as const, value: 'world' },
         ],
@@ -1849,7 +1849,7 @@ describe('criteria with assert runs only declared evaluators (#452)', () => {
       evalCase: {
         ...criteriaTestCase,
         criteria: 'Response should be polite',
-        evaluators: [
+        assertions: [
           { name: 'quality-check', type: 'llm-judge' as const },
           { name: 'has-hello', type: 'contains' as const, value: 'hello' },
         ],
@@ -1884,7 +1884,7 @@ describe('required gates', () => {
     {
       label: 'boolean required gate triggers when required evaluator fails',
       output: 'The answer is goodbye',
-      evaluators: [
+      assertions: [
         {
           name: 'must-have',
           type: 'contains' as const,
@@ -1899,7 +1899,7 @@ describe('required gates', () => {
     {
       label: 'boolean required gate passes when required evaluator passes',
       output: 'hello world',
-      evaluators: [
+      assertions: [
         {
           name: 'must-have',
           type: 'contains' as const,
@@ -1914,7 +1914,7 @@ describe('required gates', () => {
     {
       label: 'numeric required threshold triggers gate when score is below threshold',
       output: 'The answer is goodbye',
-      evaluators: [
+      assertions: [
         {
           name: 'must-pass',
           type: 'contains' as const,
@@ -1929,7 +1929,7 @@ describe('required gates', () => {
     {
       label: 'numeric required threshold passes when score meets threshold',
       output: 'hello world',
-      evaluators: [
+      assertions: [
         {
           name: 'must-pass',
           type: 'contains' as const,
@@ -1943,7 +1943,7 @@ describe('required gates', () => {
     },
   ])(
     '$label',
-    async ({ output, evaluators: evalEvaluators, expectedScore, expectedIndividualScores }) => {
+    async ({ output, assertions: evalEvaluators, expectedScore, expectedIndividualScores }) => {
       const provider = new SequenceProvider('mock', {
         responses: [{ output: [{ role: 'assistant', content: output }] }],
       });
@@ -1951,7 +1951,7 @@ describe('required gates', () => {
       const result = await runEvalCase({
         evalCase: {
           ...assertionTestCase,
-          evaluators: evalEvaluators,
+          assertions: evalEvaluators,
         },
         provider,
         target: baseTarget,
@@ -1981,7 +1981,7 @@ describe('required gates', () => {
     const result = await runEvalCase({
       evalCase: {
         ...assertionTestCase,
-        evaluators: [
+        assertions: [
           { name: 'pass-eval', type: 'contains', value: 'hello' },
           { name: 'fail-eval', type: 'contains', value: 'foo' },
         ],
@@ -2024,7 +2024,7 @@ describe('required gates', () => {
     const result = await runEvalCase({
       evalCase: {
         ...assertionTestCase,
-        evaluators: [{ name: 'quality-check', type: 'llm-judge', required: true }],
+        assertions: [{ name: 'quality-check', type: 'llm-judge', required: true }],
       },
       provider,
       target: baseTarget,
@@ -2047,7 +2047,7 @@ describe('required gates', () => {
     const result = await runEvalCase({
       evalCase: {
         ...assertionTestCase,
-        evaluators: [{ name: 'must-contain', type: 'contains', value: 'hello', required: true }],
+        assertions: [{ name: 'must-contain', type: 'contains', value: 'hello', required: true }],
       },
       provider,
       target: baseTarget,
@@ -2721,7 +2721,7 @@ describe('--workspace flag', () => {
     const result = await runEvalCase({
       evalCase: {
         ...baseTestCase,
-        evaluators: [{ name: 'quality', type: 'llm-judge' }],
+        assertions: [{ name: 'quality', type: 'llm-judge' }],
       },
       provider,
       target: baseTarget,
@@ -2770,7 +2770,7 @@ describe('--workspace flag', () => {
     const result = await runEvalCase({
       evalCase: {
         ...baseTestCase,
-        evaluators: [{ name: 'broken', type: 'llm-judge' }],
+        assertions: [{ name: 'broken', type: 'llm-judge' }],
       },
       provider,
       target: baseTarget,

--- a/plugins/agentv-dev/skills/agentv-eval-builder/references/eval-schema.json
+++ b/plugins/agentv-dev/skills/agentv-eval-builder/references/eval-schema.json
@@ -197,6 +197,1077 @@
                       }
                     ]
                   },
+                  "assertions": {
+                    "type": "array",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": ["code-judge", "code_judge"]
+                            },
+                            "command": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              ]
+                            },
+                            "script": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              ]
+                            },
+                            "cwd": {
+                              "type": "string"
+                            },
+                            "target": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "max_calls": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              ]
+                            },
+                            "config": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            }
+                          },
+                          "required": ["type", "command"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": ["llm-judge", "llm_judge"]
+                            },
+                            "prompt": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "script": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "config": {
+                                      "type": "object",
+                                      "additionalProperties": {}
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              ]
+                            },
+                            "rubrics": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "outcome": {
+                                    "type": "string"
+                                  },
+                                  "weight": {
+                                    "type": "number"
+                                  },
+                                  "required": {
+                                    "type": "boolean"
+                                  },
+                                  "required_min_score": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 10
+                                  },
+                                  "score_ranges": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "score_range": {
+                                          "type": "array",
+                                          "minItems": 2,
+                                          "maxItems": 2,
+                                          "items": [
+                                            {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "maximum": 10
+                                            },
+                                            {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "maximum": 10
+                                            }
+                                          ]
+                                        },
+                                        "outcome": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        }
+                                      },
+                                      "required": ["score_range", "outcome"],
+                                      "additionalProperties": false
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "model": {
+                              "type": "string"
+                            },
+                            "config": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            }
+                          },
+                          "required": ["type"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "composite"
+                            },
+                            "assertions": {
+                              "type": "array",
+                              "items": {}
+                            },
+                            "assert": {
+                              "type": "array",
+                              "items": {}
+                            },
+                            "evaluators": {
+                              "type": "array",
+                              "items": {}
+                            },
+                            "aggregator": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "weighted_average"
+                                    },
+                                    "weights": {
+                                      "type": "object",
+                                      "additionalProperties": {
+                                        "type": "number"
+                                      }
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "threshold"
+                                    },
+                                    "threshold": {
+                                      "type": "number",
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    }
+                                  },
+                                  "required": ["type", "threshold"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "code-judge"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "cwd": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["type", "path"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "llm-judge"
+                                    },
+                                    "prompt": {
+                                      "type": "string"
+                                    },
+                                    "model": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            }
+                          },
+                          "required": ["type", "aggregator"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": ["tool-trajectory", "tool_trajectory"]
+                            },
+                            "mode": {
+                              "type": "string",
+                              "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                            },
+                            "minimums": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "integer",
+                                "minimum": 0
+                              }
+                            },
+                            "expected": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "tool": {
+                                    "type": "string"
+                                  },
+                                  "args": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string",
+                                        "const": "any"
+                                      },
+                                      {
+                                        "type": "object",
+                                        "additionalProperties": {}
+                                      }
+                                    ]
+                                  },
+                                  "max_duration_ms": {
+                                    "type": "number",
+                                    "minimum": 0
+                                  },
+                                  "maxDurationMs": {
+                                    "type": "number",
+                                    "minimum": 0
+                                  },
+                                  "args_match": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string",
+                                        "enum": ["exact", "ignore", "subset", "superset"]
+                                      },
+                                      {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "argsMatch": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string",
+                                        "enum": ["exact", "ignore", "subset", "superset"]
+                                      },
+                                      {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": ["tool"],
+                                "additionalProperties": false
+                              }
+                            },
+                            "args_match": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              ]
+                            },
+                            "argsMatch": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "required": ["type", "mode"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": ["field-accuracy", "field_accuracy"]
+                            },
+                            "fields": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "match": {
+                                    "type": "string",
+                                    "enum": ["exact", "numeric_tolerance", "date"]
+                                  },
+                                  "required": {
+                                    "type": "boolean"
+                                  },
+                                  "weight": {
+                                    "type": "number"
+                                  },
+                                  "tolerance": {
+                                    "type": "number",
+                                    "minimum": 0
+                                  },
+                                  "relative": {
+                                    "type": "boolean"
+                                  },
+                                  "formats": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": ["path", "match"],
+                                "additionalProperties": false
+                              },
+                              "minItems": 1
+                            },
+                            "aggregation": {
+                              "type": "string",
+                              "enum": ["weighted_average", "all_or_nothing"]
+                            }
+                          },
+                          "required": ["type", "fields"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "latency"
+                            },
+                            "threshold": {
+                              "type": "number",
+                              "minimum": 0
+                            }
+                          },
+                          "required": ["type", "threshold"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "cost"
+                            },
+                            "budget": {
+                              "type": "number",
+                              "minimum": 0
+                            }
+                          },
+                          "required": ["type", "budget"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": ["token-usage", "token_usage"]
+                            },
+                            "max_total": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "max_input": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "max_output": {
+                              "type": "number",
+                              "minimum": 0
+                            }
+                          },
+                          "required": ["type"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": ["execution-metrics", "execution_metrics"]
+                            },
+                            "max_tool_calls": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "max_llm_calls": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "max_tokens": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "max_cost_usd": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "max_duration_ms": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "target_exploration_ratio": {
+                              "type": "number",
+                              "minimum": 0,
+                              "maximum": 1
+                            },
+                            "exploration_tolerance": {
+                              "type": "number",
+                              "minimum": 0
+                            }
+                          },
+                          "required": ["type"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": ["agent-judge", "agent_judge"]
+                            },
+                            "prompt": {
+                              "type": "string"
+                            },
+                            "rubrics": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "outcome": {
+                                    "type": "string"
+                                  },
+                                  "weight": {
+                                    "type": "number"
+                                  },
+                                  "required": {
+                                    "type": "boolean"
+                                  },
+                                  "required_min_score": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 10
+                                  },
+                                  "score_ranges": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "score_range": {
+                                          "type": "array",
+                                          "minItems": 2,
+                                          "maxItems": 2,
+                                          "items": [
+                                            {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "maximum": 10
+                                            },
+                                            {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "maximum": 10
+                                            }
+                                          ]
+                                        },
+                                        "outcome": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        }
+                                      },
+                                      "required": ["score_range", "outcome"],
+                                      "additionalProperties": false
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "max_steps": {
+                              "type": "integer",
+                              "minimum": 1,
+                              "maximum": 50
+                            },
+                            "temperature": {
+                              "type": "number",
+                              "minimum": 0,
+                              "maximum": 2
+                            },
+                            "target": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["type"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "contains"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["type", "value"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "regex"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["type", "value"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": ["is-json", "is_json"]
+                            }
+                          },
+                          "required": ["type"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "equals"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["type", "value"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "rubrics"
+                            },
+                            "criteria": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "outcome": {
+                                    "type": "string"
+                                  },
+                                  "weight": {
+                                    "type": "number"
+                                  },
+                                  "required": {
+                                    "type": "boolean"
+                                  },
+                                  "required_min_score": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 10
+                                  },
+                                  "score_ranges": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "score_range": {
+                                          "type": "array",
+                                          "minItems": 2,
+                                          "maxItems": 2,
+                                          "items": [
+                                            {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "maximum": 10
+                                            },
+                                            {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "maximum": 10
+                                            }
+                                          ]
+                                        },
+                                        "outcome": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        }
+                                      },
+                                      "required": ["score_range", "outcome"],
+                                      "additionalProperties": false
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "minItems": 1
+                            }
+                          },
+                          "required": ["type", "criteria"],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  },
                   "assert": {
                     "type": "array",
                     "items": {
@@ -451,6 +1522,10 @@
                             "type": {
                               "type": "string",
                               "const": "composite"
+                            },
+                            "assertions": {
+                              "type": "array",
+                              "items": {}
                             },
                             "assert": {
                               "type": "array",
@@ -1519,6 +2594,10 @@
                               "type": "string",
                               "const": "composite"
                             },
+                            "assertions": {
+                              "type": "array",
+                              "items": {}
+                            },
                             "assert": {
                               "type": "array",
                               "items": {}
@@ -2343,6 +3422,1077 @@
                           "type": "string"
                         }
                       },
+                      "assertions": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["code-judge", "code_judge"]
+                                },
+                                "command": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "script": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "cwd": {
+                                  "type": "string"
+                                },
+                                "target": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "max_calls": {
+                                          "type": "number"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                },
+                                "config": {
+                                  "type": "object",
+                                  "additionalProperties": {}
+                                }
+                              },
+                              "required": ["type", "command"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["llm-judge", "llm_judge"]
+                                },
+                                "prompt": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "script": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "config": {
+                                          "type": "object",
+                                          "additionalProperties": {}
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                },
+                                "rubrics": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "outcome": {
+                                        "type": "string"
+                                      },
+                                      "weight": {
+                                        "type": "number"
+                                      },
+                                      "required": {
+                                        "type": "boolean"
+                                      },
+                                      "required_min_score": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 10
+                                      },
+                                      "score_ranges": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "score_range": {
+                                              "type": "array",
+                                              "minItems": 2,
+                                              "maxItems": 2,
+                                              "items": [
+                                                {
+                                                  "type": "integer",
+                                                  "minimum": 0,
+                                                  "maximum": 10
+                                                },
+                                                {
+                                                  "type": "integer",
+                                                  "minimum": 0,
+                                                  "maximum": 10
+                                                }
+                                              ]
+                                            },
+                                            "outcome": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["score_range", "outcome"],
+                                          "additionalProperties": false
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "model": {
+                                  "type": "string"
+                                },
+                                "config": {
+                                  "type": "object",
+                                  "additionalProperties": {}
+                                }
+                              },
+                              "required": ["type"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "const": "composite"
+                                },
+                                "assertions": {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                "assert": {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                "evaluators": {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                "aggregator": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "weighted_average"
+                                        },
+                                        "weights": {
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "number"
+                                          }
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "threshold"
+                                        },
+                                        "threshold": {
+                                          "type": "number",
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      },
+                                      "required": ["type", "threshold"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "code-judge"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "cwd": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": ["type", "path"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "llm-judge"
+                                        },
+                                        "prompt": {
+                                          "type": "string"
+                                        },
+                                        "model": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": ["type", "aggregator"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["tool-trajectory", "tool_trajectory"]
+                                },
+                                "mode": {
+                                  "type": "string",
+                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                                },
+                                "minimums": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  }
+                                },
+                                "expected": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "tool": {
+                                        "type": "string"
+                                      },
+                                      "args": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string",
+                                            "const": "any"
+                                          },
+                                          {
+                                            "type": "object",
+                                            "additionalProperties": {}
+                                          }
+                                        ]
+                                      },
+                                      "max_duration_ms": {
+                                        "type": "number",
+                                        "minimum": 0
+                                      },
+                                      "maxDurationMs": {
+                                        "type": "number",
+                                        "minimum": 0
+                                      },
+                                      "args_match": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string",
+                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "argsMatch": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string",
+                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": ["tool"],
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "args_match": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "argsMatch": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": ["type", "mode"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["field-accuracy", "field_accuracy"]
+                                },
+                                "fields": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "match": {
+                                        "type": "string",
+                                        "enum": ["exact", "numeric_tolerance", "date"]
+                                      },
+                                      "required": {
+                                        "type": "boolean"
+                                      },
+                                      "weight": {
+                                        "type": "number"
+                                      },
+                                      "tolerance": {
+                                        "type": "number",
+                                        "minimum": 0
+                                      },
+                                      "relative": {
+                                        "type": "boolean"
+                                      },
+                                      "formats": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "required": ["path", "match"],
+                                    "additionalProperties": false
+                                  },
+                                  "minItems": 1
+                                },
+                                "aggregation": {
+                                  "type": "string",
+                                  "enum": ["weighted_average", "all_or_nothing"]
+                                }
+                              },
+                              "required": ["type", "fields"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "const": "latency"
+                                },
+                                "threshold": {
+                                  "type": "number",
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["type", "threshold"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "const": "cost"
+                                },
+                                "budget": {
+                                  "type": "number",
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["type", "budget"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["token-usage", "token_usage"]
+                                },
+                                "max_total": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "max_input": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "max_output": {
+                                  "type": "number",
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["type"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["execution-metrics", "execution_metrics"]
+                                },
+                                "max_tool_calls": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "max_llm_calls": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "max_tokens": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "max_cost_usd": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "max_duration_ms": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "target_exploration_ratio": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1
+                                },
+                                "exploration_tolerance": {
+                                  "type": "number",
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["type"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["agent-judge", "agent_judge"]
+                                },
+                                "prompt": {
+                                  "type": "string"
+                                },
+                                "rubrics": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "outcome": {
+                                        "type": "string"
+                                      },
+                                      "weight": {
+                                        "type": "number"
+                                      },
+                                      "required": {
+                                        "type": "boolean"
+                                      },
+                                      "required_min_score": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 10
+                                      },
+                                      "score_ranges": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "score_range": {
+                                              "type": "array",
+                                              "minItems": 2,
+                                              "maxItems": 2,
+                                              "items": [
+                                                {
+                                                  "type": "integer",
+                                                  "minimum": 0,
+                                                  "maximum": 10
+                                                },
+                                                {
+                                                  "type": "integer",
+                                                  "minimum": 0,
+                                                  "maximum": 10
+                                                }
+                                              ]
+                                            },
+                                            "outcome": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["score_range", "outcome"],
+                                          "additionalProperties": false
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "max_steps": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 50
+                                },
+                                "temperature": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 2
+                                },
+                                "target": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["type"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "const": "contains"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["type", "value"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "const": "regex"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["type", "value"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["is-json", "is_json"]
+                                }
+                              },
+                              "required": ["type"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "const": "equals"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["type", "value"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "const": "rubrics"
+                                },
+                                "criteria": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "outcome": {
+                                        "type": "string"
+                                      },
+                                      "weight": {
+                                        "type": "number"
+                                      },
+                                      "required": {
+                                        "type": "boolean"
+                                      },
+                                      "required_min_score": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 10
+                                      },
+                                      "score_ranges": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "score_range": {
+                                              "type": "array",
+                                              "minItems": 2,
+                                              "maxItems": 2,
+                                              "items": [
+                                                {
+                                                  "type": "integer",
+                                                  "minimum": 0,
+                                                  "maximum": 10
+                                                },
+                                                {
+                                                  "type": "integer",
+                                                  "minimum": 0,
+                                                  "maximum": 10
+                                                }
+                                              ]
+                                            },
+                                            "outcome": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["score_range", "outcome"],
+                                          "additionalProperties": false
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "minItems": 1
+                                }
+                              },
+                              "required": ["type", "criteria"],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
                       "assert": {
                         "type": "array",
                         "items": {
@@ -2597,6 +4747,10 @@
                                 "type": {
                                   "type": "string",
                                   "const": "composite"
+                                },
+                                "assertions": {
+                                  "type": "array",
+                                  "items": {}
                                 },
                                 "assert": {
                                   "type": "array",
@@ -3664,6 +5818,10 @@
                                 "type": {
                                   "type": "string",
                                   "const": "composite"
+                                },
+                                "assertions": {
+                                  "type": "array",
+                                  "items": {}
                                 },
                                 "assert": {
                                   "type": "array",
@@ -4892,6 +7050,1077 @@
                       }
                     ]
                   },
+                  "assertions": {
+                    "type": "array",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": ["code-judge", "code_judge"]
+                            },
+                            "command": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              ]
+                            },
+                            "script": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              ]
+                            },
+                            "cwd": {
+                              "type": "string"
+                            },
+                            "target": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "max_calls": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              ]
+                            },
+                            "config": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            }
+                          },
+                          "required": ["type", "command"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": ["llm-judge", "llm_judge"]
+                            },
+                            "prompt": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "script": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "config": {
+                                      "type": "object",
+                                      "additionalProperties": {}
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              ]
+                            },
+                            "rubrics": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "outcome": {
+                                    "type": "string"
+                                  },
+                                  "weight": {
+                                    "type": "number"
+                                  },
+                                  "required": {
+                                    "type": "boolean"
+                                  },
+                                  "required_min_score": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 10
+                                  },
+                                  "score_ranges": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "score_range": {
+                                          "type": "array",
+                                          "minItems": 2,
+                                          "maxItems": 2,
+                                          "items": [
+                                            {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "maximum": 10
+                                            },
+                                            {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "maximum": 10
+                                            }
+                                          ]
+                                        },
+                                        "outcome": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        }
+                                      },
+                                      "required": ["score_range", "outcome"],
+                                      "additionalProperties": false
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "model": {
+                              "type": "string"
+                            },
+                            "config": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            }
+                          },
+                          "required": ["type"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "composite"
+                            },
+                            "assertions": {
+                              "type": "array",
+                              "items": {}
+                            },
+                            "assert": {
+                              "type": "array",
+                              "items": {}
+                            },
+                            "evaluators": {
+                              "type": "array",
+                              "items": {}
+                            },
+                            "aggregator": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "weighted_average"
+                                    },
+                                    "weights": {
+                                      "type": "object",
+                                      "additionalProperties": {
+                                        "type": "number"
+                                      }
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "threshold"
+                                    },
+                                    "threshold": {
+                                      "type": "number",
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    }
+                                  },
+                                  "required": ["type", "threshold"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "code-judge"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "cwd": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["type", "path"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "llm-judge"
+                                    },
+                                    "prompt": {
+                                      "type": "string"
+                                    },
+                                    "model": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            }
+                          },
+                          "required": ["type", "aggregator"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": ["tool-trajectory", "tool_trajectory"]
+                            },
+                            "mode": {
+                              "type": "string",
+                              "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                            },
+                            "minimums": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "integer",
+                                "minimum": 0
+                              }
+                            },
+                            "expected": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "tool": {
+                                    "type": "string"
+                                  },
+                                  "args": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string",
+                                        "const": "any"
+                                      },
+                                      {
+                                        "type": "object",
+                                        "additionalProperties": {}
+                                      }
+                                    ]
+                                  },
+                                  "max_duration_ms": {
+                                    "type": "number",
+                                    "minimum": 0
+                                  },
+                                  "maxDurationMs": {
+                                    "type": "number",
+                                    "minimum": 0
+                                  },
+                                  "args_match": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string",
+                                        "enum": ["exact", "ignore", "subset", "superset"]
+                                      },
+                                      {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "argsMatch": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string",
+                                        "enum": ["exact", "ignore", "subset", "superset"]
+                                      },
+                                      {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": ["tool"],
+                                "additionalProperties": false
+                              }
+                            },
+                            "args_match": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              ]
+                            },
+                            "argsMatch": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "required": ["type", "mode"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": ["field-accuracy", "field_accuracy"]
+                            },
+                            "fields": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "match": {
+                                    "type": "string",
+                                    "enum": ["exact", "numeric_tolerance", "date"]
+                                  },
+                                  "required": {
+                                    "type": "boolean"
+                                  },
+                                  "weight": {
+                                    "type": "number"
+                                  },
+                                  "tolerance": {
+                                    "type": "number",
+                                    "minimum": 0
+                                  },
+                                  "relative": {
+                                    "type": "boolean"
+                                  },
+                                  "formats": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "required": ["path", "match"],
+                                "additionalProperties": false
+                              },
+                              "minItems": 1
+                            },
+                            "aggregation": {
+                              "type": "string",
+                              "enum": ["weighted_average", "all_or_nothing"]
+                            }
+                          },
+                          "required": ["type", "fields"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "latency"
+                            },
+                            "threshold": {
+                              "type": "number",
+                              "minimum": 0
+                            }
+                          },
+                          "required": ["type", "threshold"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "cost"
+                            },
+                            "budget": {
+                              "type": "number",
+                              "minimum": 0
+                            }
+                          },
+                          "required": ["type", "budget"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": ["token-usage", "token_usage"]
+                            },
+                            "max_total": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "max_input": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "max_output": {
+                              "type": "number",
+                              "minimum": 0
+                            }
+                          },
+                          "required": ["type"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": ["execution-metrics", "execution_metrics"]
+                            },
+                            "max_tool_calls": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "max_llm_calls": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "max_tokens": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "max_cost_usd": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "max_duration_ms": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "target_exploration_ratio": {
+                              "type": "number",
+                              "minimum": 0,
+                              "maximum": 1
+                            },
+                            "exploration_tolerance": {
+                              "type": "number",
+                              "minimum": 0
+                            }
+                          },
+                          "required": ["type"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": ["agent-judge", "agent_judge"]
+                            },
+                            "prompt": {
+                              "type": "string"
+                            },
+                            "rubrics": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "outcome": {
+                                    "type": "string"
+                                  },
+                                  "weight": {
+                                    "type": "number"
+                                  },
+                                  "required": {
+                                    "type": "boolean"
+                                  },
+                                  "required_min_score": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 10
+                                  },
+                                  "score_ranges": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "score_range": {
+                                          "type": "array",
+                                          "minItems": 2,
+                                          "maxItems": 2,
+                                          "items": [
+                                            {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "maximum": 10
+                                            },
+                                            {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "maximum": 10
+                                            }
+                                          ]
+                                        },
+                                        "outcome": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        }
+                                      },
+                                      "required": ["score_range", "outcome"],
+                                      "additionalProperties": false
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "max_steps": {
+                              "type": "integer",
+                              "minimum": 1,
+                              "maximum": 50
+                            },
+                            "temperature": {
+                              "type": "number",
+                              "minimum": 0,
+                              "maximum": 2
+                            },
+                            "target": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["type"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "contains"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["type", "value"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "regex"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["type", "value"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": ["is-json", "is_json"]
+                            }
+                          },
+                          "required": ["type"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "equals"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["type", "value"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 1
+                                }
+                              ]
+                            },
+                            "negate": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "rubrics"
+                            },
+                            "criteria": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "outcome": {
+                                    "type": "string"
+                                  },
+                                  "weight": {
+                                    "type": "number"
+                                  },
+                                  "required": {
+                                    "type": "boolean"
+                                  },
+                                  "required_min_score": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 10
+                                  },
+                                  "score_ranges": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "score_range": {
+                                          "type": "array",
+                                          "minItems": 2,
+                                          "maxItems": 2,
+                                          "items": [
+                                            {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "maximum": 10
+                                            },
+                                            {
+                                              "type": "integer",
+                                              "minimum": 0,
+                                              "maximum": 10
+                                            }
+                                          ]
+                                        },
+                                        "outcome": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        }
+                                      },
+                                      "required": ["score_range", "outcome"],
+                                      "additionalProperties": false
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "minItems": 1
+                            }
+                          },
+                          "required": ["type", "criteria"],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  },
                   "assert": {
                     "type": "array",
                     "items": {
@@ -5146,6 +8375,10 @@
                             "type": {
                               "type": "string",
                               "const": "composite"
+                            },
+                            "assertions": {
+                              "type": "array",
+                              "items": {}
                             },
                             "assert": {
                               "type": "array",
@@ -6214,6 +9447,10 @@
                               "type": "string",
                               "const": "composite"
                             },
+                            "assertions": {
+                              "type": "array",
+                              "items": {}
+                            },
                             "assert": {
                               "type": "array",
                               "items": {}
@@ -7038,6 +10275,1077 @@
                           "type": "string"
                         }
                       },
+                      "assertions": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["code-judge", "code_judge"]
+                                },
+                                "command": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "script": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "cwd": {
+                                  "type": "string"
+                                },
+                                "target": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "max_calls": {
+                                          "type": "number"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                },
+                                "config": {
+                                  "type": "object",
+                                  "additionalProperties": {}
+                                }
+                              },
+                              "required": ["type", "command"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["llm-judge", "llm_judge"]
+                                },
+                                "prompt": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "script": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "config": {
+                                          "type": "object",
+                                          "additionalProperties": {}
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                },
+                                "rubrics": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "outcome": {
+                                        "type": "string"
+                                      },
+                                      "weight": {
+                                        "type": "number"
+                                      },
+                                      "required": {
+                                        "type": "boolean"
+                                      },
+                                      "required_min_score": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 10
+                                      },
+                                      "score_ranges": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "score_range": {
+                                              "type": "array",
+                                              "minItems": 2,
+                                              "maxItems": 2,
+                                              "items": [
+                                                {
+                                                  "type": "integer",
+                                                  "minimum": 0,
+                                                  "maximum": 10
+                                                },
+                                                {
+                                                  "type": "integer",
+                                                  "minimum": 0,
+                                                  "maximum": 10
+                                                }
+                                              ]
+                                            },
+                                            "outcome": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["score_range", "outcome"],
+                                          "additionalProperties": false
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "model": {
+                                  "type": "string"
+                                },
+                                "config": {
+                                  "type": "object",
+                                  "additionalProperties": {}
+                                }
+                              },
+                              "required": ["type"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "const": "composite"
+                                },
+                                "assertions": {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                "assert": {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                "evaluators": {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                "aggregator": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "weighted_average"
+                                        },
+                                        "weights": {
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "number"
+                                          }
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "threshold"
+                                        },
+                                        "threshold": {
+                                          "type": "number",
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      },
+                                      "required": ["type", "threshold"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "code-judge"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "cwd": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": ["type", "path"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "llm-judge"
+                                        },
+                                        "prompt": {
+                                          "type": "string"
+                                        },
+                                        "model": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": ["type", "aggregator"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["tool-trajectory", "tool_trajectory"]
+                                },
+                                "mode": {
+                                  "type": "string",
+                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                                },
+                                "minimums": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  }
+                                },
+                                "expected": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "tool": {
+                                        "type": "string"
+                                      },
+                                      "args": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string",
+                                            "const": "any"
+                                          },
+                                          {
+                                            "type": "object",
+                                            "additionalProperties": {}
+                                          }
+                                        ]
+                                      },
+                                      "max_duration_ms": {
+                                        "type": "number",
+                                        "minimum": 0
+                                      },
+                                      "maxDurationMs": {
+                                        "type": "number",
+                                        "minimum": 0
+                                      },
+                                      "args_match": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string",
+                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "argsMatch": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string",
+                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": ["tool"],
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "args_match": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "argsMatch": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": ["type", "mode"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["field-accuracy", "field_accuracy"]
+                                },
+                                "fields": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "match": {
+                                        "type": "string",
+                                        "enum": ["exact", "numeric_tolerance", "date"]
+                                      },
+                                      "required": {
+                                        "type": "boolean"
+                                      },
+                                      "weight": {
+                                        "type": "number"
+                                      },
+                                      "tolerance": {
+                                        "type": "number",
+                                        "minimum": 0
+                                      },
+                                      "relative": {
+                                        "type": "boolean"
+                                      },
+                                      "formats": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "required": ["path", "match"],
+                                    "additionalProperties": false
+                                  },
+                                  "minItems": 1
+                                },
+                                "aggregation": {
+                                  "type": "string",
+                                  "enum": ["weighted_average", "all_or_nothing"]
+                                }
+                              },
+                              "required": ["type", "fields"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "const": "latency"
+                                },
+                                "threshold": {
+                                  "type": "number",
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["type", "threshold"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "const": "cost"
+                                },
+                                "budget": {
+                                  "type": "number",
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["type", "budget"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["token-usage", "token_usage"]
+                                },
+                                "max_total": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "max_input": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "max_output": {
+                                  "type": "number",
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["type"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["execution-metrics", "execution_metrics"]
+                                },
+                                "max_tool_calls": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "max_llm_calls": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "max_tokens": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "max_cost_usd": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "max_duration_ms": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "target_exploration_ratio": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1
+                                },
+                                "exploration_tolerance": {
+                                  "type": "number",
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["type"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["agent-judge", "agent_judge"]
+                                },
+                                "prompt": {
+                                  "type": "string"
+                                },
+                                "rubrics": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "outcome": {
+                                        "type": "string"
+                                      },
+                                      "weight": {
+                                        "type": "number"
+                                      },
+                                      "required": {
+                                        "type": "boolean"
+                                      },
+                                      "required_min_score": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 10
+                                      },
+                                      "score_ranges": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "score_range": {
+                                              "type": "array",
+                                              "minItems": 2,
+                                              "maxItems": 2,
+                                              "items": [
+                                                {
+                                                  "type": "integer",
+                                                  "minimum": 0,
+                                                  "maximum": 10
+                                                },
+                                                {
+                                                  "type": "integer",
+                                                  "minimum": 0,
+                                                  "maximum": 10
+                                                }
+                                              ]
+                                            },
+                                            "outcome": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["score_range", "outcome"],
+                                          "additionalProperties": false
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "max_steps": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 50
+                                },
+                                "temperature": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 2
+                                },
+                                "target": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["type"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "const": "contains"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["type", "value"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "const": "regex"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["type", "value"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["is-json", "is_json"]
+                                }
+                              },
+                              "required": ["type"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "const": "equals"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["type", "value"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "weight": {
+                                  "type": "number",
+                                  "minimum": 0
+                                },
+                                "required": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "number",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 1
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "const": "rubrics"
+                                },
+                                "criteria": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "outcome": {
+                                        "type": "string"
+                                      },
+                                      "weight": {
+                                        "type": "number"
+                                      },
+                                      "required": {
+                                        "type": "boolean"
+                                      },
+                                      "required_min_score": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 10
+                                      },
+                                      "score_ranges": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "score_range": {
+                                              "type": "array",
+                                              "minItems": 2,
+                                              "maxItems": 2,
+                                              "items": [
+                                                {
+                                                  "type": "integer",
+                                                  "minimum": 0,
+                                                  "maximum": 10
+                                                },
+                                                {
+                                                  "type": "integer",
+                                                  "minimum": 0,
+                                                  "maximum": 10
+                                                }
+                                              ]
+                                            },
+                                            "outcome": {
+                                              "type": "string",
+                                              "minLength": 1
+                                            }
+                                          },
+                                          "required": ["score_range", "outcome"],
+                                          "additionalProperties": false
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "minItems": 1
+                                }
+                              },
+                              "required": ["type", "criteria"],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
                       "assert": {
                         "type": "array",
                         "items": {
@@ -7292,6 +11600,10 @@
                                 "type": {
                                   "type": "string",
                                   "const": "composite"
+                                },
+                                "assertions": {
+                                  "type": "array",
+                                  "items": {}
                                 },
                                 "assert": {
                                   "type": "array",
@@ -8359,6 +12671,10 @@
                                 "type": {
                                   "type": "string",
                                   "const": "composite"
+                                },
+                                "assertions": {
+                                  "type": "array",
+                                  "items": {}
                                 },
                                 "assert": {
                                   "type": "array",
@@ -9491,6 +13807,1077 @@
                 "type": "string"
               }
             },
+            "assertions": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "weight": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "required": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "maximum": 1
+                          }
+                        ]
+                      },
+                      "negate": {
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": ["code-judge", "code_judge"]
+                      },
+                      "command": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        ]
+                      },
+                      "script": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        ]
+                      },
+                      "cwd": {
+                        "type": "string"
+                      },
+                      "target": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "max_calls": {
+                                "type": "number"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ]
+                      },
+                      "config": {
+                        "type": "object",
+                        "additionalProperties": {}
+                      }
+                    },
+                    "required": ["type", "command"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "weight": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "required": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "maximum": 1
+                          }
+                        ]
+                      },
+                      "negate": {
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": ["llm-judge", "llm_judge"]
+                      },
+                      "prompt": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
+                              },
+                              "script": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
+                              },
+                              "config": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ]
+                      },
+                      "rubrics": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "outcome": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number"
+                            },
+                            "required": {
+                              "type": "boolean"
+                            },
+                            "required_min_score": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 10
+                            },
+                            "score_ranges": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "score_range": {
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "maxItems": 2,
+                                    "items": [
+                                      {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 10
+                                      },
+                                      {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 10
+                                      }
+                                    ]
+                                  },
+                                  "outcome": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  }
+                                },
+                                "required": ["score_range", "outcome"],
+                                "additionalProperties": false
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "model": {
+                        "type": "string"
+                      },
+                      "config": {
+                        "type": "object",
+                        "additionalProperties": {}
+                      }
+                    },
+                    "required": ["type"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "weight": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "required": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "maximum": 1
+                          }
+                        ]
+                      },
+                      "negate": {
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "type": "string",
+                        "const": "composite"
+                      },
+                      "assertions": {
+                        "type": "array",
+                        "items": {}
+                      },
+                      "assert": {
+                        "type": "array",
+                        "items": {}
+                      },
+                      "evaluators": {
+                        "type": "array",
+                        "items": {}
+                      },
+                      "aggregator": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "const": "weighted_average"
+                              },
+                              "weights": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "number"
+                                }
+                              }
+                            },
+                            "required": ["type"],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "const": "threshold"
+                              },
+                              "threshold": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
+                              }
+                            },
+                            "required": ["type", "threshold"],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "const": "code-judge"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "cwd": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["type", "path"],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "const": "llm-judge"
+                              },
+                              "prompt": {
+                                "type": "string"
+                              },
+                              "model": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["type"],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    },
+                    "required": ["type", "aggregator"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "weight": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "required": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "maximum": 1
+                          }
+                        ]
+                      },
+                      "negate": {
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": ["tool-trajectory", "tool_trajectory"]
+                      },
+                      "mode": {
+                        "type": "string",
+                        "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                      },
+                      "minimums": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "integer",
+                          "minimum": 0
+                        }
+                      },
+                      "expected": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "tool": {
+                              "type": "string"
+                            },
+                            "args": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "const": "any"
+                                },
+                                {
+                                  "type": "object",
+                                  "additionalProperties": {}
+                                }
+                              ]
+                            },
+                            "max_duration_ms": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "maxDurationMs": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "args_match": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              ]
+                            },
+                            "argsMatch": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "required": ["tool"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "args_match": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": ["exact", "ignore", "subset", "superset"]
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        ]
+                      },
+                      "argsMatch": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": ["exact", "ignore", "subset", "superset"]
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "required": ["type", "mode"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "weight": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "required": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "maximum": 1
+                          }
+                        ]
+                      },
+                      "negate": {
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": ["field-accuracy", "field_accuracy"]
+                      },
+                      "fields": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "path": {
+                              "type": "string"
+                            },
+                            "match": {
+                              "type": "string",
+                              "enum": ["exact", "numeric_tolerance", "date"]
+                            },
+                            "required": {
+                              "type": "boolean"
+                            },
+                            "weight": {
+                              "type": "number"
+                            },
+                            "tolerance": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "relative": {
+                              "type": "boolean"
+                            },
+                            "formats": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "required": ["path", "match"],
+                          "additionalProperties": false
+                        },
+                        "minItems": 1
+                      },
+                      "aggregation": {
+                        "type": "string",
+                        "enum": ["weighted_average", "all_or_nothing"]
+                      }
+                    },
+                    "required": ["type", "fields"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "weight": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "required": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "maximum": 1
+                          }
+                        ]
+                      },
+                      "negate": {
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "type": "string",
+                        "const": "latency"
+                      },
+                      "threshold": {
+                        "type": "number",
+                        "minimum": 0
+                      }
+                    },
+                    "required": ["type", "threshold"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "weight": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "required": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "maximum": 1
+                          }
+                        ]
+                      },
+                      "negate": {
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "type": "string",
+                        "const": "cost"
+                      },
+                      "budget": {
+                        "type": "number",
+                        "minimum": 0
+                      }
+                    },
+                    "required": ["type", "budget"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "weight": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "required": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "maximum": 1
+                          }
+                        ]
+                      },
+                      "negate": {
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": ["token-usage", "token_usage"]
+                      },
+                      "max_total": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "max_input": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "max_output": {
+                        "type": "number",
+                        "minimum": 0
+                      }
+                    },
+                    "required": ["type"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "weight": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "required": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "maximum": 1
+                          }
+                        ]
+                      },
+                      "negate": {
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": ["execution-metrics", "execution_metrics"]
+                      },
+                      "max_tool_calls": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "max_llm_calls": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "max_tokens": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "max_cost_usd": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "max_duration_ms": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "target_exploration_ratio": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1
+                      },
+                      "exploration_tolerance": {
+                        "type": "number",
+                        "minimum": 0
+                      }
+                    },
+                    "required": ["type"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "weight": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "required": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "maximum": 1
+                          }
+                        ]
+                      },
+                      "negate": {
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": ["agent-judge", "agent_judge"]
+                      },
+                      "prompt": {
+                        "type": "string"
+                      },
+                      "rubrics": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "outcome": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number"
+                            },
+                            "required": {
+                              "type": "boolean"
+                            },
+                            "required_min_score": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 10
+                            },
+                            "score_ranges": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "score_range": {
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "maxItems": 2,
+                                    "items": [
+                                      {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 10
+                                      },
+                                      {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 10
+                                      }
+                                    ]
+                                  },
+                                  "outcome": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  }
+                                },
+                                "required": ["score_range", "outcome"],
+                                "additionalProperties": false
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "max_steps": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 50
+                      },
+                      "temperature": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 2
+                      },
+                      "target": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["type"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "weight": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "required": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "maximum": 1
+                          }
+                        ]
+                      },
+                      "negate": {
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "type": "string",
+                        "const": "contains"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["type", "value"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "weight": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "required": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "maximum": 1
+                          }
+                        ]
+                      },
+                      "negate": {
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "type": "string",
+                        "const": "regex"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["type", "value"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "weight": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "required": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "maximum": 1
+                          }
+                        ]
+                      },
+                      "negate": {
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": ["is-json", "is_json"]
+                      }
+                    },
+                    "required": ["type"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "weight": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "required": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "maximum": 1
+                          }
+                        ]
+                      },
+                      "negate": {
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "type": "string",
+                        "const": "equals"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["type", "value"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "weight": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "required": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "maximum": 1
+                          }
+                        ]
+                      },
+                      "negate": {
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "type": "string",
+                        "const": "rubrics"
+                      },
+                      "criteria": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "outcome": {
+                              "type": "string"
+                            },
+                            "weight": {
+                              "type": "number"
+                            },
+                            "required": {
+                              "type": "boolean"
+                            },
+                            "required_min_score": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 10
+                            },
+                            "score_ranges": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "score_range": {
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "maxItems": 2,
+                                    "items": [
+                                      {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 10
+                                      },
+                                      {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 10
+                                      }
+                                    ]
+                                  },
+                                  "outcome": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  }
+                                },
+                                "required": ["score_range", "outcome"],
+                                "additionalProperties": false
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "minItems": 1
+                      }
+                    },
+                    "required": ["type", "criteria"],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            },
             "assert": {
               "type": "array",
               "items": {
@@ -9745,6 +15132,10 @@
                       "type": {
                         "type": "string",
                         "const": "composite"
+                      },
+                      "assertions": {
+                        "type": "array",
+                        "items": {}
                       },
                       "assert": {
                         "type": "array",
@@ -10812,6 +16203,10 @@
                       "type": {
                         "type": "string",
                         "const": "composite"
+                      },
+                      "assertions": {
+                        "type": "array",
+                        "items": {}
                       },
                       "assert": {
                         "type": "array",
@@ -11925,6 +17320,10 @@
                   "type": {
                     "type": "string",
                     "const": "composite"
+                  },
+                  "assertions": {
+                    "type": "array",
+                    "items": {}
                   },
                   "assert": {
                     "type": "array",


### PR DESCRIPTION
## Summary
- Renames `EvalTest.evaluators` → `EvalTest.assertions` and `CompositeEvaluatorConfig.evaluators` → `CompositeEvaluatorConfig.assertions`
- YAML `assert` remains the canonical shorthand (no user-facing change)
- YAML `assertions` now also accepted as highest-priority alias
- YAML `evaluators` still accepted as deprecated fallback
- Regenerated eval-schema.json
- All 1184 tests pass, typecheck clean, lint clean

## Risk
low — mechanical rename of internal TypeScript field. YAML schema is backward-compatible (all three field names accepted).

Closes #546