### PR TITLE
feat(serve): start without results and add result picker

### DIFF
--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -166,20 +166,22 @@ export function createApp(
     });
   });
 
-  // Load results from a specific run file
+  // Load results from a specific run file.
+  // Security: we look up the filename against the enumerated file list rather than
+  // constructing a path from user input, preventing path traversal.
   app.get('/api/runs/:filename', (c) => {
     const filename = c.req.param('filename');
     const metas = listResultFiles(searchDir);
     const meta = metas.find((m) => m.filename === filename);
     if (!meta) {
-      return c.json({ error: `Run not found: ${filename}` }, 404);
+      return c.json({ error: 'Run not found' }, 404);
     }
     try {
       const loaded = patchTestIds(loadManifestResults(meta.path));
       const lightResults = stripHeavyFields(loaded);
-      return c.json({ results: lightResults, source: meta.path });
+      return c.json({ results: lightResults, source: meta.filename });
     } catch (err) {
-      return c.json({ error: `Failed to load run: ${(err as Error).message}` }, 500);
+      return c.json({ error: 'Failed to load run' }, 500);
     }
   });
 
@@ -268,17 +270,7 @@ function escapeHtml(s: string): string {
 }
 
 function generateServeHtml(results: readonly EvaluationResult[], sourceFile?: string): string {
-  const lightResults = results.map((r) => {
-    const { requests, trace, ...rest } = r as EvaluationResult & Record<string, unknown>;
-    const toolCalls =
-      trace?.toolCalls && Object.keys(trace.toolCalls).length > 0 ? trace.toolCalls : undefined;
-    const graderDurationMs = (r.scores ?? []).reduce((sum, s) => sum + (s.durationMs ?? 0), 0);
-    return {
-      ...rest,
-      ...(toolCalls && { _toolCalls: toolCalls }),
-      ...(graderDurationMs > 0 && { _graderDurationMs: graderDurationMs }),
-    };
-  });
+  const lightResults = stripHeavyFields(results);
   // Escape for safe embedding in <script>: prevent </script> breakout,
   // HTML comment injection, and Unicode line terminators.
   const dataJson = JSON.stringify(lightResults)
@@ -923,7 +915,7 @@ const SERVE_SCRIPT = `
       if(INITIAL_SOURCE&&runs.length>0){
         runPicker.value=INITIAL_SOURCE;
       }
-    }).catch(function(){});
+    }).catch(function(err){console.warn("Failed to refresh run list:",err);});
   }
 
   function loadRun(filename){

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -309,6 +309,23 @@ describe('serve app', () => {
       const app = createApp([], tempDir);
       const res = await app.request('/api/runs/nonexistent');
       expect(res.status).toBe(404);
+      const data = (await res.json()) as { error: string };
+      expect(data.error).toBe('Run not found');
+    });
+
+    it('loads results from an existing run file', async () => {
+      const runsDir = path.join(tempDir, '.agentv', 'results', 'runs');
+      mkdirSync(runsDir, { recursive: true });
+      const filename = 'eval_2026-03-25T10-00-00-000Z.jsonl';
+      writeFileSync(path.join(runsDir, filename), toJsonl(RESULT_A, RESULT_B));
+
+      const app = createApp([], tempDir, tempDir);
+      const res = await app.request(`/api/runs/${filename}`);
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { results: { testId: string }[]; source: string };
+      expect(data.results).toHaveLength(2);
+      expect(data.results[0].testId).toBe('test-greeting');
+      expect(data.source).toBe(filename);
     });
   });
 


### PR DESCRIPTION
## Summary

- `agentv serve` now starts successfully with no results in `.agentv/results/`, showing a welcome/empty state instead of crashing
- Dashboard includes a result picker dropdown in the header that lists available result files and allows switching between them without restarting
- New API endpoints: `GET /api/runs` (list runs with metadata) and `GET /api/runs/:filename` (load a specific run's results)
- Dashboard polls for new result files every 5 seconds and auto-loads the first run when starting from empty state

## Test plan

- [x] `agentv serve` starts successfully with no results (empty directory)
- [x] Dashboard shows welcome state with guidance message
- [x] Dashboard lists available result files when they exist
- [x] User can switch between result files via the picker dropdown
- [x] New result files are detected without manual refresh (5s polling)
- [x] All 1555 existing tests pass
- [x] 5 new tests added for empty state, /api/runs, and run picker
- [x] Typecheck and lint pass
- [x] Pre-push hooks all green

Closes #768