### PR TITLE
feat: support evals.json in agentv prompt eval subcommands

### DIFF
--- a/apps/cli/src/commands/eval/shared.ts
+++ b/apps/cli/src/commands/eval/shared.ts
@@ -19,7 +19,7 @@ export async function resolveEvalPaths(evalPaths: string[], cwd: string): Promis
       : path.resolve(cwd, pattern);
     try {
       const stats = await stat(candidatePath);
-      if (stats.isFile() && /\.(ya?ml|jsonl)$/i.test(candidatePath)) {
+      if (stats.isFile() && /\.(ya?ml|jsonl|json)$/i.test(candidatePath)) {
         results.add(candidatePath);
         continue;
       }
@@ -37,7 +37,7 @@ export async function resolveEvalPaths(evalPaths: string[], cwd: string): Promis
       followSymbolicLinks: true,
     });
 
-    const yamlMatches = matches.filter((filePath) => /\.(ya?ml|jsonl)$/i.test(filePath));
+    const yamlMatches = matches.filter((filePath) => /\.(ya?ml|jsonl|json)$/i.test(filePath));
     if (yamlMatches.length === 0) {
       unmatched.push(pattern);
       continue;
@@ -52,7 +52,7 @@ export async function resolveEvalPaths(evalPaths: string[], cwd: string): Promis
     throw new Error(
       `No eval files matched: ${unmatched.join(
         ', ',
-      )}. Provide YAML or JSONL paths or globs (e.g., "evals/**/*.yaml", "evals/**/*.jsonl").`,
+      )}. Provide YAML, JSONL, or JSON paths or globs (e.g., "evals/**/*.yaml", "evals/**/*.jsonl", "evals.json").`,
     );
   }
 

--- a/apps/cli/test/commands/eval/prompt-overview-mode.test.ts
+++ b/apps/cli/test/commands/eval/prompt-overview-mode.test.ts
@@ -8,6 +8,11 @@ const BASIC_EVAL_PATH = path.resolve(
   '../../../../examples/features/basic/evals/dataset.eval.yaml',
 );
 
+const AGENT_SKILLS_EVAL_PATH = path.resolve(
+  import.meta.dir,
+  '../../../../examples/features/agent-skills-evals/evals.json',
+);
+
 describe('generateOverviewPrompt', () => {
   let originalEnv: string | undefined;
 
@@ -72,5 +77,17 @@ describe('generateOverviewPrompt', () => {
     process.env.AGENTV_PROMPT_EVAL_MODE = 'cli';
     const output = await generateOverviewPrompt([BASIC_EVAL_PATH]);
     expect(output).toContain('code-review-javascript');
+  });
+
+  it('accepts Agent Skills evals.json files', async () => {
+    process.env.AGENTV_PROMPT_EVAL_MODE = undefined;
+    const output = await generateOverviewPrompt([AGENT_SKILLS_EVAL_PATH]);
+    expect(output).toContain('Mode: agent');
+    expect(output).toContain('eval-candidate');
+    // Test IDs from evals.json (promoted from numeric id)
+    expect(output).toContain('### 1');
+    expect(output).toContain('### 2');
+    // Promoted assertions should appear as evaluators
+    expect(output).toContain('assertion-1 (llm-judge)');
   });
 });


### PR DESCRIPTION
## Summary
- Add `.json` extension to `resolveEvalPaths` so `agentv eval` and `agentv prompt eval` accept Agent Skills evals.json files
- The prompt subcommands (overview, input, judge) already handle promoted EvalTest format — this removes the file extension gate
- Add test verifying evals.json works end-to-end through `generateOverviewPrompt`

Closes #545

## Risk
low — only widens a file extension filter; all prompt subcommands already handle the promoted format

🤖 Generated with [Claude Code](https://claude.com/claude-code)