### PR TITLE
feat(eval): add score + verdict to eval progress lines, drop provider suffix

### DIFF
--- a/apps/cli/src/commands/eval/progress-display.ts
+++ b/apps/cli/src/commands/eval/progress-display.ts
@@ -1,3 +1,5 @@
+export type Verdict = 'PASS' | 'FAIL' | 'ERROR';
+
 export interface WorkerProgress {
   workerId: number;
   testId: string;
@@ -6,6 +8,33 @@ export interface WorkerProgress {
   completedAt?: number;
   error?: string;
   targetLabel?: string;
+  score?: number;
+  verdict?: Verdict;
+}
+
+const ANSI_BOLD = '\x1b[1m';
+const ANSI_GREEN = '\x1b[32m';
+const ANSI_RED = '\x1b[31m';
+const ANSI_YELLOW = '\x1b[33m';
+const ANSI_RESET = '\x1b[0m';
+
+function useColors(): boolean {
+  if (process.env.NO_COLOR !== undefined) return false;
+  return process.stdout.isTTY ?? false;
+}
+
+function formatVerdict(score: number | undefined, verdict: Verdict | undefined): string {
+  if (verdict === undefined) return '';
+
+  const colors = useColors();
+  const scoreStr = score !== undefined ? score.toFixed(3) : '';
+  const verdictLabel = verdict === 'ERROR' ? 'ERROR' : `${scoreStr} ${verdict}`;
+
+  if (!colors) return ` | ${verdictLabel}`;
+
+  const color = verdict === 'PASS' ? ANSI_GREEN : verdict === 'FAIL' ? ANSI_RED : ANSI_YELLOW;
+
+  return ` | ${color}${ANSI_BOLD}${verdictLabel}${ANSI_RESET}`;
 }
 
 /**
@@ -68,11 +97,13 @@ export class ProgressDisplay {
         }
         break;
       case 'completed':
-        console.log(`${countPrefix}   ✅ ${progress.testId}${targetSuffix}`);
+        console.log(
+          `${countPrefix}   ✅ ${progress.testId}${targetSuffix}${formatVerdict(progress.score, progress.verdict)}`,
+        );
         break;
       case 'failed':
         console.log(
-          `${countPrefix}   ❌ ${progress.testId}${targetSuffix}${progress.error ? `: ${progress.error}` : ''}`,
+          `${countPrefix}   ❌ ${progress.testId}${targetSuffix}${formatVerdict(progress.score, progress.verdict)}${progress.error ? `: ${progress.error}` : ''}`,
         );
         break;
     }

--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -37,7 +37,7 @@ import {
   createOutputWriter,
   getDefaultExtension,
 } from './output-writer.js';
-import { ProgressDisplay, type WorkerProgress } from './progress-display.js';
+import { ProgressDisplay, type Verdict, type WorkerProgress } from './progress-display.js';
 import { loadErrorTestIds, loadNonErrorResults } from './retry-errors.js';
 import { findRepoRoot } from './shared.js';
 import {
@@ -430,15 +430,10 @@ async function prepareFileMetadata(params: {
       targetNames,
     });
 
-    selections = multiSelections.map((sel) => {
-      const providerLabel = options.dryRun
-        ? `${sel.resolvedTarget.kind} (dry-run)`
-        : sel.resolvedTarget.kind;
-      return {
-        selection: sel,
-        inlineTargetLabel: `${sel.targetName} ${buildTargetLabelSuffix(providerLabel, sel.resolvedTarget)}`,
-      };
-    });
+    selections = multiSelections.map((sel) => ({
+      selection: sel,
+      inlineTargetLabel: sel.targetName,
+    }));
   } else {
     // Single target mode (legacy path)
     const selection = await selectTarget({
@@ -454,13 +449,10 @@ async function prepareFileMetadata(params: {
       env: process.env,
     });
 
-    const providerLabel = options.dryRun
-      ? `${selection.resolvedTarget.kind} (dry-run)`
-      : selection.resolvedTarget.kind;
     selections = [
       {
         selection,
-        inlineTargetLabel: `${selection.targetName} ${buildTargetLabelSuffix(providerLabel, selection.resolvedTarget)}`,
+        inlineTargetLabel: selection.targetName,
       },
     ];
   }
@@ -662,6 +654,12 @@ async function runSingleEvalFile(params: {
         streamingObserver.startEvalCase(event.testId, targetName, testFilePath);
       }
 
+      // Map executionStatus to verdict for display
+      let verdict: Verdict | undefined;
+      if (event.executionStatus === 'ok') verdict = 'PASS';
+      else if (event.executionStatus === 'quality_failure') verdict = 'FAIL';
+      else if (event.executionStatus === 'execution_error') verdict = 'ERROR';
+
       progressReporter.update(displayId, {
         workerId: displayId,
         testId: matrixMode ? `${event.testId}@${targetName}` : event.testId,
@@ -670,6 +668,8 @@ async function runSingleEvalFile(params: {
         completedAt: event.completedAt,
         error: event.error,
         targetLabel: inlineTargetLabel,
+        score: event.score,
+        verdict,
       });
     },
   });

--- a/apps/cli/src/commands/eval/statistics.ts
+++ b/apps/cli/src/commands/eval/statistics.ts
@@ -193,7 +193,24 @@ export function formatEvaluationSummary(summary: EvaluationSummary): string {
     lines.push('');
   }
 
+  // Overall verdict line
+  const overallPassed =
+    summary.passedCount === summary.total - summary.executionErrorCount ||
+    (summary.qualityFailureCount === 0 && summary.executionErrorCount === 0);
+  const overallVerdict = overallPassed ? 'PASS' : 'FAIL';
+  const useColor = !(process.env.NO_COLOR !== undefined) && (process.stdout.isTTY ?? false);
+  const verdictColor = overallPassed ? '\x1b[32m' : '\x1b[31m';
+  const verdictText = `RESULT: ${overallVerdict}  (${summary.passedCount}/${summary.total} passed, mean score: ${formatScore(summary.mean)})`;
+
   lines.push('\n==================================================');
+  if (useColor) {
+    lines.push(`\x1b[1m${verdictColor}${verdictText}\x1b[0m`);
+  } else {
+    lines.push(verdictText);
+  }
+  lines.push('==================================================');
+
+  lines.push('');
   lines.push('EVALUATION SUMMARY');
   lines.push('==================================================');
   lines.push(`Total tests: ${summary.total}`);

--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -185,6 +185,10 @@ export interface ProgressEvent {
   readonly startedAt?: number;
   readonly completedAt?: number;
   readonly error?: string;
+  /** Final score for completed/failed tests */
+  readonly score?: number;
+  /** Execution status classification for completed/failed tests */
+  readonly executionStatus?: ExecutionStatus;
 }
 
 export interface RunEvaluationOptions {
@@ -815,6 +819,8 @@ export async function runEvaluation(
               status: 'failed',
               completedAt: Date.now(),
               error: budgetResult.error,
+              score: budgetResult.score,
+              executionStatus: budgetResult.executionStatus,
             });
           }
           if (onResult) {
@@ -849,6 +855,8 @@ export async function runEvaluation(
               status: 'failed',
               completedAt: Date.now(),
               error: haltResult.error,
+              score: haltResult.score,
+              executionStatus: haltResult.executionStatus,
             });
           }
           if (onResult) {
@@ -945,6 +953,8 @@ export async function runEvaluation(
               startedAt: 0, // Not used for completed status
               completedAt: Date.now(),
               error: result.error,
+              score: result.score,
+              executionStatus: result.executionStatus,
             });
           }
 
