### PR TITLE
refactor: use new template variables in default LLM grader prompt

### DIFF
--- a/packages/core/src/evaluation/evaluators/llm-grader.ts
+++ b/packages/core/src/evaluation/evaluators/llm-grader.ts
@@ -74,13 +74,13 @@ Be concise and focused in your evaluation. Provide succinct, specific feedback r
 {{${TEMPLATE_VARIABLES.CRITERIA}}}
 
 [[ ## question ## ]]
-{{${TEMPLATE_VARIABLES.QUESTION}}}
+{{${TEMPLATE_VARIABLES.INPUT_TEXT}}}
 
 [[ ## reference_answer ## ]]
-{{${TEMPLATE_VARIABLES.REFERENCE_ANSWER}}}
+{{${TEMPLATE_VARIABLES.EXPECTED_OUTPUT_TEXT}}}
 
 [[ ## answer ## ]]
-{{${TEMPLATE_VARIABLES.ANSWER}}}`;
+{{${TEMPLATE_VARIABLES.OUTPUT_TEXT}}}`;
 
 type GraderProviderResolver = (context: EvaluationContext) => Promise<Provider | undefined>;
 


### PR DESCRIPTION
## Summary
- Updates `DEFAULT_EVALUATOR_TEMPLATE` to use `INPUT_TEXT`, `OUTPUT_TEXT`, and `EXPECTED_OUTPUT_TEXT` template variable constants instead of deprecated `QUESTION`, `ANSWER`, and `REFERENCE_ANSWER`.
- Section headers (`## question ##`, `## answer ##`, `## reference_answer ##`) are kept as-is — they're LLM-readable labels, not variable names.
- Deprecated template variable aliases still resolve via the variables map, so user custom prompt templates using `{{ question }}`/`{{ answer }}` continue to work.

## Risk
Low — only changes which constant is used to reference the template variable key in the default template. The actual substituted values are identical (both old and new keys point to the same values in the variables map).

Related: #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)