### PR TITLE
feat(results): add index manifest for eval artifacts

### DIFF
--- a/apps/cli/src/commands/eval/artifact-writer.ts
+++ b/apps/cli/src/commands/eval/artifact-writer.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { EvaluationResult, EvaluatorResult } from '@agentv/core';
+import { toSnakeCaseDeep } from '../../utils/case-conversion.js';
 
 // ---------------------------------------------------------------------------
 // Artifact interfaces (snake_case to match skill-creator conventions)
@@ -90,6 +91,25 @@ export interface AggregateGradingArtifact {
     readonly total: number;
     readonly pass_rate: number;
   };
+}
+
+export interface IndexArtifactEntry {
+  readonly timestamp: string;
+  readonly test_id: string;
+  readonly eval_set?: string;
+  readonly conversation_id?: string;
+  readonly score: number;
+  readonly target: string;
+  readonly scores?: readonly Record<string, unknown>[];
+  readonly execution_status?: string;
+  readonly error?: string;
+  readonly failure_stage?: string;
+  readonly failure_reason_code?: string;
+  readonly workspace_path?: string;
+  readonly grading_path: string;
+  readonly timing_path: string;
+  readonly output_path?: string;
+  readonly input_path?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -425,6 +445,50 @@ export function buildAggregateGradingArtifact(
   };
 }
 
