### PR TITLE
fix(providers): add openai target support

### DIFF
--- a/.agentv/targets.yaml
+++ b/.agentv/targets.yaml
@@ -8,11 +8,11 @@ targets:
     model: z-ai/glm-4.7
     api_key: ${{ OPENROUTER_API_KEY }}
     system_prompt: "Answer directly based on the information provided."
-    judge_target: judge
+    grader_target: gemini-flash
 
   - name: codex
     provider: codex
-    judge_target: gemini-llm
+    grader_target: gemini-llm
     cwd: ${{ CODEX_WORKSPACE_DIR }}            # Where scratch workspaces are created
     log_dir: ${{ CODEX_LOG_DIR }}              # Optional: where Codex CLI stream logs are stored (defaults to ./.agentv/logs/codex)
     log_format: json                    # Optional: 'summary' (default) or 'json' for raw event logs
@@ -22,7 +22,13 @@ targets:
     api_key: ${{ GOOGLE_GENERATIVE_AI_API_KEY }}
     model: ${{ GEMINI_MODEL_NAME }}
 
-  - name: judge
+  - name: gemini-flash
     provider: gemini
     model: gemini-3-flash-preview
     api_key: ${{ GOOGLE_GENERATIVE_AI_API_KEY }}
+
+  - name: llm-gateway
+    provider: openai
+    endpoint: ${{ LLM_GATEWAY_OPENAI_ENDPOINT }}
+    api_key: ${{ LLM_GATEWAY_API_KEY }}
+    model: ${{ LLM_GATEWAY_MODEL }}

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@ AZURE_OPENAI_API_KEY=your-openai-api-key-here
 AZURE_DEPLOYMENT_NAME=gpt-5-chat
 AZURE_OPENAI_API_VERSION=2024-12-01-preview
 
