### PR TITLE
feat(results): restructure into raw/ + export/ with inputs/ folder

### DIFF
--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -322,7 +322,7 @@ function buildDefaultOutputPath(cwd: string, format: OutputFormat): string {
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
   const baseName = 'eval';
   const extension = getDefaultExtension(format);
-  return path.join(cwd, '.agentv', 'results', `${baseName}_${timestamp}${extension}`);
+  return path.join(cwd, '.agentv', 'results', 'raw', `${baseName}_${timestamp}${extension}`);
 }
 
 type ProgressReporter = {

--- a/apps/cli/src/commands/results/export.ts
+++ b/apps/cli/src/commands/results/export.ts
@@ -10,6 +10,8 @@
  *       <test-id>.json         — per-test grading artifact (assertions, evaluators)
  *     outputs/
  *       <test-id>.md           — human-readable agent response per test
+ *     inputs/
+ *       <test-id>.md           — human-readable input messages per test
  *
  * This module delegates artifact building to the shared artifact-writer so
  * that `agentv results export` and `agentv eval` produce identical schemas.
@@ -81,6 +83,18 @@ export function exportResults(sourceFile: string, content: string, outputDir: st
       writeFileSync(path.join(outputsDir, `${id}.md`), md);
     }
   }
+
+  // inputs/<test-id>.md — human-readable input messages per test
+  const inputsDir = path.join(outputDir, 'inputs');
+  mkdirSync(inputsDir, { recursive: true });
+
+  for (const result of patched) {
+    const id = safeTestId(result);
+    const input = extractInput(result);
+    if (input) {
+      writeFileSync(path.join(inputsDir, `${id}.md`), input);
+    }
+  }
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────
@@ -91,6 +105,20 @@ export function exportResults(sourceFile: string, content: string, outputDir: st
  */
 function formatOutputMarkdown(output: readonly { role: string; content?: unknown }[]): string {
   return output.map((msg) => `@[${msg.role}]:\n${String(msg.content ?? '')}`).join('\n\n');
+}
+
+/**
+ * Extract human-readable input from a result.
+ * Handles both string input (single question) and Message[] input (multi-message).
+ */
+function extractInput(result: EvaluationResult): string | null {
+  const input = (result as unknown as Record<string, unknown>).input;
+  if (!input) return null;
+  if (typeof input === 'string') return input;
+  if (Array.isArray(input) && input.length > 0) {
+    return formatOutputMarkdown(input as { role: string; content?: unknown }[]);
+  }
+  return null;
 }
 
 /**
@@ -110,7 +138,7 @@ function deriveOutputDir(cwd: string, sourceFile: string): string {
   const basename = path.basename(sourceFile, '.jsonl');
   // Strip leading "eval_" prefix if present to get the timestamp
   const dirName = basename.startsWith('eval_') ? basename.slice(5) : basename;
-  return path.join(cwd, '.agentv', 'results', dirName);
+  return path.join(cwd, '.agentv', 'results', 'export', dirName);
 }
 
 // ── CLI command ──────────────────────────────────────────────────────────
@@ -128,7 +156,7 @@ export const resultsExportCommand = command({
       type: optional(string),
       long: 'out',
       short: 'o',
-      description: 'Output directory (defaults to .agentv/results/<run-timestamp>/)',
+      description: 'Output directory (defaults to .agentv/results/export/<run-timestamp>/)',
     }),
     dir: option({
       type: optional(string),

--- a/apps/cli/src/commands/trace/utils.ts
+++ b/apps/cli/src/commands/trace/utils.ts
@@ -117,32 +117,49 @@ export interface ResultFileMeta {
 
 /**
  * Enumerate result files in the .agentv/results/ directory.
+ * Scans both raw/ (new layout) and the base directory (legacy) for backward compatibility.
  */
 export function listResultFiles(cwd: string, limit?: number): ResultFileMeta[] {
-  const resultsDir = path.join(cwd, '.agentv', 'results');
+  const baseDir = path.join(cwd, '.agentv', 'results');
+  const rawDir = path.join(baseDir, 'raw');
 
-  let files: string[];
-  try {
-    files = readdirSync(resultsDir).filter((f) => f.endsWith('.jsonl'));
-  } catch {
-    return [];
+  // Scan both raw/ (new) and root (legacy) for backward compatibility
+  const files: string[] = [];
+  for (const dir of [rawDir, baseDir]) {
+    try {
+      const entries = readdirSync(dir).filter((f) => f.endsWith('.jsonl'));
+      for (const entry of entries) {
+        files.push(path.join(dir, entry));
+      }
+    } catch {
+      // Directory doesn't exist yet
+    }
   }
 
-  // Sort by filename (which contains timestamp) descending (most recent first)
-  files.sort((a, b) => b.localeCompare(a));
-
-  if (limit !== undefined && limit > 0) {
-    files = files.slice(0, limit);
+  // Deduplicate by filename (prefer raw/ version since it appears first)
+  const seen = new Set<string>();
+  const uniqueFiles: string[] = [];
+  for (const filePath of files) {
+    const basename = path.basename(filePath);
+    if (!seen.has(basename)) {
+      seen.add(basename);
+      uniqueFiles.push(filePath);
+    }
   }
+
+  // Sort by filename descending (most recent first)
+  uniqueFiles.sort((a, b) => path.basename(b).localeCompare(path.basename(a)));
+
+  const limited = limit !== undefined && limit > 0 ? uniqueFiles.slice(0, limit) : uniqueFiles;
 
   const metas: ResultFileMeta[] = [];
 
-  for (const filename of files) {
-    const filePath = path.join(resultsDir, filename);
+  for (const filePath of limited) {
     try {
       const stat = statSync(filePath);
       const results = loadResultFile(filePath);
 
+      const filename = path.basename(filePath);
       const testCount = results.length;
       const passCount = results.filter((r) => r.score >= 1.0).length;
       const passRate = testCount > 0 ? passCount / testCount : 0;

--- a/apps/cli/test/commands/results/export.test.ts
+++ b/apps/cli/test/commands/results/export.test.ts
@@ -280,6 +280,49 @@ describe('results export', () => {
     expect(grading.summary.total).toBe(0);
   });
 
+  it('should write string input to inputs/<test-id>.md', () => {
+    const outputDir = path.join(tempDir, 'output');
+    const resultWithInput = {
+      ...RESULT_FULL,
+      input: 'What is the capital of France?',
+    };
+    const content = toJsonl(resultWithInput);
+
+    exportResults('test.jsonl', content, outputDir);
+
+    const inputPath = path.join(outputDir, 'inputs', 'test-greeting.md');
+    expect(existsSync(inputPath)).toBe(true);
+    expect(readFileSync(inputPath, 'utf8')).toBe('What is the capital of France?');
+  });
+
+  it('should write Message[] input to inputs/<test-id>.md as markdown', () => {
+    const outputDir = path.join(tempDir, 'output');
+    const resultWithMessages = {
+      ...RESULT_FULL,
+      input: [
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi there!' },
+      ],
+    };
+    const content = toJsonl(resultWithMessages);
+
+    exportResults('test.jsonl', content, outputDir);
+
+    const inputPath = path.join(outputDir, 'inputs', 'test-greeting.md');
+    expect(existsSync(inputPath)).toBe(true);
+    expect(readFileSync(inputPath, 'utf8')).toBe('@[user]:\nHello\n\n@[assistant]:\nHi there!');
+  });
+
+  it('should not create input file when input is missing', () => {
+    const outputDir = path.join(tempDir, 'output');
+    const content = toJsonl(RESULT_FULL);
+
+    exportResults('test.jsonl', content, outputDir);
+
+    const inputPath = path.join(outputDir, 'inputs', 'test-greeting.md');
+    expect(existsSync(inputPath)).toBe(false);
+  });
+
   it('should handle results with missing target and testId fields', () => {
     const outputDir = path.join(tempDir, 'output');
     const bare = {

--- a/apps/cli/test/commands/trace/trace.test.ts
+++ b/apps/cli/test/commands/trace/trace.test.ts
@@ -122,16 +122,16 @@ describe('trace utils', () => {
       expect(metas).toEqual([]);
     });
 
-    it('should enumerate JSONL files in .agentv/results/', () => {
-      const resultsDir = path.join(tempDir, '.agentv', 'results');
-      mkdirSync(resultsDir, { recursive: true });
+    it('should enumerate JSONL files in .agentv/results/raw/', () => {
+      const rawDir = path.join(tempDir, '.agentv', 'results', 'raw');
+      mkdirSync(rawDir, { recursive: true });
 
       writeFileSync(
-        path.join(resultsDir, 'eval_2026-02-20T21-38-05-833Z.jsonl'),
+        path.join(rawDir, 'eval_2026-02-20T21-38-05-833Z.jsonl'),
         `${RESULT_WITH_TRACE}\n${RESULT_WITHOUT_TRACE}\n`,
       );
       writeFileSync(
-        path.join(resultsDir, 'eval_2026-02-21T10-00-00-000Z.jsonl'),
+        path.join(rawDir, 'eval_2026-02-21T10-00-00-000Z.jsonl'),
         `${RESULT_FAILING}\n`,
       );
 
@@ -148,7 +148,7 @@ describe('trace utils', () => {
       expect(metas[1].passRate).toBe(0.5);
     });
 
-    it('should respect limit', () => {
+    it('should find legacy files in .agentv/results/ (backward compat)', () => {
       const resultsDir = path.join(tempDir, '.agentv', 'results');
       mkdirSync(resultsDir, { recursive: true });
 
@@ -156,8 +156,43 @@ describe('trace utils', () => {
         path.join(resultsDir, 'eval_2026-02-20T21-38-05-833Z.jsonl'),
         `${RESULT_WITH_TRACE}\n`,
       );
+
+      const metas = listResultFiles(tempDir);
+      expect(metas).toHaveLength(1);
+      expect(metas[0].filename).toBe('eval_2026-02-20T21-38-05-833Z.jsonl');
+    });
+
+    it('should deduplicate files preferring raw/ over legacy root', () => {
+      const resultsDir = path.join(tempDir, '.agentv', 'results');
+      const rawDir = path.join(resultsDir, 'raw');
+      mkdirSync(rawDir, { recursive: true });
+
+      // Same filename in both locations
       writeFileSync(
-        path.join(resultsDir, 'eval_2026-02-21T10-00-00-000Z.jsonl'),
+        path.join(rawDir, 'eval_2026-02-20T21-38-05-833Z.jsonl'),
+        `${RESULT_WITH_TRACE}\n`,
+      );
+      writeFileSync(
+        path.join(resultsDir, 'eval_2026-02-20T21-38-05-833Z.jsonl'),
+        `${RESULT_WITH_TRACE}\n`,
+      );
+
+      const metas = listResultFiles(tempDir);
+      expect(metas).toHaveLength(1);
+      // Should prefer the raw/ version
+      expect(metas[0].path).toContain(path.join('raw', 'eval_2026-02-20T21-38-05-833Z.jsonl'));
+    });
+
+    it('should respect limit', () => {
+      const rawDir = path.join(tempDir, '.agentv', 'results', 'raw');
+      mkdirSync(rawDir, { recursive: true });
+
+      writeFileSync(
+        path.join(rawDir, 'eval_2026-02-20T21-38-05-833Z.jsonl'),
+        `${RESULT_WITH_TRACE}\n`,
+      );
+      writeFileSync(
+        path.join(rawDir, 'eval_2026-02-21T10-00-00-000Z.jsonl'),
         `${RESULT_FAILING}\n`,
       );
 
@@ -167,12 +202,12 @@ describe('trace utils', () => {
     });
 
     it('should ignore non-JSONL files', () => {
-      const resultsDir = path.join(tempDir, '.agentv', 'results');
-      mkdirSync(resultsDir, { recursive: true });
+      const rawDir = path.join(tempDir, '.agentv', 'results', 'raw');
+      mkdirSync(rawDir, { recursive: true });
 
-      writeFileSync(path.join(resultsDir, 'notes.txt'), 'not a result file');
+      writeFileSync(path.join(rawDir, 'notes.txt'), 'not a result file');
       writeFileSync(
-        path.join(resultsDir, 'eval_2026-02-20T21-38-05-833Z.jsonl'),
+        path.join(rawDir, 'eval_2026-02-20T21-38-05-833Z.jsonl'),
         `${RESULT_WITH_TRACE}\n`,
       );
 


### PR DESCRIPTION
## Summary

Closes #707

- JSONL result files now write to `.agentv/results/raw/` instead of flat `.agentv/results/`
- `agentv results export` outputs to `.agentv/results/export/<timestamp>/` instead of `.agentv/results/<timestamp>/`
- Exports now include `inputs/<test-id>.md` alongside `outputs/<test-id>.md` — reviewers can see what was sent to the agent without parsing JSONL
- `listResultFiles()` scans both `raw/` and the legacy root for backward compatibility (no migration needed)

## Test plan

- [x] Typecheck passes (`tsc --noEmit`)
- [x] All 266 CLI tests pass
- [x] All 1152 core tests pass
- [x] Biome lint clean
- [x] CI pre-push hooks pass (build, typecheck, lint, test, YAML validation)
- [x] Manual: `agentv eval` writes JSONL to `.agentv/results/raw/`
- [x] Manual: `agentv results export` reads from `raw/` and writes to `export/`
- [x] Manual: Export produces `inputs/` folder with correct content (string input, multi-message system+user input)
- [x] Manual: Legacy files in `.agentv/results/*.jsonl` are still found by `results export` (auto-discovery without `raw/` dir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)