+function toRelativeArtifactPath(outputDir: string, filePath: string): string {
+  return path.relative(outputDir, filePath).split(path.sep).join('/');
+}
+
+function safeTestId(result: EvaluationResult): string {
+  return (result.testId ?? 'unknown').replace(/[/\\:*?"<>|]/g, '_');
+}
+
+export function buildIndexArtifactEntry(
+  result: EvaluationResult,
+  options: {
+    outputDir: string;
+    gradingPath: string;
+    timingPath: string;
+    outputPath?: string;
+    inputPath?: string;
+  },
+): IndexArtifactEntry {
+  return {
+    timestamp: result.timestamp,
+    test_id: result.testId ?? 'unknown',
+    eval_set: result.eval_set,
+    conversation_id: result.conversationId,
+    score: result.score,
+    target: result.target ?? 'unknown',
+    scores: result.scores
+      ? (toSnakeCaseDeep(result.scores) as IndexArtifactEntry['scores'])
+      : undefined,
+    execution_status: result.executionStatus,
+    error: result.error,
+    failure_stage: result.failureStage,
+    failure_reason_code: result.failureReasonCode,
+    workspace_path: result.workspacePath,
+    grading_path: toRelativeArtifactPath(options.outputDir, options.gradingPath),
+    timing_path: toRelativeArtifactPath(options.outputDir, options.timingPath),
+    output_path: options.outputPath
+      ? toRelativeArtifactPath(options.outputDir, options.outputPath)
+      : undefined,
+    input_path: options.inputPath
+      ? toRelativeArtifactPath(options.outputDir, options.inputPath)
+      : undefined,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Snake_case to camelCase conversion for reading JSONL files
 // ---------------------------------------------------------------------------
@@ -475,7 +539,7 @@ export function parseJsonlResults(content: string): EvaluationResult[] {
 }
 
 // ---------------------------------------------------------------------------
-// Artifact writer — reads JSONL and writes all three artifact types
+// Artifact writer — reads JSONL and writes the per-test artifact workspace
 // ---------------------------------------------------------------------------
 
 export async function writeArtifacts(
@@ -484,6 +548,7 @@ export async function writeArtifacts(
   options?: { evalFile?: string },
 ): Promise<{
   testArtifactDir: string;
+  indexPath: string;
   timingPath: string;
   benchmarkPath: string;
 }> {
@@ -499,26 +564,39 @@ export async function writeArtifactsFromResults(
   options?: { evalFile?: string },
 ): Promise<{
   testArtifactDir: string;
+  indexPath: string;
   timingPath: string;
   benchmarkPath: string;
 }> {
   const testArtifactDir = outputDir;
+  const indexPath = path.join(outputDir, 'index.jsonl');
   const timingPath = path.join(outputDir, 'timing.json');
   const benchmarkPath = path.join(outputDir, 'benchmark.json');
+  const indexLines: string[] = [];
   await mkdir(outputDir, { recursive: true });
 
   // Write per-test grading artifacts
   for (const result of results) {
     const grading = buildGradingArtifact(result);
     const timing = buildTimingArtifact([result]);
-    const safeTestId = (result.testId ?? 'unknown').replace(/[/\\:*?"<>|]/g, '_');
-    const testDir = path.join(outputDir, safeTestId);
+    const testDir = path.join(outputDir, safeTestId(result));
     const gradingPath = path.join(testDir, 'grading.json');
     const perTestTimingPath = path.join(testDir, 'timing.json');
     await mkdir(testDir, { recursive: true });
     await writeFile(gradingPath, `${JSON.stringify(grading, null, 2)}\n`, 'utf8');
     await writeFile(perTestTimingPath, `${JSON.stringify(timing, null, 2)}\n`, 'utf8');
+    indexLines.push(
+      JSON.stringify(
+        buildIndexArtifactEntry(result, {
+          outputDir,
+          gradingPath,
+          timingPath: perTestTimingPath,
+        }),
+      ),
+    );
   }
+
+  await writeFile(indexPath, indexLines.length > 0 ? `${indexLines.join('\n')}\n` : '', 'utf8');
 
   // Write aggregate timing
   const timing = buildTimingArtifact(results);
@@ -528,5 +606,5 @@ export async function writeArtifactsFromResults(
   const benchmark = buildBenchmarkArtifact(results, options?.evalFile);
   await writeFile(benchmarkPath, `${JSON.stringify(benchmark, null, 2)}\n`, 'utf8');
 
-  return { testArtifactDir, timingPath, benchmarkPath };
+  return { testArtifactDir, indexPath, timingPath, benchmarkPath };
 }

--- a/apps/cli/src/commands/eval/commands/run.ts
+++ b/apps/cli/src/commands/eval/commands/run.ts
@@ -161,7 +161,7 @@ export const evalRunCommand = command({
       type: optional(string),
       long: 'artifacts',
       description:
-        'Write companion artifacts (<test>/grading.json, <test>/timing.json, timing.json, benchmark.json) to the specified directory',
+        'Write companion artifacts (index.jsonl, <test>/grading.json, <test>/timing.json, timing.json, benchmark.json) to the specified directory',
     }),
     graderTarget: option({
       type: optional(string),

--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -1170,6 +1170,7 @@ export async function runEvalCommand(
       const evalFile = resolvedTestFiles.length === 1 ? resolvedTestFiles[0] : '';
       const {
         testArtifactDir,
+        indexPath,
         timingPath,
         benchmarkPath: abp,
       } = await writeArtifactsFromResults(allResults, artifactsDir, { evalFile });
@@ -1177,6 +1178,7 @@ export async function runEvalCommand(
       console.log(
         `  Per-test artifacts: ${testArtifactDir} (${allResults.length} test directories)`,
       );
+      console.log(`  Index:   ${indexPath}`);
       console.log(`  Timing:  ${timingPath}`);
       console.log(`  Benchmark: ${abp}`);
     }

--- a/apps/cli/src/commands/results/export.ts
+++ b/apps/cli/src/commands/results/export.ts
@@ -5,6 +5,7 @@
  * Output structure:
  *   <output-dir>/
  *     benchmark.json           — aggregate scores, pass/fail counts, timing
+ *     index.jsonl              — per-test manifest with artifact pointers
  *     <test-id>/
  *       grading.json           — per-test grading artifact (assertions, evaluators)
  *       timing.json            — per-test timing artifact
@@ -28,6 +29,7 @@ import type { EvaluationResult } from '@agentv/core';
 import {
   buildBenchmarkArtifact,
   buildGradingArtifact,
+  buildIndexArtifactEntry,
   buildTimingArtifact,
   parseJsonlResults,
 } from '../eval/artifact-writer.js';
@@ -56,6 +58,7 @@ export function exportResults(sourceFile: string, content: string, outputDir: st
   // benchmark.json — aggregate across all results
   const benchmark = buildBenchmarkArtifact(patched, sourceFile);
   writeFileSync(path.join(outputDir, 'benchmark.json'), `${JSON.stringify(benchmark, null, 2)}\n`);
+  const indexLines: string[] = [];
 
   // <test-id>/... — per-test workspace artifacts
   for (const result of patched) {
@@ -64,19 +67,38 @@ export function exportResults(sourceFile: string, content: string, outputDir: st
     const outputsDir = path.join(testDir, 'outputs');
     const grading = buildGradingArtifact(result);
     const perTestTiming = buildTimingArtifact([result]);
+    const gradingPath = path.join(testDir, 'grading.json');
+    const perTestTimingPath = path.join(testDir, 'timing.json');
     mkdirSync(testDir, { recursive: true });
-    writeFileSync(path.join(testDir, 'grading.json'), `${JSON.stringify(grading, null, 2)}\n`);
-    writeFileSync(path.join(testDir, 'timing.json'), `${JSON.stringify(perTestTiming, null, 2)}\n`);
+    writeFileSync(gradingPath, `${JSON.stringify(grading, null, 2)}\n`);
+    writeFileSync(perTestTimingPath, `${JSON.stringify(perTestTiming, null, 2)}\n`);
+    let outputPath: string | undefined;
     if (result.output && result.output.length > 0) {
       const md = formatOutputMarkdown(result.output);
       mkdirSync(outputsDir, { recursive: true });
-      writeFileSync(path.join(outputsDir, 'response.md'), md);
+      outputPath = path.join(outputsDir, 'response.md');
+      writeFileSync(outputPath, md);
     }
+    let inputPath: string | undefined;
     const input = extractInput(result);
     if (input) {
-      writeFileSync(path.join(testDir, 'input.md'), input);
+      inputPath = path.join(testDir, 'input.md');
+      writeFileSync(inputPath, input);
     }
+    indexLines.push(
+      JSON.stringify(
+        buildIndexArtifactEntry(result, {
+          outputDir,
+          gradingPath,
+          timingPath: perTestTimingPath,
+          outputPath,
+          inputPath,
+        }),
+      ),
+    );
   }
+
+  writeFileSync(path.join(outputDir, 'index.jsonl'), `${indexLines.join('\n')}\n`);
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────

--- a/apps/cli/test/commands/eval/artifact-writer.test.ts
+++ b/apps/cli/test/commands/eval/artifact-writer.test.ts
@@ -8,10 +8,12 @@ import {
   type AggregateGradingArtifact,
   type BenchmarkArtifact,
   type GradingArtifact,
+  type IndexArtifactEntry,
   type TimingArtifact,
   buildAggregateGradingArtifact,
   buildBenchmarkArtifact,
   buildGradingArtifact,
+  buildIndexArtifactEntry,
   buildTimingArtifact,
   parseJsonlResults,
   writeArtifacts,
@@ -409,6 +411,53 @@ describe('buildAggregateGradingArtifact', () => {
   });
 });
 
+describe('buildIndexArtifactEntry', () => {
+  it('reuses result fields and writes relative artifact pointers', () => {
+    const entry = buildIndexArtifactEntry(
+      makeResult({
+        testId: 'alpha',
+        target: 'claude',
+        eval_set: 'demo',
+        scores: [makeEvaluatorResult({ name: 'quality', score: 0.7 })],
+        executionStatus: 'quality_failure',
+        error: 'model drift',
+      }),
+      {
+        outputDir: '/tmp/artifacts',
+        gradingPath: '/tmp/artifacts/alpha/grading.json',
+        timingPath: '/tmp/artifacts/alpha/timing.json',
+        outputPath: '/tmp/artifacts/alpha/outputs/response.md',
+        inputPath: '/tmp/artifacts/alpha/input.md',
+      },
+    );
+
+    expect(JSON.parse(JSON.stringify(entry))).toEqual({
+      timestamp: '2026-03-13T00:00:00.000Z',
+      test_id: 'alpha',
+      eval_set: 'demo',
+      score: 0.9,
+      target: 'claude',
+      scores: [
+        {
+          name: 'quality',
+          type: 'llm-grader',
+          score: 0.7,
+          assertions: [
+            { text: 'criterion-a', passed: true },
+            { text: 'criterion-b', passed: false },
+          ],
+        },
+      ],
+      execution_status: 'quality_failure',
+      error: 'model drift',
+      grading_path: 'alpha/grading.json',
+      timing_path: 'alpha/timing.json',
+      output_path: 'alpha/outputs/response.md',
+      input_path: 'alpha/input.md',
+    });
+  });
+});
+
 // ---------------------------------------------------------------------------
 // JSONL parsing
 // ---------------------------------------------------------------------------
@@ -531,7 +580,13 @@ describe('writeArtifactsFromResults', () => {
 
     // Check per-test artifact directories
     const artifactEntries = await readdir(paths.testArtifactDir);
-    expect(artifactEntries.sort()).toEqual(['alpha', 'benchmark.json', 'beta', 'timing.json']);
+    expect(artifactEntries.sort()).toEqual([
+      'alpha',
+      'benchmark.json',
+      'beta',
+      'index.jsonl',
+      'timing.json',
+    ]);
 
     const alphaGrading: GradingArtifact = JSON.parse(
       await readFile(path.join(paths.testArtifactDir, 'alpha', 'grading.json'), 'utf8'),
@@ -548,6 +603,14 @@ describe('writeArtifactsFromResults', () => {
     const timing: TimingArtifact = JSON.parse(await readFile(paths.timingPath, 'utf8'));
     expect(timing.duration_ms).toBe(13000);
 
+    const indexLines = (await readFile(paths.indexPath, 'utf8'))
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as IndexArtifactEntry);
+    expect(indexLines).toHaveLength(2);
+    expect(indexLines[0]?.grading_path).toBe('alpha/grading.json');
+    expect(indexLines[0]?.timing_path).toBe('alpha/timing.json');
+
     // Check benchmark
     const benchmark: BenchmarkArtifact = JSON.parse(await readFile(paths.benchmarkPath, 'utf8'));
     expect(benchmark.metadata.eval_file).toBe('my-eval.yaml');
@@ -558,13 +621,14 @@ describe('writeArtifactsFromResults', () => {
     const paths = await writeArtifactsFromResults([], testDir);
 
     const artifactEntries = await readdir(paths.testArtifactDir);
-    expect(artifactEntries.sort()).toEqual(['benchmark.json', 'timing.json']);
+    expect(artifactEntries.sort()).toEqual(['benchmark.json', 'index.jsonl', 'timing.json']);
 
     const timing: TimingArtifact = JSON.parse(await readFile(paths.timingPath, 'utf8'));
     expect(timing.total_tokens).toBe(0);
 
     const benchmark: BenchmarkArtifact = JSON.parse(await readFile(paths.benchmarkPath, 'utf8'));
     expect(benchmark.notes).toContain('No results to summarize');
+    expect(await readFile(paths.indexPath, 'utf8')).toBe('');
   });
 
   it('writes grading.json and timing.json inside each test directory', async () => {
@@ -643,6 +707,7 @@ describe('writeArtifacts (from JSONL file)', () => {
 
     const artifactEntries = await readdir(paths.testArtifactDir);
     expect(artifactEntries).toContain('from-file');
+    expect(artifactEntries).toContain('index.jsonl');
 
     const timing: TimingArtifact = JSON.parse(await readFile(paths.timingPath, 'utf8'));
     expect(timing.duration_ms).toBe(12000);

--- a/apps/cli/test/commands/results/export.test.ts
+++ b/apps/cli/test/commands/results/export.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import type {
   BenchmarkArtifact,
   GradingArtifact,
+  IndexArtifactEntry,
   TimingArtifact,
 } from '../../../src/commands/eval/artifact-writer.js';
 import { exportResults } from '../../../src/commands/results/export.js';
@@ -127,6 +128,37 @@ describe('results export', () => {
     expect(benchmark.run_summary['gpt-4o'].pass_rate).toHaveProperty('stddev');
   });
 
+  it('should create index.jsonl with per-test artifact pointers', () => {
+    const outputDir = path.join(tempDir, 'output');
+    const resultWithInput = {
+      ...RESULT_FULL,
+      execution_status: 'ok',
+      input: [{ role: 'user', content: 'Hello' }],
+    };
+    const content = toJsonl(resultWithInput);
+
+    exportResults('test.jsonl', content, outputDir);
+
+    const indexPath = path.join(outputDir, 'index.jsonl');
+    expect(existsSync(indexPath)).toBe(true);
+
+    const entries = readFileSync(indexPath, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as IndexArtifactEntry);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      test_id: 'test-greeting',
+      target: 'gpt-4o',
+      execution_status: 'ok',
+      grading_path: 'test-greeting/grading.json',
+      timing_path: 'test-greeting/timing.json',
+      output_path: 'test-greeting/outputs/response.md',
+      input_path: 'test-greeting/input.md',
+    });
+  });
+
   it('should create per-test timing.json with run timing', () => {
     const outputDir = path.join(tempDir, 'output');
     const content = toJsonl(RESULT_FULL, RESULT_PARTIAL);
@@ -224,6 +256,7 @@ describe('results export', () => {
     exportResults('test.jsonl', content, outputDir);
 
     expect(existsSync(path.join(outputDir, 'benchmark.json'))).toBe(true);
+    expect(existsSync(path.join(outputDir, 'index.jsonl'))).toBe(true);
     expect(existsSync(path.join(outputDir, 'timing.json'))).toBe(false);
     expect(existsSync(path.join(outputDir, 'test-greeting', 'grading.json'))).toBe(true);
     expect(existsSync(path.join(outputDir, 'test-math', 'grading.json'))).toBe(true);

--- a/apps/web/src/content/docs/guides/skill-improvement-workflow.mdx
+++ b/apps/web/src/content/docs/guides/skill-improvement-workflow.mdx
@@ -269,6 +269,7 @@ If you've been using the Agent Skills skill-creator workflow, AgentV reads your 
 | `claude -p "prompt"` | `agentv eval evals.json --target claude` | Same eval, richer engine |
 | `grading.json` (read) | `<test-id>/grading.json` (write) | Same per-test schema, AgentV writes one grading file per test case |
 | `benchmark.json` (read) | `benchmark.json` (write) | Same schema, AgentV produces it |
+| n/a | `index.jsonl` (write) | AgentV-specific per-test manifest for filtering, retry, and replay workflows |
 | with-skill vs without-skill | `--target baseline --target candidate` | Structured comparison |
 | Graduate to richer evals | `agentv convert evals.json` → EVAL.yaml | Adds workspace, code graders, etc. |
 


### PR DESCRIPTION
Closes #737

## Summary
- add an AgentV-specific `index.jsonl` manifest alongside eval artifact workspaces
- keep records thin and pointer-oriented by reusing existing result fields plus relative artifact paths
- extend `results export` to emit the same manifest when input/output artifact files are present
- document the new manifest in the skill improvement workflow guide

## Verification
- `bun test apps/cli/test/commands/eval/artifact-writer.test.ts apps/cli/test/commands/results/export.test.ts apps/cli/test/commands/results/export-e2e-providers.test.ts`
- `bunx biome check apps/cli/src/commands/eval/artifact-writer.ts apps/cli/src/commands/eval/commands/run.ts apps/cli/src/commands/eval/run-eval.ts apps/cli/src/commands/results/export.ts apps/cli/test/commands/eval/artifact-writer.test.ts apps/cli/test/commands/results/export.test.ts apps/web/src/content/docs/guides/skill-improvement-workflow.mdx`
- pre-push hook on `git push` passed: build, typecheck, lint, test, validate:examples

## Red/Green UAT
- Red on `main`: running `bun --no-env-file apps/cli/dist/cli.js eval <tmp>/sample.eval.yaml --artifacts <tmp>/artifacts --out <tmp>/results.jsonl` produced `benchmark.json`, `case-alpha/grading.json`, `case-alpha/timing.json`, and `timing.json`, with no `index.jsonl` and no index line in the CLI summary.
- Green on this branch: the same command produced the same files plus `index.jsonl`; the CLI summary now prints the index path, and the manifest line included `test_id`, `target`, `score`, `scores`, `execution_status`, `grading_path`, and `timing_path`.