### PR TITLE
fix(pipeline): set AGENTV_RUN_TIMESTAMP so CLI targets share one output folder

### DIFF
--- a/apps/cli/src/commands/pipeline/run.ts
+++ b/apps/cli/src/commands/pipeline/run.ts
@@ -178,6 +178,13 @@ export const evalRunCommand = command({
     // ── Step 2: Invoke CLI targets in parallel ───────────────────────
     if (targetInfo) {
       const envVars = loadEnvFile(evalDir);
+      // Set AGENTV_RUN_TIMESTAMP so CLI targets group artifacts under one run folder.
+      if (!process.env.AGENTV_RUN_TIMESTAMP) {
+        process.env.AGENTV_RUN_TIMESTAMP = new Date()
+          .toISOString()
+          .replace(/:/g, '-')
+          .replace(/\./g, '-');
+      }
       const mergedEnv = { ...process.env, ...envVars };
       const maxWorkers = workers ?? testIds.length;
 


### PR DESCRIPTION
## Problem

\gentv pipeline run\ invoked CLI targets in parallel without setting \AGENTV_RUN_TIMESTAMP\, causing each test case to create a **separate timestamped output directory**. For a 5-test eval, this produced 5 output folders instead of 1.

The \gentv eval\ command (CLI mode) already sets this env var once at run start (\un-eval.ts:766-770\), so CLI mode doesn't have this issue.

## Fix

Apply the same pattern in \pipeline/run.ts\: set \AGENTV_RUN_TIMESTAMP\ once before invoking CLI targets, so all targets within a single pipeline run share one output folder.

## Verification

- All 349 tests pass
- Build, typecheck, lint all pass
- Pre-push hooks all pass