### PR TITLE
feat: parse Agent Skills evals.json format

### DIFF
--- a/examples/features/agent-skills-evals/evals.json
+++ b/examples/features/agent-skills-evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill_name": "csv-analyzer",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I have a CSV of monthly sales data in data/sales.csv. Find the top 3 months by revenue and make a bar chart.",
+      "expected_output": "A bar chart image showing the top 3 months by revenue, with labeled axes and values.",
+      "assertions": [
+        "Output includes a bar chart image file",
+        "Chart shows exactly 3 months",
+        "Both axes are labeled"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Clean up customers.csv — some rows have missing emails",
+      "expected_output": "A cleaned CSV with missing emails handled, plus a count of how many were missing."
+    }
+  ]
+}

--- a/packages/core/src/evaluation/loaders/agent-skills-parser.ts
+++ b/packages/core/src/evaluation/loaders/agent-skills-parser.ts
@@ -1,0 +1,132 @@
+import { readFile } from 'node:fs/promises';
+
+import type { EvalTest, EvaluatorConfig } from '../types.js';
+
+const ANSI_RED = '\u001b[31m';
+const ANSI_RESET = '\u001b[0m';
+
+function logError(msg: string): void {
+  console.error(`${ANSI_RED}Error: ${msg}${ANSI_RESET}`);
+}
+
+/**
+ * Raw Agent Skills evals.json schema.
+ * @see https://agentskills.io/skill-creation/evaluating-skills
+ */
+interface AgentSkillsEvalsFile {
+  readonly skill_name?: string;
+  readonly evals: readonly AgentSkillsEvalCase[];
+}
+
+interface AgentSkillsEvalCase {
+  readonly id: number;
+  readonly prompt: string;
+  readonly expected_output?: string;
+  readonly files?: readonly string[];
+  readonly assertions?: readonly string[];
+}
+
+/**
+ * Detect whether a JSON file is in Agent Skills evals.json format.
+ * Returns true if the parsed content has an `evals` array.
+ */
+export function isAgentSkillsFormat(parsed: unknown): parsed is AgentSkillsEvalsFile {
+  if (typeof parsed !== 'object' || parsed === null) return false;
+  const obj = parsed as Record<string, unknown>;
+  return Array.isArray(obj.evals);
+}
+
+/**
+ * Load and parse an Agent Skills evals.json file into AgentV EvalTest[].
+ *
+ * Promotion rules:
+ * - id (number) → id (string)
+ * - prompt → input: [{role: "user", content: prompt}]
+ * - expected_output → expected_output: [{role: "assistant", content}] as JsonObject[]
+ * - assertions (string[]) → assertions: EvaluatorConfig[] (each → llm-judge)
+ * - files → metadata.agent_skills_files (resolved by #541)
+ * - skill_name → metadata.skill_name
+ */
+export async function loadTestsFromAgentSkills(filePath: string): Promise<readonly EvalTest[]> {
+  const raw = await readFile(filePath, 'utf8');
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`Invalid Agent Skills evals.json: failed to parse JSON in '${filePath}'`);
+  }
+
+  return parseAgentSkillsEvals(parsed, filePath);
+}
+
+/**
+ * Parse already-loaded Agent Skills evals data into EvalTest[].
+ * Exported for testing without file I/O.
+ */
+export function parseAgentSkillsEvals(parsed: unknown, source = 'evals.json'): readonly EvalTest[] {
+  if (!isAgentSkillsFormat(parsed)) {
+    throw new Error(`Invalid Agent Skills evals.json: missing 'evals' array in '${source}'`);
+  }
+
+  const { evals, skill_name } = parsed;
+
+  if (evals.length === 0) {
+    throw new Error(`Invalid Agent Skills evals.json: 'evals' array is empty in '${source}'`);
+  }
+
+  const tests: EvalTest[] = [];
+
+  for (const evalCase of evals) {
+    const id = evalCase.id;
+
+    if (typeof evalCase.prompt !== 'string' || evalCase.prompt.trim() === '') {
+      const caseRef = id !== undefined ? `id=${id}` : 'unknown';
+      logError(`Skipping eval case ${caseRef} in '${source}': missing or empty 'prompt'`);
+      continue;
+    }
+
+    // Promote assertions → llm-judge evaluators
+    let assertions: readonly EvaluatorConfig[] | undefined;
+    if (evalCase.assertions && evalCase.assertions.length > 0) {
+      assertions = evalCase.assertions.map(
+        (text, i): EvaluatorConfig => ({
+          name: `assertion-${i + 1}`,
+          type: 'llm-judge',
+          prompt: text,
+        }),
+      );
+    }
+
+    // Build metadata
+    const metadata: Record<string, unknown> = {};
+    if (skill_name) {
+      metadata.skill_name = skill_name;
+    }
+    if (evalCase.files && evalCase.files.length > 0) {
+      metadata.agent_skills_files = evalCase.files;
+    }
+
+    const prompt = evalCase.prompt;
+
+    const test: EvalTest = {
+      id: String(id),
+      question: prompt,
+      input: [{ role: 'user', content: prompt }],
+      input_segments: [{ type: 'text', value: prompt }],
+      expected_output: evalCase.expected_output
+        ? [{ role: 'assistant', content: evalCase.expected_output }]
+        : [],
+      reference_answer: evalCase.expected_output,
+      guideline_paths: [],
+      file_paths: [],
+      criteria: evalCase.expected_output ?? '',
+      assertions,
+      ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+    };
+
+    tests.push(test);
+  }
+
+  return tests;
+}