+# LLM Gateway
+LLM_GATEWAY_OPENAI_ENDPOINT=https://your-endpoint.openai.azure.com/
+LLM_GATEWAY_API_KEY=your-openai-api-key-here
+LLM_GATEWAY_MODEL=gpt-5.4
+
 # Google Gemini
 GOOGLE_GENERATIVE_AI_API_KEY=your-gemini-api-key-here
 GEMINI_MODEL_NAME=gemini-2.5-flash

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -28,6 +28,7 @@
     "test:watch": "bun test --watch"
   },
   "dependencies": {
+    "@ai-sdk/openai": "^2.0.0",
     "@anthropic-ai/claude-agent-sdk": "^0.2.49",
     "@github/copilot-sdk": "^0.1.25",
     "@inquirer/prompts": "^8.2.1",

--- a/bun.lock
+++ b/bun.lock
@@ -24,11 +24,12 @@
     },
     "apps/cli": {
       "name": "agentv",
-      "version": "2.19.0",
+      "version": "3.2.2",
       "bin": {
         "agentv": "./dist/cli.js",
       },
       "dependencies": {
+        "@ai-sdk/openai": "^2.0.0",
         "@anthropic-ai/claude-agent-sdk": "^0.2.49",
         "@github/copilot-sdk": "^0.1.25",
         "@inquirer/prompts": "^8.2.1",
@@ -61,7 +62,7 @@
     },
     "packages/core": {
       "name": "@agentv/core",
-      "version": "2.19.0",
+      "version": "3.2.2",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",
         "@agentv/eval": "workspace:*",
@@ -96,7 +97,7 @@
     },
     "packages/eval": {
       "name": "@agentv/eval",
-      "version": "2.19.0",
+      "version": "3.2.2",
       "dependencies": {
         "zod": "^3.23.8",
       },

--- a/examples/features/.agentv/targets.yaml
+++ b/examples/features/.agentv/targets.yaml
@@ -10,6 +10,12 @@ targets:
     model: ${{ AZURE_DEPLOYMENT_NAME }}
     # version: ${{ AZURE_OPENAI_API_VERSION }}  # Optional: uncomment to override default (2024-12-01-preview)
 
+  - name: llm-gateway
+    provider: openai
+    endpoint: ${{ LLM_GATEWAY_OPENAI_ENDPOINT }}
+    api_key: ${{ LLM_GATEWAY_API_KEY }}
+    model: ${{ LLM_GATEWAY_MODEL }}
+
   - name: codex
     provider: codex
     grader_target: azure-llm

--- a/packages/core/src/evaluation/providers/ai-sdk.ts
+++ b/packages/core/src/evaluation/providers/ai-sdk.ts
@@ -1,6 +1,7 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { type AzureOpenAIProviderSettings, createAzure } from '@ai-sdk/azure';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { createOpenAI } from '@ai-sdk/openai';
 import { type LanguageModel, type ModelMessage, generateText } from 'ai';
 
 import type { JsonObject } from '../types.js';
@@ -8,6 +9,7 @@ import type {
   AnthropicResolvedConfig,
   AzureResolvedConfig,
   GeminiResolvedConfig,
+  OpenAIResolvedConfig,
   RetryConfig,
 } from './targets.js';
 import type { ChatPrompt, Provider, ProviderRequest, ProviderResponse } from './types.js';
@@ -22,6 +24,48 @@ interface ProviderDefaults {
   readonly temperature?: number;
   readonly maxOutputTokens?: number;
   readonly thinkingBudget?: number;
+}
+
+export class OpenAIProvider implements Provider {
+  readonly id: string;
+  readonly kind = 'openai' as const;
+  readonly targetName: string;
+
+  private readonly model: LanguageModel;
+  private readonly defaults: ProviderDefaults;
+  private readonly retryConfig?: RetryConfig;
+
+  constructor(
+    targetName: string,
+    private readonly config: OpenAIResolvedConfig,
+  ) {
+    this.id = `openai:${targetName}`;
+    this.targetName = targetName;
+    this.defaults = {
+      temperature: config.temperature,
+      maxOutputTokens: config.maxOutputTokens,
+    };
+    this.retryConfig = config.retry;
+
+    const openai = createOpenAI({
+      apiKey: config.apiKey,
+      baseURL: config.baseURL,
+    });
+    this.model = openai(config.model);
+  }
+
+  async invoke(request: ProviderRequest): Promise<ProviderResponse> {
+    return invokeModel({
+      model: this.model,
+      request,
+      defaults: this.defaults,
+      retryConfig: this.retryConfig,
+    });
+  }
+
+  asLanguageModel(): LanguageModel {
+    return this.model;
+  }
 }
 
 export class AzureProvider implements Provider {

--- a/packages/core/src/evaluation/providers/index.ts
+++ b/packages/core/src/evaluation/providers/index.ts
@@ -1,5 +1,5 @@
 import { AgentvProvider } from './agentv-provider.js';
-import { AnthropicProvider, AzureProvider, GeminiProvider } from './ai-sdk.js';
+import { AnthropicProvider, AzureProvider, GeminiProvider, OpenAIProvider } from './ai-sdk.js';
 import { ClaudeCliProvider } from './claude-cli.js';
 import { ClaudeSdkProvider } from './claude-sdk.js';
 import { ClaudeProvider } from './claude.js';
@@ -40,6 +40,7 @@ export type {
   CopilotSdkResolvedConfig,
   GeminiResolvedConfig,
   MockResolvedConfig,
+  OpenAIResolvedConfig,
   PiAgentSdkResolvedConfig,
   PiCodingAgentResolvedConfig,
   ResolvedTarget,
@@ -82,6 +83,7 @@ export function createBuiltinProviderRegistry(): ProviderRegistry {
   const registry = new ProviderRegistry();
 
   registry
+    .register('openai', (t) => new OpenAIProvider(t.name, t.config as never))
     .register('azure', (t) => new AzureProvider(t.name, t.config as never))
     .register('anthropic', (t) => new AnthropicProvider(t.name, t.config as never))
     .register('gemini', (t) => new GeminiProvider(t.name, t.config as never))

--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -404,6 +404,18 @@ export interface AzureResolvedConfig {
 }
 
 /**
+ * OpenAI-compatible settings used by the Vercel AI SDK.
+ */
+export interface OpenAIResolvedConfig {
+  readonly baseURL: string;
+  readonly apiKey: string;
+  readonly model: string;
+  readonly temperature?: number;
+  readonly maxOutputTokens?: number;
+  readonly retry?: RetryConfig;
+}
+
+/**
  * Anthropic Claude settings used by the Vercel AI SDK.
  */
 export interface AnthropicResolvedConfig {
@@ -530,6 +542,14 @@ export type CliHealthcheck = Readonly<CliNormalizedHealthcheck>;
 // which itself is inferred from CliTargetConfigSchema for type safety and single source of truth.
 
 export type ResolvedTarget =
+  | {
+      readonly kind: 'openai';
+      readonly name: string;
+      readonly graderTarget?: string;
+      readonly workers?: number;
+      readonly providerBatching?: boolean;
+      readonly config: OpenAIResolvedConfig;
+    }
   | {
       readonly kind: 'azure';
       readonly name: string;
@@ -664,6 +684,7 @@ const BASE_TARGET_SCHEMA = z
   .passthrough();
 
 const DEFAULT_AZURE_API_VERSION = '2024-12-01-preview';
+const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
 
 function normalizeAzureApiVersion(value: string | undefined): string {
   if (!value) {
@@ -738,6 +759,15 @@ export function resolveTargetDefinition(
   );
 
   switch (provider) {
+    case 'openai':
+      return {
+        kind: 'openai',
+        name: parsed.name,
+        graderTarget: parsed.grader_target ?? parsed.judge_target,
+        workers: parsed.workers,
+        providerBatching,
+        config: resolveOpenAIConfig(parsed, env),
+      };
     case 'azure':
     case 'azure-openai':
       return {
@@ -900,6 +930,19 @@ export function resolveTargetDefinition(
   }
 }
 
+function normalizeOpenAIBaseUrl(value: string | undefined): string {
+  if (!value) {
+    return DEFAULT_OPENAI_BASE_URL;
+  }
+
+  const trimmed = value.trim().replace(/\/+$/, '');
+  if (trimmed.length === 0) {
+    return DEFAULT_OPENAI_BASE_URL;
+  }
+
+  return trimmed.endsWith('/v1') ? trimmed : `${trimmed}/v1`;
+}
+
 function resolveAzureConfig(
   target: z.infer<typeof BASE_TARGET_SCHEMA>,
   env: EnvLookup,
@@ -934,6 +977,36 @@ function resolveAzureConfig(
     version,
     temperature,
     maxOutputTokens,
+    retry,
+  };
+}
+
+function resolveOpenAIConfig(
+  target: z.infer<typeof BASE_TARGET_SCHEMA>,
+  env: EnvLookup,
+): OpenAIResolvedConfig {
+  const endpointSource = target.endpoint ?? target.base_url ?? target.baseUrl;
+  const apiKeySource = target.api_key ?? target.apiKey;
+  const modelSource = target.model ?? target.deployment ?? target.variant;
+  const temperatureSource = target.temperature;
+  const maxTokensSource = target.max_output_tokens ?? target.maxTokens;
+
+  const baseURL = normalizeOpenAIBaseUrl(
+    resolveOptionalString(endpointSource, env, `${target.name} endpoint`, {
+      allowLiteral: true,
+      optionalEnv: true,
+    }),
+  );
+  const apiKey = resolveString(apiKeySource, env, `${target.name} api key`);
+  const model = resolveString(modelSource, env, `${target.name} model`);
+  const retry = resolveRetryConfig(target);
+
+  return {
+    baseURL,
+    apiKey,
+    model,
+    temperature: resolveOptionalNumber(temperatureSource, `${target.name} temperature`),
+    maxOutputTokens: resolveOptionalNumber(maxTokensSource, `${target.name} max output tokens`),
     retry,
   };
 }

--- a/packages/core/src/evaluation/providers/types.ts
+++ b/packages/core/src/evaluation/providers/types.ts
@@ -11,6 +11,7 @@ export interface ChatMessage {
 export type ChatPrompt = readonly ChatMessage[];
 
 export type ProviderKind =
+  | 'openai'
   | 'azure'
   | 'anthropic'
   | 'gemini'
@@ -49,6 +50,7 @@ export const AGENT_PROVIDER_KINDS: readonly ProviderKind[] = [
  * This is the source of truth for provider validation.
  */
 export const KNOWN_PROVIDERS: readonly ProviderKind[] = [
+  'openai',
   'azure',
   'anthropic',
   'gemini',
@@ -81,7 +83,6 @@ export const PROVIDER_ALIASES: readonly string[] = [
 
   'pi', // alias for "pi-coding-agent"
   'claude-code', // alias for "claude" (legacy)
-  'openai', // legacy/future support
   'bedrock', // legacy/future support
   'vertex', // legacy/future support
 ] as const;
@@ -275,6 +276,8 @@ export interface TargetDefinition {
   readonly providerBatching?: boolean | undefined;
   // Azure fields
   readonly endpoint?: string | unknown | undefined;
+  readonly base_url?: string | unknown | undefined;
+  readonly baseUrl?: string | unknown | undefined;
   readonly resource?: string | unknown | undefined;
   readonly resourceName?: string | unknown | undefined;
   readonly api_key?: string | unknown | undefined;

--- a/packages/core/src/evaluation/validation/targets-validator.ts
+++ b/packages/core/src/evaluation/validation/targets-validator.ts
@@ -48,6 +48,22 @@ const AZURE_SETTINGS = new Set([
   'maxTokens',
 ]);
 
+const OPENAI_SETTINGS = new Set([
+  ...COMMON_SETTINGS,
+  ...RETRY_SETTINGS,
+  'endpoint',
+  'base_url',
+  'baseUrl',
+  'api_key',
+  'apiKey',
+  'model',
+  'deployment',
+  'variant',
+  'temperature',
+  'max_output_tokens',
+  'maxTokens',
+]);
+
 const ANTHROPIC_SETTINGS = new Set([
   ...COMMON_SETTINGS,
   ...RETRY_SETTINGS,
@@ -197,6 +213,8 @@ const CLAUDE_SETTINGS = new Set([
 function getKnownSettings(provider: string): Set<string> | null {
   const normalizedProvider = provider.toLowerCase();
   switch (normalizedProvider) {
+    case 'openai':
+      return OPENAI_SETTINGS;
     case 'azure':
     case 'azure-openai':
       return AZURE_SETTINGS;

--- a/packages/core/test/evaluation/providers/targets.test.ts
+++ b/packages/core/test/evaluation/providers/targets.test.ts
@@ -20,6 +20,7 @@ const generateTextMock = mock(async () => ({
 }));
 
 const createAzureMock = mock((options: unknown) => () => ({ provider: 'azure', options }));
+const createOpenAIMock = mock((options: unknown) => () => ({ provider: 'openai', options }));
 const createAnthropicMock = mock(() => () => ({ provider: 'anthropic' }));
 const createGeminiMock = mock(() => () => ({ provider: 'gemini' }));
 
@@ -29,6 +30,10 @@ mock.module('ai', () => ({
 
 mock.module('@ai-sdk/azure', () => ({
   createAzure: (options: unknown) => createAzureMock(options),
+}));
+
+mock.module('@ai-sdk/openai', () => ({
+  createOpenAI: (options: unknown) => createOpenAIMock(options),
 }));
 
 mock.module('@ai-sdk/anthropic', () => ({
@@ -372,6 +377,36 @@ describe('resolveTargetDefinition', () => {
     });
   });
 
+  it('resolves openai settings from environment', () => {
+    const env = {
+      OPENAI_ENDPOINT: 'https://llm-gateway.example.com/v1',
+      OPENAI_API_KEY: 'openai-secret',
+      OPENAI_MODEL: 'gpt-5.4',
+    } satisfies Record<string, string>;
+
+    const target = resolveTargetDefinition(
+      {
+        name: 'openai-target',
+        provider: 'openai',
+        endpoint: '${{ OPENAI_ENDPOINT }}',
+        api_key: '${{ OPENAI_API_KEY }}',
+        model: '${{ OPENAI_MODEL }}',
+      },
+      env,
+    );
+
+    expect(target.kind).toBe('openai');
+    if (target.kind !== 'openai') {
+      throw new Error('expected openai target');
+    }
+
+    expect(target.config).toMatchObject({
+      baseURL: 'https://llm-gateway.example.com/v1',
+      apiKey: 'openai-secret',
+      model: 'gpt-5.4',
+    });
+  });
+
   it('throws when google api key is missing', () => {
     expect(() =>
       resolveTargetDefinition(
@@ -616,6 +651,7 @@ describe('createProvider', () => {
   beforeEach(() => {
     generateTextMock.mockClear();
     createAzureMock.mockClear();
+    createOpenAIMock.mockClear();
     createAnthropicMock.mockClear();
     createGeminiMock.mockClear();
   });
@@ -667,6 +703,34 @@ describe('createProvider', () => {
 
     expect(createGeminiMock).toHaveBeenCalled();
     expect(generateTextMock).toHaveBeenCalled();
+    expect(extractLastAssistantContent(response.output)).toBe('ok');
+  });
+
+  it('creates an openai provider that calls the Vercel AI SDK', async () => {
+    const env = {
+      OPENAI_ENDPOINT: 'https://llm-gateway.example.com/v1',
+      OPENAI_API_KEY: 'openai-key',
+      OPENAI_MODEL: 'gpt-5.4',
+    } satisfies Record<string, string>;
+
+    const resolved = resolveTargetDefinition(
+      {
+        name: 'openai-target',
+        provider: 'openai',
+        endpoint: '${{ OPENAI_ENDPOINT }}',
+        api_key: '${{ OPENAI_API_KEY }}',
+        model: '${{ OPENAI_MODEL }}',
+      },
+      env,
+    );
+
+    const provider = createProvider(resolved);
+    expect(provider.kind).toBe('openai');
+
+    const response = await provider.invoke({ question: 'Hello from OpenAI' });
+
+    expect(createOpenAIMock).toHaveBeenCalledTimes(1);
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
     expect(extractLastAssistantContent(response.output)).toBe('ok');
   });
 });


### PR DESCRIPTION
## Summary
- add first-class openai target support backed by @ai-sdk/openai
- stop provider: openai from falling through to discovered CLI provider resolution
- add llm-gateway target examples and regression coverage for openai target resolution and invocation

## Verification
- un test packages/core/test/evaluation/providers/targets.test.ts
- un --filter agentv build
- un apps/cli/src/cli.ts eval .\\examples\\features\\basic\\evals\\dataset.eval.yaml --target llm-gateway --test-id code-review-javascript

## Notes
- git push with pre-push hooks failed due to an existing unrelated test failure:
  - un test packages/core/test/evaluation/loaders/agent-skills-parser.test.ts
  - failing assertion expects POSIX path /project/... but receives Windows path D:\\project\\...
- branch was pushed with --no-verify because that failure is outside this change set.