### PR TITLE
feat: emit Agent Skills benchmark.json alongside result JSONL

### DIFF
--- a/apps/cli/src/commands/eval/benchmark-writer.ts
+++ b/apps/cli/src/commands/eval/benchmark-writer.ts
@@ -1,0 +1,87 @@
+import { writeFile } from 'node:fs/promises';
+
+import type { EvaluationResult } from '@agentv/core';
+
+const PASS_THRESHOLD = 0.8;
+
+interface BenchmarkStats {
+  readonly mean: number;
+  readonly stddev: number;
+}
+
+interface BenchmarkRunSummary {
+  readonly pass_rate: BenchmarkStats;
+  readonly time_seconds: BenchmarkStats;
+  readonly tokens: BenchmarkStats;
+}
+
+interface BenchmarkJson {
+  readonly run_summary: {
+    readonly with_skill: BenchmarkRunSummary;
+  };
+}
+
+function computeStats(values: readonly number[]): BenchmarkStats {
+  if (values.length === 0) {
+    return { mean: 0, stddev: 0 };
+  }
+  const mean = values.reduce((sum, v) => sum + v, 0) / values.length;
+  const variance = values.reduce((sum, v) => sum + (v - mean) ** 2, 0) / values.length;
+  return {
+    mean: Math.round(mean * 1000) / 1000,
+    stddev: Math.round(Math.sqrt(variance) * 1000) / 1000,
+  };
+}
+
+/**
+ * Compute per-test pass_rate from evaluator scores.
+ *
+ * For each test, pass_rate = count(evaluator.score >= 0.8) / total_evaluators.
+ * If no per-evaluator scores exist, falls back to the top-level result score
+ * with the same threshold (>= 0.8 → 1.0, else 0.0).
+ */
+function computePassRate(result: EvaluationResult): number {
+  const scores = result.scores;
+  if (scores && scores.length > 0) {
+    const passed = scores.filter((s) => s.score >= PASS_THRESHOLD).length;
+    return passed / scores.length;
+  }
+  return result.score >= PASS_THRESHOLD ? 1.0 : 0.0;
+}
+
+/**
+ * Build an Agent Skills benchmark.json from AgentV evaluation results.
+ */
+export function buildBenchmarkJson(results: readonly EvaluationResult[]): BenchmarkJson {
+  const passRates = results.map(computePassRate);
+  const timings = results
+    .filter((r) => r.durationMs != null)
+    .map((r) => (r.durationMs as number) / 1000);
+  const tokens = results
+    .filter((r) => r.tokenUsage != null)
+    .map((r) => {
+      const usage = r.tokenUsage as { input?: number; output?: number };
+      return (usage.input ?? 0) + (usage.output ?? 0);
+    });
+
+  return {
+    run_summary: {
+      with_skill: {
+        pass_rate: computeStats(passRates),
+        time_seconds: computeStats(timings),
+        tokens: computeStats(tokens),
+      },
+    },
+  };
+}
+
+/**
+ * Write benchmark.json to disk.
+ */
+export async function writeBenchmarkJson(
+  outputPath: string,
+  results: readonly EvaluationResult[],
+): Promise<void> {
+  const benchmark = buildBenchmarkJson(results);
+  await writeFile(outputPath, `${JSON.stringify(benchmark, null, 2)}\n`, 'utf8');
+}

--- a/apps/cli/src/commands/eval/commands/run.ts
+++ b/apps/cli/src/commands/eval/commands/run.ts
@@ -152,6 +152,11 @@ export const evalRunCommand = command({
       long: 'strict',
       description: 'Exit with error on version mismatch (instead of warning)',
     }),
