### PR TITLE
fix(providers): use azure.chat() to restore Chat Completions API after AI SDK 6 upgrade

### DIFF
--- a/packages/core/src/evaluation/providers/agentv-provider.ts
+++ b/packages/core/src/evaluation/providers/agentv-provider.ts
@@ -35,7 +35,7 @@ function createLanguageModel(modelString: string): LanguageModel {
     case 'anthropic':
       return createAnthropic()(modelName);
     case 'azure':
-      return createAzure()(modelName);
+      return createAzure().chat(modelName);
     case 'google':
       return createGoogleGenerativeAI()(modelName);
     default:

--- a/packages/core/src/evaluation/providers/ai-sdk.ts
+++ b/packages/core/src/evaluation/providers/ai-sdk.ts
@@ -92,7 +92,7 @@ export class AzureProvider implements Provider {
     this.retryConfig = config.retry;
 
     const azure = createAzure(buildAzureOptions(config));
-    this.model = azure(config.deploymentName);
+    this.model = azure.chat(config.deploymentName);
   }
 
   async invoke(request: ProviderRequest): Promise<ProviderResponse> {

--- a/packages/core/test/evaluation/providers/agentv-provider.test.ts
+++ b/packages/core/test/evaluation/providers/agentv-provider.test.ts
@@ -19,10 +19,12 @@ vi.mock('@ai-sdk/anthropic', () => ({
 }));
 
 vi.mock('@ai-sdk/azure', () => ({
-  createAzure: () => (modelId: string) => ({
-    modelId,
-    specificationVersion: 'v3',
-    provider: 'azure',
+  createAzure: () => ({
+    chat: (modelId: string) => ({
+      modelId,
+      specificationVersion: 'v3',
+      provider: 'azure',
+    }),
   }),
 }));
 

--- a/packages/core/test/evaluation/providers/targets.test.ts
+++ b/packages/core/test/evaluation/providers/targets.test.ts
@@ -19,7 +19,9 @@ const generateTextMock = mock(async () => ({
   providerMetadata: undefined,
 }));
 
-const createAzureMock = mock((options: unknown) => () => ({ provider: 'azure', options }));
+const createAzureMock = mock((options: unknown) => ({
+  chat: () => ({ provider: 'azure', options }),
+}));
 const createOpenAIMock = mock((options: unknown) => () => ({ provider: 'openai', options }));
 const createOpenRouterMock = mock((options: unknown) => () => ({
   provider: 'openrouter',


### PR DESCRIPTION
## Summary
- `@ai-sdk/azure` v3 (upgraded in #632) changed the default model type from **Chat Completions** to **Responses API**, causing "resource not found" errors on Azure deployments
- The Responses API requires newer API versions (`2025-03-01-preview`+), but agentv defaults to `2024-12-01-preview`
- Fix: explicitly use `azure.chat()` instead of `azure()` in both `AzureProvider` and `AgentvProvider` to restore Chat Completions behavior

## Test plan
- [x] All 1136 core unit tests pass
- [x] Pre-push hooks pass (build, typecheck, lint, test)
- [x] Real eval against Azure deployment succeeds: `shorthand-string-example` scores 1.000

🤖 Generated with [Claude Code](https://claude.com/claude-code)