### PR TITLE
chore: remove AGENTV_PROMPT_EVAL_MODE, add AGENT_EVAL_MODE to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,9 @@ PROJECTX_WORKSPACE_PATH=C:/Users/your-username/OneDrive - Company Pty Ltd/sample
 # Custom VS Code executable path (optional, defaults to 'code')
 # VSCODE_CMD=C:/Program Files/Microsoft VS Code/bin/code.cmd
 
+# Eval run mode (used by agentv-bench skill)
+AGENT_EVAL_MODE=agent # agent | cli
+
 # CLI provider sample (used by the local_cli target)
 CLI_EVALS_DIR=./docs/examples/simple/evals/local-cli
 LOCAL_AGENT_TOKEN=dummytoken

--- a/plugins/agentv-dev/skills/agentv-bench/SKILL.md
+++ b/plugins/agentv-dev/skills/agentv-bench/SKILL.md
@@ -183,15 +183,13 @@ grep AGENT_EVAL_MODE .env 2>/dev/null || echo "AGENT_EVAL_MODE=agent"
 | `AGENT_EVAL_MODE` | Mode | How |
 |-------------------|------|-----|
 | `cli` | **AgentV CLI** | `agentv eval <path>` — end-to-end, EVAL.yaml |
-| `agent` (default) | **Agent mode** | `python scripts/run_eval.py` (calls `claude -p` today; will use `agentv prompt eval` in future) |
+| `agent` (default) | **Agent mode** | `python scripts/run_eval.py` (calls `claude -p`) |
 
 Set `AGENT_EVAL_MODE` in `.env` at the project root. If absent, default to `agent`.
 
 **`cli`** — AgentV CLI handles execution, grading, and artifact generation end-to-end. Best for EVAL.yaml evals when `agentv` is installed.
 
-**`agent`** — `run_eval.py` runs each test case via `claude -p` and captures outputs for grading. Will migrate to `agentv prompt eval` accessors + subagents once issue #599 lands.
-
-> Note: `AGENT_EVAL_MODE` replaces the deprecated `AGENTV_PROMPT_EVAL_MODE` from `agentv prompt eval --overview` (see issue #599).
+**`agent`** — `run_eval.py` runs each test case via `claude -p` and captures outputs for grading.
 
 ### Running evaluations
 


### PR DESCRIPTION
## Summary
- Remove deprecation note referencing `AGENTV_PROMPT_EVAL_MODE` from `plugins/agentv-dev/skills/agentv-bench/SKILL.md`
- Remove stale forward-reference to issue #599 from the agent mode description
- Add `AGENT_EVAL_MODE=agent # agent | cli` to `.env.example`

Note: `--overview` flag and `overview.ts` were already removed in #590 (simplify prompt eval accessors). This PR completes the cleanup by removing the deprecation note and documenting the env var.

## Risk
low — documentation and config only; no code behavior changes

Closes #599