+    benchmarkJson: option({
+      type: optional(string),
+      long: 'benchmark-json',
+      description: 'Write Agent Skills benchmark.json to the specified path',
+    }),
   },
   handler: async (args) => {
     // Launch interactive wizard when no eval paths and stdin is a TTY
@@ -190,6 +195,7 @@ export const evalRunCommand = command({
       otelGroupTurns: args.otelGroupTurns,
       retryErrors: args.retryErrors,
       strict: args.strict,
+      benchmarkJson: args.benchmarkJson,
     };
     await runEvalCommand({ testFiles: resolvedPaths, rawOptions });
   },

--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -26,6 +26,7 @@ import {
 } from '@agentv/core';
 
 import { enforceRequiredVersion } from '../../version-check.js';
+import { writeBenchmarkJson } from './benchmark-writer.js';
 import { loadEnvFromHierarchy } from './env.js';
 import {
   type OutputFormat,
@@ -78,6 +79,7 @@ interface NormalizedOptions {
   readonly retryErrors?: string;
   readonly workspaceMode?: 'pooled' | 'temp' | 'static';
   readonly workspacePath?: string;
+  readonly benchmarkJson?: string;
 }
 
 function normalizeBoolean(value: unknown): boolean {
@@ -243,6 +245,7 @@ function normalizeOptions(
     retryErrors: normalizeString(rawOptions.retryErrors),
     workspaceMode,
     workspacePath,
+    benchmarkJson: normalizeString(rawOptions.benchmarkJson),
   } satisfies NormalizedOptions;
 }
 
@@ -1010,6 +1013,13 @@ export async function runEvalCommand(input: RunEvalCommandInput): Promise<void> 
     // Print matrix summary when multiple targets were evaluated
     if (isMatrixMode && allResults.length > 0) {
       console.log(formatMatrixSummary(allResults));
+    }
+
+    // Write Agent Skills benchmark.json if requested
+    if (options.benchmarkJson && allResults.length > 0) {
+      const benchmarkPath = path.resolve(options.benchmarkJson);
+      await writeBenchmarkJson(benchmarkPath, allResults);
+      console.log(`Benchmark written to: ${benchmarkPath}`);
     }
 
     // Print workspace paths for failed cases (when preserved for debugging)

--- a/apps/cli/test/commands/eval/benchmark-writer.test.ts
+++ b/apps/cli/test/commands/eval/benchmark-writer.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { EvaluationResult } from '@agentv/core';
+import { buildBenchmarkJson } from '../../../src/commands/eval/benchmark-writer.js';
+
+function makeResult(overrides: Partial<EvaluationResult> = {}): EvaluationResult {
+  return {
+    timestamp: '2026-03-13T00:00:00.000Z',
+    testId: 'test-1',
+    score: 0.9,
+    hits: [],
+    misses: [],
+    answer: 'test answer',
+    target: 'test-target',
+    verdict: 'pass',
+    executionStatus: 'ok',
+    ...overrides,
+  } as EvaluationResult;
+}
+
+describe('buildBenchmarkJson', () => {
+  it('computes pass_rate from per-evaluator scores', () => {
+    const results = [
+      makeResult({
+        scores: [
+          { name: 'a1', type: 'llm-judge', score: 0.9, hits: [], misses: [] },
+          { name: 'a2', type: 'llm-judge', score: 0.7, hits: [], misses: [] },
+          { name: 'a3', type: 'llm-judge', score: 0.85, hits: [], misses: [] },
+        ],
+      }),
+    ];
+    const benchmark = buildBenchmarkJson(results);
+    // 2 of 3 pass (>= 0.8), so pass_rate = 2/3 ≈ 0.667
+    expect(benchmark.run_summary.with_skill.pass_rate.mean).toBeCloseTo(0.667, 2);
+    expect(benchmark.run_summary.with_skill.pass_rate.stddev).toBe(0);
+  });
+
+  it('falls back to top-level score when no evaluator scores', () => {
+    const results = [makeResult({ score: 0.9 }), makeResult({ score: 0.5 })];
+    const benchmark = buildBenchmarkJson(results);
+    // First passes (>= 0.8 → 1.0), second fails (< 0.8 → 0.0), mean = 0.5
+    expect(benchmark.run_summary.with_skill.pass_rate.mean).toBe(0.5);
+    expect(benchmark.run_summary.with_skill.pass_rate.stddev).toBe(0.5);
+  });
+
+  it('computes time_seconds from durationMs', () => {
+    const results = [makeResult({ durationMs: 30000 }), makeResult({ durationMs: 60000 })];
+    const benchmark = buildBenchmarkJson(results);
+    expect(benchmark.run_summary.with_skill.time_seconds.mean).toBe(45);
+    expect(benchmark.run_summary.with_skill.time_seconds.stddev).toBe(15);
+  });
+
+  it('computes tokens from tokenUsage', () => {
+    const results = [
+      makeResult({ tokenUsage: { input: 1000, output: 500 } } as Partial<EvaluationResult>),
+      makeResult({ tokenUsage: { input: 2000, output: 1000 } } as Partial<EvaluationResult>),
+    ];
+    const benchmark = buildBenchmarkJson(results);
+    expect(benchmark.run_summary.with_skill.tokens.mean).toBe(2250);
+    expect(benchmark.run_summary.with_skill.tokens.stddev).toBe(750);
+  });
+
+  it('handles empty results', () => {
+    const benchmark = buildBenchmarkJson([]);
+    expect(benchmark.run_summary.with_skill.pass_rate.mean).toBe(0);
+    expect(benchmark.run_summary.with_skill.pass_rate.stddev).toBe(0);
+  });
+
+  it('handles results without timing or token data', () => {
+    const results = [makeResult({})];
+    const benchmark = buildBenchmarkJson(results);
+    expect(benchmark.run_summary.with_skill.time_seconds.mean).toBe(0);
+    expect(benchmark.run_summary.with_skill.tokens.mean).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `--benchmark-json` flag to `agentv eval` that produces an Agent Skills compatible benchmark.json
- Score mapping: evaluator score >= 0.8 counts as passed assertion, pass_rate = passed/total
- Computes aggregate stats (mean, stddev) for pass_rate, time_seconds, and tokens
- Standard result JSONL is still produced — benchmark.json is additive

Closes #542

## Test plan
- [x] Unit tests for `buildBenchmarkJson` covering per-evaluator scores, fallback to top-level score, timing, tokens, empty results
- [x] Full verify suite passes (build + typecheck + lint + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)