### PR TITLE
feat(workspace): validate local repo paths before eval execution

### DIFF
--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -478,6 +478,34 @@ export async function runEvaluation(
     }
   };
 
+  // Validate local repo source paths upfront before any materialization attempt.
+  // Collect repos from all test cases (suite-level + per-case) and check that local paths exist.
+  const allRepos = new Map<string, import('./types.js').RepoConfig>();
+  for (const ec of filteredEvalCases) {
+    if (ec.workspace?.repos) {
+      for (const repo of ec.workspace.repos) {
+        // Deduplicate by repo path + source path
+        const key = `${repo.path}::${repo.source.type === 'local' ? repo.source.path : ''}`;
+        if (!allRepos.has(key)) {
+          allRepos.set(key, repo);
+        }
+      }
+    }
+  }
+  if (allRepos.size > 0) {
+    const localPathErrors = RepoManager.validateLocalPaths([...allRepos.values()]);
+    if (localPathErrors.length > 0) {
+      const message = RepoManager.formatValidationErrors(localPathErrors);
+      console.warn(`Warning: ${message}`);
+      // Store invalid repo paths so affected tests can be failed with execution_error
+      const invalidLocalRepoPaths = new Set(localPathErrors.map((e) => e.repoPath));
+      // If suite-level repos have invalid paths, fail the entire run early
+      if (suiteWorkspace?.repos?.some((r) => invalidLocalRepoPaths.has(r.path))) {
+        throw new Error(message);
+      }
+    }
+  }
+
   // Resolve worker count and pool mode
   const isPerTestIsolation = suiteWorkspace?.isolation === 'per_test';
 
@@ -1333,6 +1361,25 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
     ) {
       workspacePath = getWorkspacePath(evalRunId, evalCase.id);
       await mkdir(workspacePath, { recursive: true });
+    }
+
+    // Validate local repo paths before per-case materialization
+    if (evalCase.workspace?.repos?.length && workspacePath) {
+      const localPathErrors = RepoManager.validateLocalPaths(evalCase.workspace.repos);
+      if (localPathErrors.length > 0) {
+        const message = RepoManager.formatValidationErrors(localPathErrors);
+        console.warn(`Warning: test=${evalCase.id} ${message}`);
+        return buildErrorResult(
+          evalCase,
+          target.name,
+          nowFn(),
+          new Error(message),
+          promptInputs,
+          provider,
+          'repo_setup',
+          'local_path_not_found',
+        );
+      }
     }
 
     // Materialize repos into per-case workspace

