### PR TITLE
fix(validator): accept string shorthand in assertions array

### DIFF
--- a/packages/core/src/evaluation/validation/eval-validator.ts
+++ b/packages/core/src/evaluation/validation/eval-validator.ts
@@ -469,19 +469,36 @@ function validateAssertArray(
     return;
   }
 
+  // String items in the assertions array are valid shorthand — the parser collects them
+  // into a single rubrics/llm-grader evaluator. Filter them out before object validation.
+  const objectItems: { item: JsonObject; index: number }[] = [];
   for (let i = 0; i < assertField.length; i++) {
     const item = assertField[i];
-    const location = `${parentLocation}.assertions[${i}]`;
-
+    if (typeof item === 'string') {
+      if (item.trim().length === 0) {
+        errors.push({
+          severity: 'warning',
+          filePath,
+          location: `${parentLocation}.assertions[${i}]`,
+          message: 'Empty string assertion item will be ignored.',
+        });
+      }
+      continue; // Valid shorthand — skip object validation
+    }
     if (!isObject(item)) {
       errors.push({
         severity: 'warning',
         filePath,
-        location,
-        message: 'Assertion item must be an object with a type field.',
+        location: `${parentLocation}.assertions[${i}]`,
+        message: 'Assertion item must be a string or an object with a type field.',
       });
       continue;
     }
+    objectItems.push({ item, index: i });
+  }
+
+  for (const { item, index } of objectItems) {
+    const location = `${parentLocation}.assertions[${index}]`;
 
     // Validate type field
     const rawTypeValue = item.type;

--- a/packages/core/test/evaluation/validation/eval-validator.test.ts
+++ b/packages/core/test/evaluation/validation/eval-validator.test.ts
@@ -394,7 +394,27 @@ describe('validateEvalFile', () => {
       expect(warnings.some((e) => e.message.includes('assertions'))).toBe(true);
     });
 
-    it('warns when assert item is not an object', async () => {
+    it('accepts string shorthand in assertions array', async () => {
+      const filePath = path.join(tempDir, 'assert-string-shorthand.yaml');
+      await writeFile(
+        filePath,
+        `tests:
+  - id: test-1
+    input: "Explain quicksort"
+    assertions:
+      - Mentions divide-and-conquer approach
+      - Explains partition step
+      - States time complexity correctly
+`,
+      );
+
+      const result = await validateEvalFile(filePath);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('warns on non-string non-object assertion items', async () => {
       const filePath = path.join(tempDir, 'assert-item-not-object.yaml');
       await writeFile(
         filePath,
@@ -402,14 +422,14 @@ describe('validateEvalFile', () => {
   - id: test-1
     input: "What is 2+2?"
     assertions:
-      - "contains"
+      - 42
 `,
       );
 
       const result = await validateEvalFile(filePath);
 
       const warnings = result.errors.filter((e) => e.severity === 'warning');
-      expect(warnings.some((e) => e.message.includes('object'))).toBe(true);
+      expect(warnings.some((e) => e.message.includes('string or an object'))).toBe(true);
     });
 
     it('passes valid assert array', async () => {


### PR DESCRIPTION
## Summary
- Validator now accepts string items in `assertions` arrays as valid rubrics/llm-grader shorthand, matching the parser behavior
- Updated error message for truly invalid items (non-string, non-object) to be more descriptive
- Added test for string shorthand acceptance; updated existing test to cover non-string/non-object items

Closes #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)