### PR TITLE
docs: update convert docs and eval skills for evals.json coverage

### DIFF
--- a/apps/web/src/content/docs/tools/convert.mdx
+++ b/apps/web/src/content/docs/tools/convert.mdx
@@ -1,27 +1,48 @@
 ---
 title: Convert
-description: Convert between YAML and JSONL formats
+description: Convert between evaluation file formats
 sidebar:
   order: 2
 ---
 
-The `convert` command converts evaluation files between YAML and JSONL formats.
+The `convert` command converts evaluation files between formats: YAML ↔ JSONL, and Agent Skills `evals.json` → AgentV EVAL YAML.
 
 ## Usage
 
 ### YAML to JSONL
 
 ```bash
-agentv convert evals/dataset.eval.yaml --format jsonl
+agentv convert evals/dataset.eval.yaml
 ```
+
+Outputs a `.jsonl` file alongside the input.
 
 ### JSONL to YAML
 
 ```bash
-agentv convert evals/dataset.jsonl --format yaml
+agentv convert evals/dataset.jsonl
 ```
+
+Outputs a `.eval.yaml` file alongside the input.
+
+### Agent Skills evals.json to EVAL YAML
+
+```bash
+agentv convert evals.json
+```
+
+Converts an [Agent Skills `evals.json`](/guides/agent-skills-evals) file into an AgentV EVAL YAML file. The converter:
+
+- Maps `prompt` → `input` message array
+- Maps `expected_output` → `expected_output`
+- Maps `assertions` → `assert` evaluators (llm-judge)
+- Resolves `files[]` paths relative to the evals.json directory
+- Adds TODO comments for AgentV-specific features (workspace setup, code judges, rubrics)
+
+This is a one-way conversion — use it as a starting point, then enhance the generated YAML with AgentV features.
 
 ## When to Use
 
+- **evals.json → YAML** to onboard Agent Skills evaluations into AgentV with full feature access
 - **YAML → JSONL** for large-scale evaluations, programmatic processing, or compatibility with other tools
 - **JSONL → YAML** for human editing, adding execution config, or better readability

--- a/plugins/agentv-dev/skills/agentv-eval-builder/SKILL.md
+++ b/plugins/agentv-dev/skills/agentv-eval-builder/SKILL.md
@@ -1,11 +1,28 @@
 ---
 name: agentv-eval-builder
-description: Create and maintain AgentV YAML evaluation files for testing AI agent performance. Use this skill when creating new eval files, adding tests, or configuring evaluators.
+description: Create and maintain AgentV evaluation files for testing AI agent performance. Use this skill when creating new eval files, adding tests, configuring evaluators, or converting Agent Skills evals.json files to AgentV format.
 ---
 
 # AgentV Eval Builder
 
 Comprehensive docs: https://agentv.dev
+
+## Starting from evals.json?
+
+If the project already has an Agent Skills `evals.json` file, use it as a starting point instead of writing YAML from scratch:
+
+```bash
+# Convert evals.json to AgentV EVAL YAML
+agentv convert evals.json
+
+# Run directly without converting (all commands accept evals.json)
+agentv eval evals.json
+agentv prompt eval evals.json
+```
+
+The converter maps `prompt` → `input`, `expected_output` → `expected_output`, `assertions` → `assert` (llm-judge), and resolves `files[]` paths. The generated YAML includes TODO comments for AgentV features to add (workspace setup, code judges, rubrics, required gates).
+
+After converting, enhance the YAML with AgentV-specific capabilities shown below.
 
 ## Quick Start
 

--- a/plugins/agentv-dev/skills/agentv-eval-orchestrator/SKILL.md
+++ b/plugins/agentv-dev/skills/agentv-eval-orchestrator/SKILL.md
@@ -1,28 +1,76 @@
 ---
 name: agentv-eval-orchestrator
-description: Run AgentV evaluations by orchestrating eval subcommands. Use this skill when asked to run evals, evaluate an agent, or test prompt quality using agentv.
+description: Run AgentV evaluations by orchestrating eval subcommands. Use this skill when asked to run evals, evaluate an agent, test prompt quality using agentv, or run Agent Skills evals.json files.
 ---
 
 # AgentV Eval Orchestrator
 
 Run AgentV evaluations using the orchestration prompt system.
 
+## Supported Formats
+
+AgentV accepts evaluation files in multiple formats:
+
+- **EVAL YAML** (`.eval.yaml`) — Full-featured AgentV native format
+- **JSONL** (`.jsonl`) — One test per line, with optional YAML sidecar
+- **Agent Skills evals.json** (`.json`) — Open standard format from Agent Skills
+
+All commands below work with any of these formats.
+
 ## Usage
 
 ```bash
-agentv prompt eval <eval-file.yaml>
+agentv prompt eval <eval-file>
 ```
 
 This outputs a complete orchestration prompt with mode-specific instructions and all test IDs. **Follow its instructions exactly.**
 
 The orchestration mode is controlled by the `AGENTV_PROMPT_EVAL_MODE` environment variable:
 
-- **`agent`** (default) — You act as the candidate LLM and judge via two agents (`eval-candidate`, `eval-judge`). No API keys needed.
+- **`agent`** (default) — Act as the candidate LLM and judge via two agents (`eval-candidate`, `eval-judge`). No API keys needed.
 - **`cli`** — The CLI runs the evaluation end-to-end. Requires API keys.
 
-## How it works
+## How It Works
 
-1. Run `agentv prompt eval <path>` to get your orchestration instructions
+1. Run `agentv prompt eval <path>` to get orchestration instructions
 2. The output tells you exactly what to do based on the current mode
 3. Follow the instructions — dispatch agents (agent mode) or run CLI commands (cli mode)
 4. Results are written to `.agentv/results/` in JSONL format
+
+## Agent Skills evals.json
+
+When running an `evals.json` file, AgentV automatically:
+
+- Promotes `prompt` → input messages, `expected_output` → reference answer
+- Converts `assertions` → llm-judge evaluators
+- Resolves `files[]` paths relative to the evals.json directory and copies them into the workspace
+- Sets agent mode by default (since evals.json targets agent workflows)
+
+```bash
+# Run directly
+agentv prompt eval evals.json
+
+# Or convert to YAML first for full feature access
+agentv convert evals.json
+agentv prompt eval evals.eval.yaml
+```
+
+## Benchmark Output
+
+After running evaluations, generate an Agent Skills-compatible `benchmark.json` summary:
+
+```bash
+agentv eval evals.json --benchmark-json benchmark.json
+```
+
+This produces aggregate pass rates, timing, and token statistics in the Agent Skills benchmark format.
+
+## Converting Formats
+
+To unlock AgentV-specific features (workspace setup, code judges, rubrics, retry policies), convert evals.json to YAML:
+
+```bash
+agentv convert evals.json
+```
+
+See the [convert command docs](https://agentv.dev/tools/convert/) for details.


### PR DESCRIPTION
## Summary
- **convert.mdx**: Added evals.json → EVAL YAML section, corrected CLI usage (removed incorrect `--format` flag)
- **agentv-eval-orchestrator SKILL.md**: Added supported formats, evals.json workflow, benchmark output, and convert sections
- **agentv-eval-builder SKILL.md**: Added "Starting from evals.json?" onramp section

## Risk
Low — documentation and skill description changes only, no code changes.