### PR TITLE
fix(trace): migrate trace commands to exported trace sources

### DIFF
--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -645,8 +645,13 @@ async function runSingleEvalFile(params: {
     });
   }
 
-  // Create streaming observer for real-time OTel span export
-  const streamingObserver = otelExporter?.createStreamingObserver() ?? null;
+  // Use streaming spans only for live remote export. File exports should use
+  // post-hoc exportResult(result), which has the complete EvaluationResult and
+  // avoids cross-test interleaving issues under parallel execution.
+  const useStreamingObserver = !!(otelExporter && options.exportOtel);
+  const streamingObserver = useStreamingObserver
+    ? (otelExporter?.createStreamingObserver() ?? null)
+    : null;
   const results = await evaluationRunner({
     testFilePath,
     repoRoot,
@@ -681,6 +686,9 @@ async function runSingleEvalFile(params: {
     model: options.model,
     streamCallbacks: streamingObserver?.getStreamCallbacks(),
     onResult: async (result: EvaluationResult) => {
+      (
+        streamingObserver as { completeFromResult?: (result: EvaluationResult) => void } | null
+      )?.completeFromResult?.(result);
       // Finalize streaming observer span with score
       streamingObserver?.finalizeEvalCase(result.score, result.error);
 
@@ -829,9 +837,17 @@ export async function runEvalCommand(
     console.log(`Repository root: ${repoRoot}`);
   }
 
+  const usesDefaultArtifactWorkspace = !options.outPath;
+  const outputPath = options.outPath ? path.resolve(options.outPath) : buildDefaultOutputPath(cwd);
+  const defaultTraceFile =
+    usesDefaultArtifactWorkspace && !options.traceFile
+      ? path.join(path.dirname(outputPath), 'trace.jsonl')
+      : undefined;
+  const traceFilePath = options.traceFile ? path.resolve(options.traceFile) : defaultTraceFile;
+
   // Initialize OTel exporter if --export-otel flag is set or file export flags are used
   let otelExporter: OtelTraceExporterType | null = null;
-  const useFileExport = !!(options.otelFile || options.traceFile);
+  const useFileExport = !!(options.otelFile || traceFilePath);
 
   if (options.exportOtel || useFileExport) {
     try {
@@ -868,7 +884,7 @@ export async function runEvalCommand(
         captureContent,
         groupTurns: options.otelGroupTurns,
         otlpFilePath: options.otelFile ? path.resolve(options.otelFile) : undefined,
-        traceFilePath: options.traceFile ? path.resolve(options.traceFile) : undefined,
+        traceFilePath,
       });
 
       const initialized = await otelExporter.init();
@@ -886,8 +902,6 @@ export async function runEvalCommand(
     }
   }
 
-  const usesDefaultArtifactWorkspace = !options.outPath;
-  const outputPath = options.outPath ? path.resolve(options.outPath) : buildDefaultOutputPath(cwd);
   const primaryWritePath = usesDefaultArtifactWorkspace
     ? path.join(path.dirname(outputPath), LEGACY_RESULTS_FILENAME)
     : outputPath;
@@ -921,8 +935,8 @@ export async function runEvalCommand(
   if (options.otelFile) {
     console.log(`OTLP JSON file: ${path.resolve(options.otelFile)}`);
   }
-  if (options.traceFile) {
-    console.log(`Trace file: ${path.resolve(options.traceFile)}`);
+  if (traceFilePath) {
+    console.log(`Trace file: ${traceFilePath}`);
   }
 
   // Determine cache state after loading file metadata (need YAML config)

--- a/apps/cli/src/commands/trace/score.ts
+++ b/apps/cli/src/commands/trace/score.ts
@@ -9,12 +9,19 @@ import {
   type Provider,
   type ProviderRequest,
   type ProviderResponse,
-  type TraceSummary,
   createBuiltinRegistry,
   toCamelCaseDeep,
 } from '@agentv/core';
 import { command, oneOf, option, optional, positional, string } from 'cmd-ts';
-import { type RawResult, c, formatScore, loadResultFile, padLeft, padRight } from './utils.js';
+import {
+  type RawResult,
+  c,
+  formatScore,
+  loadResultFile,
+  padLeft,
+  padRight,
+  toTraceSummary,
+} from './utils.js';
 
 /**
  * Evaluator types that work without an LLM provider.
@@ -121,14 +128,6 @@ export function parseAssertSpec(spec: string): EvaluatorConfig {
         `Unsupported evaluator type: "${type}". Supported: ${SUPPORTED_TYPES.join(', ')}`,
       );
   }
-}
-
-/**
- * Convert a snake_case RawResult trace to camelCase TraceSummary.
- */
-function toTraceSummary(raw: RawResult): TraceSummary | undefined {
-  if (!raw.trace) return undefined;
-  return toCamelCaseDeep(raw.trace) as TraceSummary;
 }
 
 /**
@@ -300,8 +299,9 @@ export const traceScoreCommand = command({
   args: {
     file: positional({
       type: string,
-      displayName: 'result-file',
-      description: 'Path to JSONL result file',
+      displayName: 'trace-source',
+      description:
+        'Path to a run workspace, result manifest, simple trace JSONL, or OTLP JSON file',
     }),
     assert: option({
       type: string,
@@ -355,14 +355,14 @@ export const traceScoreCommand = command({
     if (traceRequired) {
       const hasTrace = results.some(
         (r) =>
-          r.trace ||
+          toTraceSummary(r) ||
           r.cost_usd !== undefined ||
           r.duration_ms !== undefined ||
           r.token_usage !== undefined,
       );
       if (!hasTrace) {
         console.error(
-          `${c.red}Error:${c.reset} Result file lacks trace data. Re-run eval with ${c.bold}--trace${c.reset} to capture trace summaries.`,
+          `${c.red}Error:${c.reset} Source lacks trace metrics. Export a trace file with ${c.bold}--trace-file${c.reset} or ${c.bold}--otel-file${c.reset}.`,
         );
         process.exit(1);
       }

--- a/apps/cli/src/commands/trace/show.ts
+++ b/apps/cli/src/commands/trace/show.ts
@@ -6,6 +6,8 @@ import {
   formatDuration,
   formatNumber,
   formatScore,
+  getTraceSpans,
+  getTraceSummary,
   loadResultFile,
 } from './utils.js';
 
@@ -13,7 +15,7 @@ import {
  * Render flat trace summary line (fallback when full output messages not available).
  */
 function renderFlatTrace(result: RawResult): string {
-  const trace = result.trace;
+  const trace = getTraceSummary(result);
   const parts: string[] = [];
 
   if (trace?.tool_calls && Object.keys(trace.tool_calls).length > 0) {
@@ -81,10 +83,18 @@ interface RawToolCall {
  */
 function renderTree(result: RawResult): string {
   const messages = result.output as RawMessage[] | undefined;
+  const spans = getTraceSpans(result);
 
   if (!messages || messages.length === 0) {
+    if (spans.length > 0) {
+      return renderSpanTree(result, spans);
+    }
     // Fallback to flat summary
-    if (result.trace || result.duration_ms !== undefined || result.cost_usd !== undefined) {
+    if (
+      getTraceSummary(result) ||
+      result.duration_ms !== undefined ||
+      result.cost_usd !== undefined
+    ) {
       return renderFlatTrace(result);
     }
     return `${c.dim}No trace data available${c.reset}`;
@@ -161,6 +171,36 @@ function renderTree(result: RawResult): string {
   }
 
   // Scores line
+  if (result.scores && result.scores.length > 0) {
+    lines.push('');
+    lines.push(`${c.dim}Scores:${c.reset} ${renderScores(result.scores)}`);
+  }
+
+  return lines.join('\n');
+}
+
+function renderSpanTree(result: RawResult, spans: ReturnType<typeof getTraceSpans>): string {
+  const lines: string[] = [];
+  const testId = result.test_id ?? result.eval_id ?? 'unknown';
+  const totalTokens = result.token_usage
+    ? result.token_usage.input + result.token_usage.output
+    : undefined;
+  const rootParts: string[] = [testId];
+  if (result.duration_ms !== undefined) rootParts.push(formatDuration(result.duration_ms));
+  if (totalTokens !== undefined) rootParts.push(`${formatNumber(totalTokens)} tok`);
+  if (result.cost_usd !== undefined) rootParts.push(formatCost(result.cost_usd));
+  lines.push(`${c.bold}${rootParts.join(', ')}${c.reset}`);
+
+  spans.forEach((span, index) => {
+    const connector = index === spans.length - 1 ? '└─' : '├─';
+    const color = span.type === 'llm' ? c.cyan : c.yellow;
+    const parts = [`${color}${span.name}${c.reset}`];
+    if (span.duration_ms !== undefined) {
+      parts.push(formatDuration(span.duration_ms));
+    }
+    lines.push(`${connector} ${parts.join(', ')}`);
+  });
+
   if (result.scores && result.scores.length > 0) {
     lines.push('');
     lines.push(`${c.dim}Scores:${c.reset} ${renderScores(result.scores)}`);
@@ -278,8 +318,9 @@ export const traceShowCommand = command({
   args: {
     file: positional({
       type: string,
-      displayName: 'result-file',
-      description: 'Path to JSONL result file',
+      displayName: 'trace-source',
+      description:
+        'Path to a run workspace, result manifest, simple trace JSONL, or OTLP JSON file',
     }),
     testId: option({
       type: optional(string),
@@ -288,7 +329,7 @@ export const traceShowCommand = command({
     }),
     tree: flag({
       long: 'tree',
-      description: 'Show hierarchical trace tree (requires results with --trace output)',
+      description: 'Show hierarchical trace tree from output messages or exported trace spans',
     }),
     format: option({
       type: optional(oneOf(['table', 'json'])),

--- a/apps/cli/src/commands/trace/stats.ts
+++ b/apps/cli/src/commands/trace/stats.ts
@@ -5,6 +5,7 @@ import {
   c,
   formatCost,
   formatNumber,
+  getTraceSummary,
   loadResultFile,
   padLeft,
   padRight,
@@ -75,7 +76,7 @@ function collectMetrics(results: RawResult[]): MetricRow[] {
 
   // Tool calls
   const toolCalls = results
-    .map((r) => r.trace?.event_count)
+    .map((r) => getTraceSummary(r)?.event_count)
     .filter((v): v is number => v !== undefined);
   if (toolCalls.length > 0) {
     rows.push({ name: 'tool_calls', values: toolCalls, formatter: (n) => String(Math.round(n)) });
@@ -83,7 +84,7 @@ function collectMetrics(results: RawResult[]): MetricRow[] {
 
   // LLM calls
   const llmCalls = results
-    .map((r) => r.trace?.llm_call_count)
+    .map((r) => getTraceSummary(r)?.llm_call_count)
     .filter((v): v is number => v !== undefined);
   if (llmCalls.length > 0) {
     rows.push({ name: 'llm_calls', values: llmCalls, formatter: (n) => String(Math.round(n)) });
@@ -216,8 +217,9 @@ export const traceStatsCommand = command({
   args: {
     file: positional({
       type: string,
-      displayName: 'result-file',
-      description: 'Path to JSONL result file',
+      displayName: 'trace-source',
+      description:
+        'Path to a run workspace, result manifest, simple trace JSONL, or OTLP JSON file',
     }),
     groupBy: option({
       type: optional(oneOf(['target', 'eval-set', 'test-id'])),

--- a/apps/cli/src/commands/trace/utils.ts
+++ b/apps/cli/src/commands/trace/utils.ts
@@ -1,12 +1,14 @@
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
+import type { EvaluationResult, TraceSummary } from '@agentv/core';
+import { toCamelCaseDeep } from '@agentv/core';
 import {
   LEGACY_RESULTS_FILENAME,
   RESULT_INDEX_FILENAME,
   resolveExistingRunPrimaryPath,
-  resolveExistingRunTracePath,
   resolveWorkspaceOrFilePath,
 } from '../eval/result-layout.js';
+import { loadManifestResults } from '../results/manifest.js';
 
 // ANSI color codes (no dependency needed)
 const colors = {
@@ -65,6 +67,7 @@ export interface RawResult {
   end_time?: string;
   input?: unknown;
   output?: unknown;
+  spans?: RawTraceSpan[];
   trials?: unknown[];
   aggregation?: unknown;
   file_changes?: string;
@@ -90,12 +93,49 @@ export interface RawTraceSummary {
   duration_ms?: number;
 }
 
+export interface RawTraceSpan {
+  type?: 'tool' | 'llm' | string;
+  name: string;
+  duration_ms?: number;
+}
+
 /**
- * Load all result records from a JSONL file.
+ * Load all result or trace records from a supported source.
+ *
+ * Supported sources:
+ * - Run workspace directories / index.jsonl manifests (summary fallback)
+ * - Legacy results.jsonl files (explicit path only)
+ * - Simple trace JSONL files written via --trace-file
+ * - OTLP JSON trace files written via --otel-file
  */
 export function loadResultFile(filePath: string): RawResult[] {
   const resolvedFilePath = resolveTraceResultPath(filePath);
-  const content = readFileSync(resolvedFilePath, 'utf8');
+
+  if (path.extname(resolvedFilePath) === '.json') {
+    return loadOtlpTraceFile(resolvedFilePath);
+  }
+
+  if (path.basename(resolvedFilePath) === RESULT_INDEX_FILENAME) {
+    return loadManifestAsRawResults(resolvedFilePath);
+  }
+
+  return loadJsonlRecords(resolvedFilePath);
+}
+
+function resolveTraceResultPath(filePath: string): string {
+  if (path.basename(filePath) === LEGACY_RESULTS_FILENAME) {
+    return filePath;
+  }
+
+  if (!filePath.endsWith('.jsonl') && !filePath.endsWith('.json')) {
+    return resolveWorkspaceOrFilePath(filePath);
+  }
+
+  return resolveWorkspaceOrFilePath(filePath);
+}
+
+function loadJsonlRecords(filePath: string): RawResult[] {
+  const content = readFileSync(filePath, 'utf8');
   const lines = content
     .trim()
     .split('\n')
@@ -110,26 +150,358 @@ export function loadResultFile(filePath: string): RawResult[] {
   });
 }
 
-function resolveTraceResultPath(filePath: string): string {
-  if (path.basename(filePath) === RESULT_INDEX_FILENAME) {
-    const legacySibling = path.join(path.dirname(filePath), LEGACY_RESULTS_FILENAME);
-    try {
-      statSync(legacySibling);
-      return legacySibling;
-    } catch {
-      return filePath;
+function loadManifestAsRawResults(filePath: string): RawResult[] {
+  return loadManifestResults(filePath).map(toRawResult);
+}
+
+function toRawResult(result: EvaluationResult): RawResult {
+  return {
+    timestamp: result.timestamp,
+    test_id: result.testId,
+    eval_set: result.eval_set,
+    conversation_id: result.conversationId,
+    score: result.score,
+    assertions: result.assertions?.map((assertion) => ({
+      text: assertion.text,
+      passed: assertion.passed,
+      evidence: assertion.evidence,
+    })),
+    target: result.target,
+    error: result.error,
+    scores: result.scores?.map((score) => ({
+      name: score.name,
+      type: score.type,
+      score: score.score,
+      assertions: score.assertions?.map((assertion) => ({
+        text: assertion.text,
+        passed: assertion.passed,
+        evidence: assertion.evidence,
+      })),
+      weight: score.weight,
+    })),
+    token_usage: result.tokenUsage
+      ? {
+          input: result.tokenUsage.input,
+          output: result.tokenUsage.output,
+          cached: result.tokenUsage.cached,
+        }
+      : undefined,
+    cost_usd: result.costUsd,
+    duration_ms: result.durationMs,
+    start_time: result.startTime,
+    end_time: result.endTime,
+    input: result.input,
+    output: result.output,
+    file_changes: result.fileChanges,
+  };
+}
+
+type OtlpAttributeValue =
+  | { stringValue?: string; intValue?: number | string; doubleValue?: number; boolValue?: boolean }
+  | { arrayValue?: { values?: OtlpAttributeValue[] } };
+
+interface OtlpAttribute {
+  key: string;
+  value: OtlpAttributeValue;
+}
+
+interface OtlpEvent {
+  name?: string;
+  attributes?: OtlpAttribute[];
+}
+
+interface OtlpSpan {
+  traceId?: string;
+  spanId?: string;
+  parentSpanId?: string;
+  name?: string;
+  startTimeUnixNano?: string;
+  endTimeUnixNano?: string;
+  attributes?: OtlpAttribute[];
+  status?: { code?: number; message?: string };
+  events?: OtlpEvent[];
+}
+
+function loadOtlpTraceFile(filePath: string): RawResult[] {
+  const parsed = JSON.parse(readFileSync(filePath, 'utf8')) as {
+    resourceSpans?: { scopeSpans?: { spans?: OtlpSpan[] }[] }[];
+  };
+
+  const spans = parsed.resourceSpans
+    ?.flatMap((resource) => resource.scopeSpans ?? [])
+    .flatMap((scope) => scope.spans ?? []);
+
+  if (!spans || spans.length === 0) {
+    return [];
+  }
+
+  const spanMap = new Map<string, OtlpSpan>();
+  const childMap = new Map<string, OtlpSpan[]>();
+
+  for (const span of spans) {
+    if (!span.spanId) continue;
+    spanMap.set(span.spanId, span);
+    if (span.parentSpanId) {
+      const siblings = childMap.get(span.parentSpanId) ?? [];
+      siblings.push(span);
+      childMap.set(span.parentSpanId, siblings);
     }
   }
 
-  if (path.basename(filePath) === LEGACY_RESULTS_FILENAME) {
-    return filePath;
+  const roots = spans.filter((span) => !span.parentSpanId || !spanMap.has(span.parentSpanId));
+
+  return roots.map((root, index) => {
+    const descendants = collectChildSpans(root.spanId, childMap);
+    const rootAttrs = parseOtlpAttributes(root.attributes);
+    const parsedDescendants = descendants.map((span) => ({
+      ...span,
+      parsedAttributes: parseOtlpAttributes(span.attributes),
+    }));
+    const toolSpans = parsedDescendants.filter(
+      (span) => typeof span.parsedAttributes.gen_ai_tool_name === 'string',
+    );
+    const llmSpans = parsedDescendants.filter(
+      (span) =>
+        span.parsedAttributes.gen_ai_operation_name === 'chat' ||
+        (typeof span.name === 'string' && span.name.startsWith('chat ')),
+    );
+    const tokenUsage = descendants.reduce(
+      (acc, span) => {
+        const attrs = parseOtlpAttributes(span.attributes);
+        acc.input += numberAttr(attrs.gen_ai_usage_input_tokens) ?? 0;
+        acc.output += numberAttr(attrs.gen_ai_usage_output_tokens) ?? 0;
+        const cached = numberAttr(attrs.gen_ai_usage_cache_read_input_tokens);
+        if (cached !== undefined && cached > 0) {
+          acc.cached = (acc.cached ?? 0) + cached;
+        }
+        return acc;
+      },
+      { input: 0, output: 0, cached: undefined as number | undefined },
+    );
+
+    const traceSummary = buildDerivedTraceSummary({
+      trace: {
+        event_count:
+          numberAttr(rootAttrs.agentv_trace_event_count) ??
+          (toolSpans.length > 0 ? toolSpans.length : undefined),
+        tool_calls: countRawSpanNames(
+          toolSpans.map((span) => ({
+            type: 'tool',
+            name: String(span.parsedAttributes.gen_ai_tool_name),
+          })),
+        ),
+        error_count: descendants.filter((span) => span.status?.code === 2).length || undefined,
+        llm_call_count:
+          numberAttr(rootAttrs.agentv_trace_llm_call_count) ??
+          (llmSpans.length > 0 ? llmSpans.length : undefined),
+      },
+      spans: [
+        ...llmSpans.map((span) => ({
+          type: 'llm' as const,
+          name: span.name ?? 'chat',
+          duration_ms: durationFromSpan(span),
+        })),
+        ...toolSpans.map((span) => ({
+          type: 'tool' as const,
+          name: String(span.parsedAttributes.gen_ai_tool_name),
+          duration_ms: durationFromSpan(span),
+        })),
+      ],
+      duration_ms: numberAttr(rootAttrs.agentv_trace_duration_ms) ?? durationFromSpan(root),
+      cost_usd: numberAttr(rootAttrs.agentv_trace_cost_usd),
+      token_usage:
+        tokenUsage.input ||
+        tokenUsage.output ||
+        tokenUsage.cached ||
+        numberAttr(rootAttrs.agentv_trace_token_input) ||
+        numberAttr(rootAttrs.agentv_trace_token_output) ||
+        numberAttr(rootAttrs.agentv_trace_token_cached)
+          ? {
+              input: tokenUsage.input || numberAttr(rootAttrs.agentv_trace_token_input) || 0,
+              output: tokenUsage.output || numberAttr(rootAttrs.agentv_trace_token_output) || 0,
+              ...(tokenUsage.cached || numberAttr(rootAttrs.agentv_trace_token_cached)
+                ? {
+                    cached:
+                      tokenUsage.cached || numberAttr(rootAttrs.agentv_trace_token_cached) || 0,
+                  }
+                : {}),
+            }
+          : undefined,
+    });
+
+    const score = numberAttr(rootAttrs.agentv_score);
+    if (score === undefined) {
+      throw new Error(
+        `Unsupported OTLP trace root span at index ${index + 1}: missing agentv.score attribute`,
+      );
+    }
+
+    return {
+      test_id:
+        stringAttr(rootAttrs.agentv_test_id) ??
+        stringAttr(rootAttrs.agentv_eval_id) ??
+        `trace-${index + 1}`,
+      eval_set: stringAttr(rootAttrs.agentv_eval_set),
+      target: stringAttr(rootAttrs.agentv_target),
+      score,
+      error: root.status?.code === 2 ? root.status.message : undefined,
+      cost_usd: traceSummary?.cost_usd,
+      duration_ms: traceSummary?.duration_ms,
+      token_usage: traceSummary?.token_usage,
+      trace: traceSummary
+        ? {
+            event_count: traceSummary.event_count,
+            tool_calls: traceSummary.tool_calls,
+            error_count: traceSummary.error_count,
+            tool_durations: traceSummary.tool_durations,
+            llm_call_count: traceSummary.llm_call_count,
+            token_usage: traceSummary.token_usage,
+            cost_usd: traceSummary.cost_usd,
+            duration_ms: traceSummary.duration_ms,
+          }
+        : undefined,
+      spans: traceSummary?.spans,
+      output: stringAttr(rootAttrs.agentv_output_text),
+      scores: root.events
+        ?.filter((event) => event.name?.startsWith('agentv.evaluator.'))
+        .map((event) => {
+          const attrs = parseOtlpAttributes(event.attributes);
+          const name = event.name?.replace(/^agentv\.evaluator\./, '') ?? 'unknown';
+          return {
+            name,
+            type: stringAttr(attrs.agentv_evaluator_type) ?? 'unknown',
+            score: numberAttr(attrs.agentv_evaluator_score) ?? 0,
+          };
+        }),
+    } satisfies RawResult;
+  });
+}
+
+function collectChildSpans(
+  spanId: string | undefined,
+  childMap: Map<string, OtlpSpan[]>,
+): OtlpSpan[] {
+  if (!spanId) return [];
+  const direct = childMap.get(spanId) ?? [];
+  const all = [...direct];
+  for (const child of direct) {
+    all.push(...collectChildSpans(child.spanId, childMap));
+  }
+  return all;
+}
+
+function parseOtlpAttributes(attributes: OtlpAttribute[] | undefined): Record<string, unknown> {
+  const parsed: Record<string, unknown> = {};
+  for (const attribute of attributes ?? []) {
+    parsed[attribute.key.replace(/\./g, '_')] = parseOtlpValue(attribute.value);
+  }
+  return parsed;
+}
+
+function parseOtlpValue(value: OtlpAttributeValue | undefined): unknown {
+  if (!value) return undefined;
+  if ('stringValue' in value && value.stringValue !== undefined) return value.stringValue;
+  if ('intValue' in value && value.intValue !== undefined) return Number(value.intValue);
+  if ('doubleValue' in value && value.doubleValue !== undefined) return value.doubleValue;
+  if ('boolValue' in value && value.boolValue !== undefined) return value.boolValue;
+  if ('arrayValue' in value)
+    return (value.arrayValue?.values ?? []).map((entry) => parseOtlpValue(entry));
+  return undefined;
+}
+
+function durationFromSpan(
+  span: Pick<OtlpSpan, 'startTimeUnixNano' | 'endTimeUnixNano'>,
+): number | undefined {
+  const start = Number(span.startTimeUnixNano);
+  const end = Number(span.endTimeUnixNano);
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return undefined;
+  return Math.round((end - start) / 1_000_000);
+}
+
+function stringAttr(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function numberAttr(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+interface DerivedTraceSummary extends RawTraceSummary {
+  spans?: RawTraceSpan[];
+}
+
+export function buildDerivedTraceSummary(result: {
+  trace?: RawTraceSummary;
+  spans?: RawTraceSpan[];
+  token_usage?: RawResult['token_usage'];
+  cost_usd?: number;
+  duration_ms?: number;
+}): DerivedTraceSummary | undefined {
+  const toolSpans = (result.spans ?? []).filter((span) => span.type === 'tool');
+  const llmSpans = (result.spans ?? []).filter((span) => span.type === 'llm');
+  const toolCalls = result.trace?.tool_calls ?? countRawSpanNames(toolSpans);
+  const toolDurations = result.trace?.tool_durations ?? groupRawSpanDurations(toolSpans);
+  const hasSpanData = (result.spans?.length ?? 0) > 0;
+  const eventCount = result.trace?.event_count ?? (hasSpanData ? toolSpans.length : undefined);
+  const llmCallCount = result.trace?.llm_call_count ?? (hasSpanData ? llmSpans.length : undefined);
+
+  if (
+    !result.trace &&
+    !result.spans?.length &&
+    result.token_usage === undefined &&
+    result.cost_usd === undefined &&
+    result.duration_ms === undefined
+  ) {
+    return undefined;
   }
 
-  if (!filePath.endsWith('.jsonl')) {
-    return resolveExistingRunTracePath(filePath) ?? resolveWorkspaceOrFilePath(filePath);
-  }
+  return {
+    event_count: eventCount,
+    tool_calls: toolCalls,
+    error_count: result.trace?.error_count,
+    tool_durations: toolDurations,
+    llm_call_count: llmCallCount,
+    token_usage: result.trace?.token_usage ?? result.token_usage,
+    cost_usd: result.trace?.cost_usd ?? result.cost_usd,
+    duration_ms: result.trace?.duration_ms ?? result.duration_ms,
+    spans: result.spans,
+  };
+}
 
-  return resolveWorkspaceOrFilePath(filePath);
+function countRawSpanNames(spans: RawTraceSpan[]): Record<string, number> | undefined {
+  const counts: Record<string, number> = {};
+  for (const span of spans) {
+    counts[span.name] = (counts[span.name] ?? 0) + 1;
+  }
+  return Object.keys(counts).length > 0 ? counts : undefined;
+}
+
+function groupRawSpanDurations(spans: RawTraceSpan[]): Record<string, number[]> | undefined {
+  const grouped: Record<string, number[]> = {};
+  for (const span of spans) {
+    if (span.duration_ms === undefined) continue;
+    const existing = grouped[span.name] ?? [];
+    existing.push(span.duration_ms);
+    grouped[span.name] = existing;
+  }
+  return Object.keys(grouped).length > 0 ? grouped : undefined;
+}
+
+export function getTraceSummary(result: RawResult): RawTraceSummary | undefined {
+  const derived = buildDerivedTraceSummary(result);
+  if (!derived) return undefined;
+  const { spans: _spans, ...trace } = derived;
+  return trace;
+}
+
+export function getTraceSpans(result: RawResult): RawTraceSpan[] {
+  return buildDerivedTraceSummary(result)?.spans ?? [];
+}
+
+export function toTraceSummary(result: RawResult): TraceSummary | undefined {
+  const rawTrace = getTraceSummary(result);
+  if (!rawTrace) return undefined;
+  return toCamelCaseDeep(rawTrace) as TraceSummary;
 }
 
 /**

--- a/apps/cli/test/commands/trace/trace.test.ts
+++ b/apps/cli/test/commands/trace/trace.test.ts
@@ -56,6 +56,80 @@ const RESULT_FAILING = JSON.stringify({
   error: 'Agent timed out.',
 });
 
+const SIMPLE_TRACE = JSON.stringify({
+  test_id: 'trace-1',
+  target: 'default',
+  score: 0.9,
+  duration_ms: 1800,
+  cost_usd: 0.02,
+  token_usage: { input: 120, output: 80 },
+  spans: [
+    { type: 'llm', name: 'chat gpt-5-mini', duration_ms: 700 },
+    { type: 'tool', name: 'read_file', duration_ms: 200 },
+    { type: 'tool', name: 'read_file', duration_ms: 150 },
+  ],
+});
+
+const OTLP_TRACE = JSON.stringify({
+  resourceSpans: [
+    {
+      scopeSpans: [
+        {
+          spans: [
+            {
+              traceId: 'trace-abc',
+              spanId: 'root-1',
+              name: 'agentv.eval',
+              startTimeUnixNano: '1000000000',
+              endTimeUnixNano: '4000000000',
+              attributes: [
+                { key: 'agentv.test_id', value: { stringValue: 'otlp-1' } },
+                { key: 'agentv.target', value: { stringValue: 'default' } },
+                { key: 'agentv.score', value: { doubleValue: 0.8 } },
+                { key: 'agentv.trace.cost_usd', value: { doubleValue: 0.03 } },
+              ],
+              status: { code: 1 },
+              events: [
+                {
+                  name: 'agentv.evaluator.execution',
+                  attributes: [
+                    { key: 'agentv.evaluator.type', value: { stringValue: 'execution-metrics' } },
+                    { key: 'agentv.evaluator.score', value: { doubleValue: 1 } },
+                  ],
+                },
+              ],
+            },
+            {
+              traceId: 'trace-abc',
+              spanId: 'chat-1',
+              parentSpanId: 'root-1',
+              name: 'chat gpt-5-mini',
+              startTimeUnixNano: '1000000000',
+              endTimeUnixNano: '2500000000',
+              attributes: [
+                { key: 'gen_ai.operation.name', value: { stringValue: 'chat' } },
+                { key: 'gen_ai.usage.input_tokens', value: { intValue: 50 } },
+                { key: 'gen_ai.usage.output_tokens', value: { intValue: 25 } },
+              ],
+              status: { code: 1 },
+            },
+            {
+              traceId: 'trace-abc',
+              spanId: 'tool-1',
+              parentSpanId: 'chat-1',
+              name: 'execute_tool read_file',
+              startTimeUnixNano: '2500000000',
+              endTimeUnixNano: '3000000000',
+              attributes: [{ key: 'gen_ai.tool.name', value: { stringValue: 'read_file' } }],
+              status: { code: 1 },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
 describe('trace utils', () => {
   let tempDir: string;
 
@@ -115,17 +189,18 @@ describe('trace utils', () => {
       expect(() => loadResultFile(filePath)).toThrow('Missing or invalid score');
     });
 
-    it('prefers legacy results.jsonl when loading a workspace directory', () => {
+    it('loads workspace directories from index.jsonl instead of falling back to results.jsonl', () => {
       writeFileSync(path.join(tempDir, 'index.jsonl'), `${RESULT_WITHOUT_TRACE}\n`);
       writeFileSync(path.join(tempDir, 'results.jsonl'), `${RESULT_WITH_TRACE}\n`);
 
       const results = loadResultFile(tempDir);
 
       expect(results).toHaveLength(1);
-      expect(results[0].trace?.event_count).toBe(5);
+      expect(results[0].test_id).toBe('test-2');
+      expect(results[0].trace).toBeUndefined();
     });
 
-    it('prefers legacy results.jsonl when pointed at index.jsonl directly', () => {
+    it('loads index.jsonl directly without resolving the legacy results sibling', () => {
       const indexPath = path.join(tempDir, 'index.jsonl');
       writeFileSync(indexPath, `${RESULT_WITHOUT_TRACE}\n`);
       writeFileSync(path.join(tempDir, 'results.jsonl'), `${RESULT_WITH_TRACE}\n`);
@@ -133,7 +208,38 @@ describe('trace utils', () => {
       const results = loadResultFile(indexPath);
 
       expect(results).toHaveLength(1);
-      expect(results[0].trace?.tool_calls).toEqual({ read: 3, write: 2 });
+      expect(results[0].test_id).toBe('test-2');
+      expect(results[0].trace).toBeUndefined();
+    });
+
+    it('loads simple trace jsonl exports and keeps spans available for trace commands', () => {
+      const filePath = path.join(tempDir, 'trace.jsonl');
+      writeFileSync(filePath, `${SIMPLE_TRACE}\n`);
+
+      const results = loadResultFile(filePath);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].spans).toHaveLength(3);
+      expect(results[0].spans?.[1]).toEqual({
+        type: 'tool',
+        name: 'read_file',
+        duration_ms: 200,
+      });
+    });
+
+    it('loads otlp json exports and derives summary trace metrics from spans', () => {
+      const filePath = path.join(tempDir, 'otel.json');
+      writeFileSync(filePath, OTLP_TRACE);
+
+      const results = loadResultFile(filePath);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].test_id).toBe('otlp-1');
+      expect(results[0].duration_ms).toBe(3000);
+      expect(results[0].token_usage).toEqual({ input: 50, output: 25 });
+      expect(results[0].trace?.event_count).toBe(1);
+      expect(results[0].trace?.llm_call_count).toBe(1);
+      expect(results[0].trace?.tool_calls).toEqual({ read_file: 1 });
     });
   });
 

--- a/apps/web/src/content/docs/evaluation/running-evals.mdx
+++ b/apps/web/src/content/docs/evaluation/running-evals.mdx
@@ -77,6 +77,10 @@ agentv eval evals/my-eval.yaml --out results/baseline.jsonl
 
 Export execution traces (tool calls, timing, spans) to files for debugging and analysis:
 
+When AgentV writes to its default per-run workspace, it also writes a human-readable trace file at
+`<run-dir>/trace.jsonl` so `agentv trace` has a full-fidelity local trace source even when
+`index.jsonl` is the primary run manifest.
+
 ```bash
 # Human-readable JSONL trace (one record per test case)
 agentv eval evals/my-eval.yaml --trace-file traces/eval.jsonl

--- a/apps/web/src/content/docs/tools/trace.mdx
+++ b/apps/web/src/content/docs/tools/trace.mdx
@@ -5,7 +5,15 @@ sidebar:
   order: 5
 ---
 
-The `trace` command provides headless trace inspection and analysis — no server or dashboard needed. All data is read from local JSONL result files.
+The `trace` command provides headless trace inspection and analysis — no server or dashboard needed.
+
+Supported sources:
+
+- Run workspaces or `index.jsonl` manifests for summary-level fallback
+- Simple trace JSONL files written via `agentv eval --trace-file ...`
+- OTLP JSON files written via `agentv eval --otel-file ...`
+
+For full tool-call inspection, prefer exported trace files over eval manifests.
 
 ## Subcommands
 
@@ -24,13 +32,13 @@ Shows filename, test count, pass rate, average score, file size, and timestamp f
 Display evaluation results with trace details.
 
 ```bash
-agentv trace show <result-file> [--test-id <id>] [--tree] [--format json|table]
+agentv trace show <trace-source> [--test-id <id>] [--tree] [--format json|table]
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--test-id` | Filter to a specific test ID |
-| `--tree` | Show hierarchical trace tree (requires results with output messages) |
+| `--tree` | Show hierarchical trace tree from output messages or exported trace spans |
 | `--format`, `-f` | Output format: `table` (default), `json` |
 
 #### Tree View
@@ -55,7 +63,7 @@ Falls back to a flat summary when output messages are not present in the result 
 Compute summary statistics (percentiles) across evaluation results.
 
 ```bash
-agentv trace stats <result-file> [--group-by target|dataset|test-id] [--format json|table]
+agentv trace stats <trace-source> [--group-by target|dataset|test-id] [--format json|table]
 ```
 
 | Option | Description |
@@ -82,11 +90,11 @@ All commands support `--format json` for piping to `jq`:
 
 ```bash
 # Find tests costing more than $0.10
-agentv trace show results.jsonl --format json \
+agentv trace show trace.jsonl --format json \
   | jq '[.[] | select(.cost_usd > 0.10) | {test_id, score, cost: .cost_usd}]'
 
 # Compare providers
-agentv trace stats results.jsonl --group-by target --format json \
+agentv trace stats trace.jsonl --group-by target --format json \
   | jq '.groups[] | {label, score_mean: .metrics.score.mean}'
 ```
 

--- a/examples/features/trace-analysis/README.md
+++ b/examples/features/trace-analysis/README.md
@@ -8,30 +8,30 @@ Demonstrates `agentv trace` subcommands for headless trace inspection and analys
 # List result files
 bun agentv trace list
 
-# Show results with trace details from a run workspace
-bun agentv trace show .agentv/results/raw/eval_<timestamp>
+# Show results with trace details from the default exported trace file
+bun agentv trace show .agentv/results/raw/eval_<timestamp>/trace.jsonl
 
-# Show hierarchical trace tree (requires output messages)
-bun agentv trace show .agentv/results/raw/eval_<timestamp> --tree
+# Show hierarchical trace tree
+bun agentv trace show .agentv/results/raw/eval_<timestamp>/trace.jsonl --tree
 
 # Filter to a specific test
-bun agentv trace show .agentv/results/raw/eval_<timestamp> --test-id research-question --tree
+bun agentv trace show .agentv/results/raw/eval_<timestamp>/trace.jsonl --test-id research-question --tree
 
 # Compute percentile statistics
-bun agentv trace stats .agentv/results/raw/eval_<timestamp>
+bun agentv trace stats .agentv/results/raw/eval_<timestamp>/trace.jsonl
 
 # Group stats by target provider
-bun agentv trace stats .agentv/results/raw/eval_<timestamp> --group-by target
+bun agentv trace stats .agentv/results/raw/eval_<timestamp>/trace.jsonl --group-by target
 
 # JSON output for piping to jq
-bun agentv trace stats .agentv/results/raw/eval_<timestamp> --format json | jq '.groups[].metrics'
+bun agentv trace stats .agentv/results/raw/eval_<timestamp>/trace.jsonl --format json | jq '.groups[].metrics'
 ```
 
 ## What's in the Example Data
 
 The sample run workspace contains 5 test results from a multi-agent evaluation. `trace` accepts the
-workspace directory directly and falls back to the compatibility `results.jsonl` when full trace
-payloads are needed.
+workspace directory directly for summary fallback, but full tool-call inspection should read the
+exported `trace.jsonl` file.
 
 | Test ID | Score | Target | Trace |
 |---|---|---|---|
@@ -49,10 +49,10 @@ Pipe JSON output to `jq` for complex queries:
 
 ```bash
 # Find tests that cost more than $0.10
-bun agentv trace show .agentv/results/raw/eval_<timestamp> --format json \
+bun agentv trace show .agentv/results/raw/eval_<timestamp>/trace.jsonl --format json \
   | jq '[.[] | select(.cost_usd > 0.10) | {test_id, score, cost: .cost_usd}]'
 
 # Compare scores by target provider
-bun agentv trace stats .agentv/results/raw/eval_<timestamp> --group-by target --format json \
+bun agentv trace stats .agentv/results/raw/eval_<timestamp>/trace.jsonl --group-by target --format json \
   | jq '.groups[] | {label, score_mean: .metrics.score.mean}'
 ```

--- a/packages/core/src/observability/otel-exporter.ts
+++ b/packages/core/src/observability/otel-exporter.ts
@@ -203,6 +203,17 @@ export class OtelTraceExporter {
         if (result.durationMs != null)
           rootSpan.setAttribute('agentv.trace.duration_ms', result.durationMs);
         if (result.costUsd != null) rootSpan.setAttribute('agentv.trace.cost_usd', result.costUsd);
+        if (result.tokenUsage) {
+          if (result.tokenUsage.input != null) {
+            rootSpan.setAttribute('agentv.trace.token_input', result.tokenUsage.input);
+          }
+          if (result.tokenUsage.output != null) {
+            rootSpan.setAttribute('agentv.trace.token_output', result.tokenUsage.output);
+          }
+          if (result.tokenUsage.cached != null) {
+            rootSpan.setAttribute('agentv.trace.token_cached', result.tokenUsage.cached);
+          }
+        }
 
         // Trace summary attributes (tool-specific)
         if (result.trace) {
@@ -331,6 +342,7 @@ export class OtelTraceExporter {
       tracer.startActiveSpan(
         spanName,
         { startTime: startHr },
+        parentCtx,
         (span: {
           setAttribute: (...args: unknown[]) => void;
           end: (...args: unknown[]) => void;
@@ -371,6 +383,7 @@ export class OtelTraceExporter {
                 tracer.startActiveSpan(
                   `execute_tool ${tc.tool}`,
                   {},
+                  msgCtx,
                   (toolSpan: {
                     setAttribute: (...args: unknown[]) => void;
                     end: (...args: unknown[]) => void;
@@ -420,6 +433,17 @@ export class OtelStreamingObserver {
   private rootSpan: any = null;
   // biome-ignore lint/suspicious/noExplicitAny: OTel context loaded dynamically
   private rootCtx: any = null;
+  private observedChildSpans = false;
+  private pendingMetrics: {
+    durationMs?: number;
+    costUsd?: number;
+    tokenUsage?: ProviderTokenUsage;
+    trace?: {
+      eventCount: number;
+      toolCalls: Record<string, number>;
+      llmCallCount?: number;
+    };
+  } | null = null;
 
   constructor(
     private readonly tracer: Tracer,
@@ -431,6 +455,8 @@ export class OtelStreamingObserver {
 
   /** Create root eval span immediately (visible in backend right away) */
   startEvalCase(testId: string, target: string, evalSet?: string): void {
+    this.pendingMetrics = null;
+    this.observedChildSpans = false;
     const ctx = this.parentCtx ?? this.api.context.active();
     this.rootSpan = this.tracer.startSpan('agentv.eval', undefined, ctx);
     this.rootSpan.setAttribute('gen_ai.operation.name', 'evaluate');
@@ -450,8 +476,9 @@ export class OtelStreamingObserver {
     toolCallId?: string,
   ): void {
     if (!this.rootCtx) return;
+    this.observedChildSpans = true;
     this.api.context.with(this.rootCtx, () => {
-      const span = this.tracer.startSpan(`execute_tool ${name}`);
+      const span = this.tracer.startSpan(`execute_tool ${name}`, undefined, this.rootCtx);
       span.setAttribute('gen_ai.tool.name', name);
       if (toolCallId) span.setAttribute('gen_ai.tool.call.id', toolCallId);
       if (this.captureContent) {
@@ -473,8 +500,9 @@ export class OtelStreamingObserver {
   /** Create and immediately export an LLM span */
   onLlmCall(model: string, tokenUsage?: ProviderTokenUsage): void {
     if (!this.rootCtx) return;
+    this.observedChildSpans = true;
     this.api.context.with(this.rootCtx, () => {
-      const span = this.tracer.startSpan(`chat ${model}`);
+      const span = this.tracer.startSpan(`chat ${model}`, undefined, this.rootCtx);
       span.setAttribute('gen_ai.operation.name', 'chat');
       span.setAttribute('gen_ai.request.model', model);
       span.setAttribute('gen_ai.response.model', model);
@@ -490,10 +518,63 @@ export class OtelStreamingObserver {
     });
   }
 
+  /** Record final execution metrics before the root span is finalized. */
+  recordEvalMetrics(result: {
+    durationMs?: number;
+    costUsd?: number;
+    tokenUsage?: ProviderTokenUsage;
+    trace?: {
+      eventCount: number;
+      toolCalls: Record<string, number>;
+      llmCallCount?: number;
+    };
+  }): void {
+    this.pendingMetrics = result;
+  }
+
   /** Finalize root span with score/verdict after evaluation completes */
   finalizeEvalCase(score: number, error?: string): void {
     if (!this.rootSpan) return;
     this.rootSpan.setAttribute('agentv.score', score);
+    if (this.pendingMetrics?.durationMs != null) {
+      this.rootSpan.setAttribute('agentv.trace.duration_ms', this.pendingMetrics.durationMs);
+    }
+    if (this.pendingMetrics?.costUsd != null) {
+      this.rootSpan.setAttribute('agentv.trace.cost_usd', this.pendingMetrics.costUsd);
+    }
+    if (this.pendingMetrics?.tokenUsage) {
+      if (this.pendingMetrics.tokenUsage.input != null) {
+        this.rootSpan.setAttribute(
+          'agentv.trace.token_input',
+          this.pendingMetrics.tokenUsage.input,
+        );
+      }
+      if (this.pendingMetrics.tokenUsage.output != null) {
+        this.rootSpan.setAttribute(
+          'agentv.trace.token_output',
+          this.pendingMetrics.tokenUsage.output,
+        );
+      }
+      if (this.pendingMetrics.tokenUsage.cached != null) {
+        this.rootSpan.setAttribute(
+          'agentv.trace.token_cached',
+          this.pendingMetrics.tokenUsage.cached,
+        );
+      }
+    }
+    if (this.pendingMetrics?.trace) {
+      this.rootSpan.setAttribute('agentv.trace.event_count', this.pendingMetrics.trace.eventCount);
+      this.rootSpan.setAttribute(
+        'agentv.trace.tool_names',
+        Object.keys(this.pendingMetrics.trace.toolCalls).sort().join(','),
+      );
+      if (this.pendingMetrics.trace.llmCallCount != null) {
+        this.rootSpan.setAttribute(
+          'agentv.trace.llm_call_count',
+          this.pendingMetrics.trace.llmCallCount,
+        );
+      }
+    }
     if (error) {
       this.rootSpan.setStatus({ code: this.api.SpanStatusCode.ERROR, message: error });
     } else {
@@ -502,6 +583,41 @@ export class OtelStreamingObserver {
     this.rootSpan.end();
     this.rootSpan = null;
     this.rootCtx = null;
+    this.observedChildSpans = false;
+    this.pendingMetrics = null;
+  }
+
+  /** Backfill child spans from the completed result when the provider emitted no live callbacks. */
+  completeFromResult(result: EvaluationResult): void {
+    this.recordEvalMetrics({
+      durationMs: result.durationMs,
+      costUsd: result.costUsd,
+      tokenUsage: result.tokenUsage,
+      trace: result.trace,
+    });
+
+    if (this.observedChildSpans || !this.rootCtx) {
+      return;
+    }
+
+    const model =
+      result.output.find((msg) => msg.role === 'assistant')?.metadata?.model ??
+      result.target ??
+      'unknown';
+
+    this.onLlmCall(String(model), result.tokenUsage);
+
+    for (const message of result.output) {
+      for (const toolCall of message.toolCalls ?? []) {
+        this.onToolCall(
+          toolCall.tool,
+          toolCall.input,
+          toolCall.output,
+          toolCall.durationMs ?? 0,
+          toolCall.id,
+        );
+      }
+    }
   }
 
   /** Return the active eval span's trace ID and span ID for Braintrust trace bridging */

--- a/packages/core/src/observability/simple-trace-file-exporter.ts
+++ b/packages/core/src/observability/simple-trace-file-exporter.ts
@@ -15,6 +15,7 @@ export class SimpleTraceFileExporter {
   private streamReady: Promise<WriteStream> | null = null;
   private pendingWrites: Promise<void>[] = [];
   private _shuttingDown = false;
+  private spansByTraceId = new Map<string, ReadableSpan[]>();
 
   constructor(filePath: string) {
     this.filePath = filePath;
@@ -36,28 +37,27 @@ export class SimpleTraceFileExporter {
       resultCallback({ code: 0 });
       return;
     }
-    const spanMap = new Map<string, ReadableSpan>();
-    const childMap = new Map<string, ReadableSpan[]>();
-
+    const rootSpans: ReadableSpan[] = [];
     for (const span of spans) {
-      spanMap.set(span.spanContext().spanId, span);
-      const parentId = span.parentSpanId;
-      if (parentId) {
-        if (!childMap.has(parentId)) childMap.set(parentId, []);
-        childMap.get(parentId)?.push(span);
+      const traceId = span.spanContext().traceId;
+      const existing = this.spansByTraceId.get(traceId) ?? [];
+      existing.push(span);
+      this.spansByTraceId.set(traceId, existing);
+      if (span.name === 'agentv.eval') {
+        rootSpans.push(span);
       }
     }
 
-    // Root spans: no parent or parent not in this batch
-    const rootSpans = spans.filter(
-      (s: ReadableSpan) => !s.parentSpanId || !spanMap.has(s.parentSpanId),
-    );
-
     const writePromise = this.ensureStream().then((stream) => {
       for (const root of rootSpans) {
-        const children = this.collectChildren(root.spanContext().spanId, childMap);
+        const traceId = root.spanContext().traceId;
+        const traceSpans = this.spansByTraceId.get(traceId) ?? [root];
+        const children = traceSpans.filter(
+          (span) => span.spanContext().spanId !== root.spanContext().spanId,
+        );
         const record = this.buildSimpleRecord(root, children);
         stream.write(`${JSON.stringify(record)}\n`);
+        this.spansByTraceId.delete(traceId);
       }
     });
     this.pendingWrites.push(writePromise);
@@ -69,6 +69,7 @@ export class SimpleTraceFileExporter {
     this._shuttingDown = true;
     await Promise.all(this.pendingWrites);
     this.pendingWrites = [];
+    this.spansByTraceId.clear();
     return new Promise((resolve) => {
       if (this.stream) {
         this.stream.end(() => resolve());
@@ -83,18 +84,12 @@ export class SimpleTraceFileExporter {
     this.pendingWrites = [];
   }
 
-  private collectChildren(spanId: string, childMap: Map<string, ReadableSpan[]>): ReadableSpan[] {
-    const direct = childMap.get(spanId) || [];
-    const all: ReadableSpan[] = [...direct];
-    for (const child of direct) {
-      all.push(...this.collectChildren(child.spanContext().spanId, childMap));
-    }
-    return all;
-  }
-
   private buildSimpleRecord(root: ReadableSpan, children: ReadableSpan[]): Record<string, unknown> {
     const attrs = root.attributes || {};
-    const durationMs = hrTimeDiffMs(root.startTime, root.endTime);
+    const durationMs =
+      typeof attrs['agentv.trace.duration_ms'] === 'number'
+        ? attrs['agentv.trace.duration_ms']
+        : hrTimeDiffMs(root.startTime, root.endTime);
 
     let inputTokens = 0;
     let outputTokens = 0;
@@ -103,6 +98,24 @@ export class SimpleTraceFileExporter {
       if (ca['gen_ai.usage.input_tokens']) inputTokens += ca['gen_ai.usage.input_tokens'];
       if (ca['gen_ai.usage.output_tokens']) outputTokens += ca['gen_ai.usage.output_tokens'];
     }
+    const rootInputTokens =
+      typeof attrs['agentv.trace.token_input'] === 'number' ? attrs['agentv.trace.token_input'] : 0;
+    const rootOutputTokens =
+      typeof attrs['agentv.trace.token_output'] === 'number'
+        ? attrs['agentv.trace.token_output']
+        : 0;
+    const rootCachedTokens =
+      typeof attrs['agentv.trace.token_cached'] === 'number'
+        ? attrs['agentv.trace.token_cached']
+        : undefined;
+
+    const llmSpans = children
+      .filter((s: ReadableSpan) => s.attributes?.['gen_ai.operation.name'] === 'chat')
+      .map((s: ReadableSpan) => ({
+        type: 'llm' as const,
+        name: s.name,
+        duration_ms: hrTimeDiffMs(s.startTime, s.endTime),
+      }));
 
     const toolSpans = children
       .filter((s: ReadableSpan) => s.attributes?.['gen_ai.tool.name'])
@@ -119,8 +132,14 @@ export class SimpleTraceFileExporter {
       duration_ms: durationMs,
       cost_usd: attrs['agentv.trace.cost_usd'],
       token_usage:
-        inputTokens || outputTokens ? { input: inputTokens, output: outputTokens } : undefined,
-      spans: toolSpans.length > 0 ? toolSpans : undefined,
+        inputTokens || outputTokens || rootInputTokens || rootOutputTokens || rootCachedTokens
+          ? {
+              input: inputTokens || rootInputTokens,
+              output: outputTokens || rootOutputTokens,
+              ...(rootCachedTokens ? { cached: rootCachedTokens } : {}),
+            }
+          : undefined,
+      spans: [...llmSpans, ...toolSpans].length > 0 ? [...llmSpans, ...toolSpans] : undefined,
     };
   }
 }

--- a/packages/core/test/observability/file-exporters.test.ts
+++ b/packages/core/test/observability/file-exporters.test.ts
@@ -262,6 +262,63 @@ describe('SimpleTraceFileExporter', () => {
     expect(record.spans[0].duration_ms).toBe(200);
   });
 
+  it('buffers child spans across separate export calls until the root span closes', async () => {
+    const filePath = path.join(testDir, 'simple', 'streaming.jsonl');
+    const exporter = new SimpleTraceFileExporter(filePath);
+
+    const llmSpan = makeSpan({
+      traceId: 'stream-trace',
+      spanId: 'chat1',
+      parentSpanId: 'root1',
+      name: 'chat mock-model',
+      startTime: [1000, 0],
+      endTime: [1000, 500_000_000],
+      attributes: {
+        'gen_ai.operation.name': 'chat',
+        'gen_ai.usage.input_tokens': 40,
+        'gen_ai.usage.output_tokens': 20,
+      },
+    });
+
+    const toolSpan = makeSpan({
+      traceId: 'stream-trace',
+      spanId: 'tool1',
+      parentSpanId: 'root1',
+      name: 'execute_tool search',
+      startTime: [1000, 500_000_000],
+      endTime: [1000, 800_000_000],
+      attributes: { 'gen_ai.tool.name': 'search' },
+    });
+
+    const root = makeSpan({
+      traceId: 'stream-trace',
+      spanId: 'root1',
+      name: 'agentv.eval',
+      startTime: [1000, 0],
+      endTime: [1001, 0],
+      attributes: {
+        'agentv.test_id': 'streamed-test',
+        'agentv.target': 'mock-agent',
+        'agentv.score': 1,
+        'agentv.trace.cost_usd': 0.004,
+      },
+    });
+
+    exporter.export([llmSpan], (r) => expect(r.code).toBe(0));
+    exporter.export([toolSpan], (r) => expect(r.code).toBe(0));
+    exporter.export([root], (r) => expect(r.code).toBe(0));
+    await exporter.shutdown();
+
+    const record = JSON.parse((await readFile(filePath, 'utf8')).trim());
+    expect(record.test_id).toBe('streamed-test');
+    expect(record.token_usage).toEqual({ input: 40, output: 20 });
+    expect(record.cost_usd).toBe(0.004);
+    expect(record.spans).toEqual([
+      { type: 'llm', name: 'chat mock-model', duration_ms: 500 },
+      { type: 'tool', name: 'search', duration_ms: 300 },
+    ]);
+  });
+
   it('handles multiple root spans', async () => {
     const filePath = path.join(testDir, 'simple', 'multi.jsonl');
     const exporter = new SimpleTraceFileExporter(filePath);


### PR DESCRIPTION
Fixes #742

## Summary
- make trace commands load exported trace sources (simple trace JSONL and OTLP JSON) instead of relying on implicit workspace -> results.jsonl fallback
- add default trace.jsonl export in the default eval workspace
- make OTLP and simple trace exports carry complete execution metrics for trace show/stats/score
- update tests and docs for the new trace source model

## Verification
- pre-push checks passed during push (build, typecheck, lint, test, validate:examples)
- manual eval e2e verified against emitted trace artifacts
- manual trace show/stats/score verified against simple trace JSONL