### PR TITLE
fix(cli): prevent pi-coding-agent from being bundled into dist

### DIFF
--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     'micromatch',
     '@mariozechner/pi-agent-core',
     '@mariozechner/pi-ai',
+    '@mariozechner/pi-coding-agent',
     '@github/copilot-sdk',
     '@openai/codex-sdk',
     '@anthropic-ai/claude-agent-sdk',


### PR DESCRIPTION
## Summary
- Added `@mariozechner/pi-coding-agent` to the tsup `external` list in `apps/cli/tsup.config.ts`
- Prevents esbuild from bundling pi-coding-agent (and its transitive dep pi-ai + undici) into the CLI dist when the optional peer dep is installed at build time
- Fixes `TypeError: undefined is not a constructor (evaluating 'new EnvHttpProxyAgent')` crash under Bun

## Root cause
`@mariozechner/pi-coding-agent` was missing from the CLI's tsup external list. When installed during the npm publish build, esbuild bundled it and pi-ai's top-level undici proxy setup code, which crashes under Bun because the bundled undici chunk doesn't export `EnvHttpProxyAgent`. Also reduced dist size from ~8.7 MB to ~2.7 MB.

## Test plan
- [x] RED: Global install v3.11.1 crashes with `TypeError: undefined is not a constructor (evaluating 'new EnvHttpProxyAgent')`
- [x] GREEN: Fixed build runs eval successfully (`✅ 1.000 PASS`)
- [x] Verified no `EnvHttpProxyAgent` or `registerBuiltInApiProviders` in dist
- [x] Verified both `import("@mariozechner/pi-coding-agent")` and `import("@mariozechner/pi-ai")` remain external runtime imports
- [x] Pre-push hooks pass (build, typecheck, lint, test, validate examples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)