### PR TITLE
refactor: rename --dataset to --eval-set in offline grader benchmark

### DIFF
--- a/examples/showcase/offline-grader-benchmark/README.md
+++ b/examples/showcase/offline-grader-benchmark/README.md
@@ -68,13 +68,13 @@ The repository includes synthetic raw-result fixtures so you can verify the post
 ```bash
 bun examples/showcase/offline-grader-benchmark/scripts/score-grader-benchmark.ts \
   --results examples/showcase/offline-grader-benchmark/fixtures/setup-a.raw.jsonl \
-  --dataset examples/showcase/offline-grader-benchmark/fixtures/labeled-grader-export.jsonl \
+  --eval-set examples/showcase/offline-grader-benchmark/fixtures/labeled-grader-export.jsonl \
   --label grader-setup-a \
   > /tmp/grader-setup-a.scored.jsonl
 
 bun examples/showcase/offline-grader-benchmark/scripts/score-grader-benchmark.ts \
   --results examples/showcase/offline-grader-benchmark/fixtures/setup-b.raw.jsonl \
-  --dataset examples/showcase/offline-grader-benchmark/fixtures/labeled-grader-export.jsonl \
+  --eval-set examples/showcase/offline-grader-benchmark/fixtures/labeled-grader-export.jsonl \
   --label grader-setup-b \
   > /tmp/grader-setup-b.scored.jsonl
 
@@ -94,7 +94,7 @@ bun apps/cli/src/cli.ts eval \
 # Convert raw panel results into benchmark-scored JSONL (1 = matched human label, 0 = missed)
 bun examples/showcase/offline-grader-benchmark/scripts/score-grader-benchmark.ts \
   --results .agentv/results/offline-grader-setup-a.raw.jsonl \
-  --dataset examples/showcase/offline-grader-benchmark/fixtures/labeled-grader-export.jsonl \
+  --eval-set examples/showcase/offline-grader-benchmark/fixtures/labeled-grader-export.jsonl \
   --label grader-setup-a \
   > .agentv/results/offline-grader-setup-a.scored.jsonl
 
@@ -117,12 +117,12 @@ bun apps/cli/src/cli.ts eval examples/showcase/offline-grader-benchmark/evals/se
 # Score both runs against human labels
 bun examples/showcase/offline-grader-benchmark/scripts/score-grader-benchmark.ts \
   --results .agentv/results/offline-grader-setup-a.raw.jsonl \
-  --dataset examples/showcase/offline-grader-benchmark/fixtures/labeled-grader-export.jsonl \
+  --eval-set examples/showcase/offline-grader-benchmark/fixtures/labeled-grader-export.jsonl \
   --label grader-setup-a \
   > .agentv/results/offline-grader-setup-a.scored.jsonl
 bun examples/showcase/offline-grader-benchmark/scripts/score-grader-benchmark.ts \
   --results .agentv/results/offline-grader-setup-b.raw.jsonl \
-  --dataset examples/showcase/offline-grader-benchmark/fixtures/labeled-grader-export.jsonl \
+  --eval-set examples/showcase/offline-grader-benchmark/fixtures/labeled-grader-export.jsonl \
   --label grader-setup-b \
   > .agentv/results/offline-grader-setup-b.scored.jsonl
 

--- a/examples/showcase/offline-grader-benchmark/scripts/score-grader-benchmark.ts
+++ b/examples/showcase/offline-grader-benchmark/scripts/score-grader-benchmark.ts
@@ -16,7 +16,7 @@ type ScoreRecord = {
 type EvalResult = {
   timestamp?: string;
   test_id?: string;
-  dataset?: string;
+  eval_set?: string;
   target?: string;
   input?: string;
   output_text?: string;
@@ -30,14 +30,14 @@ type GroundTruth = {
 };
 
 function usage(): never {
-  console.error(`Usage: bun score-grader-benchmark.ts --results <results.jsonl> --dataset <labeled.jsonl> [--label <name>] [--evaluator <name>]
+  console.error(`Usage: bun score-grader-benchmark.ts --results <results.jsonl> --eval-set <labeled.jsonl> [--label <name>] [--evaluator <name>]
 
 Reads raw AgentV eval JSONL for a grader panel, resolves a majority verdict from child grader scores,
 and emits scored JSONL where score=1 means the panel matched human ground truth.
 
 Options:
   --results <file>     Raw AgentV eval output JSONL
-  --dataset <file>     Offline labeled export JSONL used for the eval
+  --eval-set <file>    Offline labeled export JSONL used for the eval
   --label <name>       Optional output target label (defaults to input target or results filename)
   --evaluator <name>   Composite evaluator name to inspect (defaults to first composite / first score group)
   --help               Show this help message
@@ -105,9 +105,9 @@ function parseGroundTruth(rawExpectedOutput: unknown): GroundTruth {
   throw new Error('Expected output must encode a pass/fail label');
 }
 
-function loadDataset(datasetPath: string): Map<string, GroundTruth> {
+function loadEvalSet(evalSetPath: string): Map<string, GroundTruth> {
   const map = new Map<string, GroundTruth>();
-  const lines = readFileSync(datasetPath, 'utf-8')
+  const lines = readFileSync(evalSetPath, 'utf-8')
     .split('\n')
     .map((line) => line.trim())
     .filter(Boolean);
@@ -156,13 +156,13 @@ const args = process.argv.slice(2);
 if (args.includes('--help')) usage();
 
 const resultsPath = getArg('--results');
-const datasetPath = getArg('--dataset');
+const evalSetPath = getArg('--eval-set');
 const labelOverride = getArg('--label');
 const evaluatorName = getArg('--evaluator');
 
-if (!resultsPath || !datasetPath) usage();
+if (!resultsPath || !evalSetPath) usage();
 
-const truthById = loadDataset(datasetPath);
+const truthById = loadEvalSet(evalSetPath);
 const rawResults = readFileSync(resultsPath, 'utf-8')
   .split('\n')
   .map((line) => line.trim())
@@ -178,7 +178,7 @@ for (const line of rawResults) {
 
   const truth = truthById.get(result.test_id);
   if (!truth) {
-    throw new Error(`No ground truth found for test_id '${result.test_id}' in ${datasetPath}`);
+    throw new Error(`No ground truth found for test_id '${result.test_id}' in ${evalSetPath}`);
   }
 
   const panel = selectPanel(result.scores, evaluatorName);
@@ -221,7 +221,7 @@ for (const line of rawResults) {
   const output = {
     timestamp: result.timestamp,
     test_id: result.test_id,
-    dataset: result.dataset,
+    eval_set: result.eval_set,
     target: labelOverride ?? result.target ?? labelFromPath(resultsPath),
     input: result.input,
     output_text: result.output_text,


### PR DESCRIPTION
## Summary
- Renames `--dataset` CLI flag to `--eval-set` in `score-grader-benchmark.ts`
- Updates all internal variables and output fields accordingly
- Updates README command examples

Clean break — no backward compatibility shim for `--dataset`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)