--- a/packages/core/src/evaluation/loaders/jsonl-parser.ts
+++ b/packages/core/src/evaluation/loaders/jsonl-parser.ts
@@ -56,11 +56,14 @@ type RawJsonlEvalCase = JsonObject & {
 /**
  * Detect file format by extension.
  */
-export function detectFormat(filePath: string): 'yaml' | 'jsonl' {
+export function detectFormat(filePath: string): 'yaml' | 'jsonl' | 'agent-skills-json' {
   const ext = path.extname(filePath).toLowerCase();
   if (ext === '.jsonl') return 'jsonl';
   if (ext === '.yaml' || ext === '.yml') return 'yaml';
-  throw new Error(`Unsupported file format: '${ext}'. Supported formats: .yaml, .yml, .jsonl`);
+  if (ext === '.json') return 'agent-skills-json';
+  throw new Error(
+    `Unsupported file format: '${ext}'. Supported formats: .yaml, .yml, .jsonl, .json`,
+  );
 }
 
 /**

--- a/packages/core/src/evaluation/yaml-parser.ts
+++ b/packages/core/src/evaluation/yaml-parser.ts
@@ -4,6 +4,7 @@ import micromatch from 'micromatch';
 import { parse } from 'yaml';
 
 import { interpolateEnv } from './interpolation.js';
+import { loadTestsFromAgentSkills } from './loaders/agent-skills-parser.js';
 import { expandFileReferences, loadCasesFromFile } from './loaders/case-file-loader.js';
 import {
   extractCacheConfig,
@@ -183,6 +184,9 @@ export async function loadTestSuite(
   if (format === 'jsonl') {
     return { tests: await loadTestsFromJsonl(evalFilePath, repoRoot, options) };
   }
+  if (format === 'agent-skills-json') {
+    return { tests: await loadTestsFromAgentSkills(evalFilePath) };
+  }
   const { tests, parsed } = await loadTestsFromYaml(evalFilePath, repoRoot, options);
   const metadata = parseMetadata(parsed);
   const failOnError = extractFailOnError(parsed);
@@ -209,6 +213,9 @@ export async function loadTests(
   const format = detectFormat(evalFilePath);
   if (format === 'jsonl') {
     return loadTestsFromJsonl(evalFilePath, repoRoot, options);
+  }
+  if (format === 'agent-skills-json') {
+    return loadTestsFromAgentSkills(evalFilePath);
   }
   const { tests } = await loadTestsFromYaml(evalFilePath, repoRoot, options);
   return tests;

--- a/packages/core/test/evaluation/loaders/agent-skills-parser.test.ts
+++ b/packages/core/test/evaluation/loaders/agent-skills-parser.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  isAgentSkillsFormat,
+  parseAgentSkillsEvals,
+} from '../../../src/evaluation/loaders/agent-skills-parser.js';
+
+const FIXTURE = {
+  skill_name: 'csv-analyzer',
+  evals: [
+    {
+      id: 1,
+      prompt:
+        'I have a CSV of monthly sales data in data/sales.csv. Find the top 3 months by revenue and make a bar chart.',
+      expected_output:
+        'A bar chart image showing the top 3 months by revenue, with labeled axes and values.',
+      files: ['evals/files/sales.csv'],
+      assertions: [
+        'Output includes a bar chart image file',
+        'Chart shows exactly 3 months',
+        'Both axes are labeled',
+      ],
+    },
+    {
+      id: 2,
+      prompt: 'Clean up customers.csv — some rows have missing emails',
+      expected_output:
+        'A cleaned CSV with missing emails handled, plus a count of how many were missing.',
+    },
+  ],
+};
+
+describe('isAgentSkillsFormat', () => {
+  it('returns true for valid evals.json structure', () => {
+    expect(isAgentSkillsFormat(FIXTURE)).toBe(true);
+  });
+
+  it('returns false for non-object', () => {
+    expect(isAgentSkillsFormat(null)).toBe(false);
+    expect(isAgentSkillsFormat('string')).toBe(false);
+    expect(isAgentSkillsFormat(42)).toBe(false);
+  });
+
+  it('returns false when evals is missing', () => {
+    expect(isAgentSkillsFormat({ skill_name: 'foo' })).toBe(false);
+  });
+
+  it('returns false when evals is not an array', () => {
+    expect(isAgentSkillsFormat({ evals: 'not-array' })).toBe(false);
+  });
+});
+
+describe('parseAgentSkillsEvals', () => {
+  it('parses the full fixture into EvalTest[]', () => {
+    const tests = parseAgentSkillsEvals(FIXTURE);
+    expect(tests).toHaveLength(2);
+  });
+
+  it('converts numeric id to string', () => {
+    const tests = parseAgentSkillsEvals(FIXTURE);
+    expect(tests[0].id).toBe('1');
+    expect(tests[1].id).toBe('2');
+  });
+
+  it('promotes prompt to input message array', () => {
+    const tests = parseAgentSkillsEvals(FIXTURE);
+    expect(tests[0].input).toEqual([
+      {
+        role: 'user',
+        content:
+          'I have a CSV of monthly sales data in data/sales.csv. Find the top 3 months by revenue and make a bar chart.',
+      },
+    ]);
+  });
+
+  it('promotes expected_output to output message array', () => {
+    const tests = parseAgentSkillsEvals(FIXTURE);
+    expect(tests[0].expected_output).toEqual([
+      {
+        role: 'assistant',
+        content:
+          'A bar chart image showing the top 3 months by revenue, with labeled axes and values.',
+      },
+    ]);
+  });
+
+  it('sets reference_answer from expected_output', () => {
+    const tests = parseAgentSkillsEvals(FIXTURE);
+    expect(tests[0].reference_answer).toBe(
+      'A bar chart image showing the top 3 months by revenue, with labeled axes and values.',
+    );
+  });
+
+  it('promotes assertions to llm-judge evaluators', () => {
+    const tests = parseAgentSkillsEvals(FIXTURE);
+    const assertions = tests[0].assertions;
+    expect(assertions).toHaveLength(3);
+    expect(assertions?.[0]).toEqual({
+      name: 'assertion-1',
+      type: 'llm-judge',
+      prompt: 'Output includes a bar chart image file',
+    });
+    expect(assertions?.[1]).toEqual({
+      name: 'assertion-2',
+      type: 'llm-judge',
+      prompt: 'Chart shows exactly 3 months',
+    });
+    expect(assertions?.[2]).toEqual({
+      name: 'assertion-3',
+      type: 'llm-judge',
+      prompt: 'Both axes are labeled',
+    });
+  });
+
+  it('stores files in metadata.agent_skills_files', () => {
+    const tests = parseAgentSkillsEvals(FIXTURE);
+    expect(tests[0].metadata?.agent_skills_files).toEqual(['evals/files/sales.csv']);
+  });
+
+  it('stores skill_name in metadata', () => {
+    const tests = parseAgentSkillsEvals(FIXTURE);
+    expect(tests[0].metadata?.skill_name).toBe('csv-analyzer');
+    expect(tests[1].metadata?.skill_name).toBe('csv-analyzer');
+  });
+
+  it('handles test case without assertions or files', () => {
+    const tests = parseAgentSkillsEvals(FIXTURE);
+    const test2 = tests[1];
+    expect(test2.assertions).toBeUndefined();
+    expect(test2.metadata?.agent_skills_files).toBeUndefined();
+  });
+
+  it('sets criteria from expected_output', () => {
+    const tests = parseAgentSkillsEvals(FIXTURE);
+    expect(tests[0].criteria).toBe(
+      'A bar chart image showing the top 3 months by revenue, with labeled axes and values.',
+    );
+  });
+
+  it('sets question from prompt', () => {
+    const tests = parseAgentSkillsEvals(FIXTURE);
+    expect(tests[0].question).toBe(
+      'I have a CSV of monthly sales data in data/sales.csv. Find the top 3 months by revenue and make a bar chart.',
+    );
+  });
+
+  it('initializes empty arrays for guideline_paths and file_paths', () => {
+    const tests = parseAgentSkillsEvals(FIXTURE);
+    expect(tests[0].guideline_paths).toEqual([]);
+    expect(tests[0].file_paths).toEqual([]);
+  });
+
+  it('throws on missing evals array', () => {
+    expect(() => parseAgentSkillsEvals({ skill_name: 'test' })).toThrow(
+      "Invalid Agent Skills evals.json: missing 'evals' array",
+    );
+  });
+
+  it('throws on empty evals array', () => {
+    expect(() => parseAgentSkillsEvals({ evals: [] })).toThrow(
+      "Invalid Agent Skills evals.json: 'evals' array is empty",
+    );
+  });
+
+  it('skips test case with missing prompt', () => {
+    const data = {
+      evals: [
+        { id: 1, expected_output: 'something' },
+        { id: 2, prompt: 'valid prompt' },
+      ],
+    };
+    const tests = parseAgentSkillsEvals(data);
+    expect(tests).toHaveLength(1);
+    expect(tests[0].id).toBe('2');
+  });
+
+  it('skips test case with empty prompt', () => {
+    const data = {
+      evals: [
+        { id: 1, prompt: '   ' },
+        { id: 2, prompt: 'valid prompt' },
+      ],
+    };
+    const tests = parseAgentSkillsEvals(data);
+    expect(tests).toHaveLength(1);
+    expect(tests[0].id).toBe('2');
+  });
+
+  it('works without skill_name', () => {
+    const data = {
+      evals: [{ id: 1, prompt: 'test prompt' }],
+    };
+    const tests = parseAgentSkillsEvals(data);
+    expect(tests).toHaveLength(1);
+    expect(tests[0].metadata).toBeUndefined();
+  });
+
+  it('includes source in error messages', () => {
+    expect(() => parseAgentSkillsEvals({}, 'my-evals.json')).toThrow('my-evals.json');
+  });
+});

--- a/packages/core/test/evaluation/loaders/jsonl-parser.test.ts
+++ b/packages/core/test/evaluation/loaders/jsonl-parser.test.ts
@@ -22,8 +22,12 @@ describe('detectFormat', () => {
     expect(detectFormat('/path/to/config.yml')).toBe('yaml');
   });
 
+  it('returns agent-skills-json for .json extension', () => {
+    expect(detectFormat('evals.json')).toBe('agent-skills-json');
+    expect(detectFormat('/path/to/evals.json')).toBe('agent-skills-json');
+  });
+
   it('throws for unsupported extensions', () => {
-    expect(() => detectFormat('test.json')).toThrow('Unsupported file format');
     expect(() => detectFormat('test.txt')).toThrow('Unsupported file format');
     expect(() => detectFormat('test')).toThrow('Unsupported file format');
   });


### PR DESCRIPTION
## Summary
- New `agent-skills-parser.ts` transforms Agent Skills `evals.json` into AgentV `EvalTest[]`
- Extends `detectFormat()` to route `.json` files to the new parser
- Wires into `loadTests()` and `loadTestSuite()` so `agentv eval evals.json` works
- 22 unit tests covering all promotion rules, error handling, and edge cases
- Example fixture at `examples/features/agent-skills-evals/evals.json`

### Field promotion
| Agent Skills | AgentV EvalTest |
|---|---|
| `prompt` | `input: [{role: "user", content}]` |
| `expected_output` | `expected_output`, `reference_answer`, `criteria` |
| `assertions[]` | `assertions: [{type: "llm-judge", prompt}]` |
| `files[]` | `metadata.agent_skills_files` |
| `skill_name` | `metadata.skill_name` |

## Risk
low — new additive parser, no changes to existing eval behavior. Existing formats unaffected.

Closes #538