### PR TITLE
feat(cli): add `agentv results export` subcommand

### DIFF
--- a/apps/cli/src/commands/results/export.ts
+++ b/apps/cli/src/commands/results/export.ts
@@ -1,0 +1,281 @@
+/**
+ * `agentv results export` — converts JSONL eval results into a per-test
+ * directory structure compatible with agentv-bench's workspace layout.
+ *
+ * Output structure:
+ *   <output-dir>/
+ *     benchmark.json       — aggregate scores, pass/fail counts, timing
+ *     <test-id>/
+ *       grading.json       — per-assertion results (hits, misses, evaluator details)
+ *       timing.json        — tokens, duration, cost, tool names
+ *       outputs/           — raw agent output text
+ *
+ * How to extend:
+ *   - To add a new aggregate field to benchmark.json, update `buildBenchmark()`.
+ *   - To include additional per-test data, add a new file writer in `exportTestCase()`.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { command, option, optional, positional, string } from 'cmd-ts';
+
+import {
+  type RawResult,
+  extractTimestampFromFilename,
+  listResultFiles,
+  loadResultFile,
+} from '../trace/utils.js';
+
+// ── Types ───────────────────────────────────────────────────────────────
+
+interface BenchmarkJson {
+  metadata: {
+    eval_file: string;
+    timestamp: string;
+    tests_run: number;
+  };
+  run_summary: Record<string, TargetSummary>;
+}
+
+interface TargetSummary {
+  pass_rate: { mean: number };
+  time_seconds: { mean: number };
+  tokens: { mean: number };
+  cost_usd: { mean: number };
+}
+
+interface GradingJson {
+  id: string;
+  verdict: 'pass' | 'fail';
+  score: number;
+  evaluators: readonly GradingEvaluator[];
+  hits: readonly string[];
+  misses: readonly string[];
+}
+
+interface GradingEvaluator {
+  name: string;
+  type: string;
+  score: number;
+  reasoning?: string;
+  hits?: readonly string[];
+  misses?: readonly string[];
+}
+
+interface TimingJson {
+  eventCount: number;
+  toolNames: readonly string[];
+  tokenUsage: { input: number; output: number; cached: number };
+  costUsd: number;
+  durationMs: number;
+  llmCallCount: number;
+}
+
+// ── Builders ────────────────────────────────────────────────────────────
+
+function buildBenchmark(results: RawResult[], sourceFile: string): BenchmarkJson {
+  const timestamp =
+    results[0]?.timestamp ?? extractTimestampFromFilename(path.basename(sourceFile)) ?? 'unknown';
+
+  // Group results by target
+  const byTarget = new Map<string, RawResult[]>();
+  for (const r of results) {
+    const target = r.target ?? 'default';
+    if (!byTarget.has(target)) byTarget.set(target, []);
+    byTarget.get(target)?.push(r);
+  }
+
+  const runSummary: Record<string, TargetSummary> = {};
+
+  for (const [target, group] of byTarget) {
+    const n = group.length;
+    const passCount = group.filter((r) => r.score >= 1.0).length;
+    const totalDurationMs = group.reduce(
+      (sum, r) => sum + (r.trace?.duration_ms ?? r.duration_ms ?? 0),
+      0,
+    );
+    const totalTokens = group.reduce((sum, r) => {
+      const tu = r.trace?.token_usage ?? r.token_usage;
+      return sum + (tu ? tu.input + tu.output : 0);
+    }, 0);
+    const totalCost = group.reduce((sum, r) => sum + (r.trace?.cost_usd ?? r.cost_usd ?? 0), 0);
+
+    runSummary[target] = {
+      pass_rate: { mean: round(passCount / n) },
+      time_seconds: { mean: round(totalDurationMs / n / 1000) },
+      tokens: { mean: round(totalTokens / n) },
+      cost_usd: { mean: round(totalCost / n) },
+    };
+  }
+
+  return {
+    metadata: {
+      eval_file: sourceFile,
+      timestamp,
+      tests_run: results.length,
+    },
+    run_summary: runSummary,
+  };
+}
+
+function buildGrading(result: RawResult): GradingJson {
+  const evaluators: GradingEvaluator[] = (result.scores ?? []).map((s) => ({
+    name: s.name,
+    type: s.type,
+    score: s.score,
+    reasoning: s.reasoning,
+    hits: s.hits,
+    misses: s.misses,
+  }));
+
+  return {
+    id: result.test_id ?? result.eval_id ?? 'unknown',
+    verdict: result.score >= 1.0 ? 'pass' : 'fail',
+    score: result.score,
+    evaluators,
+    hits: result.hits ?? [],
+    misses: result.misses ?? [],
+  };
+}
+
+function buildTiming(result: RawResult): TimingJson {
+  const trace = result.trace;
+  const tu = trace?.token_usage ?? result.token_usage;
+
+  return {
+    eventCount: trace?.event_count ?? 0,
+    toolNames: trace?.tool_names ?? [],
+    tokenUsage: {
+      input: tu?.input ?? 0,
+      output: tu?.output ?? 0,
+      cached: tu?.cached ?? 0,
+    },
+    costUsd: trace?.cost_usd ?? result.cost_usd ?? 0,
+    durationMs: trace?.duration_ms ?? result.duration_ms ?? 0,
+    llmCallCount: trace?.llm_call_count ?? 0,
+  };
+}
+
+// ── Export logic ─────────────────────────────────────────────────────────
+
+function exportTestCase(result: RawResult, outputDir: string): void {
+  const testId = result.test_id ?? result.eval_id ?? 'unknown';
+  const testDir = path.join(outputDir, testId);
+  const outputsDir = path.join(testDir, 'outputs');
+
+  mkdirSync(outputsDir, { recursive: true });
+
+  // grading.json
+  writeFileSync(path.join(testDir, 'grading.json'), JSON.stringify(buildGrading(result), null, 2));
+
+  // timing.json
+  writeFileSync(path.join(testDir, 'timing.json'), JSON.stringify(buildTiming(result), null, 2));
+
+  // outputs/answer.txt — raw agent response text
+  const answer = result.answer;
+  if (answer) {
+    writeFileSync(path.join(outputsDir, 'answer.txt'), answer);
+  }
+}
+
+export function exportResults(sourceFile: string, results: RawResult[], outputDir: string): void {
+  mkdirSync(outputDir, { recursive: true });
+
+  // benchmark.json
+  const benchmark = buildBenchmark(results, sourceFile);
+  writeFileSync(path.join(outputDir, 'benchmark.json'), JSON.stringify(benchmark, null, 2));
+
+  // Per-test directories
+  for (const result of results) {
+    exportTestCase(result, outputDir);
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function round(n: number, decimals = 4): number {
+  const factor = 10 ** decimals;
+  return Math.round(n * factor) / factor;
+}
+
+/**
+ * Derive the default output directory from a JSONL filename.
+ * e.g. eval_2026-03-18T12-00-00-000Z.jsonl → .agentv/results/2026-03-18T12-00-00-000Z/
+ */
+function deriveOutputDir(cwd: string, sourceFile: string): string {
+  const basename = path.basename(sourceFile, '.jsonl');
+  // Strip leading "eval_" prefix if present to get the timestamp
+  const dirName = basename.startsWith('eval_') ? basename.slice(5) : basename;
+  return path.join(cwd, '.agentv', 'results', dirName);
+}
+
+// ── CLI command ──────────────────────────────────────────────────────────
+
+export const resultsExportCommand = command({
+  name: 'export',
+  description: 'Export JSONL eval results into a per-test directory structure',
+  args: {
+    source: positional({
+      type: optional(string),
+      displayName: 'source',
+      description: 'JSONL result file to export (defaults to most recent in .agentv/results/)',
+    }),
+    out: option({
+      type: optional(string),
+      long: 'out',
+      short: 'o',
+      description: 'Output directory (defaults to .agentv/results/<run-timestamp>/)',
+    }),
+    dir: option({
+      type: optional(string),
+      long: 'dir',
+      short: 'd',
+      description: 'Working directory (default: current directory)',
+    }),
+  },
+  handler: async ({ source, out, dir }) => {
+    const cwd = dir ?? process.cwd();
+
+    try {
+      let sourceFile: string;
+
+      if (source) {
+        // Explicit source file
+        sourceFile = path.isAbsolute(source) ? source : path.resolve(cwd, source);
+      } else {
+        // Find most recent result file
+        const metas = listResultFiles(cwd, 1);
+        if (metas.length === 0) {
+          console.error('Error: No result files found in .agentv/results/');
+          console.error('Run an evaluation first: agentv eval <eval-file>');
+          process.exit(1);
+        }
+        sourceFile = metas[0].path;
+      }
+
+      const results = loadResultFile(sourceFile);
+
+      if (results.length === 0) {
+        console.error(`Error: No results found in ${sourceFile}`);
+        process.exit(1);
+      }
+
+      const outputDir = out
+        ? path.isAbsolute(out)
+          ? out
+          : path.resolve(cwd, out)
+        : deriveOutputDir(cwd, sourceFile);
+
+      exportResults(sourceFile, results, outputDir);
+
+      const testIds = results.map((r) => r.test_id ?? r.eval_id ?? 'unknown');
+      console.log(`Exported ${results.length} test(s) to ${outputDir}`);
+      for (const id of testIds) {
+        console.log(`  ${id}/`);
+      }
+    } catch (error) {
+      console.error(`Error: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  },
+});

--- a/apps/cli/src/commands/results/index.ts
+++ b/apps/cli/src/commands/results/index.ts
@@ -1,0 +1,11 @@
+import { subcommands } from 'cmd-ts';
+
+import { resultsExportCommand } from './export.js';
+
+export const resultsCommand = subcommands({
+  name: 'results',
+  description: 'Inspect, export, and manage evaluation results',
+  cmds: {
+    export: resultsExportCommand,
+  },
+});

--- a/apps/cli/src/commands/trace/utils.ts
+++ b/apps/cli/src/commands/trace/utils.ts
@@ -83,6 +83,10 @@ export interface RawTraceSummary {
   error_count?: number;
   tool_durations?: Record<string, number[]>;
   llm_call_count?: number;
+  // Execution metrics (present when trace includes provider metrics)
+  token_usage?: { input: number; output: number; cached?: number };
+  cost_usd?: number;
+  duration_ms?: number;
 }
 
 /**

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -8,6 +8,7 @@ import { evalPromptCommand } from './commands/eval/commands/prompt/index.js';
 import { evalCommand } from './commands/eval/index.js';
 import { generateCommand } from './commands/generate/index.js';
 import { initCmdTsCommand } from './commands/init/index.js';
+import { resultsCommand } from './commands/results/index.js';
 import { selfCommand } from './commands/self/index.js';
 import { traceCommand } from './commands/trace/index.js';
 import { transpileCommand } from './commands/transpile/index.js';
@@ -28,6 +29,7 @@ export const app = subcommands({
     create: createCommand,
     generate: generateCommand,
     init: initCmdTsCommand,
+    results: resultsCommand,
     self: selfCommand,
     trace: traceCommand,
     transpile: transpileCommand,
@@ -54,6 +56,7 @@ const TOP_LEVEL_COMMANDS = new Set([
   'create',
   'generate',
   'init',
+  'results',
   'self',
   'trace',
   'transpile',

--- a/apps/cli/test/commands/results/export.test.ts
+++ b/apps/cli/test/commands/results/export.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { exportResults } from '../../../src/commands/results/export.js';
+
+// ── Sample JSONL records (snake_case, matching on-disk format) ──────────
+
+const RESULT_FULL = {
+  timestamp: '2026-03-18T10:00:01.000Z',
+  test_id: 'test-greeting',
+  dataset: 'demo',
+  score: 1.0,
+  hits: ['Says hello', 'Uses name'],
+  misses: [],
+  answer: 'Hello, Alice!',
+  target: 'gpt-4o',
+  reasoning: 'Perfect greeting.',
+  scores: [
+    {
+      name: 'greeting_quality',
+      type: 'llm-grader',
+      score: 1.0,
+      reasoning: 'Correct greeting.',
+      hits: ['Says hello'],
+      misses: [],
+    },
+  ],
+  trace: {
+    event_count: 3,
+    tool_names: ['Read', 'Write'],
+    tool_calls_by_name: { Read: 2, Write: 1 },
+    error_count: 0,
+    token_usage: { input: 1000, output: 500, cached: 100 },
+    cost_usd: 0.015,
+    duration_ms: 3500,
+    llm_call_count: 2,
+  },
+};
+
+const RESULT_PARTIAL = {
+  timestamp: '2026-03-18T10:00:05.000Z',
+  test_id: 'test-math',
+  dataset: 'demo',
+  score: 0.5,
+  hits: ['Correct formula'],
+  misses: ['Wrong answer'],
+  target: 'gpt-4o',
+  reasoning: 'Partial score.',
+  scores: [
+    {
+      name: 'math_accuracy',
+      type: 'contains',
+      score: 0.5,
+      reasoning: 'Formula correct but result wrong.',
+    },
+  ],
+  trace: {
+    event_count: 1,
+    tool_names: [],
+    tool_calls_by_name: {},
+    error_count: 0,
+    token_usage: { input: 200, output: 100 },
+    cost_usd: 0.003,
+    duration_ms: 1200,
+    llm_call_count: 1,
+  },
+};
+
+const RESULT_DIFFERENT_TARGET = {
+  timestamp: '2026-03-18T10:00:10.000Z',
+  test_id: 'test-greeting',
+  dataset: 'demo',
+  score: 0.75,
+  hits: ['Says hello'],
+  misses: ['Missing name'],
+  target: 'claude-sonnet',
+  reasoning: 'Decent greeting.',
+  trace: {
+    event_count: 2,
+    tool_names: ['Read'],
+    tool_calls_by_name: { Read: 2 },
+    error_count: 0,
+    token_usage: { input: 800, output: 400 },
+    cost_usd: 0.01,
+    duration_ms: 2000,
+    llm_call_count: 1,
+  },
+};
+
+const RESULT_NO_TRACE = {
+  timestamp: '2026-03-18T10:00:15.000Z',
+  test_id: 'test-simple',
+  dataset: 'demo',
+  score: 1.0,
+  hits: ['Correct'],
+  misses: [],
+  answer: 'Yes.',
+  target: 'default',
+  token_usage: { input: 50, output: 20 },
+  cost_usd: 0.001,
+  duration_ms: 500,
+};
+
+describe('results export', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'agentv-export-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should create benchmark.json with aggregate data', () => {
+    const outputDir = path.join(tempDir, 'output');
+    const results = [RESULT_FULL, RESULT_PARTIAL];
+
+    exportResults('eval_2026-03-18.jsonl', results, outputDir);
+
+    const benchmarkPath = path.join(outputDir, 'benchmark.json');
+    expect(existsSync(benchmarkPath)).toBe(true);
+
+    const benchmark = JSON.parse(readFileSync(benchmarkPath, 'utf8'));
+    expect(benchmark.metadata.eval_file).toBe('eval_2026-03-18.jsonl');
+    expect(benchmark.metadata.timestamp).toBe('2026-03-18T10:00:01.000Z');
+    expect(benchmark.metadata.tests_run).toBe(2);
+
+    // Both results target gpt-4o
+    expect(benchmark.run_summary['gpt-4o']).toBeDefined();
+    expect(benchmark.run_summary['gpt-4o'].pass_rate.mean).toBe(0.5); // 1 pass out of 2
+  });
+
+  it('should create per-test directories with grading.json and timing.json', () => {
+    const outputDir = path.join(tempDir, 'output');
+    exportResults('test.jsonl', [RESULT_FULL], outputDir);
+
+    // Check directory structure
+    const testDir = path.join(outputDir, 'test-greeting');
+    expect(existsSync(testDir)).toBe(true);
+    expect(existsSync(path.join(testDir, 'grading.json'))).toBe(true);
+    expect(existsSync(path.join(testDir, 'timing.json'))).toBe(true);
+    expect(existsSync(path.join(testDir, 'outputs'))).toBe(true);
+  });
+
+  it('should populate grading.json correctly', () => {
+    const outputDir = path.join(tempDir, 'output');
+    exportResults('test.jsonl', [RESULT_FULL], outputDir);
+
+    const grading = JSON.parse(
+      readFileSync(path.join(outputDir, 'test-greeting', 'grading.json'), 'utf8'),
+    );
+
+    expect(grading.id).toBe('test-greeting');
+    expect(grading.verdict).toBe('pass');
+    expect(grading.score).toBe(1.0);
+    expect(grading.hits).toEqual(['Says hello', 'Uses name']);
+    expect(grading.misses).toEqual([]);
+    expect(grading.evaluators).toHaveLength(1);
+    expect(grading.evaluators[0].name).toBe('greeting_quality');
+    expect(grading.evaluators[0].type).toBe('llm-grader');
+    expect(grading.evaluators[0].score).toBe(1.0);
+  });
+
+  it('should populate timing.json correctly', () => {
+    const outputDir = path.join(tempDir, 'output');
+    exportResults('test.jsonl', [RESULT_FULL], outputDir);
+
+    const timing = JSON.parse(
+      readFileSync(path.join(outputDir, 'test-greeting', 'timing.json'), 'utf8'),
+    );
+
+    expect(timing.eventCount).toBe(3);
+    expect(timing.toolNames).toEqual(['Read', 'Write']);
+    expect(timing.tokenUsage.input).toBe(1000);
+    expect(timing.tokenUsage.output).toBe(500);
+    expect(timing.tokenUsage.cached).toBe(100);
+    expect(timing.costUsd).toBe(0.015);
+    expect(timing.durationMs).toBe(3500);
+    expect(timing.llmCallCount).toBe(2);
+  });
+
+  it('should write answer text to outputs/answer.txt', () => {
+    const outputDir = path.join(tempDir, 'output');
+    exportResults('test.jsonl', [RESULT_FULL], outputDir);
+
+    const answerPath = path.join(outputDir, 'test-greeting', 'outputs', 'answer.txt');
+    expect(existsSync(answerPath)).toBe(true);
+    expect(readFileSync(answerPath, 'utf8')).toBe('Hello, Alice!');
+  });
+
+  it('should set verdict to fail when score < 1.0', () => {
+    const outputDir = path.join(tempDir, 'output');
+    exportResults('test.jsonl', [RESULT_PARTIAL], outputDir);
+
+    const grading = JSON.parse(
+      readFileSync(path.join(outputDir, 'test-math', 'grading.json'), 'utf8'),
+    );
+
+    expect(grading.verdict).toBe('fail');
+    expect(grading.score).toBe(0.5);
+  });
+
+  it('should group results by target in benchmark.json', () => {
+    const outputDir = path.join(tempDir, 'output');
+    exportResults('test.jsonl', [RESULT_FULL, RESULT_DIFFERENT_TARGET], outputDir);
+
+    const benchmark = JSON.parse(readFileSync(path.join(outputDir, 'benchmark.json'), 'utf8'));
+
+    expect(benchmark.run_summary['gpt-4o']).toBeDefined();
+    expect(benchmark.run_summary['claude-sonnet']).toBeDefined();
+    expect(benchmark.run_summary['gpt-4o'].pass_rate.mean).toBe(1.0);
+    expect(benchmark.run_summary['claude-sonnet'].pass_rate.mean).toBe(0);
+  });
+
+  it('should handle results without trace data', () => {
+    const outputDir = path.join(tempDir, 'output');
+    exportResults('test.jsonl', [RESULT_NO_TRACE], outputDir);
+
+    const timing = JSON.parse(
+      readFileSync(path.join(outputDir, 'test-simple', 'timing.json'), 'utf8'),
+    );
+
+    // Falls back to top-level metrics when trace is missing
+    expect(timing.eventCount).toBe(0);
+    expect(timing.toolNames).toEqual([]);
+    expect(timing.tokenUsage.input).toBe(50);
+    expect(timing.tokenUsage.output).toBe(20);
+    expect(timing.costUsd).toBe(0.001);
+    expect(timing.durationMs).toBe(500);
+  });
+
+  it('should handle multiple test cases in a single export', () => {
+    const outputDir = path.join(tempDir, 'output');
+    const results = [RESULT_FULL, RESULT_PARTIAL, RESULT_NO_TRACE];
+    exportResults('test.jsonl', results, outputDir);
+
+    expect(existsSync(path.join(outputDir, 'benchmark.json'))).toBe(true);
+    expect(existsSync(path.join(outputDir, 'test-greeting'))).toBe(true);
+    expect(existsSync(path.join(outputDir, 'test-math'))).toBe(true);
+    expect(existsSync(path.join(outputDir, 'test-simple'))).toBe(true);
+  });
+
+  it('should compute correct aggregate timing in benchmark.json', () => {
+    const outputDir = path.join(tempDir, 'output');
+    exportResults('test.jsonl', [RESULT_FULL, RESULT_PARTIAL], outputDir);
+
+    const benchmark = JSON.parse(readFileSync(path.join(outputDir, 'benchmark.json'), 'utf8'));
+    const summary = benchmark.run_summary['gpt-4o'];
+
+    // Mean duration: (3500 + 1200) / 2 = 2350ms = 2.35s
+    expect(summary.time_seconds.mean).toBe(2.35);
+    // Mean tokens: ((1000+500) + (200+100)) / 2 = 900
+    expect(summary.tokens.mean).toBe(900);
+    // Mean cost: (0.015 + 0.003) / 2 = 0.009
+    expect(summary.cost_usd.mean).toBe(0.009);
+  });
+
+  it('should not create outputs/answer.txt when answer is missing', () => {
+    const outputDir = path.join(tempDir, 'output');
+    exportResults('test.jsonl', [RESULT_PARTIAL], outputDir);
+
+    const answerPath = path.join(outputDir, 'test-math', 'outputs', 'answer.txt');
+    expect(existsSync(answerPath)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `agentv results export` subcommand that converts JSONL eval results into a per-test directory structure compatible with agentv-bench's workspace layout.

### CLI variants
```bash
agentv results export                           # exports most recent result
agentv results export eval_2026-03-18.jsonl     # explicit source file
agentv results export -o ./my-run/              # explicit output directory
```

### Output structure
```
<output-dir>/
├── benchmark.json              # aggregate scores, pass/fail counts, timing
├── <test-id>/
│   ├── grading.json            # per-assertion results
│   ├── timing.json             # tokens, duration, cost, tool names
│   └── outputs/                # raw agent output text
└── ...
```

### Changes
- New `apps/cli/src/commands/results/` directory with `index.ts` (subcommand group) and `export.ts` (export logic + CLI command)
- Wire `results` into `apps/cli/src/index.ts` top-level commands
- Extend `RawTraceSummary` in `trace/utils.ts` to include `token_usage`, `cost_usd`, `duration_ms` fields that exist in JSONL output
- 11 unit tests covering all export scenarios (pass/fail, multi-target, missing trace, missing answer)

Closes #646