### PR TITLE
refactor(pipeline): simplify invoke.json to two paths

### DIFF
--- a/apps/cli/src/commands/pipeline/input.ts
+++ b/apps/cli/src/commands/pipeline/input.ts
@@ -130,8 +130,9 @@ export const evalInputCommand = command({
         metadata: test.metadata ?? {},
       });
 
-      // invoke.json — CLI targets get command info; non-CLI targets get agent
-      // mode unless subagent_mode_allowed: false forces CLI-based evaluation.
+      // invoke.json — CLI targets get command info; non-CLI targets get agent mode.
+      // The manifest carries subagent_mode_allowed so consumers (the bench skill)
+      // can decide whether to dispatch executor subagents or use `agentv eval`.
       if (targetInfo) {
         await writeJson(join(testDir, 'invoke.json'), {
           kind: 'cli',
@@ -140,19 +141,10 @@ export const evalInputCommand = command({
           timeout_ms: targetInfo.timeoutMs,
           env: {},
         });
-      } else if (subagentModeAllowed) {
+      } else {
         await writeJson(join(testDir, 'invoke.json'), {
           kind: 'agent',
           instructions: 'Execute this task in the current workspace. The agent IS the target.',
-        });
-      } else {
-        // Non-CLI provider with subagent_mode_allowed: false — use agentv eval
-        // CLI runner instead of executor subagents.
-        await writeJson(join(testDir, 'invoke.json'), {
-          kind: targetKind,
-          subagent_mode_allowed: false,
-          instructions:
-            'This target has subagent_mode_allowed: false. Use `agentv eval` CLI to run this target.',
         });
       }
 


### PR DESCRIPTION
## Summary
- Remove dead third invoke.json path that wrote `kind: "<provider>"` with `subagent_mode_allowed: false` — no consumer read this format
- `manifest.json` already carries `target.subagent_mode_allowed` so the bench skill decides execution mode from there

Follow-up to #804 based on code review feedback.

## Test plan
- [x] All 1610 tests pass
- [x] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)