### PR TITLE
feat(eval): show model name in eval run output

### DIFF
--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -336,10 +336,7 @@ function extractModelName(target: ResolvedTarget): string | undefined {
 /**
  * Build the inline label suffix (e.g. `[provider=azure, model=gpt-4]`).
  */
-function buildTargetLabelSuffix(
-  providerLabel: string,
-  target: ResolvedTarget,
-): string {
+function buildTargetLabelSuffix(providerLabel: string, target: ResolvedTarget): string {
   const parts = [`provider=${providerLabel}`];
   const model = extractModelName(target);
   if (model) parts.push(`model=${model}`);


### PR DESCRIPTION
## Summary
- Display the model name alongside the provider in eval run progress output when the target has a model configured
- Azure targets show `deploymentName`; other providers show the `model` field; CLI/mock providers show no model
- Adds `extractModelName` and `buildTargetLabelSuffix` helper functions to keep label construction DRY across all three sites

Example output:
```
0/1   🔄 git-diff-compare-two-real-prs | copilot [provider=copilot-cli, model=gpt-5-mini]
```

## Risk
Low — additive display-only change, no behavior change.

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)