### PR TITLE
fix: add variable substitution to targets.yaml parsing

### DIFF
--- a/packages/core/src/evaluation/providers/targets-file.ts
+++ b/packages/core/src/evaluation/providers/targets-file.ts
@@ -3,6 +3,7 @@ import { access, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { parse } from 'yaml';
 
+import { interpolateEnv } from '../interpolation.js';
 import { TARGETS_SCHEMA_V2 } from './types.js';
 import type { TargetDefinition } from './types.js';
 
@@ -59,7 +60,7 @@ export async function readTargetDefinitions(
   }
 
   const raw = await readFile(absolutePath, 'utf8');
-  const parsed = parse(raw) as unknown;
+  const parsed = interpolateEnv(parse(raw), process.env) as unknown;
 
   if (!isRecord(parsed)) {
     throw new Error(`targets.yaml at ${absolutePath} must be a YAML object with a 'targets' field`);

--- a/packages/core/src/evaluation/validation/targets-validator.ts
+++ b/packages/core/src/evaluation/validation/targets-validator.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { parse } from 'yaml';
 
+import { interpolateEnv } from '../interpolation.js';
 import { CLI_PLACEHOLDERS } from '../providers/targets.js';
 import { KNOWN_PROVIDERS, PROVIDER_ALIASES } from '../providers/types.js';
 import type { ValidationError, ValidationResult } from './types.js';
@@ -325,7 +326,7 @@ export async function validateTargetsFile(filePath: string): Promise<ValidationR
   let parsed: unknown;
   try {
     const content = await readFile(absolutePath, 'utf8');
-    parsed = parse(content);
+    parsed = interpolateEnv(parse(content), process.env);
   } catch (error) {
     errors.push({
       severity: 'error',


### PR DESCRIPTION
## Summary
- `targets-file.ts` and `targets-validator.ts` were the only YAML loaders that didn't call `interpolateEnv()` after parsing
- `${{ VAR }}` references in `targets.yaml` (e.g. `provider: ${{ LLM_PROVIDER }}`) were never resolved, causing "Unknown provider" warnings
- Added `interpolateEnv()` call to both files, matching the pattern used by all other YAML loaders

## Test plan
- [x] All 1465 unit tests pass
- [ ] Verify `${{ LLM_PROVIDER }}` in targets.yaml resolves correctly at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)