### PR TITLE
refactor(targets): rename pi_provider to subprovider

### DIFF
--- a/.agentv/targets.yaml
+++ b/.agentv/targets.yaml
@@ -5,7 +5,7 @@ targets:
   - name: default
     provider: pi-coding-agent
     executable: ${{ PI_CLI_PATH }}
-    pi_provider: openrouter
+    subprovider: openrouter
     model: z-ai/glm-4.7
     api_key: ${{ OPENROUTER_API_KEY }}
     system_prompt: "Answer directly based on the information provided."

--- a/examples/features/.agentv/targets.yaml
+++ b/examples/features/.agentv/targets.yaml
@@ -53,7 +53,7 @@ targets:
   - name: pi
     provider: pi-coding-agent
     executable: ${{ PI_CLI_PATH }}  # Optional: defaults to `pi` if omitted
-    pi_provider: openrouter
+    subprovider: openrouter
     model: openai/gpt-5.4
     api_key: ${{ OPENROUTER_API_KEY }}
     grader_target: gemini-llm

--- a/packages/core/src/evaluation/providers/pi-agent-sdk.ts
+++ b/packages/core/src/evaluation/providers/pi-agent-sdk.ts
@@ -98,7 +98,7 @@ export class PiAgentSdkProvider implements Provider {
 
     const startTimeIso = new Date().toISOString();
     const startMs = Date.now();
-    const providerName = this.config.provider ?? 'anthropic';
+    const providerName = this.config.subprovider ?? 'anthropic';
     const modelId = this.config.model ?? 'claude-sonnet-4-20250514';
     // Use type assertion since getModel has strict generic constraints for compile-time known values
     // but we're working with runtime configuration strings
@@ -248,7 +248,7 @@ export class PiAgentSdkProvider implements Provider {
           messages: agentMessages,
           systemPrompt,
           model: this.config.model,
-          provider: this.config.provider,
+          subprovider: this.config.subprovider,
         },
         output,
         tokenUsage,

--- a/packages/core/src/evaluation/providers/pi-coding-agent.ts
+++ b/packages/core/src/evaluation/providers/pi-coding-agent.ts
@@ -165,8 +165,8 @@ export class PiCodingAgentProvider implements Provider {
     const args: string[] = [];
 
     // Provider and model configuration
-    if (this.config.provider) {
-      args.push('--provider', this.config.provider);
+    if (this.config.subprovider) {
+      args.push('--provider', this.config.subprovider);
     }
     if (this.config.model) {
       args.push('--model', this.config.model);
@@ -252,7 +252,7 @@ export class PiCodingAgentProvider implements Provider {
 
     // Map provider-specific API key to the correct env var
     if (this.config.apiKey) {
-      const provider = this.config.provider?.toLowerCase() ?? 'google';
+      const provider = this.config.subprovider?.toLowerCase() ?? 'google';
       switch (provider) {
         case 'google':
         case 'gemini':

--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -487,7 +487,7 @@ export interface CopilotSdkResolvedConfig {
 
 export interface PiCodingAgentResolvedConfig {
   readonly executable: string;
-  readonly provider?: string;
+  readonly subprovider?: string;
   readonly model?: string;
   readonly apiKey?: string;
   readonly tools?: string;
@@ -502,7 +502,7 @@ export interface PiCodingAgentResolvedConfig {
 }
 
 export interface PiAgentSdkResolvedConfig {
-  readonly provider?: string;
+  readonly subprovider?: string;
   readonly model?: string;
   readonly apiKey?: string;
   readonly timeoutMs?: number;
@@ -1416,7 +1416,9 @@ function resolvePiCodingAgentConfig(
   evalFilePath?: string,
 ): PiCodingAgentResolvedConfig {
   const executableSource = target.executable ?? target.command ?? target.binary;
-  const providerSource = target.pi_provider ?? target.piProvider ?? target.llm_provider;
+  // subprovider is canonical; pi_provider, piProvider, llm_provider are deprecated aliases
+  const subproviderSource =
+    target.subprovider ?? target.pi_provider ?? target.piProvider ?? target.llm_provider;
   const modelSource = target.model ?? target.pi_model ?? target.piModel;
   const apiKeySource = target.api_key ?? target.apiKey;
   const toolsSource = target.tools ?? target.pi_tools ?? target.piTools;
@@ -1436,10 +1438,15 @@ function resolvePiCodingAgentConfig(
       optionalEnv: true,
     }) ?? 'pi';
 
-  const provider = resolveOptionalString(providerSource, env, `${target.name} pi provider`, {
-    allowLiteral: true,
-    optionalEnv: true,
-  });
+  const subprovider = resolveOptionalString(
+    subproviderSource,
+    env,
+    `${target.name} pi subprovider`,
+    {
+      allowLiteral: true,
+      optionalEnv: true,
+    },
+  );
 
   const model = resolveOptionalString(modelSource, env, `${target.name} pi model`, {
     allowLiteral: true,
@@ -1507,7 +1514,7 @@ function resolvePiCodingAgentConfig(
 
   return {
     executable,
-    provider,
+    subprovider,
     model,
     apiKey,
     tools,
@@ -1526,16 +1533,18 @@ function resolvePiAgentSdkConfig(
   target: z.infer<typeof BASE_TARGET_SCHEMA>,
   env: EnvLookup,
 ): PiAgentSdkResolvedConfig {
-  const providerSource = target.pi_provider ?? target.piProvider ?? target.llm_provider;
+  // subprovider is canonical; pi_provider, piProvider, llm_provider are deprecated aliases
+  const subproviderSource =
+    target.subprovider ?? target.pi_provider ?? target.piProvider ?? target.llm_provider;
   const modelSource = target.model ?? target.pi_model ?? target.piModel;
   const apiKeySource = target.api_key ?? target.apiKey;
   const timeoutSource = target.timeout_seconds ?? target.timeoutSeconds;
   const systemPromptSource = target.system_prompt ?? target.systemPrompt;
 
-  const provider = resolveOptionalString(
-    providerSource,
+  const subprovider = resolveOptionalString(
+    subproviderSource,
     env,
-    `${target.name} pi-agent-sdk provider`,
+    `${target.name} pi-agent-sdk subprovider`,
     {
       allowLiteral: true,
       optionalEnv: true,
@@ -1560,7 +1569,7 @@ function resolvePiAgentSdkConfig(
       : undefined;
 
   return {
-    provider,
+    subprovider,
     model,
     apiKey,
     timeoutMs,


### PR DESCRIPTION
## Summary

- Renames `pi_provider` to `subprovider` as the canonical field name in pi-coding-agent (and pi-agent-sdk) target config
- Keeps `pi_provider`, `piProvider`, and `llm_provider` as deprecated aliases for backward compatibility
- Updates example target configs to use the new field name

Closes #703

## Test plan

- [x] All 1159 core tests pass
- [x] Pre-push hooks pass (build, typecheck, lint, test, validate examples)
- [ ] Existing configs using `pi_provider` still work via deprecated alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)