### PR TITLE
fix(cli): clean dist/templates before copying to prevent stale artifacts

### DIFF
--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -1,4 +1,4 @@
-import { cpSync } from 'node:fs';
+import { cpSync, rmSync } from 'node:fs';
 import path from 'node:path';
 import { defineConfig } from 'tsup';
 
@@ -30,6 +30,10 @@ export default defineConfig({
   onSuccess: async () => {
     const srcTemplatesDir = path.join('src', 'templates');
     const distTemplatesDir = path.join('dist', 'templates');
+
+    // Remove stale templates so externally-added files (e.g. plugin skills)
+    // don't survive builds and accidentally ship in the npm package
+    rmSync(distTemplatesDir, { recursive: true, force: true });
 
     // Copy entire templates directory structure recursively
     cpSync(srcTemplatesDir, distTemplatesDir, {


### PR DESCRIPTION
## Summary
- Adds `rmSync` to wipe `dist/templates/` before copying source templates in the tsup build hook
- Prevents externally-added files (e.g. locally installed plugin skills) from surviving builds and shipping in the npm package

## Root cause
tsup's `clean: true` only removes its own JS/map output, not the `dist/templates/` directory populated by the `onSuccess` hook. Files placed there by external tools (e.g. `allagents plugin install`) persisted across builds.

This is what caused the deprecated `assert:` field in bundled skill templates reported in #770 — those skill files weren't from source, they were stale local artifacts that got published.

Closes #770

## Test plan
- [x] Pre-push hooks pass (build, typecheck, lint, test, validate)
- [x] Verified `.agents/`, `.claude/`, `.github/` directories are removed after rebuild
- [x] Verified legitimate templates (`.agentv/`, `.env.example`) still present after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)