### PR TITLE
feat: handle Agent Skills evals files[] in workspace

### DIFF
--- a/packages/core/src/evaluation/loaders/agent-skills-parser.ts
+++ b/packages/core/src/evaluation/loaders/agent-skills-parser.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import path from 'node:path';
 
 import type { EvalTest, EvaluatorConfig } from '../types.js';
 
@@ -57,14 +58,18 @@ export async function loadTestsFromAgentSkills(filePath: string): Promise<readon
     throw new Error(`Invalid Agent Skills evals.json: failed to parse JSON in '${filePath}'`);
   }
 
-  return parseAgentSkillsEvals(parsed, filePath);
+  return parseAgentSkillsEvals(parsed, filePath, path.dirname(path.resolve(filePath)));
 }
 
 /**
  * Parse already-loaded Agent Skills evals data into EvalTest[].
  * Exported for testing without file I/O.
  */
-export function parseAgentSkillsEvals(parsed: unknown, source = 'evals.json'): readonly EvalTest[] {
+export function parseAgentSkillsEvals(
+  parsed: unknown,
+  source = 'evals.json',
+  baseDir?: string,
+): readonly EvalTest[] {
   if (!isAgentSkillsFormat(parsed)) {
     throw new Error(`Invalid Agent Skills evals.json: missing 'evals' array in '${source}'`);
   }
@@ -103,8 +108,17 @@ export function parseAgentSkillsEvals(parsed: unknown, source = 'evals.json'): r
     if (skill_name) {
       metadata.skill_name = skill_name;
     }
+
+    // Resolve file paths relative to evals.json location
+    const filePaths: string[] = [];
     if (evalCase.files && evalCase.files.length > 0) {
       metadata.agent_skills_files = evalCase.files;
+      if (baseDir) {
+        metadata.agent_skills_base_dir = baseDir;
+        for (const file of evalCase.files) {
+          filePaths.push(path.resolve(baseDir, file));
+        }
+      }
     }
 
     const prompt = evalCase.prompt;
@@ -119,7 +133,7 @@ export function parseAgentSkillsEvals(parsed: unknown, source = 'evals.json'): r
         : [],
       reference_answer: evalCase.expected_output,
       guideline_paths: [],
-      file_paths: [],
+      file_paths: filePaths,
       criteria: evalCase.expected_output ?? '',
       assertions,
       ...(Object.keys(metadata).length > 0 ? { metadata } : {}),

--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { mkdir, readdir, stat } from 'node:fs/promises';
+import { copyFile, mkdir, readdir, stat } from 'node:fs/promises';
 import path from 'node:path';
 import micromatch from 'micromatch';
 import pLimit from 'p-limit';
@@ -1333,6 +1333,36 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
           'repo_setup',
           'clone_error',
         );
+      }
+    }
+
+    // Copy Agent Skills files into workspace
+    if (workspacePath && evalCase.metadata?.agent_skills_files) {
+      const baseDir = evalCase.metadata.agent_skills_base_dir as string | undefined;
+      const files = evalCase.metadata.agent_skills_files as readonly string[];
+      if (baseDir && files.length > 0) {
+        for (const relPath of files) {
+          const srcPath = path.resolve(baseDir, relPath);
+          const destPath = path.resolve(workspacePath, relPath);
+          try {
+            await mkdir(path.dirname(destPath), { recursive: true });
+            await copyFile(srcPath, destPath);
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            return buildErrorResult(
+              evalCase,
+              target.name,
+              nowFn(),
+              new Error(
+                `Agent Skills eval file not found: ${relPath} (resolved from ${baseDir}): ${message}`,
+              ),
+              promptInputs,
+              provider,
+              'setup',
+              'file_copy_error',
+            );
+          }
+        }
       }
     }
 

--- a/packages/core/test/evaluation/loaders/agent-skills-parser.test.ts
+++ b/packages/core/test/evaluation/loaders/agent-skills-parser.test.ts
@@ -144,10 +144,31 @@ describe('parseAgentSkillsEvals', () => {
     );
   });
 
-  it('initializes empty arrays for guideline_paths and file_paths', () => {
+  it('initializes empty arrays for guideline_paths and file_paths when no baseDir', () => {
     const tests = parseAgentSkillsEvals(FIXTURE);
     expect(tests[0].guideline_paths).toEqual([]);
     expect(tests[0].file_paths).toEqual([]);
+  });
+
+  it('resolves file_paths relative to baseDir when provided', () => {
+    const tests = parseAgentSkillsEvals(FIXTURE, 'evals.json', '/project/skills/csv-analyzer');
+    expect(tests[0].file_paths).toEqual(['/project/skills/csv-analyzer/evals/files/sales.csv']);
+  });
+
+  it('stores agent_skills_base_dir in metadata when baseDir provided', () => {
+    const tests = parseAgentSkillsEvals(FIXTURE, 'evals.json', '/project/skills/csv-analyzer');
+    expect(tests[0].metadata?.agent_skills_base_dir).toBe('/project/skills/csv-analyzer');
+  });
+
+  it('does not resolve file_paths when baseDir is not provided', () => {
+    const tests = parseAgentSkillsEvals(FIXTURE);
+    expect(tests[0].file_paths).toEqual([]);
+    expect(tests[0].metadata?.agent_skills_base_dir).toBeUndefined();
+  });
+
+  it('still stores agent_skills_files in metadata without baseDir', () => {
+    const tests = parseAgentSkillsEvals(FIXTURE);
+    expect(tests[0].metadata?.agent_skills_files).toEqual(['evals/files/sales.csv']);
   });
 
   it('throws on missing evals array', () => {


### PR DESCRIPTION
## Summary
- Resolve `files[]` paths relative to evals.json location during parsing, storing `agent_skills_base_dir` in metadata
- Copy Agent Skills files into workspace directory before hooks/provider invocation in orchestrator
- Add tests for `baseDir` file resolution and metadata storage

Closes #541

## Risk
low — additive feature behind metadata flag, no behavioral change for existing evals

🤖 Generated with [Claude Code](https://claude.com/claude-code)