### PR TITLE
feat: agentv convert command — evals.json to EVAL.yaml

### DIFF
--- a/apps/cli/src/commands/convert/index.ts
+++ b/apps/cli/src/commands/convert/index.ts
@@ -1,6 +1,6 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { normalizeLineEndings } from '@agentv/core';
+import { isAgentSkillsFormat, normalizeLineEndings, parseAgentSkillsEvals } from '@agentv/core';
 import { command, option, optional, positional, string } from 'cmd-ts';
 import { stringify as stringifyYaml } from 'yaml';
 
@@ -31,36 +31,168 @@ function convertJsonlToYaml(inputPath: string, outputPath: string): number {
   return lines.length;
 }
 
+/**
+ * Convert an Agent Skills evals.json file into an AgentV EVAL.yaml.
+ * Returns the YAML string.
+ */
+export function convertEvalsJsonToYaml(inputPath: string): string {
+  const content = readFileSync(inputPath, 'utf8');
+  const parsed = JSON.parse(content);
+
+  if (!isAgentSkillsFormat(parsed)) {
+    throw new Error(`Not a valid Agent Skills evals.json: missing 'evals' array`);
+  }
+
+  const tests = parseAgentSkillsEvals(parsed, inputPath, path.dirname(path.resolve(inputPath)));
+  const lines: string[] = [];
+
+  lines.push('# Converted from Agent Skills evals.json');
+  lines.push('# See: https://agentskills.io/skill-creation/evaluating-skills');
+  lines.push('#');
+  lines.push('# AgentV features you can add:');
+  lines.push('#   - type: is_json, contains, regex for deterministic evaluators');
+  lines.push('#   - type: code-judge for custom scoring scripts');
+  lines.push('#   - Multi-turn conversations via input message arrays');
+  lines.push('#   - Composite evaluators with weighted scoring');
+  lines.push('#   - Workspace isolation with repos and hooks');
+  lines.push('');
+
+  if (parsed.skill_name) {
+    lines.push(`description: "Evals for ${parsed.skill_name} skill"`);
+    lines.push('');
+  }
+
+  lines.push('tests:');
+
+  for (const test of tests) {
+    lines.push(`  - id: "${test.id}"`);
+    lines.push('');
+
+    // Emit criteria
+    if (test.criteria) {
+      lines.push('    criteria: |-');
+      for (const line of test.criteria.split('\n')) {
+        lines.push(`      ${line}`);
+      }
+      lines.push('');
+    }
+
+    // Emit input as simple user message
+    lines.push('    input:');
+    for (const msg of test.input) {
+      lines.push(`      - role: ${msg.role}`);
+      if (typeof msg.content === 'string' && msg.content.includes('\n')) {
+        lines.push('        content: |-');
+        for (const line of msg.content.split('\n')) {
+          lines.push(`          ${line}`);
+        }
+      } else {
+        lines.push(
+          `        content: "${typeof msg.content === 'string' ? msg.content.replace(/"/g, '\\"') : msg.content}"`,
+        );
+      }
+    }
+    lines.push('');
+
+    // Emit expected_output
+    if (test.expected_output && test.expected_output.length > 0) {
+      lines.push('    expected_output:');
+      for (const msg of test.expected_output) {
+        lines.push(`      - role: ${msg.role}`);
+        if (typeof msg.content === 'string' && msg.content.includes('\n')) {
+          lines.push('        content: |-');
+          for (const line of msg.content.split('\n')) {
+            lines.push(`          ${line}`);
+          }
+        } else {
+          lines.push(
+            `        content: "${typeof msg.content === 'string' ? msg.content.replace(/"/g, '\\"') : msg.content}"`,
+          );
+        }
+      }
+      lines.push('');
+    }
+
+    // Emit assertions as llm-judge evaluators
+    if (test.assertions && test.assertions.length > 0) {
+      lines.push('    # Promoted from evals.json assertions[]');
+      lines.push('    # Replace with type: is_json, contains, or regex for deterministic checks');
+      lines.push('    assert:');
+      for (const assertion of test.assertions) {
+        lines.push(`      - name: ${assertion.name}`);
+        lines.push(`        type: ${assertion.type}`);
+        if (assertion.type === 'llm-judge' && 'prompt' in assertion) {
+          const prompt = (assertion as { prompt: string }).prompt;
+          lines.push(`        prompt: "${prompt.replace(/"/g, '\\"')}"`);
+        }
+      }
+      lines.push('');
+    }
+
+    // Note about files
+    if (test.file_paths && test.file_paths.length > 0) {
+      lines.push('    # TODO: Configure workspace.repos or file references for these files:');
+      const agentSkillsFiles = test.metadata?.agent_skills_files as readonly string[] | undefined;
+      if (agentSkillsFiles) {
+        for (const file of agentSkillsFiles) {
+          lines.push(`    #   - ${file}`);
+        }
+      }
+      lines.push('');
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
 export const convertCommand = command({
   name: 'convert',
-  description: 'Convert evaluation results from JSONL to YAML format',
+  description: 'Convert between evaluation formats (JSONL→YAML, evals.json→EVAL.yaml)',
   args: {
     input: positional({
       type: string,
       displayName: 'input',
-      description: 'Path to input JSONL file',
+      description: 'Path to input file (.jsonl or .json)',
     }),
     out: option({
       type: optional(string),
       long: 'out',
       short: 'o',
-      description: 'Output file path (defaults to input path with .yaml extension)',
+      description: 'Output file path (defaults to stdout for evals.json, or .yaml for JSONL)',
     }),
   },
   handler: async ({ input, out }) => {
-    if (!input.endsWith('.jsonl')) {
-      console.error('Error: Input file must be a .jsonl file');
-      process.exit(1);
+    const ext = path.extname(input).toLowerCase();
+
+    if (ext === '.json') {
+      try {
+        const yaml = convertEvalsJsonToYaml(input);
+        if (out) {
+          writeFileSync(out, yaml);
+          console.log(`Converted to ${path.resolve(out)}`);
+        } else {
+          process.stdout.write(yaml);
+        }
+      } catch (error) {
+        console.error(`Error: ${(error as Error).message}`);
+        process.exit(1);
+      }
+      return;
     }
 
-    const outputPath = out ?? input.replace(/\.jsonl$/, '.yaml');
-
-    try {
-      const count = convertJsonlToYaml(input, outputPath);
-      console.log(`Converted ${count} records to ${path.resolve(outputPath)}`);
-    } catch (error) {
-      console.error(`Error: ${(error as Error).message}`);
-      process.exit(1);
+    if (ext === '.jsonl') {
+      const outputPath = out ?? input.replace(/\.jsonl$/, '.yaml');
+      try {
+        const count = convertJsonlToYaml(input, outputPath);
+        console.log(`Converted ${count} records to ${path.resolve(outputPath)}`);
+      } catch (error) {
+        console.error(`Error: ${(error as Error).message}`);
+        process.exit(1);
+      }
+      return;
     }
+
+    console.error(`Error: Unsupported input format '${ext}'. Supported: .json, .jsonl`);
+    process.exit(1);
   },
 });

--- a/apps/cli/test/commands/convert/convert-evals-json.test.ts
+++ b/apps/cli/test/commands/convert/convert-evals-json.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { convertEvalsJsonToYaml } from '../../../src/commands/convert/index.js';
+
+describe('convertEvalsJsonToYaml', () => {
+  function writeTempJson(data: unknown): string {
+    const dir = mkdtempSync(path.join(tmpdir(), 'convert-test-'));
+    const filePath = path.join(dir, 'evals.json');
+    writeFileSync(filePath, JSON.stringify(data));
+    return filePath;
+  }
+
+  it('converts basic evals.json to YAML', () => {
+    const filePath = writeTempJson({
+      skill_name: 'test-skill',
+      evals: [
+        {
+          id: 1,
+          prompt: 'Do something',
+          expected_output: 'Something done',
+          assertions: ['Check A', 'Check B'],
+        },
+      ],
+    });
+
+    const yaml = convertEvalsJsonToYaml(filePath);
+    expect(yaml).toContain('Converted from Agent Skills evals.json');
+    expect(yaml).toContain('description: "Evals for test-skill skill"');
+    expect(yaml).toContain('id: "1"');
+    expect(yaml).toContain('role: user');
+    expect(yaml).toContain('Do something');
+    expect(yaml).toContain('assertion-1');
+    expect(yaml).toContain('type: llm-judge');
+    expect(yaml).toContain('Check A');
+    expect(yaml).toContain('Check B');
+  });
+
+  it('handles evals without assertions or expected_output', () => {
+    const filePath = writeTempJson({
+      evals: [{ id: 1, prompt: 'Just a prompt' }],
+    });
+
+    const yaml = convertEvalsJsonToYaml(filePath);
+    expect(yaml).toContain('id: "1"');
+    expect(yaml).toContain('Just a prompt');
+    expect(yaml).not.toContain('assert:');
+    expect(yaml).not.toContain('expected_output:');
+  });
+
+  it('adds TODO comments for files', () => {
+    const filePath = writeTempJson({
+      evals: [
+        {
+          id: 1,
+          prompt: 'Analyze data',
+          files: ['data/input.csv'],
+        },
+      ],
+    });
+
+    const yaml = convertEvalsJsonToYaml(filePath);
+    expect(yaml).toContain('# TODO:');
+    expect(yaml).toContain('data/input.csv');
+  });
+
+  it('throws on invalid format', () => {
+    const filePath = writeTempJson({ not_evals: true });
+    expect(() => convertEvalsJsonToYaml(filePath)).toThrow("missing 'evals' array");
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,10 @@
 export * from './evaluation/types.js';
 export * from './evaluation/trace.js';
 export * from './evaluation/yaml-parser.js';
+export {
+  isAgentSkillsFormat,
+  parseAgentSkillsEvals,
+} from './evaluation/loaders/agent-skills-parser.js';
 export * from './evaluation/file-utils.js';
 export * from './evaluation/providers/index.js';
 export * from './evaluation/evaluators.js';


### PR DESCRIPTION
## Summary
- Extend `agentv convert` to accept Agent Skills evals.json and output equivalent EVAL.yaml
- Output to stdout by default, or to file with `-o` flag
- Generated YAML includes comments about available AgentV features (deterministic evaluators, composite scoring, workspace isolation)
- Export `isAgentSkillsFormat` and `parseAgentSkillsEvals` from `@agentv/core` for reuse

Closes #540

## Test plan
- [x] Unit tests for `convertEvalsJsonToYaml` covering basic conversion, no assertions, files TODO comments, invalid format
- [x] Manual verification with example fixture produces valid YAML
- [x] Full verify suite passes (build + typecheck + lint + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)