@@ -1242,6 +1252,8 @@ async function runBatchEvaluation(options: {
           status: 'failed',
           completedAt: Date.now(),
           error: error instanceof Error ? error.message : String(error),
+          score: errorResult.score,
+          executionStatus: errorResult.executionStatus,
         });
       }
       continue;
@@ -1260,6 +1272,8 @@ async function runBatchEvaluation(options: {
         startedAt: 0,
         completedAt: Date.now(),
         error: result.error,
+        score: result.score,
+        executionStatus: result.executionStatus,
       });
     }
   }


### PR DESCRIPTION
Closes #652

## Summary
- Add score and color-coded PASS/FAIL/ERROR verdict to completed eval progress lines for at-a-glance result status
- Remove `[provider=xxx, model=xxx]` suffix from inline target labels in progress output (kept in `--verbose` mode)
- Prepend a one-line `RESULT: PASS/FAIL` overall verdict at the top of the evaluation summary block
- Colors respect `NO_COLOR` env var and non-TTY output

## Changes
- **`ProgressEvent`** (`orchestrator.ts`): added optional `score` and `executionStatus` fields, populated at all completion/failure emission sites
- **`WorkerProgress`** (`progress-display.ts`): added `score` and `verdict` fields; `updateWorker()` appends colored verdict to completed/failed lines
- **`run-eval.ts`**: maps `executionStatus` to verdict enum; dropped `buildTargetLabelSuffix` from `inlineTargetLabel` (function retained for verbose log)
- **`formatEvaluationSummary()`** (`statistics.ts`): prepends `RESULT: PASS/FAIL (N/M passed, mean score: X.XXX)` verdict line

## Risk
Low — additive display-only changes; all 1436 existing tests pass.