### PR TITLE
docs: update Agent Skills evals guide with full feature coverage and realistic examples

### DIFF
--- a/apps/web/src/content/docs/guides/agent-skills-evals.mdx
+++ b/apps/web/src/content/docs/guides/agent-skills-evals.mdx
@@ -27,12 +27,13 @@ Create `evals.json`:
   "evals": [
     {
       "id": 1,
-      "prompt": "Analyze sales.csv and find the top 3 months by revenue.",
-      "expected_output": "A summary of the top 3 months with revenue figures.",
+      "prompt": "I have a CSV of monthly sales data in evals/files/sales.csv. Find the top 3 months by revenue.",
+      "expected_output": "The top 3 months by revenue are November ($22,500), September ($20,100), and December ($19,400).",
+      "files": ["evals/files/sales.csv"],
       "assertions": [
-        "Output identifies exactly 3 months",
-        "Revenue figures are included for each month",
-        "Months are ordered by revenue descending"
+        "Output identifies November as the highest revenue month",
+        "Output includes exactly 3 months",
+        "Revenue figures are included for each month"
       ]
     }
   ]
@@ -56,9 +57,104 @@ When AgentV loads `evals.json`, it promotes fields to its internal representatio
 | `prompt` | `input` | Wrapped as `[{role: "user", content: prompt}]` |
 | `expected_output` | `expected_output` + `criteria` | Used as reference answer and evaluation criteria |
 | `assertions[]` | `assert[]` | Each string becomes `{type: llm-judge, prompt: text}` |
-| `files[]` | `metadata.agent_skills_files` | File paths relative to evals.json location |
+| `files[]` | `file_paths` | Resolved relative to evals.json, copied into workspace |
 | `skill_name` | `metadata.skill_name` | Carried as metadata |
 | `id` (number) | `id` (string) | Converted via `String(id)` |
+
+## Files support
+
+The `files[]` field lists files that the agent needs during evaluation. Paths are relative to the evals.json location:
+
+```json
+{
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Analyze the sales data",
+      "files": ["evals/files/sales.csv", "evals/files/config.json"]
+    }
+  ]
+}
+```
+
+AgentV resolves these paths and copies the files into the workspace before the agent runs. If a file is missing, the test case fails with a `file_copy_error`.
+
+## Agent mode (no API keys)
+
+AgentV's prompt subcommands work with evals.json, enabling agent-mode evaluation without API keys:
+
+```bash
+# Show orchestration overview
+agentv prompt eval evals.json
+
+# Get input for a specific test
+agentv prompt eval input evals.json --test-id 1
+
+# Get judge prompts for a test
+agentv prompt eval judge evals.json --test-id 1 --answer-file answer.txt
+```
+
+The eval-candidate and eval-judge agents can be dispatched against evals.json just like EVAL.yaml files.
+
+## Benchmark output
+
+Generate an Agent Skills compatible `benchmark.json` alongside the standard result JSONL:
+
+```bash
+agentv eval evals.json --target claude --benchmark-json benchmark.json
+```
+
+The benchmark uses AgentV's pass threshold (score >= 0.8) to map continuous scores to the binary pass/fail that Agent Skills `pass_rate` expects:
+
+```json
+{
+  "run_summary": {
+    "with_skill": {
+      "pass_rate": {"mean": 0.83, "stddev": 0.06},
+      "time_seconds": {"mean": 45.0, "stddev": 12.0},
+      "tokens": {"mean": 3800, "stddev": 400}
+    }
+  }
+}
+```
+
+## Converting to EVAL.yaml
+
+When you're ready to graduate, convert your evals.json to EVAL.yaml:
+
+```bash
+# Output to stdout
+agentv convert evals.json
+
+# Write to file
+agentv convert evals.json -o eval.yaml
+```
+
+The generated YAML includes comments about available AgentV features you can use:
+
+```yaml
+# Converted from Agent Skills evals.json
+# AgentV features you can add:
+#   - type: is_json, contains, regex for deterministic evaluators
+#   - type: code-judge for custom scoring scripts
+#   - Multi-turn conversations via input message arrays
+#   - Composite evaluators with weighted scoring
+#   - Workspace isolation with repos and hooks
+
+tests:
+  - id: "1"
+    criteria: |-
+      The top 3 months by revenue are November, September, and December.
+    input:
+      - role: user
+        content: "Find the top 3 months by revenue."
+    # Promoted from evals.json assertions[]
+    # Replace with type: is_json, contains, or regex for deterministic checks
+    assert:
+      - name: assertion-1
+        type: llm-judge
+        prompt: "Output identifies November as the highest revenue month"
+```
 
 ## When to stay with evals.json
 

--- a/examples/features/agent-skills-evals/.agentv/targets.yaml
+++ b/examples/features/agent-skills-evals/.agentv/targets.yaml
@@ -1,0 +1,3 @@
+targets:
+  - name: default
+    provider: echo

--- a/examples/features/agent-skills-evals/evals.json
+++ b/examples/features/agent-skills-evals/evals.json
@@ -3,18 +3,19 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "I have a CSV of monthly sales data in data/sales.csv. Find the top 3 months by revenue and make a bar chart.",
-      "expected_output": "A bar chart image showing the top 3 months by revenue, with labeled axes and values.",
+      "prompt": "I have a CSV of monthly sales data in evals/files/sales.csv. Find the top 3 months by revenue.",
+      "expected_output": "The top 3 months by revenue are November ($22,500), September ($20,100), and December ($19,400).",
+      "files": ["evals/files/sales.csv"],
       "assertions": [
-        "Output includes a bar chart image file",
-        "Chart shows exactly 3 months",
-        "Both axes are labeled"
+        "Output identifies November as the highest revenue month",
+        "Output includes exactly 3 months",
+        "Revenue figures are included for each month"
       ]
     },
     {
       "id": 2,
-      "prompt": "Clean up customers.csv — some rows have missing emails",
-      "expected_output": "A cleaned CSV with missing emails handled, plus a count of how many were missing."
+      "prompt": "Summarize the total annual revenue from the sales data.",
+      "expected_output": "The total annual revenue is $191,900."
     }
   ]
 }

--- a/examples/features/agent-skills-evals/evals/files/sales.csv
+++ b/examples/features/agent-skills-evals/evals/files/sales.csv
@@ -1,0 +1,13 @@
+month,revenue,units_sold
+January,12500,150
+February,9800,120
+March,15200,180
+April,11300,140
+May,18900,220
+June,14700,175
+July,16500,195
+August,13200,160
+September,20100,240
+October,17800,210
+November,22500,265
+December,19400,230


### PR DESCRIPTION
## Summary
- Add docs sections for: files[] workspace support, agent mode (prompt eval), --benchmark-json flag, agentv convert command
- Update example evals.json with realistic CSV data and actual file references
- Add sales.csv example file and minimal targets.yaml so the example is self-contained

## E2E verification performed
All commands tested manually against the example fixture:

1. `agentv eval evals.json --dry-run --benchmark-json benchmark.json` — loads, parses, runs both test cases, produces benchmark.json
2. `agentv prompt eval evals.json` — shows agent mode orchestration with test IDs 1 and 2
3. `agentv prompt eval input evals.json --test-id 1` — returns promoted input messages and criteria
4. `agentv convert evals.json` — outputs valid EVAL.yaml with assertions, files TODO, and feature comments

## Risk
low — docs and example data only, no code behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)