--- a/packages/core/src/evaluation/workspace/index.ts
+++ b/packages/core/src/evaluation/workspace/index.ts
@@ -14,7 +14,7 @@ export {
 export { initializeBaseline, captureFileChanges } from './file-changes.js';
 export { resolveWorkspaceTemplate } from './resolve.js';
 export type { ResolvedWorkspaceTemplate } from './resolve.js';
-export { RepoManager } from './repo-manager.js';
+export { RepoManager, type LocalPathValidationError } from './repo-manager.js';
 export {
   WorkspacePoolManager,
   computeWorkspaceFingerprint,

--- a/packages/core/src/evaluation/workspace/repo-manager.ts
+++ b/packages/core/src/evaluation/workspace/repo-manager.ts
@@ -1,8 +1,18 @@
 import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
 import type { RepoConfig, RepoSource } from '../types.js';
+
+/**
+ * Validation error for a local repo source path that doesn't exist or is unresolved.
+ */
+export interface LocalPathValidationError {
+  readonly repoPath: string;
+  readonly resolvedSourcePath: string;
+  readonly reason: 'not_found' | 'empty_path';
+}
 
 const execFileAsync = promisify(execFile);
 const DEFAULT_TIMEOUT_MS = 300_000; // 5 minutes
@@ -43,6 +53,46 @@ export class RepoManager {
 
   constructor(verbose = false) {
     this.verbose = verbose;
+  }
+
+  /**
+   * Validate that all local repo source paths exist before attempting materialization.
+   * Returns an array of validation errors (empty if all paths are valid).
+   */
+  static validateLocalPaths(repos: readonly RepoConfig[]): readonly LocalPathValidationError[] {
+    const errors: LocalPathValidationError[] = [];
+    for (const repo of repos) {
+      if (repo.source.type !== 'local') continue;
+
+      const sourcePath = repo.source.path;
+      if (!sourcePath || sourcePath.trim() === '') {
+        errors.push({
+          repoPath: repo.path,
+          resolvedSourcePath: sourcePath ?? '',
+          reason: 'empty_path',
+        });
+      } else if (!existsSync(sourcePath)) {
+        errors.push({
+          repoPath: repo.path,
+          resolvedSourcePath: sourcePath,
+          reason: 'not_found',
+        });
+      }
+    }
+    return errors;
+  }
+
+  /**
+   * Format validation errors into a human-readable warning message.
+   */
+  static formatValidationErrors(errors: readonly LocalPathValidationError[]): string {
+    const lines = errors.map((e) => {
+      if (e.reason === 'empty_path') {
+        return `  - repo "${e.repoPath}": local source path is empty (check that the env var is set)`;
+      }
+      return `  - repo "${e.repoPath}": local source path not found: ${e.resolvedSourcePath}`;
+    });
+    return `Local repo path validation failed:\n${lines.join('\n')}`;
   }
 
   private async runGit(args: string[], opts?: { cwd?: string; timeout?: number }): Promise<string> {

--- a/packages/core/test/evaluation/workspace/repo-manager.test.ts
+++ b/packages/core/test/evaluation/workspace/repo-manager.test.ts
@@ -162,6 +162,110 @@ describe('RepoManager', () => {
     });
   });
 
+  describe('validateLocalPaths', () => {
+    it('returns empty array when all local paths exist', () => {
+      const repoDir = path.join(tmpDir, 'valid-repo');
+      mkdirSync(repoDir, { recursive: true });
+
+      const errors = RepoManager.validateLocalPaths([
+        { path: './my-repo', source: { type: 'local', path: repoDir } },
+      ]);
+
+      expect(errors).toEqual([]);
+    });
+
+    it('returns not_found error for non-existent local path', () => {
+      const missingPath = path.join(tmpDir, 'does-not-exist');
+
+      const errors = RepoManager.validateLocalPaths([
+        { path: './my-repo', source: { type: 'local', path: missingPath } },
+      ]);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toEqual({
+        repoPath: './my-repo',
+        resolvedSourcePath: missingPath,
+        reason: 'not_found',
+      });
+    });
+
+    it('returns empty_path error when source path is empty string', () => {
+      const errors = RepoManager.validateLocalPaths([
+        { path: './my-repo', source: { type: 'local', path: '' } },
+      ]);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toEqual({
+        repoPath: './my-repo',
+        resolvedSourcePath: '',
+        reason: 'empty_path',
+      });
+    });
+
+    it('returns empty_path error when source path is whitespace-only', () => {
+      const errors = RepoManager.validateLocalPaths([
+        { path: './my-repo', source: { type: 'local', path: '   ' } },
+      ]);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].reason).toBe('empty_path');
+    });
+
+    it('skips git source repos', () => {
+      const errors = RepoManager.validateLocalPaths([
+        { path: './my-repo', source: { type: 'git', url: 'https://github.com/org/repo' } },
+      ]);
+
+      expect(errors).toEqual([]);
+    });
+
+    it('reports multiple errors for multiple invalid repos', () => {
+      const errors = RepoManager.validateLocalPaths([
+        { path: './repo-a', source: { type: 'local', path: '/nonexistent/path-a' } },
+        { path: './repo-b', source: { type: 'local', path: '' } },
+      ]);
+
+      expect(errors).toHaveLength(2);
+      expect(errors[0].reason).toBe('not_found');
+      expect(errors[1].reason).toBe('empty_path');
+    });
+
+    it('validates mix of valid and invalid repos', () => {
+      const validDir = path.join(tmpDir, 'valid-repo');
+      mkdirSync(validDir, { recursive: true });
+
+      const errors = RepoManager.validateLocalPaths([
+        { path: './valid', source: { type: 'local', path: validDir } },
+        { path: './invalid', source: { type: 'local', path: '/nonexistent' } },
+      ]);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].repoPath).toBe('./invalid');
+    });
+  });
+
+  describe('formatValidationErrors', () => {
+    it('formats not_found error with path', () => {
+      const message = RepoManager.formatValidationErrors([
+        { repoPath: './my-repo', resolvedSourcePath: '/missing/path', reason: 'not_found' },
+      ]);
+
+      expect(message).toContain('my-repo');
+      expect(message).toContain('/missing/path');
+      expect(message).toContain('not found');
+    });
+
+    it('formats empty_path error with env var hint', () => {
+      const message = RepoManager.formatValidationErrors([
+        { repoPath: './my-repo', resolvedSourcePath: '', reason: 'empty_path' },
+      ]);
+
+      expect(message).toContain('my-repo');
+      expect(message).toContain('empty');
+      expect(message).toContain('env var');
+    });
+  });
+
   describe('reset', () => {
     it('hard reset restores repo to checkout state', async () => {
       const repoDir = path.join(tmpDir, 'source-repo');


### PR DESCRIPTION
## Summary
- Validate local repo source paths upfront before any workspace materialization
- When `source.type: local` paths don't exist or are empty (unset env var), fail early with a clear error instead of a cryptic git clone failure mid-test
- Suite-level repos with invalid paths throw immediately; per-test repos return `execution_error` with `failureStage: repo_setup` / `failureReasonCode: local_path_not_found`

## Changes
- `packages/core/src/evaluation/workspace/repo-manager.ts` — Add `validateLocalPaths()` and `formatValidationErrors()` static methods, plus `LocalPathValidationError` type
- `packages/core/src/evaluation/orchestrator.ts` — Call validation early in `runEvaluation()` (before materialization) and in `runEvalCase()` (before per-test materialization)
- `packages/core/src/evaluation/workspace/index.ts` — Export new type
- `packages/core/test/evaluation/workspace/repo-manager.test.ts` — Add tests for validation logic and error formatting

## Risk
Low — additive feature, no existing behavior changes. Validation only triggers for repos with `source.type: local` when paths are missing.