### PR TITLE
fix: add pi-agent-sdk to AGENT_PROVIDER_KINDS

### DIFF
--- a/packages/core/src/evaluation/providers/types.ts
+++ b/packages/core/src/evaluation/providers/types.ts
@@ -39,6 +39,7 @@ export const AGENT_PROVIDER_KINDS: readonly ProviderKind[] = [
   'copilot-sdk',
   'copilot-cli',
   'pi-coding-agent',
+  'pi-agent-sdk',
   'claude',
   'claude-cli',
   'claude-sdk',


### PR DESCRIPTION
## Summary
- Adds `pi-agent-sdk` to the `AGENT_PROVIDER_KINDS` array in `packages/core/src/evaluation/providers/types.ts`
- `pi-agent-sdk` has filesystem access like `pi-coding-agent` but was missing from this array, causing `isAgentProvider()` to return `false` for it
- This affected guideline handling and agent-specific logic paths in the orchestrator and LLM grader

## Test plan
- [x] All 1136 core tests pass
- [x] Build, typecheck, and lint all pass
- [ ] Manual e2e: run an eval with `pi-agent-sdk` target and verify guidelines are handled correctly (as agent provider, not non-agent)

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)