### PR TITLE
docs: set home page tab title to catchphrase

### DIFF
--- a/apps/web/src/content/docs/index.mdx
+++ b/apps/web/src/content/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: AgentV
+title: Evals that make agents better
 description: CLI-first AI agent evaluation framework
 hero:
   tagline: CLI-first AI agent evaluation. No server. No signup. No overhead.


### PR DESCRIPTION
## Summary
- Changes home page `title` from "AgentV" to "Evals that make agents better"
- Fixes the redundant "AgentV | AgentV" browser tab — now shows "Evals that make agents better | AgentV"

## Risk
low — docs-only