### PR TITLE
fix(providers): measure candidate execution duration in ai-sdk provider

### DIFF
--- a/packages/core/src/evaluation/providers/ai-sdk.ts
+++ b/packages/core/src/evaluation/providers/ai-sdk.ts
@@ -369,6 +369,9 @@ async function invokeModel(options: {
   const chatPrompt = buildChatPrompt(request);
   const { temperature, maxOutputTokens } = resolveModelSettings(request, defaults);
 
+  const startTime = new Date().toISOString();
+  const startMs = Date.now();
+
   const result = await withRetry(
     () =>
       generateText({
@@ -384,10 +387,16 @@ async function invokeModel(options: {
     request.signal,
   );
 
-  return mapResponse(result);
+  const endTime = new Date().toISOString();
+  const durationMs = Date.now() - startMs;
+
+  return mapResponse(result, { durationMs, startTime, endTime });
 }
 
-function mapResponse(result: TextResult): ProviderResponse {
+function mapResponse(
+  result: TextResult,
+  timing?: { durationMs: number; startTime: string; endTime: string },
+): ProviderResponse {
   const content = result.text ?? '';
   const rawUsage = result.totalUsage ?? result.usage;
   const reasoning = rawUsage?.outputTokenDetails?.reasoningTokens ?? undefined;
@@ -407,6 +416,9 @@ function mapResponse(result: TextResult): ProviderResponse {
     usage: toJsonObject(rawUsage),
     output: [{ role: 'assistant' as const, content }],
     tokenUsage,
+    durationMs: timing?.durationMs,
+    startTime: timing?.startTime,
+    endTime: timing?.endTime,
   };
 }
 


### PR DESCRIPTION
## Summary
- The ai-sdk provider (azure, openai, gemini, openrouter, anthropic) was the only provider that did not measure `durationMs`. All other providers (claude-cli, codex, copilot-cli, pi-coding-agent) already did this.
- Adds wall-clock timing around `generateText()`, returning `durationMs`, `startTime`, and `endTime` in the ProviderResponse.
- Verified e2e: gemini-flash eval now reports `duration_ms: 1061` in JSONL and `time_seconds: 1.061` in exported benchmark artifact (was 0 before).

## Risk
Low — adds timing measurement that was already expected by the orchestrator but never provided by this provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)