### PR TITLE
fix(copilot-sdk): improve error message for vscode-jsonrpc ESM failure

### DIFF
--- a/packages/core/src/evaluation/providers/copilot-sdk.ts
+++ b/packages/core/src/evaluation/providers/copilot-sdk.ts
@@ -29,8 +29,14 @@ async function loadCopilotSdk(): Promise<typeof import('@github/copilot-sdk')> {
     try {
       copilotSdkModule = await import('@github/copilot-sdk');
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes('vscode-jsonrpc')) {
+        throw new Error(
+          `Failed to load @github/copilot-sdk due to a known ESM compatibility issue with vscode-jsonrpc (https://github.com/github/copilot-sdk/issues/710).\n\nWorkarounds:\n  - Use the copilot-cli target instead (recommended): set target type to "copilot-cli" in your eval YAML\n  - If running under Node.js 24+: set NODE_OPTIONS="--experimental-specifier-resolution=node"\n  - Wait for vscode-jsonrpc@9.0.0 stable to be released upstream`,
+        );
+      }
       throw new Error(
-        `Failed to load @github/copilot-sdk. Please install it:\n  npm install @github/copilot-sdk\n\nOriginal error: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to load @github/copilot-sdk. Please install it:\n  npm install @github/copilot-sdk\n\nOriginal error: ${message}`,
       );
     }
   }


### PR DESCRIPTION
## Summary
- Detect the known `vscode-jsonrpc` ESM resolution failure when loading `@github/copilot-sdk` and surface a targeted error message with actionable workarounds
- Links to upstream issue (github/copilot-sdk#710) and recommends `copilot-cli` target as the primary alternative
- Preserves the generic "please install" error for cases where the SDK is genuinely missing

## Test plan
- [x] Build passes
- [x] All 1139 core tests pass
- [x] Pre-push hooks pass (build, typecheck, lint, test, validate examples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)