### PR TITLE
fix(agentv-bench): simplify AGENT_EVAL_MODE to 2 modes (cli | agent)

### DIFF
--- a/plugins/agentv-dev/skills/agentv-bench/SKILL.md
+++ b/plugins/agentv-dev/skills/agentv-bench/SKILL.md
@@ -183,17 +183,13 @@ grep AGENT_EVAL_MODE .env 2>/dev/null || echo "AGENT_EVAL_MODE=agent"
 | `AGENT_EVAL_MODE` | Mode | How |
 |-------------------|------|-----|
 | `cli` | **AgentV CLI** | `agentv eval <path>` — end-to-end, EVAL.yaml |
-| `python` | **Python scripts** | `python scripts/run_eval.py` — evals.json via `claude -p` |
-| `agent` (default) | **Agent mode** | `agentv prompt eval` accessors + spawn subagents |
-| _(no subagents, no CLI)_ | **Serial manual** | Run each test case in conversation, grade inline |
+| `agent` (default) | **Agent mode** | `python scripts/run_eval.py` (calls `claude -p` today; will use `agentv prompt eval` in future) |
 
 Set `AGENT_EVAL_MODE` in `.env` at the project root. If absent, default to `agent`.
 
 **`cli`** — AgentV CLI handles execution, grading, and artifact generation end-to-end. Best for EVAL.yaml evals when `agentv` is installed.
 
-**`python`** — `run_eval.py` calls `claude -p` directly. Use for evals.json skill-creator workflows.
-
-**`agent`** — The orchestrating agent acts as both candidate and judge via `agentv prompt eval` accessors. No external API calls required; works wherever subagents are available.
+**`agent`** — `run_eval.py` runs each test case via `claude -p` and captures outputs for grading. Will migrate to `agentv prompt eval` accessors + subagents once issue #599 lands.
 
 > Note: `AGENT_EVAL_MODE` replaces the deprecated `AGENTV_PROMPT_EVAL_MODE` from `agentv prompt eval --overview` (see issue #599).
 
@@ -204,18 +200,11 @@ Set `AGENT_EVAL_MODE` in `.env` at the project root. If absent, default to `agen
 agentv eval <eval-path> --artifacts .agentv/artifacts/
 ```
 
-**Python scripts mode** (evals.json, calls `claude -p`):
+**Agent mode** (evals.json via `run_eval.py`):
 ```bash
 cd plugins/agentv-dev/skills/agentv-bench
 python scripts/quick_validate.py --eval evals/evals.json
 python scripts/run_eval.py --eval evals/evals.json --output iteration-1/
-```
-
-**Agent mode** (orchestrator as candidate + judge):
-```bash
-agentv prompt eval --list <eval-path>
-agentv prompt eval --input <eval-path> --test-id <id>
-agentv prompt eval --expected-output <eval-path> --test-id <id>
 ```
 
 **Spawn all runs in the same turn.** For each test case that needs both a "with change" and a "baseline" run, launch them simultaneously. Don't run one set first and come back for the other — launch everything at once so results arrive around the same time.


### PR DESCRIPTION
## Summary

Fixes the run-mode router introduced in #592 — removes the spurious `python` third mode.

Two modes only:
- `cli` → `agentv eval` end-to-end (EVAL.yaml)
- `agent` (default) → `run_eval.py` via `claude -p` today; will migrate to `agentv prompt eval` accessors once issue #599 lands

## Related
- #592 (introduced the router)
- #599 (will replace `run_eval.py` with `agentv prompt eval` in agent mode)