### PR TITLE
feat(eval): retry-errors in interactive TUI + CLI hint

### DIFF
--- a/apps/cli/src/commands/eval/interactive.ts
+++ b/apps/cli/src/commands/eval/interactive.ts
@@ -333,8 +333,55 @@ async function executeConfig(config: InteractiveConfig): Promise<void> {
     trace: false,
   };
 
-  await runEvalCommand({
+  const result = await runEvalCommand({
     testFiles: [...config.evalPaths],
     rawOptions,
   });
+
+  // Prompt to retry errors when execution errors were detected in a TTY
+  if (result && result.executionErrorCount > 0 && process.stdin.isTTY) {
+    await promptRetryErrors(config, result.outputPath);
+  }
+}
+
+async function promptRetryErrors(config: InteractiveConfig, outputPath: string): Promise<void> {
+  const shouldRetry = await confirm({
+    message: `Retry ${ANSI_BOLD}execution errors${ANSI_RESET} from this run?`,
+    default: true,
+  });
+
+  if (!shouldRetry) {
+    return;
+  }
+
+  console.log(`\n${ANSI_DIM}Retrying execution errors...${ANSI_RESET}\n`);
+
+  const rawOptions: Record<string, unknown> = {
+    target: config.target,
+    workers: config.workers,
+    dryRun: config.dryRun,
+    cache: config.cache,
+    outputFormat: 'jsonl',
+    retryErrors: outputPath,
+    out: outputPath,
+    dryRunDelay: 0,
+    dryRunDelayMin: 0,
+    dryRunDelayMax: 0,
+    agentTimeout: 120,
+    maxRetries: 2,
+    verbose: false,
+    keepWorkspaces: false,
+    cleanupWorkspaces: false,
+    trace: false,
+  };
+
+  const retryResult = await runEvalCommand({
+    testFiles: [...config.evalPaths],
+    rawOptions,
+  });
+
+  // Allow chained retries if there are still errors
+  if (retryResult && retryResult.executionErrorCount > 0 && process.stdin.isTTY) {
+    await promptRetryErrors(config, retryResult.outputPath);
+  }
 }

--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -677,7 +677,16 @@ async function runSingleEvalFile(params: {
   return { results: [...results] };
 }
 
-export async function runEvalCommand(input: RunEvalCommandInput): Promise<void> {
+export interface RunEvalResult {
+  readonly executionErrorCount: number;
+  readonly outputPath: string;
+  readonly testFiles: readonly string[];
+  readonly target?: string;
+}
+
+export async function runEvalCommand(
+  input: RunEvalCommandInput,
+): Promise<RunEvalResult | undefined> {
   const cwd = process.cwd();
 
   // Load agentv.config.ts (if present) for default values
@@ -1122,6 +1131,24 @@ export async function runEvalCommand(input: RunEvalCommandInput): Promise<void> 
         }
       }
     }
+
+    // Suggest retry-errors command when execution errors are detected
+    if (summary.executionErrorCount > 0 && !options.retryErrors) {
+      const evalFileArgs = resolvedTestFiles.map((f) => path.relative(cwd, f)).join(' ');
+      const targetFlag = options.target ? ` --target ${options.target}` : '';
+      const relativeOutputPath = path.relative(cwd, outputPath);
+      console.log(
+        `\nTip: ${summary.executionErrorCount} execution error(s) detected. Re-run failed tests with:\n` +
+          `  agentv eval run ${evalFileArgs}${targetFlag} --retry-errors ${relativeOutputPath} -o ${relativeOutputPath}`,
+      );
+    }
+
+    return {
+      executionErrorCount: summary.executionErrorCount,
+      outputPath,
+      testFiles: resolvedTestFiles,
+      target: options.target,
+    };
   } finally {
     unsubscribeCodexLogs();
     unsubscribePiLogs();


### PR DESCRIPTION
## Summary
- After an eval run with execution errors, print a **CLI hint** with the full `--retry-errors` command so users can re-run failed tests
- In **interactive TUI mode** (`agentv eval run` with no args), prompt the user to retry errors directly after completion
- Support chained retries — if a retry still has errors, prompt again

Follows up on #645 (snake_case retry-errors fix).

## Test plan
- [x] `bun test apps/cli/test/unit/retry-errors.test.ts` — all 6 tests pass
- [x] Type-check passes (`tsc --noEmit`)
- [x] Lint passes (biome)
- [x] Verified retry-errors CLI flow with agent-tui: loads error IDs, retries matching tests, merges non-error results
- [x] Verified interactive TUI wizard flow with agent-tui: full navigation through eval selection, target, review

🤖 Generated with [Claude Code](https://claude.com/claude-code)