### PR TITLE
feat: auto-set AGENTV_RUN_TIMESTAMP in eval runner

### DIFF
--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -763,6 +763,14 @@ export async function runEvalCommand(
 ): Promise<RunEvalResult | undefined> {
   const cwd = process.cwd();
 
+  // Set AGENTV_RUN_TIMESTAMP so CLI targets can group artifacts under the same run folder.
+  if (!process.env.AGENTV_RUN_TIMESTAMP) {
+    process.env.AGENTV_RUN_TIMESTAMP = new Date()
+      .toISOString()
+      .replace(/:/g, '-')
+      .replace(/\./g, '-');
+  }
+
   // Load agentv.config.ts (if present) for default values
   let config: Awaited<ReturnType<typeof loadTsConfig>> = null;
   try {

--- a/apps/cli/test/commands/eval/pipeline/fixtures/grader-score-1.js
+++ b/apps/cli/test/commands/eval/pipeline/fixtures/grader-score-1.js
@@ -1,0 +1,1 @@
+process.stdout.write(JSON.stringify({ score: 1 }));

--- a/apps/cli/test/commands/eval/pipeline/fixtures/input-test.eval.yaml
+++ b/apps/cli/test/commands/eval/pipeline/fixtures/input-test.eval.yaml
@@ -6,7 +6,7 @@ tests:
     assertions:
       - name: contains_hello
         type: code-grader
-        command: echo '{"score":1}'
+        command: node grader-score-1.js
         weight: 1.0
       - name: relevance
         type: llm-grader

--- a/plugins/agentv-dev/skills/agentv-bench/scripts/run_tests.py
+++ b/plugins/agentv-dev/skills/agentv-bench/scripts/run_tests.py
@@ -31,6 +31,7 @@ import sys
 import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -124,6 +125,10 @@ def main():
         "--workers", type=int, default=3, help="Parallel workers (default: 3)"
     )
     args = parser.parse_args()
+
+    if "AGENTV_RUN_TIMESTAMP" not in os.environ:
+        ts = datetime.now(timezone.utc).isoformat().replace(":", "-").replace(".", "-")
+        os.environ["AGENTV_RUN_TIMESTAMP"] = ts
 
     manifest = run_agentv_input(args.eval_path, args.out)
     out = Path(args.out)


### PR DESCRIPTION
## Summary
- Set `AGENTV_RUN_TIMESTAMP` env var at the start of `runEvalCommand` so all CLI target invocations in a run share the same timestamp folder for debug artifacts
- Also set it in `run_tests.py` for agent-mode eval runs
- Fix Windows pipeline e2e test: replace `echo '{"score":1}'` with a node script to avoid `cmd.exe` quoting issues

## Test plan
- [x] All core tests pass (1160 pass)
- [x] All CLI tests pass (341 pass)
- [x] Pipeline e2e test now passes on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)