### PR TITLE
fix(eval): support snake_case retry-errors JSONL

### DIFF
--- a/apps/cli/src/commands/eval/retry-errors.ts
+++ b/apps/cli/src/commands/eval/retry-errors.ts
@@ -3,6 +3,31 @@ import { createInterface } from 'node:readline';
 
 import type { EvaluationResult } from '@agentv/core';
 
+type RetryResultRecord = Partial<EvaluationResult> & {
+  readonly test_id?: string;
+  readonly execution_status?: string;
+};
+
+function getTestId(result: RetryResultRecord): string | undefined {
+  return result.testId ?? result.test_id;
+}
+
+function getExecutionStatus(result: RetryResultRecord): string | undefined {
+  return result.executionStatus ?? result.execution_status;
+}
+
+function toEvaluationResult(result: RetryResultRecord): EvaluationResult {
+  if (result.testId !== undefined && result.executionStatus !== undefined) {
+    return result as EvaluationResult;
+  }
+
+  return {
+    ...result,
+    testId: getTestId(result) ?? '',
+    executionStatus: getExecutionStatus(result),
+  } as EvaluationResult;
+}
+
 /**
  * Load test IDs from a JSONL results file that have executionStatus === 'execution_error'.
  */
@@ -17,9 +42,11 @@ export async function loadErrorTestIds(jsonlPath: string): Promise<readonly stri
     const trimmed = line.trim();
     if (!trimmed) continue;
     try {
-      const parsed = JSON.parse(trimmed) as Partial<EvaluationResult>;
-      if (parsed.executionStatus === 'execution_error' && parsed.testId) {
-        ids.push(parsed.testId);
+      const parsed = JSON.parse(trimmed) as RetryResultRecord;
+      const executionStatus = getExecutionStatus(parsed);
+      const testId = getTestId(parsed);
+      if (executionStatus === 'execution_error' && testId) {
+        ids.push(testId);
       }
     } catch {
       // Skip malformed lines
@@ -44,10 +71,12 @@ export async function loadNonErrorResults(jsonlPath: string): Promise<readonly E
     const trimmed = line.trim();
     if (!trimmed) continue;
     try {
-      const parsed = JSON.parse(trimmed) as Partial<EvaluationResult>;
-      if (!parsed.testId || parsed.score === undefined) continue;
-      if (parsed.executionStatus !== 'execution_error') {
-        results.push(parsed as EvaluationResult);
+      const parsed = JSON.parse(trimmed) as RetryResultRecord;
+      const testId = getTestId(parsed);
+      const executionStatus = getExecutionStatus(parsed);
+      if (!testId || parsed.score === undefined) continue;
+      if (executionStatus !== 'execution_error') {
+        results.push(toEvaluationResult(parsed));
       }
     } catch {
       // Skip malformed lines

--- a/apps/cli/test/unit/retry-errors.test.ts
+++ b/apps/cli/test/unit/retry-errors.test.ts
@@ -66,6 +66,22 @@ describe('retry-errors', () => {
     expect(results[1].testId).toBe('case-3');
   });
 
+  it('supports snake_case result files written by the CLI', async () => {
+    const filePath = createJsonlFile([
+      { test_id: 'case-1', execution_status: 'ok', score: 0.9 },
+      { test_id: 'case-2', execution_status: 'execution_error', score: 0 },
+      { test_id: 'case-3', execution_status: 'quality_failure', score: 0.5 },
+    ]);
+
+    const ids = await loadErrorTestIds(filePath);
+    expect(ids).toEqual(['case-2']);
+
+    const results = await loadNonErrorResults(filePath);
+    expect(results).toHaveLength(2);
+    expect(results[0].testId).toBe('case-1');
+    expect(results[1].testId).toBe('case-3');
+  });
+
   it('skips malformed JSON lines', async () => {
     tmpDir = mkdtempSync(path.join(tmpdir(), 'retry-errors-test-'));
     const filePath = path.join(tmpDir, 'results.jsonl');


### PR DESCRIPTION
## Summary
- support `--retry-errors` when previous JSONL results use snake_case fields like `test_id` and `execution_status`
- preserve non-error snake_case rows when merging retry output back into the new results file
- add a regression test covering CLI-written snake_case results

## Test Plan
- `bun test apps/cli/test/unit/retry-errors.test.ts`
- `bun --filter @agentv/core build`
- `bun --filter agentv build`
- reran `agentv eval run ... --retry-errors ...` against a real results file and confirmed it retried 10 execution-error tests and merged 42 preserved rows
