### PR TITLE
fix: resolve lint errors and failing tests

### DIFF
--- a/apps/cli/src/commands/eval/shared.ts
+++ b/apps/cli/src/commands/eval/shared.ts
@@ -25,10 +25,7 @@ export async function resolveEvalPaths(evalPaths: string[], cwd: string): Promis
       }
       if (stats.isDirectory()) {
         // Auto-expand directory to recursive eval file glob
-        const dirGlob = path.posix.join(
-          candidatePath.replace(/\\/g, '/'),
-          '**/*.eval.{yaml,yml}',
-        );
+        const dirGlob = path.posix.join(candidatePath.replace(/\\/g, '/'), '**/*.eval.{yaml,yml}');
         const dirMatches = await fg(dirGlob, {
           absolute: true,
           onlyFiles: true,

--- a/apps/cli/test/commands/eval/artifact-writer.test.ts
+++ b/apps/cli/test/commands/eval/artifact-writer.test.ts
@@ -592,19 +592,13 @@ describe('writeArtifactsFromResults', () => {
     expect(alphaEntries.sort()).toEqual(['grading.json', 'outputs', 'timing.json']);
 
     const alphaGrading: GradingArtifact = JSON.parse(
-      await readFile(
-        path.join(paths.testArtifactDir, 'alpha', 'grading.json'),
-        'utf8',
-      ),
+      await readFile(path.join(paths.testArtifactDir, 'alpha', 'grading.json'), 'utf8'),
     );
     expect(alphaGrading.summary).toBeDefined();
     expect(alphaGrading.execution_metrics).toBeDefined();
 
     const alphaTiming: TimingArtifact = JSON.parse(
-      await readFile(
-        path.join(paths.testArtifactDir, 'alpha', 'timing.json'),
-        'utf8',
-      ),
+      await readFile(path.join(paths.testArtifactDir, 'alpha', 'timing.json'), 'utf8'),
     );
     expect(alphaTiming.duration_ms).toBe(5000);
 

--- a/apps/cli/test/commands/results/export-e2e-providers.test.ts
+++ b/apps/cli/test/commands/results/export-e2e-providers.test.ts
@@ -212,15 +212,10 @@ function toJsonl(...records: object[]): string {
 
 function artifactDir(
   outputDir: string,
-  record: { dataset?: string; test_id?: string; eval_id?: string; target?: string },
+  record: { dataset?: string; test_id?: string; eval_id?: string },
 ): string {
   const testId = record.test_id ?? record.eval_id ?? 'unknown';
-  return path.join(
-    outputDir,
-    ...(record.dataset ? [record.dataset] : []),
-    testId,
-    record.target ?? 'default',
-  );
+  return path.join(outputDir, ...(record.dataset ? [record.dataset] : []), testId);
 }
 
 describe('export e2e — multi-provider metrics verification', () => {

--- a/apps/cli/test/commands/results/export.test.ts
+++ b/apps/cli/test/commands/results/export.test.ts
@@ -97,15 +97,10 @@ function toJsonl(...records: object[]): string {
 
 function artifactDir(
   outputDir: string,
-  record: { dataset?: string; test_id?: string; eval_id?: string; target?: string },
+  record: { dataset?: string; test_id?: string; eval_id?: string },
 ): string {
   const testId = record.test_id ?? record.eval_id ?? 'unknown';
-  return path.join(
-    outputDir,
-    ...(record.dataset ? [record.dataset] : []),
-    testId,
-    record.target ?? 'default',
-  );
+  return path.join(outputDir, ...(record.dataset ? [record.dataset] : []), testId);
 }
 
 describe('results export', () => {
@@ -165,10 +160,10 @@ describe('results export', () => {
       test_id: 'test-greeting',
       target: 'gpt-4o',
       execution_status: 'ok',
-      grading_path: 'demo/test-greeting/gpt-4o/grading.json',
-      timing_path: 'demo/test-greeting/gpt-4o/timing.json',
-      output_path: 'demo/test-greeting/gpt-4o/outputs/response.md',
-      input_path: 'demo/test-greeting/gpt-4o/input.md',
+      grading_path: 'demo/test-greeting/grading.json',
+      timing_path: 'demo/test-greeting/timing.json',
+      output_path: 'demo/test-greeting/outputs/response.md',
+      input_path: 'demo/test-greeting/input.md',
     });
   });
 

--- a/packages/core/src/evaluation/providers/claude-content.ts
+++ b/packages/core/src/evaluation/providers/claude-content.ts
@@ -52,11 +52,12 @@ export function toContentArray(content: unknown): Content[] | undefined {
             ? src.media_type
             : 'application/octet-stream';
       const data =
-        typeof src.data === 'string'
+        typeof src.data === 'string' && src.data !== ''
           ? `data:${mediaType};base64,${src.data}`
-          : typeof p.url === 'string'
+          : typeof p.url === 'string' && p.url !== ''
             ? (p.url as string)
             : '';
+      if (!data) continue;
       blocks.push({ type: 'image', media_type: mediaType, source: data });
       hasNonText = true;
     } else if (p.type === 'tool_use') {

--- a/packages/core/src/evaluation/providers/pi-utils.ts
+++ b/packages/core/src/evaluation/providers/pi-utils.ts
@@ -59,12 +59,8 @@ export function toPiContentArray(content: unknown): Content[] | undefined {
       let source = '';
       if (typeof p.source === 'object' && p.source !== null) {
         const src = p.source as Record<string, unknown>;
-        const srcMediaType =
-          typeof src.media_type === 'string' ? src.media_type : mediaType;
-        source =
-          typeof src.data === 'string'
-            ? `data:${srcMediaType};base64,${src.data}`
-            : '';
+        const srcMediaType = typeof src.media_type === 'string' ? src.media_type : mediaType;
+        source = typeof src.data === 'string' ? `data:${srcMediaType};base64,${src.data}` : '';
       }
       if (!source && typeof p.url === 'string') {
         source = p.url;

--- a/packages/core/src/evaluation/validation/prompt-validator.ts
+++ b/packages/core/src/evaluation/validation/prompt-validator.ts
@@ -45,7 +45,9 @@ export function validateTemplateVariables(content: string, source: string): void
   const hasCandidateAnswer =
     foundVariables.has(TEMPLATE_VARIABLES.OUTPUT) ||
     foundVariables.has(TEMPLATE_VARIABLES.OUTPUT_TEXT);
-  const hasExpectedOutput = foundVariables.has(TEMPLATE_VARIABLES.EXPECTED_OUTPUT);
+  const hasExpectedOutput =
+    foundVariables.has(TEMPLATE_VARIABLES.EXPECTED_OUTPUT) ||
+    foundVariables.has(TEMPLATE_VARIABLES.EXPECTED_OUTPUT_TEXT);
   const hasRequiredFields = hasCandidateAnswer || hasExpectedOutput;
 
   // ERROR: Missing required fields - throw error to skip this evaluator/eval case

--- a/packages/core/src/evaluation/yaml-parser.ts
+++ b/packages/core/src/evaluation/yaml-parser.ts
@@ -269,8 +269,10 @@ async function loadTestsFromYaml(
   const suite = interpolated as RawTestSuite;
   const evalSetNameFromSuite = asString(suite.name)?.trim();
   const fallbackEvalSet =
-    path.basename(absoluteTestPath).replace(/\.eval\.ya?ml$/i, '').replace(/\.ya?ml$/i, '') ||
-    'eval';
+    path
+      .basename(absoluteTestPath)
+      .replace(/\.eval\.ya?ml$/i, '')
+      .replace(/\.ya?ml$/i, '') || 'eval';
   const evalSetName =
     evalSetNameFromSuite && evalSetNameFromSuite.length > 0
       ? evalSetNameFromSuite

--- a/packages/core/test/evaluation/llm-grader-multimodal.test.ts
+++ b/packages/core/test/evaluation/llm-grader-multimodal.test.ts
@@ -9,10 +9,10 @@
  * - Images in non-assistant messages are ignored
  */
 
-import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
 
-import type { Message } from '../../src/evaluation/providers/types.js';
 import type { ResolvedTarget } from '../../src/evaluation/providers/targets.js';
+import type { Message } from '../../src/evaluation/providers/types.js';
 import type { EvalTest } from '../../src/evaluation/types.js';
 
 // ---------------------------------------------------------------------------
@@ -220,8 +220,8 @@ describe('LlmGraderEvaluator multimodal', () => {
     expect(capturedGenerateTextArgs).toBeDefined();
 
     // When no images, generateText should receive `prompt` (string), not `messages`
-    expect(capturedGenerateTextArgs!.prompt).toBeTypeOf('string');
-    expect(capturedGenerateTextArgs!.messages).toBeUndefined();
+    expect(capturedGenerateTextArgs?.prompt).toBeTypeOf('string');
+    expect(capturedGenerateTextArgs?.messages).toBeUndefined();
   });
 
   it('sends multi-part messages when output contains images', async () => {
@@ -256,10 +256,10 @@ describe('LlmGraderEvaluator multimodal', () => {
     expect(capturedGenerateTextArgs).toBeDefined();
 
     // When images exist, generateText should receive `messages` with multi-part content
-    expect(capturedGenerateTextArgs!.messages).toBeDefined();
-    expect(capturedGenerateTextArgs!.prompt).toBeUndefined();
+    expect(capturedGenerateTextArgs?.messages).toBeDefined();
+    expect(capturedGenerateTextArgs?.prompt).toBeUndefined();
 
-    const messages = capturedGenerateTextArgs!.messages as Array<Record<string, unknown>>;
+    const messages = capturedGenerateTextArgs?.messages as Array<Record<string, unknown>>;
     expect(messages).toHaveLength(1);
     expect(messages[0].role).toBe('user');
 
@@ -307,7 +307,7 @@ describe('LlmGraderEvaluator multimodal', () => {
     });
 
     expect(capturedGenerateTextArgs).toBeDefined();
-    const messages = capturedGenerateTextArgs!.messages as Array<Record<string, unknown>>;
+    const messages = capturedGenerateTextArgs?.messages as Array<Record<string, unknown>>;
     const content = messages[0].content as Array<Record<string, unknown>>;
 
     const imageParts = content.filter((p) => p.type === 'image');
@@ -350,7 +350,7 @@ describe('LlmGraderEvaluator multimodal', () => {
     expect(capturedGenerateTextArgs).toBeDefined();
 
     // No images in assistant messages → should use plain prompt
-    expect(capturedGenerateTextArgs!.prompt).toBeTypeOf('string');
-    expect(capturedGenerateTextArgs!.messages).toBeUndefined();
+    expect(capturedGenerateTextArgs?.prompt).toBeTypeOf('string');
+    expect(capturedGenerateTextArgs?.messages).toBeUndefined();
   });
 });

--- a/packages/core/test/evaluation/providers/content-preserve.test.ts
+++ b/packages/core/test/evaluation/providers/content-preserve.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { getTextContent } from '../../../src/evaluation/content.js';
+import type { Content } from '../../../src/evaluation/content.js';
 import {
   extractTextContent,
   toContentArray,
@@ -9,7 +10,6 @@ import {
   extractPiTextContent,
   toPiContentArray,
 } from '../../../src/evaluation/providers/pi-utils.js';
-import type { Content } from '../../../src/evaluation/content.js';
 import type { Message } from '../../../src/evaluation/providers/types.js';
 
 // ---------------------------------------------------------------------------
@@ -42,8 +42,8 @@ describe('toContentArray', () => {
     const result = toContentArray(content);
     expect(result).toBeDefined();
     expect(result).toHaveLength(2);
-    expect(result![0]).toEqual({ type: 'text', text: 'Here is an image:' });
-    expect(result![1]).toEqual({
+    expect(result?.[0]).toEqual({ type: 'text', text: 'Here is an image:' });
+    expect(result?.[1]).toEqual({
       type: 'image',
       media_type: 'image/png',
       source: 'data:image/png;base64,abc123',
@@ -61,7 +61,7 @@ describe('toContentArray', () => {
     ];
     const result = toContentArray(content);
     expect(result).toBeDefined();
-    expect(result![0]).toEqual({
+    expect(result?.[0]).toEqual({
       type: 'image',
       media_type: 'image/png',
       source: 'https://example.com/img.png',
@@ -81,8 +81,8 @@ describe('toContentArray', () => {
     const result = toContentArray(content);
     expect(result).toBeDefined();
     expect(result).toHaveLength(2);
-    expect(result![0]).toEqual({ type: 'text', text: 'hi' });
-    expect(result![1].type).toBe('image');
+    expect(result?.[0]).toEqual({ type: 'text', text: 'hi' });
+    expect(result?.[1].type).toBe('image');
   });
 
   it('handles invalid parts gracefully', () => {
@@ -159,8 +159,8 @@ describe('toPiContentArray', () => {
     const result = toPiContentArray(content);
     expect(result).toBeDefined();
     expect(result).toHaveLength(2);
-    expect(result![0]).toEqual({ type: 'text', text: 'Here is an image:' });
-    expect(result![1]).toEqual({
+    expect(result?.[0]).toEqual({ type: 'text', text: 'Here is an image:' });
+    expect(result?.[1]).toEqual({
       type: 'image',
       media_type: 'image/png',
       source: 'data:image/png;base64,abc123',
@@ -177,7 +177,7 @@ describe('toPiContentArray', () => {
     ];
     const result = toPiContentArray(content);
     expect(result).toBeDefined();
-    expect(result![0]).toEqual({
+    expect(result?.[0]).toEqual({
       type: 'image',
       media_type: 'image/png',
       source: 'https://example.com/img.png',
@@ -198,8 +198,8 @@ describe('toPiContentArray', () => {
     const result = toPiContentArray(content);
     expect(result).toBeDefined();
     expect(result).toHaveLength(2);
-    expect(result![0]).toEqual({ type: 'text', text: 'hi' });
-    expect(result![1].type).toBe('image');
+    expect(result?.[0]).toEqual({ type: 'text', text: 'hi' });
+    expect(result?.[1].type).toBe('image');
   });
 });
 
@@ -269,9 +269,7 @@ describe('End-to-end content preservation', () => {
   });
 
   it('text-only content falls back to string', () => {
-    const rawClaudeContent = [
-      { type: 'text', text: 'Just text' },
-    ];
+    const rawClaudeContent = [{ type: 'text', text: 'Just text' }];
 
     const structuredContent = toContentArray(rawClaudeContent);
     const textContent = extractTextContent(rawClaudeContent);

--- a/packages/core/test/fixtures/test-grader.cjs
+++ b/packages/core/test/fixtures/test-grader.cjs
@@ -6,7 +6,9 @@ const input = JSON.parse(fs.readFileSync(0, 'utf8'));
 const hasExpected = Array.isArray(input.expected_output);
 // Extract candidate text from the output message array
 const outputMessages = Array.isArray(input.output) ? input.output : [];
-const candidateText = outputMessages.map((m) => (typeof m.content === 'string' ? m.content : JSON.stringify(m.content))).join('');
+const candidateText = outputMessages
+  .map((m) => (typeof m.content === 'string' ? m.content : JSON.stringify(m.content)))
+  .join('');
 const hasCandidate = candidateText.length > 0;
 let candidateDecisionOk = false;
 


### PR DESCRIPTION
## Summary

- Apply biome auto-fixes (formatting, non-null assertions → optional chain operators)
- Fix `validateTemplateVariables` to accept deprecated `expected_output_text` (was missing the check for this alias alongside `output_text`)
- Fix `toContentArray` to skip image blocks with empty `source.data` or empty `url` (previously pushed empty `data:...;base64,` strings)
- Update export test helpers (`artifactDir`) to use correct artifact path structure without target subdirectory, matching the current implementation

## Tests

All checks pass: build ✓, typecheck ✓, lint ✓, tests (1647 pass, 0 fail) ✓, validate:examples ✓