### PR TITLE
fix(validator): accept required_version and execution in config.yaml

### DIFF
--- a/packages/core/src/evaluation/validation/config-validator.ts
+++ b/packages/core/src/evaluation/validation/config-validator.ts
@@ -88,7 +88,7 @@ export async function validateConfigFile(filePath: string): Promise<ValidationRe
           severity: 'error',
           filePath,
           location: 'required_version',
-          message: "Field 'required_version' must be a non-empty string (e.g. \">=3.1.0\")",
+          message: 'Field \'required_version\' must be a non-empty string (e.g. ">=3.1.0")',
         });
       }
     }

--- a/packages/core/test/evaluation/validation/config-validator.test.ts
+++ b/packages/core/test/evaluation/validation/config-validator.test.ts
@@ -50,7 +50,7 @@ guideline_patterns:
 
   it('errors on invalid required_version type', async () => {
     const filePath = path.join(tempDir, 'config-bad-version.yaml');
-    await writeFile(filePath, `required_version: 3\n`);
+    await writeFile(filePath, 'required_version: 3\n');
 
     const result = await validateConfigFile(filePath);
 
@@ -62,7 +62,7 @@ guideline_patterns:
 
   it('warns on truly unexpected fields', async () => {
     const filePath = path.join(tempDir, 'config-unexpected.yaml');
-    await writeFile(filePath, `foo: bar\n`);
+    await writeFile(filePath, 'foo: bar\n');
 
     const result = await validateConfigFile(filePath);
 


### PR DESCRIPTION
## Summary
- Added `required_version` and `execution` to the config validator's allowed fields set, matching the config loader
- Added validation for `required_version` (must be a non-empty string when present)
- Added config-validator test suite

Closes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)