### PR TITLE
docs: add Langfuse OTel export example

### DIFF
--- a/examples/features/langfuse-export/.agentv/config.yaml
+++ b/examples/features/langfuse-export/.agentv/config.yaml
@@ -1,0 +1,12 @@
+$schema: agentv-config-v2
+
+# Langfuse OTel Export Configuration
+#
+# Credentials are loaded from .env (LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY).
+# No CLI flags needed — this config enables export automatically.
+
+execution:
+  export_otel: true
+  otel_backend: langfuse
+  otel_group_turns: true
+  otel_file: .agentv/results/otel-{timestamp}.json

--- a/examples/features/langfuse-export/.env.example
+++ b/examples/features/langfuse-export/.env.example
@@ -1,0 +1,6 @@
+# Langfuse credentials — get these from your Langfuse project settings
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+LANGFUSE_SECRET_KEY=sk-lf-...
+
+# Optional: self-hosted Langfuse (defaults to cloud.langfuse.com)
+# LANGFUSE_HOST=https://your-langfuse-instance.com

--- a/examples/features/langfuse-export/README.md
+++ b/examples/features/langfuse-export/README.md
@@ -1,0 +1,48 @@
+# Langfuse OTel Export
+
+Demonstrates exporting eval traces to [Langfuse](https://langfuse.com) via OpenTelemetry.
+
+AgentV uses OTLP/HTTP — no Langfuse SDK required. The `langfuse` backend preset handles endpoint and auth automatically.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your Langfuse credentials:
+
+```bash
+cp .env.example .env
+```
+
+2. Run evals — traces appear in your Langfuse dashboard automatically:
+
+```bash
+agentv eval examples/features/langfuse-export/evals/eval.yaml
+```
+
+No `--export-otel` or `--otel-backend` flags needed — the config.yaml handles it.
+
+## How It Works
+
+- `.agentv/config.yaml` declares `export_otel: true` and `otel_backend: langfuse`
+- AgentV constructs Basic Auth from `LANGFUSE_PUBLIC_KEY:LANGFUSE_SECRET_KEY`
+- Spans are sent to `https://cloud.langfuse.com/api/public/otel/v1/traces` (or your self-hosted instance via `LANGFUSE_HOST`)
+- Uses GenAI semantic conventions (`gen_ai.*`) that Langfuse dashboards recognize
+
+## Self-Hosted Langfuse
+
+Add `LANGFUSE_HOST` to your `.env`:
+
+```bash
+LANGFUSE_HOST=https://your-langfuse-instance.com
+```
+
+## CLI Override
+
+Config.yaml defaults can always be overridden by CLI flags:
+
+```bash
+# Disable OTel export for a single run
+agentv eval evals/eval.yaml  # export_otel in config still applies
+
+# Use a different backend
+agentv eval evals/eval.yaml --export-otel --otel-backend braintrust
+```

--- a/examples/features/langfuse-export/evals/eval.yaml
+++ b/examples/features/langfuse-export/evals/eval.yaml
@@ -1,0 +1,30 @@
+# Langfuse Export Example Eval
+#
+# Run: agentv eval examples/features/langfuse-export/evals/eval.yaml
+#
+# Traces will appear in your Langfuse dashboard with gen_ai.* semantic
+# conventions, per-span token usage, and turn-level grouping.
+
+description: Sample eval with Langfuse trace export
+
+execution:
+  target: default
+
+tests:
+  - id: greeting
+    input: "Hello, who are you?"
+    criteria: "Responds with a self-introduction"
+
+  - id: math
+    input: "What is 15 * 23?"
+    criteria: "Provides the correct answer: 345"
+
+  - id: multi-turn
+    input:
+      - role: user
+        content: "Remember the number 42."
+      - role: assistant
+        content: "Got it, I'll remember 42."
+      - role: user
+        content: "What number did I ask you to remember?"
+    criteria: "Correctly recalls the number 42"


### PR DESCRIPTION
## Summary
- Add `examples/features/langfuse-export/` with config.yaml-driven Langfuse export
- Includes `.env.example`, sample eval with multi-turn test, and README walkthrough
- Demonstrates the new `export_otel` + `otel_backend` config.yaml fields from #720

Partial progress on #719

## Risk
Low — docs/examples only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)