### PR TITLE
docs: add issue templates and tracker conventions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report
+about: Report broken behavior that should be fixed
+title: ""
+labels: "bug"
+assignees: ""
+---
+
+## Problem
+
+Describe the broken behavior clearly and concretely.
+
+## Expected Behavior
+
+Describe what should have happened instead.
+
+## Observed Behavior
+
+Describe what actually happened, including error messages if relevant.
+
+## Reproduction
+
+1. Step one
+2. Step two
+3. Observe the problem
+
+## Acceptance Signals
+
+- [ ] The bug no longer reproduces with the steps above
+- [ ] Adjacent behavior still works as expected
+
+## Non-Goals
+
+- Anything explicitly out of scope for this fix
+
+## Related
+
+- Link related issues, PRs, logs, or research docs

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Repository Guidelines
+    url: https://github.com/EntityProcess/agentv/blob/main/CLAUDE.md
+    about: Issue bodies are the handoff contract. Include objective, design latitude, acceptance signals, non-goals, and related links.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature Request
+about: Propose a feature, architecture change, or implementation request
+title: ""
+labels: ""
+assignees: ""
+---
+
+## Objective
+
+Describe the outcome we want to achieve.
+
+## Current Problem
+
+Describe the current gap, friction, or missing capability.
+
+## Design Latitude
+
+State what is fixed versus what the implementer can choose.
+
+## Acceptance Signals
+
+- [ ] Concrete signal 1
+- [ ] Concrete signal 2
+
+## Non-Goals
+
+- Not in scope
+
+## Related
+
+- Link related issues, PRs, or research docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,16 @@ When working on a GitHub issue, **ALWAYS** follow this workflow:
 
 **IMPORTANT:** Never push directly to `main`. Always use branches and PRs.
 
+### Tracker Conventions
+
+- The roadmap project is the source of truth for prioritization.
+- Issues in the roadmap are prioritized; issues outside it are not.
+- `bug` marks defects.
+- Issues without `bug` are non-bug work by default.
+- `core`, `wui`, and `tui` are area labels.
+- Keep issue bodies focused on the handoff contract: objective, design latitude, acceptance signals, non-goals, and related links.
+- Do not put priority metadata in issue bodies.
+
 ### Pull Requests
 
 **Always use squash merge** when merging PRs to main. This keeps the commit history clean with one commit per feature/fix.


### PR DESCRIPTION
## Summary
- add minimal bug and feature issue templates aligned with the issue handoff contract
- add a short tracker-conventions section to CLAUDE.md
- document roadmap-project prioritization, bug labeling, and area labels without adding priority metadata to issue bodies

## Risk
low — docs/process only
