### PR TITLE
chore(studio): remove legacy inline HTML dashboard and serve alias

### DIFF
--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -1,20 +1,12 @@
 /**
- * `agentv results serve` — starts a local HTTP server that renders an
- * interactive HTML dashboard for reviewing evaluation results.
- *
- * Features:
- *   - Overview tab: stat cards, targets table, score histogram
- *   - Test Cases tab: filterable/sortable table with expandable detail panels
- *   - Feedback UI: textarea + save button per test, persisted to feedback.json
- *   - Feedback API: GET/POST /api/feedback for reading/writing reviews
- *   - Result picker: dropdown to switch between available result files
- *   - Empty state: starts successfully with no results, shows guidance
- *   - Auto-refresh: polls for new result files every 5 seconds
+ * `agentv studio` — starts the AgentV Studio server, a React SPA for
+ * reviewing evaluation results.
  *
  * The server uses Hono for routing and @hono/node-server to listen.
+ * The Studio SPA is served from a pre-built dist directory.
  *
  * API endpoints:
- *   - GET /           — dashboard HTML (renders empty state if no results)
+ *   - GET /           — Studio SPA (React app)
  *   - GET /api/runs   — list available result files with metadata
  *   - GET /api/runs/:filename — load results from a specific run file
  *   - GET /api/feedback  — read feedback reviews
@@ -147,23 +139,22 @@ export function createApp(
   resultDir: string,
   cwd?: string,
   sourceFile?: string,
-  options?: { studioDir?: string | false },
+  options?: { studioDir?: string },
 ): Hono {
   const searchDir = cwd ?? resultDir;
   const app = new Hono();
 
-  // Dashboard HTML — serve Studio SPA if available, otherwise inline HTML.
-  // Pass studioDir: false to disable SPA serving (used in tests).
-  const studioDistPath =
-    options?.studioDir === false ? undefined : (options?.studioDir ?? resolveStudioDistDir());
+  // Dashboard HTML — serve Studio SPA (React app).
+  const studioDistPath = options?.studioDir ?? resolveStudioDistDir();
+  if (!studioDistPath || !existsSync(path.join(studioDistPath, 'index.html'))) {
+    throw new Error('Studio dist not found. Run "bun run build" in apps/studio/ to build the SPA.');
+  }
   app.get('/', (c) => {
-    if (studioDistPath) {
-      const indexPath = path.join(studioDistPath, 'index.html');
-      if (existsSync(indexPath)) {
-        return c.html(readFileSync(indexPath, 'utf8'));
-      }
+    const indexPath = path.join(studioDistPath, 'index.html');
+    if (existsSync(indexPath)) {
+      return c.html(readFileSync(indexPath, 'utf8'));
     }
-    return c.html(generateServeHtml(results, sourceFile));
+    return c.notFound();
   });
 
   // List available result files (for the result picker)
@@ -683,47 +674,45 @@ export function createApp(
 
   // ── Static file serving for Studio SPA ────────────────────────────────
 
-  if (studioDistPath) {
-    // Serve static assets from studio dist
-    app.get('/assets/*', (c) => {
-      const assetPath = c.req.path;
-      const filePath = path.join(studioDistPath, assetPath);
-      if (!existsSync(filePath)) {
-        return c.notFound();
-      }
-      const content = readFileSync(filePath);
-      const ext = path.extname(filePath);
-      const mimeTypes: Record<string, string> = {
-        '.js': 'application/javascript',
-        '.css': 'text/css',
-        '.html': 'text/html',
-        '.json': 'application/json',
-        '.svg': 'image/svg+xml',
-        '.png': 'image/png',
-        '.woff2': 'font/woff2',
-        '.woff': 'font/woff',
-      };
-      const contentType = mimeTypes[ext] ?? 'application/octet-stream';
-      return new Response(content, {
-        headers: {
-          'Content-Type': contentType,
-          'Cache-Control': 'public, max-age=31536000, immutable',
-        },
-      });
-    });
-
-    // SPA fallback: serve index.html for any non-API route that isn't matched
-    app.get('*', (c) => {
-      if (c.req.path.startsWith('/api/')) {
-        return c.json({ error: 'Not found' }, 404);
-      }
-      const indexPath = path.join(studioDistPath, 'index.html');
-      if (existsSync(indexPath)) {
-        return c.html(readFileSync(indexPath, 'utf8'));
-      }
+  // Serve static assets from studio dist
+  app.get('/assets/*', (c) => {
+    const assetPath = c.req.path;
+    const filePath = path.join(studioDistPath, assetPath);
+    if (!existsSync(filePath)) {
       return c.notFound();
+    }
+    const content = readFileSync(filePath);
+    const ext = path.extname(filePath);
+    const mimeTypes: Record<string, string> = {
+      '.js': 'application/javascript',
+      '.css': 'text/css',
+      '.html': 'text/html',
+      '.json': 'application/json',
+      '.svg': 'image/svg+xml',
+      '.png': 'image/png',
+      '.woff2': 'font/woff2',
+      '.woff': 'font/woff',
+    };
+    const contentType = mimeTypes[ext] ?? 'application/octet-stream';
+    return new Response(content, {
+      headers: {
+        'Content-Type': contentType,
+        'Cache-Control': 'public, max-age=31536000, immutable',
+      },
     });
-  }
+  });
+
+  // SPA fallback: serve index.html for any non-API route that isn't matched
+  app.get('*', (c) => {
+    if (c.req.path.startsWith('/api/')) {
+      return c.json({ error: 'Not found' }, 404);
+    }
+    const indexPath = path.join(studioDistPath, 'index.html');
+    if (existsSync(indexPath)) {
+      return c.html(readFileSync(indexPath, 'utf8'));
+    }
+    return c.notFound();
+  });
 
   return app;
 }
@@ -759,7 +748,7 @@ function resolveStudioDistDir(): string | undefined {
 
 /**
  * Strip heavy fields (requests, trace) from results for JSON API responses.
- * Mirrors the logic used in generateServeHtml for the embedded DATA.
+ * Used by JSON API responses to reduce payload size.
  */
 function stripHeavyFields(results: readonly EvaluationResult[]) {
   return results.map((r) => {
@@ -774,696 +763,6 @@ function stripHeavyFields(results: readonly EvaluationResult[]) {
     };
   });
 }
-
-// ── HTML generation ──────────────────────────────────────────────────────
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
-}
-
-function generateServeHtml(results: readonly EvaluationResult[], sourceFile?: string): string {
-  const lightResults = stripHeavyFields(results);
-  // Escape for safe embedding in <script>: prevent </script> breakout,
-  // HTML comment injection, and Unicode line terminators.
-  const dataJson = JSON.stringify(lightResults)
-    .replace(/</g, '\\u003c')
-    .replace(/>/g, '\\u003e')
-    .replace(/\u2028/g, '\\u2028')
-    .replace(/\u2029/g, '\\u2029');
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>AgentV Results Review</title>
-    <style>
-${SERVE_STYLES}
-    </style>
-</head>
-<body>
-    <header class="header">
-        <div class="header-left">
-            <h1 class="header-title">AgentV</h1>
-            <span class="header-subtitle">Results Review</span>
-        </div>
-        <div class="header-center">
-            <select id="run-picker" class="run-picker" title="Switch result file">
-                <option value="">Loading runs...</option>
-            </select>
-        </div>
-        <div class="header-right">
-            <span class="timestamp">${escapeHtml(new Date().toISOString())}</span>
-        </div>
-    </header>
-    <nav class="tabs" id="tabs">
-        <button class="tab active" data-tab="overview">Overview</button>
-        <button class="tab" data-tab="tests">Test Cases</button>
-    </nav>
-    <main id="app"></main>
-    <script>
-    var DATA = ${dataJson};
-    var INITIAL_SOURCE = ${sourceFile ? JSON.stringify(path.basename(sourceFile)).replace(/</g, '\\u003c').replace(/>/g, '\\u003e') : 'null'};
-${SERVE_SCRIPT}
-    </script>
-</body>
-</html>`;
-}
-
-// ── Embedded CSS ─────────────────────────────────────────────────────────
-
-const SERVE_STYLES = `
-*{margin:0;padding:0;box-sizing:border-box}
-:root{
-  --bg:#f6f8fa;--surface:#fff;--border:#d0d7de;--border-light:#e8ebee;
-  --text:#1f2328;--text-muted:#656d76;
-  --primary:#0969da;--primary-bg:#ddf4ff;
-  --success:#1a7f37;--success-bg:#dafbe1;
-  --danger:#cf222e;--danger-bg:#ffebe9;
-  --warning:#9a6700;--warning-bg:#fff8c5;
-  --radius:6px;
-  --shadow:0 1px 3px rgba(31,35,40,.04),0 1px 2px rgba(31,35,40,.06);
-  --font:-apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif;
-  --mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace;
-}
-body{font-family:var(--font);background:var(--bg);color:var(--text);line-height:1.5;font-size:14px}
-
-/* Header */
-.header{background:var(--surface);border-bottom:1px solid var(--border);padding:12px 24px;display:flex;align-items:center;justify-content:space-between}
-.header-left{display:flex;align-items:baseline;gap:12px}
-.header-title{font-size:18px;font-weight:600}
-.header-subtitle{font-size:14px;color:var(--text-muted)}
-.header-center{flex:1;display:flex;justify-content:center;padding:0 16px}
-.run-picker{padding:6px 10px;border:1px solid var(--border);border-radius:var(--radius);font-size:13px;background:var(--surface);color:var(--text);font-family:var(--font);max-width:400px;width:100%;cursor:pointer}
-.run-picker:hover{border-color:var(--primary)}
-.run-picker:focus{outline:none;border-color:var(--primary);box-shadow:0 0 0 3px var(--primary-bg)}
-.timestamp{font-size:12px;color:var(--text-muted);font-family:var(--mono)}
-
-/* Tabs */
-.tabs{background:var(--surface);border-bottom:1px solid var(--border);padding:0 24px;display:flex}
-.tab{background:none;border:none;padding:10px 16px;font-size:14px;color:var(--text-muted);cursor:pointer;border-bottom:2px solid transparent;font-family:var(--font);transition:color .15s,border-color .15s}
-.tab:hover{color:var(--text)}
-.tab.active{color:var(--text);font-weight:600;border-bottom-color:var(--primary)}
-
-#app{max-width:1280px;margin:0 auto;padding:24px}
-
-/* Stat cards */
-.stats-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px;margin-bottom:24px}
-.stat-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:16px;text-align:center;box-shadow:var(--shadow)}
-.stat-card.pass .stat-value{color:var(--success)}
-.stat-card.fail .stat-value{color:var(--danger)}
-.stat-card.error .stat-value{color:var(--danger)}
-.stat-card.warn .stat-value{color:var(--warning)}
-.stat-card.total .stat-value{color:var(--primary)}
-.stat-value{font-size:28px;font-weight:700;line-height:1.2}
-.stat-label{font-size:12px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin-top:4px}
-
-/* Sections */
-.section{margin-bottom:24px}
-.section-title{font-size:16px;font-weight:600;margin-bottom:12px}
-
-/* Tables */
-.table-wrap{overflow-x:auto;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow)}
-.data-table{width:100%;border-collapse:collapse;font-size:13px}
-.data-table th{background:var(--bg);border-bottom:1px solid var(--border);padding:8px 12px;text-align:left;font-weight:600;font-size:12px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.3px;white-space:nowrap}
-.data-table th.sortable{cursor:pointer;user-select:none}
-.data-table th.sortable:hover{color:var(--text)}
-.data-table td{padding:8px 12px;border-bottom:1px solid var(--border-light);vertical-align:middle}
-.data-table tbody tr:last-child td{border-bottom:none}
-
-/* Status icons */
-.status-icon{display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;border-radius:50%;font-size:12px;font-weight:700}
-.status-icon.pass{background:var(--success-bg);color:var(--success)}
-.status-icon.fail{background:var(--danger-bg);color:var(--danger)}
-.status-icon.error{background:var(--warning-bg);color:var(--warning)}
-
-/* Score colors */
-.score-high{color:var(--success);font-weight:600}
-.score-mid{color:var(--warning);font-weight:600}
-.score-low{color:var(--danger);font-weight:600}
-
-/* Pass-rate bar */
-.bar-bg{width:100px;height:8px;background:var(--border-light);border-radius:4px;overflow:hidden}
-.bar-fill{height:100%;border-radius:4px;transition:width .3s}
-.bar-fill.score-high{background:var(--success)}
-.bar-fill.score-mid{background:var(--warning)}
-.bar-fill.score-low{background:var(--danger)}
-
-/* Histogram */
-.histogram{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:16px;box-shadow:var(--shadow)}
-.hist-row{display:flex;align-items:center;gap:12px;margin-bottom:8px}
-.hist-row:last-child{margin-bottom:0}
-.hist-label{width:60px;font-size:12px;color:var(--text-muted);text-align:right;flex-shrink:0}
-.hist-bar-bg{flex:1;height:20px;background:var(--border-light);border-radius:3px;overflow:hidden}
-.hist-bar{height:100%;border-radius:3px;transition:width .3s}
-.hist-count{width:30px;font-size:12px;color:var(--text-muted);text-align:right;flex-shrink:0}
-
-/* Filters */
-.filter-bar{display:flex;gap:8px;margin-bottom:16px;align-items:center;flex-wrap:wrap}
-.filter-select,.filter-search{padding:6px 10px;border:1px solid var(--border);border-radius:var(--radius);font-size:13px;background:var(--surface);color:var(--text);font-family:var(--font)}
-.filter-search{flex:1;min-width:200px}
-.filter-count{font-size:12px;color:var(--text-muted);margin-left:auto}
-
-/* Test rows */
-.test-row{cursor:pointer;transition:background .1s}
-.test-row:hover{background:var(--bg)!important}
-.test-row.expanded{background:var(--primary-bg)!important}
-.expand-col{width:32px;text-align:center}
-.expand-icon{color:var(--text-muted);font-size:12px}
-.fw-medium{font-weight:500}
-.text-pass{color:var(--success)}.text-fail{color:var(--danger)}.text-error{color:var(--warning)}
-
-/* Detail panel */
-.detail-row td{padding:0!important;background:var(--bg)!important}
-.detail-panel{padding:16px 24px}
-.detail-grid{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:16px}
-.detail-block h4{font-size:12px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.3px;margin-bottom:6px}
-.detail-pre{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:12px;font-family:var(--mono);font-size:12px;white-space:pre-wrap;word-break:break-word;max-height:300px;overflow-y:auto;line-height:1.6}
-.detail-panel h4{font-size:13px;font-weight:600;margin:16px 0 8px}
-.eval-table{width:100%;border-collapse:collapse;font-size:13px;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);margin-bottom:12px}
-.eval-table th{background:var(--bg);padding:6px 10px;text-align:left;font-size:11px;font-weight:600;color:var(--text-muted);text-transform:uppercase;border-bottom:1px solid var(--border)}
-.eval-table td{padding:8px 10px;border-bottom:1px solid var(--border-light)}
-.reasoning-cell{max-width:500px;font-size:12px;color:var(--text-muted)}
-.expect-list{list-style:none;padding:0;margin-bottom:12px}
-.expect-list li{padding:4px 8px 4px 24px;position:relative;font-size:13px}
-.expect-list.pass li::before{content:"\\2713";position:absolute;left:4px;color:var(--success);font-weight:700}
-.expect-list.fail li::before{content:"\\2717";position:absolute;left:4px;color:var(--danger);font-weight:700}
-.error-box{background:var(--danger-bg);border:1px solid var(--danger);border-radius:var(--radius);padding:12px;margin-bottom:12px}
-.error-box h4{color:var(--danger);margin:0 0 6px}
-.error-box pre{font-family:var(--mono);font-size:12px;white-space:pre-wrap;word-break:break-word}
-.detail-meta{font-size:12px;color:var(--text-muted);margin-top:12px;padding-top:12px;border-top:1px solid var(--border-light)}
-.tool-calls{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:12px}
-.tool-tag{display:inline-block;padding:2px 10px;font-size:12px;font-family:var(--mono);background:var(--primary-bg);color:var(--primary);border:1px solid var(--border);border-radius:12px}
-.empty-state{text-align:center;padding:48px 24px;color:var(--text-muted)}
-.empty-state h3{font-size:16px;margin-bottom:8px;color:var(--text)}
-.welcome-state{text-align:center;padding:80px 24px;color:var(--text-muted)}
-.welcome-state h2{font-size:24px;margin-bottom:12px;color:var(--text);font-weight:600}
-.welcome-state p{font-size:15px;margin-bottom:8px;max-width:500px;margin-left:auto;margin-right:auto}
-.welcome-state code{font-family:var(--mono);background:var(--surface);border:1px solid var(--border);border-radius:3px;padding:2px 6px;font-size:13px}
-.welcome-state .hint{margin-top:24px;font-size:13px;color:var(--text-muted)}
-
-/* Feedback */
-.feedback-section{margin-top:16px;padding-top:16px;border-top:1px solid var(--border-light)}
-.feedback-input{width:100%;min-height:80px;padding:8px 12px;border:1px solid var(--border);border-radius:var(--radius);font-family:var(--font);font-size:13px;resize:vertical;background:var(--surface);color:var(--text)}
-.feedback-input:focus{outline:none;border-color:var(--primary);box-shadow:0 0 0 3px var(--primary-bg)}
-.feedback-submit{margin-top:8px;padding:6px 16px;background:var(--primary);color:#fff;border:none;border-radius:var(--radius);font-size:13px;cursor:pointer;font-family:var(--font)}
-.feedback-submit:hover{opacity:.9}
-.feedback-submit:disabled{opacity:.5;cursor:default}
-.feedback-status{margin-left:8px;font-size:12px;color:var(--success)}
-`;
-
-// ── Embedded JavaScript ──────────────────────────────────────────────────
-
-const SERVE_SCRIPT = `
-(function(){
-  /* ---- helpers ---- */
-  function esc(s){
-    if(s==null)return"";
-    return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");
-  }
-  function getStatus(r){
-    if(r.executionStatus==="execution_error")return"error";
-    if(r.executionStatus==="quality_failure")return"fail";
-    if(r.executionStatus==="ok")return"pass";
-    if(r.error)return"error";
-    return r.score>=0.5?"pass":"fail";
-  }
-  function sIcon(s){
-    if(s==="pass")return'<span class="status-icon pass">\\u2713</span>';
-    if(s==="fail")return'<span class="status-icon fail">\\u2717</span>';
-    return'<span class="status-icon error">!</span>';
-  }
-  function fmtDur(ms){
-    if(ms==null)return"\\u2014";
-    if(ms<1000)return ms+"ms";
-    if(ms<60000)return(ms/1000).toFixed(1)+"s";
-    return Math.floor(ms/60000)+"m "+Math.round((ms%60000)/1000)+"s";
-  }
-  function fmtTok(n){
-    if(n==null)return"\\u2014";
-    if(n>=1e6)return(n/1e6).toFixed(1)+"M";
-    if(n>=1e3)return(n/1e3).toFixed(1)+"K";
-    return String(n);
-  }
-  function fmtCost(u){if(u==null)return"\\u2014";if(u<0.01)return"<$0.01";return"$"+u.toFixed(2);}
-  function fmtPct(v){if(v==null)return"\\u2014";return(v*100).toFixed(1)+"%";}
-  function sCls(v){if(v==null)return"";if(v>=0.9)return"score-high";if(v>=0.5)return"score-mid";return"score-low";}
-
-  /* ---- feedback state ---- */
-  var feedbackCache={};
-
-  function loadFeedback(){
-    fetch("/api/feedback").then(function(r){return r.json();}).then(function(d){
-      if(d&&d.reviews){
-        for(var i=0;i<d.reviews.length;i++){
-          feedbackCache[d.reviews[i].test_id]=d.reviews[i].comment;
-        }
-        populateFeedbackTextareas();
-      }
-    }).catch(function(){});
-  }
-
-  function populateFeedbackTextareas(){
-    var areas=document.querySelectorAll(".feedback-input");
-    for(var i=0;i<areas.length;i++){
-      var tid=areas[i].getAttribute("data-test-id");
-      if(tid&&feedbackCache[tid]!=null){
-        areas[i].value=feedbackCache[tid];
-      }
-    }
-  }
-
-  function saveFeedback(testId,comment,statusEl,btn){
-    btn.disabled=true;
-    statusEl.textContent="Saving...";
-    statusEl.style.color="var(--text-muted)";
-    fetch("/api/feedback",{
-      method:"POST",
-      headers:{"Content-Type":"application/json"},
-      body:JSON.stringify({reviews:[{test_id:testId,comment:comment}]})
-    }).then(function(r){return r.json();}).then(function(){
-      feedbackCache[testId]=comment;
-      statusEl.textContent="Saved";
-      statusEl.style.color="var(--success)";
-      btn.disabled=false;
-      setTimeout(function(){statusEl.textContent="";},2000);
-    }).catch(function(){
-      statusEl.textContent="Error saving";
-      statusEl.style.color="var(--danger)";
-      btn.disabled=false;
-    });
-  }
-
-  /* ---- compute stats ---- */
-  function computeStats(d){
-    var t=d.length,p=0,f=0,e=0,dur=0,ti=0,to=0,cost=0,sc=[],tc=0;
-    for(var i=0;i<d.length;i++){
-      var r=d[i],s=getStatus(r);
-      if(s==="pass")p++;else if(s==="fail")f++;else e++;
-      if(r.durationMs)dur+=r.durationMs;
-      if(r.tokenUsage){ti+=(r.tokenUsage.input||0);to+=(r.tokenUsage.output||0);}
-      if(r.costUsd)cost+=r.costUsd;
-      if(s!=="error")sc.push(r.score);
-      if(r._toolCalls){for(var k in r._toolCalls)tc+=r._toolCalls[k];}
-    }
-    var g=t-e;
-    return{total:t,passed:p,failed:f,errors:e,passRate:g>0?p/g:0,dur:dur,tokens:ti+to,inTok:ti,outTok:to,cost:cost,scores:sc,toolCalls:tc};
-  }
-  function computeTargets(d){
-    var m={};
-    for(var i=0;i<d.length;i++){
-      var r=d[i],tgt=r.target||"unknown";
-      if(!m[tgt])m[tgt]={target:tgt,results:[],p:0,f:0,e:0,ts:0,sc:0,dur:0,tok:0,cost:0};
-      var o=m[tgt];o.results.push(r);
-      var s=getStatus(r);
-      if(s==="pass")o.p++;else if(s==="fail")o.f++;else o.e++;
-      if(s!=="error"){o.ts+=r.score;o.sc++;}
-      if(r.durationMs)o.dur+=r.durationMs;
-      if(r.tokenUsage)o.tok+=(r.tokenUsage.input||0)+(r.tokenUsage.output||0);
-      if(r.costUsd)o.cost+=r.costUsd;
-    }
-    var a=[];for(var k in m)a.push(m[k]);return a;
-  }
-  function getEvalNames(){
-    var n={};
-    for(var i=0;i<DATA.length;i++){
-      var sc=DATA[i].scores;
-      if(sc)for(var j=0;j<sc.length;j++)n[sc[j].name]=true;
-    }
-    return Object.keys(n);
-  }
-  function getEvalScore(r,name){
-    if(!r.scores)return null;
-    for(var i=0;i<r.scores.length;i++)if(r.scores[i].name===name)return r.scores[i].score;
-    return null;
-  }
-
-  var stats=computeStats(DATA);
-  var tgtStats=computeTargets(DATA);
-  var tgtNames=tgtStats.map(function(t){return t.target;});
-
-  /* ---- state ---- */
-  var state={tab:"overview",filter:{status:"all",target:"all",search:""},sort:{col:"testId",dir:"asc"},expanded:{}};
-
-  /* ---- DOM refs ---- */
-  var app=document.getElementById("app");
-  var tabBtns=document.querySelectorAll(".tab");
-
-  /* ---- tabs ---- */
-  function setTab(t){
-    state.tab=t;
-    for(var i=0;i<tabBtns.length;i++)tabBtns[i].classList.toggle("active",tabBtns[i].getAttribute("data-tab")===t);
-    render();
-  }
-  for(var i=0;i<tabBtns.length;i++){
-    tabBtns[i].addEventListener("click",(function(b){return function(){setTab(b.getAttribute("data-tab"));};})(tabBtns[i]));
-  }
-
-  /* ---- render ---- */
-  function render(){
-    if(DATA.length===0){
-      app.innerHTML='<div class="welcome-state">'
-        +'<h2>No results yet</h2>'
-        +'<p>Run an evaluation or mount a results directory to see results here.</p>'
-        +'<p><code>agentv eval &lt;eval-file&gt;</code></p>'
-        +'<p class="hint">The dashboard will automatically detect new result files.</p>'
-        +'</div>';
-      return;
-    }
-    if(state.tab==="overview")renderOverview();else renderTests();
-  }
-
-  /* ---- stat card helper ---- */
-  function card(label,value,type){
-    return'<div class="stat-card '+type+'"><div class="stat-value">'+value+'</div><div class="stat-label">'+label+"</div></div>";
-  }
-
-  /* ---- overview ---- */
-  function renderOverview(){
-    var h='<div class="stats-grid">';
-    h+=card("Total Tests",stats.total,"total");
-    h+=card("Passed",stats.passed,"pass");
-    h+=card("Failed",stats.failed,"fail");
-    h+=card("Errors",stats.errors,"error");
-    var prCls=stats.passRate>=0.9?"pass":stats.passRate>=0.5?"warn":"fail";
-    h+=card("Pass Rate",fmtPct(stats.passRate),prCls);
-    h+=card("Duration",fmtDur(stats.dur),"neutral");
-    h+=card("Tokens",fmtTok(stats.tokens),"neutral");
-    h+=card("Est. Cost",fmtCost(stats.cost),"neutral");
-    if(stats.toolCalls>0)h+=card("Tool Calls",fmtTok(stats.toolCalls),"neutral");
-    h+="</div>";
-
-    /* targets table */
-    if(tgtStats.length>1){
-      h+='<div class="section"><h2 class="section-title">Targets</h2><div class="table-wrap"><table class="data-table">';
-      h+="<thead><tr><th>Target</th><th>Pass Rate</th><th></th><th>Passed</th><th>Failed</th><th>Errors</th><th>Avg Score</th><th>Duration</th><th>Tokens</th><th>Cost</th></tr></thead><tbody>";
-      for(var i=0;i<tgtStats.length;i++){
-        var t=tgtStats[i],g=t.p+t.f,pr=g>0?t.p/g:0,avg=t.sc>0?t.ts/t.sc:0;
-        h+="<tr><td class=\\"fw-medium\\">"+esc(t.target)+"</td><td>"+fmtPct(pr)+'</td><td><div class="bar-bg"><div class="bar-fill '+sCls(pr)+'" style="width:'+(pr*100)+'%"></div></div></td>';
-        h+='<td class="text-pass">'+t.p+'</td><td class="text-fail">'+t.f+'</td><td class="text-error">'+t.e+"</td>";
-        h+='<td class="'+sCls(avg)+'">'+fmtPct(avg)+"</td><td>"+fmtDur(t.dur)+"</td><td>"+fmtTok(t.tok)+"</td><td>"+fmtCost(t.cost)+"</td></tr>";
-      }
-      h+="</tbody></table></div></div>";
-    }
-
-    /* histogram */
-    if(stats.scores.length>0){
-      var bk=[0,0,0,0,0];
-      for(var i=0;i<stats.scores.length;i++){var idx=Math.min(Math.floor(stats.scores[i]*5),4);bk[idx]++;}
-      var mx=Math.max.apply(null,bk);
-      var lb=["0\\u201320%","20\\u201340%","40\\u201360%","60\\u201380%","80\\u2013100%"];
-      h+='<div class="section"><h2 class="section-title">Score Distribution</h2><div class="histogram">';
-      for(var i=0;i<bk.length;i++){
-        var pct=mx>0?(bk[i]/mx*100):0;
-        h+='<div class="hist-row"><span class="hist-label">'+lb[i]+'</span><div class="hist-bar-bg"><div class="hist-bar '+(i>=4?"score-high":i>=2?"score-mid":"score-low")+'" style="width:'+pct+'%"></div></div><span class="hist-count">'+bk[i]+"</span></div>";
-      }
-      h+="</div></div>";
-    }
-    app.innerHTML=h;
-  }
-
-  /* ---- test cases ---- */
-  function renderTests(){
-    var evalNames=getEvalNames();
-    var h='<div class="filter-bar">';
-    h+='<select id="flt-status" class="filter-select"><option value="all">All Status</option><option value="pass">Passed</option><option value="fail">Failed</option><option value="error">Errors</option></select>';
-    if(tgtNames.length>1){
-      h+='<select id="flt-target" class="filter-select"><option value="all">All Targets</option>';
-      for(var i=0;i<tgtNames.length;i++)h+='<option value="'+esc(tgtNames[i])+'">'+esc(tgtNames[i])+"</option>";
-      h+="</select>";
-    }
-    h+='<input type="text" id="flt-search" class="filter-search" placeholder="Search tests..." value="'+esc(state.filter.search)+'">';
-    h+='<span class="filter-count" id="flt-count"></span></div>';
-
-    h+='<div class="table-wrap"><table class="data-table" id="test-tbl"><thead><tr>';
-    h+='<th class="expand-col"></th>';
-    h+=sHdr("Status","status");
-    h+=sHdr("Test ID","testId");
-    if(tgtNames.length>1)h+=sHdr("Target","target");
-    h+=sHdr("Score","score");
-    for(var i=0;i<evalNames.length;i++)h+="<th>"+esc(evalNames[i])+"</th>";
-    h+=sHdr("Duration","durationMs");
-    h+=sHdr("Cost","costUsd");
-    h+="</tr></thead><tbody id=\\"test-body\\"></tbody></table></div>";
-    app.innerHTML=h;
-
-    /* wire events */
-    var selS=document.getElementById("flt-status");
-    selS.value=state.filter.status;
-    selS.addEventListener("change",function(e){state.filter.status=e.target.value;renderRows();});
-    var selT=document.getElementById("flt-target");
-    if(selT){selT.value=state.filter.target;selT.addEventListener("change",function(e){state.filter.target=e.target.value;renderRows();});}
-    document.getElementById("flt-search").addEventListener("input",function(e){state.filter.search=e.target.value;renderRows();});
-    var ths=document.querySelectorAll("th[data-sort]");
-    for(var i=0;i<ths.length;i++){
-      ths[i].addEventListener("click",(function(th){return function(){
-        var c=th.getAttribute("data-sort");
-        if(state.sort.col===c)state.sort.dir=state.sort.dir==="asc"?"desc":"asc";
-        else{state.sort.col=c;state.sort.dir="asc";}
-        renderTests();
-      };})(ths[i]));
-    }
-    renderRows();
-  }
-
-  function sHdr(label,col){
-    var arrow="";
-    if(state.sort.col===col)arrow=state.sort.dir==="asc"?" \\u2191":" \\u2193";
-    return'<th class="sortable" data-sort="'+col+'">'+label+arrow+"</th>";
-  }
-
-  function filtered(){
-    var out=[];
-    for(var i=0;i<DATA.length;i++){
-      var r=DATA[i],s=getStatus(r);
-      if(state.filter.status!=="all"&&s!==state.filter.status)continue;
-      if(state.filter.target!=="all"&&r.target!==state.filter.target)continue;
-      if(state.filter.search&&(r.testId||"").toLowerCase().indexOf(state.filter.search.toLowerCase())===-1)continue;
-      out.push(r);
-    }
-    var col=state.sort.col,dir=state.sort.dir==="asc"?1:-1;
-    out.sort(function(a,b){
-      var va=col==="status"?getStatus(a):a[col],vb=col==="status"?getStatus(b):b[col];
-      if(va==null&&vb==null)return 0;if(va==null)return 1;if(vb==null)return-1;
-      if(typeof va==="string")return va.localeCompare(vb)*dir;
-      return(va-vb)*dir;
-    });
-    return out;
-  }
-
-  function renderRows(){
-    var rows=filtered(),evalNames=getEvalNames();
-    var tbody=document.getElementById("test-body");
-    var colSpan=5+evalNames.length+(tgtNames.length>1?1:0);
-    document.getElementById("flt-count").textContent=rows.length+" of "+DATA.length+" tests";
-    var h="";
-    for(var i=0;i<rows.length;i++){
-      var r=rows[i],s=getStatus(r),key=r.testId+":"+r.target,exp=!!state.expanded[key];
-      h+='<tr class="test-row '+s+(exp?" expanded":"")+'" data-key="'+esc(key)+'" data-test-id="'+esc(r.testId)+'">';
-      h+='<td class="expand-col"><span class="expand-icon">'+(exp?"\\u25BE":"\\u25B8")+"</span></td>";
-      h+="<td>"+sIcon(s)+"</td>";
-      h+='<td class="fw-medium">'+esc(r.testId)+"</td>";
-      if(tgtNames.length>1)h+="<td>"+esc(r.target)+"</td>";
-      h+='<td class="'+sCls(r.score)+'">'+fmtPct(r.score)+"</td>";
-      for(var j=0;j<evalNames.length;j++){
-        var es=getEvalScore(r,evalNames[j]);
-        h+='<td class="'+sCls(es)+'">'+(es!=null?fmtPct(es):"\\u2014")+"</td>";
-      }
-      h+="<td>"+fmtDur(r.durationMs)+"</td><td>"+fmtCost(r.costUsd)+"</td></tr>";
-      if(exp)h+='<tr class="detail-row"><td colspan="'+colSpan+'">'+renderDetail(r)+"</td></tr>";
-    }
-    if(rows.length===0)h+='<tr><td colspan="'+colSpan+'" class="empty-state">No matching tests</td></tr>';
-    tbody.innerHTML=h;
-
-    /* row click */
-    var trs=tbody.querySelectorAll(".test-row");
-    for(var k=0;k<trs.length;k++){
-      trs[k].addEventListener("click",(function(tr){return function(){
-        var key=tr.getAttribute("data-key");
-        state.expanded[key]=!state.expanded[key];
-        renderRows();
-      };})(trs[k]));
-    }
-
-    /* wire feedback buttons */
-    var btns=tbody.querySelectorAll(".feedback-submit");
-    for(var k=0;k<btns.length;k++){
-      btns[k].addEventListener("click",(function(btn){return function(ev){
-        ev.stopPropagation();
-        var tid=btn.getAttribute("data-test-id");
-        var sec=btn.closest(".feedback-section");
-        var ta=sec.querySelector(".feedback-input");
-        var st=sec.querySelector(".feedback-status");
-        saveFeedback(tid,ta.value,st,btn);
-      };})(btns[k]));
-    }
-
-    /* prevent textarea clicks from toggling row */
-    var tas=tbody.querySelectorAll(".feedback-input");
-    for(var k=0;k<tas.length;k++){
-      tas[k].addEventListener("click",function(ev){ev.stopPropagation();});
-    }
-
-    populateFeedbackTextareas();
-  }
-
-  /* ---- detail panel ---- */
-  function renderDetail(r){
-    var h='<div class="detail-panel">';
-
-    /* input / output */
-    h+='<div class="detail-grid">';
-    if(r.input!=null){
-      h+='<div class="detail-block"><h4>Input</h4><pre class="detail-pre">'+esc(JSON.stringify(r.input,null,2))+"</pre></div>";
-    }
-    h+='<div class="detail-block"><h4>Output</h4><pre class="detail-pre">'+esc(r.output?JSON.stringify(r.output,null,2):"")+"</pre></div>";
-    h+="</div>";
-
-    /* evaluator results */
-    if(r.scores&&r.scores.length>0){
-      h+="<h4>Evaluator Results</h4>";
-      h+='<table class="eval-table"><thead><tr><th>Evaluator</th><th>Score</th><th>Status</th><th>Assertions</th></tr></thead><tbody>';
-      for(var i=0;i<r.scores.length;i++){
-        var ev=r.scores[i],evS=ev.score>=0.5?"pass":"fail";
-        var evAssertions=ev.assertions||[];
-        var evSummary=evAssertions.map(function(a){return (a.passed?"\\u2713 ":"\\u2717 ")+a.text;}).join("; ");
-        h+="<tr><td class=\\"fw-medium\\">"+esc(ev.name)+'</td><td class="'+sCls(ev.score)+'">'+fmtPct(ev.score)+"</td><td>"+sIcon(evS)+'</td><td class="reasoning-cell">'+esc(evSummary)+"</td></tr>";
-      }
-      h+="</tbody></table>";
-    }
-
-    /* assertions */
-    var passedA=r.assertions?r.assertions.filter(function(a){return a.passed;}):[];
-    var failedA=r.assertions?r.assertions.filter(function(a){return !a.passed;}):[];
-    if(passedA.length>0){
-      h+='<h4>Passed Assertions</h4><ul class="expect-list pass">';
-      for(var i=0;i<passedA.length;i++)h+="<li>"+esc(passedA[i].text)+(passedA[i].evidence?" <span class=\\"reasoning-cell\\">("+esc(passedA[i].evidence)+")</span>":"")+"</li>";
-      h+="</ul>";
-    }
-    if(failedA.length>0){
-      h+='<h4>Failed Assertions</h4><ul class="expect-list fail">';
-      for(var i=0;i<failedA.length;i++)h+="<li>"+esc(failedA[i].text)+(failedA[i].evidence?" <span class=\\"reasoning-cell\\">("+esc(failedA[i].evidence)+")</span>":"")+"</li>";
-      h+="</ul>";
-    }
-
-    /* tool calls */
-    if(r._toolCalls){
-      var tc=r._toolCalls,tcArr=[];
-      for(var k in tc)tcArr.push({name:k,count:tc[k]});
-      tcArr.sort(function(a,b){return b.count-a.count;});
-      h+='<h4>Tool Calls</h4><div class="tool-calls">';
-      for(var i=0;i<tcArr.length;i++)h+='<span class="tool-tag">'+esc(tcArr[i].name)+": "+tcArr[i].count+"</span>";
-      h+="</div>";
-    }
-
-    /* error */
-    if(r.error)h+='<div class="error-box"><h4>Error</h4><pre>'+esc(r.error)+"</pre></div>";
-
-    /* metadata */
-    h+='<div class="detail-meta">';
-    var m=[];
-    if(r.tokenUsage)m.push(fmtTok(r.tokenUsage.input)+" in / "+fmtTok(r.tokenUsage.output)+" out tokens");
-    if(r.durationMs){
-      if(r._graderDurationMs>0){
-        var execMs=r.durationMs-r._graderDurationMs;
-        m.push(fmtDur(execMs>0?execMs:0)+" executor + "+fmtDur(r._graderDurationMs)+" grader");
-      }else{
-        m.push(fmtDur(r.durationMs));
-      }
-    }
-    if(r.target)m.push(r.target);
-    if(r.costUsd)m.push(fmtCost(r.costUsd));
-    if(r.timestamp)m.push(r.timestamp);
-    h+=esc(m.join(" \\u00B7 "));
-    h+="</div>";
-
-    /* feedback section */
-    var tid=r.testId||"";
-    var existingComment=feedbackCache[tid]||"";
-    h+='<div class="feedback-section">';
-    h+='<h4>Feedback</h4>';
-    h+='<textarea class="feedback-input" data-test-id="'+esc(tid)+'" placeholder="Add feedback for this test..." onclick="event.stopPropagation()">'+esc(existingComment)+'</textarea>';
-    h+='<div style="display:flex;align-items:center">';
-    h+='<button class="feedback-submit" data-test-id="'+esc(tid)+'">Save Feedback</button>';
-    h+='<span class="feedback-status"></span>';
-    h+='</div></div>';
-
-    h+="</div>";
-    return h;
-  }
-
-  /* ---- run picker ---- */
-  var runPicker=document.getElementById("run-picker");
-  var knownRunFilenames=[];
-
-  function refreshRunList(){
-    fetch("/api/runs").then(function(r){return r.json();}).then(function(d){
-      if(!d||!d.runs)return;
-      var runs=d.runs;
-      var newFilenames=runs.map(function(r){return r.filename;});
-
-      /* Detect new runs that appeared since last poll */
-      if(knownRunFilenames.length>0){
-        var hasNew=newFilenames.some(function(f){return knownRunFilenames.indexOf(f)===-1;});
-        if(hasNew&&DATA.length===0){
-          /* Auto-load the first (most recent) run when starting from empty state */
-          loadRun(runs[0].filename);
-        }
-      }
-      knownRunFilenames=newFilenames;
-
-      /* Rebuild picker options */
-      var h='<option value="">Select a result file...</option>';
-      if(runs.length===0){
-        h='<option value="">No result files</option>';
-      }
-      for(var i=0;i<runs.length;i++){
-        var r=runs[i];
-        var label=r.filename+" ("+r.test_count+" tests, "+(r.pass_rate*100).toFixed(0)+"% pass)";
-        h+='<option value="'+esc(r.filename)+'">'+esc(label)+"</option>";
-      }
-      runPicker.innerHTML=h;
-      /* Pre-select the initially loaded run */
-      if(INITIAL_SOURCE&&runs.length>0){
-        runPicker.value=INITIAL_SOURCE;
-      }
-    }).catch(function(err){console.warn("Failed to refresh run list:",err);});
-  }
-
-  function loadRun(filename){
-    fetch("/api/runs/"+encodeURIComponent(filename)).then(function(r){return r.json();}).then(function(d){
-      if(d.error){console.error(d.error);return;}
-      DATA=d.results;
-      stats=computeStats(DATA);
-      tgtStats=computeTargets(DATA);
-      tgtNames=tgtStats.map(function(t){return t.target;});
-      state.expanded={};
-      feedbackCache={};
-      loadFeedback();
-      render();
-      /* Update picker selection */
-      runPicker.value=filename;
-    }).catch(function(err){console.error("Failed to load run:",err);});
-  }
-
-  runPicker.addEventListener("change",function(){
-    var val=runPicker.value;
-    if(val)loadRun(val);
-  });
-
-  /* Poll for new result files every 5 seconds */
-  refreshRunList();
-  setInterval(refreshRunList,5000);
-
-  /* ---- init ---- */
-  loadFeedback();
-  render();
-})();
-`;
 
 // ── CLI command ──────────────────────────────────────────────────────────
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -33,7 +33,6 @@ export const app = subcommands({
     results: resultsCommand,
     self: selfCommand,
     studio: resultsServeCommand,
-    serve: resultsServeCommand, // hidden alias for backward compatibility
     trace: traceCommand,
     transpile: transpileCommand,
     trim: trimCommand,
@@ -61,7 +60,6 @@ const TOP_LEVEL_COMMANDS = new Set([
   'pipeline',
   'results',
   'self',
-  'serve',
   'studio',
   'trace',
   'transpile',

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -82,52 +82,62 @@ describe('loadResults', () => {
   });
 });
 
-// ── Hono app (feedback API + HTML) ───────────────────────────────────────
+// ── Mock studio dist ─────────────────────────────────────────────────────
+
+const MOCK_STUDIO_HTML = `<!doctype html>
+<html lang="en" class="dark">
+<head><title>AgentV Studio</title></head>
+<body class="bg-gray-950 text-gray-100"><div id="root"></div></body>
+</html>`;
+
+function createMockStudioDir(baseDir: string): string {
+  const studioDir = path.join(baseDir, 'studio-dist');
+  mkdirSync(studioDir, { recursive: true });
+  writeFileSync(path.join(studioDir, 'index.html'), MOCK_STUDIO_HTML);
+  return studioDir;
+}
+
+// ── Hono app (Studio SPA + API) ─────────────────────────────────────────
 
 describe('serve app', () => {
   let tempDir: string;
+  let studioDir: string;
 
   beforeEach(() => {
     tempDir = mkdtempSync(path.join(tmpdir(), 'agentv-serve-test-'));
+    studioDir = createMockStudioDir(tempDir);
   });
 
   afterEach(() => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  /** Disable SPA serving in tests so inline HTML dashboard assertions pass */
-  const noStudio = { studioDir: false as const };
-
   function makeApp() {
     const content = toJsonl(RESULT_A, RESULT_B);
     const results = loadResults(content);
-    return createApp(results, tempDir, undefined, undefined, noStudio);
+    return createApp(results, tempDir, undefined, undefined, { studioDir });
   }
+
+  // ── createApp throws without studio dist ──────────────────────────────
+
+  describe('createApp', () => {
+    it('throws when studio dist is not found', () => {
+      expect(() =>
+        createApp([], tempDir, undefined, undefined, { studioDir: '/nonexistent/path' }),
+      ).toThrow('Studio dist not found');
+    });
+  });
 
   // ── GET / ──────────────────────────────────────────────────────────────
 
   describe('GET /', () => {
-    it('returns HTML with "AgentV" and "Results Review"', async () => {
+    it('serves Studio SPA index.html', async () => {
       const app = makeApp();
       const res = await app.request('/');
       expect(res.status).toBe(200);
       const html = await res.text();
-      expect(html).toContain('AgentV');
-      expect(html).toContain('Results Review');
-    });
-
-    it('does not contain meta-refresh', async () => {
-      const app = makeApp();
-      const res = await app.request('/');
-      const html = await res.text();
-      expect(html).not.toContain('meta http-equiv="refresh"');
-    });
-
-    it('contains data-test-id attributes', async () => {
-      const app = makeApp();
-      const res = await app.request('/');
-      const html = await res.text();
-      expect(html).toContain('data-test-id');
+      expect(html).toContain('AgentV Studio');
+      expect(html).toContain('<div id="root">');
     });
   });
 
@@ -274,18 +284,16 @@ describe('serve app', () => {
   // ── Empty state (no results) ────────────────────────────────────────
 
   describe('empty state', () => {
-    it('serves dashboard HTML with empty results', async () => {
-      const app = createApp([], tempDir, undefined, undefined, noStudio);
+    it('serves Studio SPA with empty results', async () => {
+      const app = createApp([], tempDir, undefined, undefined, { studioDir });
       const res = await app.request('/');
       expect(res.status).toBe(200);
       const html = await res.text();
-      expect(html).toContain('AgentV');
-      expect(html).toContain('No results yet');
-      expect(html).toContain('Run an evaluation');
+      expect(html).toContain('AgentV Studio');
     });
 
     it('serves feedback API with empty results', async () => {
-      const app = createApp([], tempDir, undefined, undefined, noStudio);
+      const app = createApp([], tempDir, undefined, undefined, { studioDir });
       const res = await app.request('/api/feedback');
       expect(res.status).toBe(200);
       const data = await res.json();
@@ -297,7 +305,7 @@ describe('serve app', () => {
 
   describe('GET /api/runs', () => {
     it('returns empty runs list for temp directory', async () => {
-      const app = createApp([], tempDir, undefined, undefined, noStudio);
+      const app = createApp([], tempDir, undefined, undefined, { studioDir });
       const res = await app.request('/api/runs');
       expect(res.status).toBe(200);
       const data = (await res.json()) as { runs: unknown[] };
@@ -309,7 +317,7 @@ describe('serve app', () => {
 
   describe('GET /api/runs/:filename', () => {
     it('returns 404 for nonexistent run', async () => {
-      const app = createApp([], tempDir, undefined, undefined, noStudio);
+      const app = createApp([], tempDir, undefined, undefined, { studioDir });
       const res = await app.request('/api/runs/nonexistent');
       expect(res.status).toBe(404);
       const data = (await res.json()) as { error: string };
@@ -322,7 +330,7 @@ describe('serve app', () => {
       const filename = 'eval_2026-03-25T10-00-00-000Z.jsonl';
       writeFileSync(path.join(runsDir, filename), toJsonl(RESULT_A, RESULT_B));
 
-      const app = createApp([], tempDir, tempDir, undefined, noStudio);
+      const app = createApp([], tempDir, tempDir, undefined, { studioDir });
       const res = await app.request(`/api/runs/${filename}`);
       expect(res.status).toBe(200);
       const data = (await res.json()) as { results: { testId: string }[]; source: string };
@@ -332,32 +340,23 @@ describe('serve app', () => {
     });
   });
 
-  // ── Run picker in HTML ──────────────────────────────────────────────
+  // ── SPA fallback ──────────────────────────────────────────────────────
 
-  describe('run picker', () => {
-    it('includes run-picker select in dashboard HTML', async () => {
+  describe('SPA fallback', () => {
+    it('serves index.html for non-API routes', async () => {
       const app = makeApp();
-      const res = await app.request('/');
+      const res = await app.request('/runs/some-run');
+      expect(res.status).toBe(200);
       const html = await res.text();
-      expect(html).toContain('run-picker');
-      expect(html).toContain('/api/runs');
+      expect(html).toContain('AgentV Studio');
     });
 
-    it('embeds INITIAL_SOURCE when sourceFile is provided', async () => {
-      const content = toJsonl(RESULT_A, RESULT_B);
-      const results = loadResults(content);
-      const app = createApp(results, tempDir, tempDir, '/some/path/results-2026.jsonl', noStudio);
-      const res = await app.request('/');
-      const html = await res.text();
-      expect(html).toContain('INITIAL_SOURCE');
-      expect(html).toContain('results-2026.jsonl');
-    });
-
-    it('sets INITIAL_SOURCE to null when no sourceFile', async () => {
-      const app = createApp([], tempDir, undefined, undefined, noStudio);
-      const res = await app.request('/');
-      const html = await res.text();
-      expect(html).toContain('INITIAL_SOURCE = null');
+    it('returns 404 JSON for unknown API routes', async () => {
+      const app = makeApp();
+      const res = await app.request('/api/nonexistent');
+      expect(res.status).toBe(404);
+      const data = (await res.json()) as { error: string };
+      expect(data.error).toBe('Not found');
     });
   });
 });

--- a/apps/studio/src/components/EvalDetail.tsx
+++ b/apps/studio/src/components/EvalDetail.tsx
@@ -11,6 +11,7 @@ import { useState } from 'react';
 import { useEvalFileContent, useEvalFiles } from '~/lib/api';
 import type { EvalResult } from '~/lib/types';
 
+import { FeedbackPanel } from './FeedbackPanel';
 import type { FileNode } from './FileTree';
 import { FileTree } from './FileTree';
 import { MonacoViewer } from './MonacoViewer';
@@ -110,6 +111,9 @@ export function EvalDetail({ eval: result, runId }: EvalDetailProps) {
         {activeTab === 'output' && <OutputTab result={result} runId={runId} />}
         {activeTab === 'task' && <TaskTab result={result} runId={runId} />}
       </div>
+
+      {/* Feedback */}
+      <FeedbackPanel testId={result.testId} />
     </div>
   );
 }

--- a/apps/studio/src/components/FeedbackPanel.tsx
+++ b/apps/studio/src/components/FeedbackPanel.tsx
@@ -1,0 +1,84 @@
+/**
+ * Feedback panel for leaving review comments on individual eval results.
+ *
+ * Reads existing feedback via the /api/feedback endpoint and persists
+ * new comments via POST /api/feedback.
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useState } from 'react';
+
+import { useFeedback } from '~/lib/api';
+
+interface FeedbackPanelProps {
+  testId: string;
+}
+
+async function saveFeedback(testId: string, comment: string) {
+  const res = await fetch('/api/feedback', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ reviews: [{ test_id: testId, comment }] }),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to save feedback: ${res.status}`);
+  }
+  return res.json();
+}
+
+export function FeedbackPanel({ testId }: FeedbackPanelProps) {
+  const { data } = useFeedback();
+  const queryClient = useQueryClient();
+
+  const existing = data?.reviews?.find((r) => r.test_id === testId);
+  const [comment, setComment] = useState(existing?.comment ?? '');
+  const [saved, setSaved] = useState(false);
+
+  // Sync when feedback data loads (existing?.comment captures testId changes
+  // since `existing` is derived from testId via the find() above)
+  useEffect(() => {
+    setComment(existing?.comment ?? '');
+    setSaved(false);
+  }, [existing?.comment]);
+
+  const mutation = useMutation({
+    mutationFn: () => saveFeedback(testId, comment),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['feedback'] });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    },
+  });
+
+  const handleSave = useCallback(() => {
+    mutation.mutate();
+  }, [mutation]);
+
+  return (
+    <div className="rounded-lg border border-gray-800 bg-gray-900 p-4">
+      <h4 className="mb-2 text-sm font-medium text-gray-400">Feedback</h4>
+      <textarea
+        value={comment}
+        onChange={(e) => {
+          setComment(e.target.value);
+          setSaved(false);
+        }}
+        placeholder="Add feedback for this test..."
+        className="w-full rounded-md border border-gray-700 bg-gray-800 p-3 text-sm text-gray-200 placeholder-gray-500 focus:border-cyan-400 focus:outline-none"
+        rows={3}
+      />
+      <div className="mt-2 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={mutation.isPending}
+          className="rounded-md bg-cyan-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-cyan-500 disabled:opacity-50"
+        >
+          {mutation.isPending ? 'Saving...' : 'Save Feedback'}
+        </button>
+        {saved && <span className="text-sm text-emerald-400">Saved</span>}
+        {mutation.isError && <span className="text-sm text-red-400">Error saving feedback</span>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Delete `generateServeHtml()` and ~700 lines of embedded HTML/CSS/JS from `serve.ts`
- Remove `agentv serve` alias — `agentv studio` is the only command name
- `createApp()` now throws a clear error if studio dist is missing instead of silently falling back to inline HTML
- Add `FeedbackPanel` component to Studio SPA — textarea + save button per eval, using the existing `/api/feedback` endpoint — preserving the feedback workflow from the old inline dashboard
- Update tests to use a mock studio dist directory instead of `studioDir: false`

## Risk
High — deletes legacy feature code and removes a CLI alias. Dashboard was never published to npm with the inline fallback being hit (studio dist is bundled in the npm package since the build step copies it), so real-world impact is low.

## Checklist
- [x] `generateServeHtml` and inline HTML/CSS/JS template strings deleted from `serve.ts`
- [x] `agentv studio` errors clearly if studio dist is missing
- [x] `agentv serve` alias removed
- [x] Feedback UI preserved in Studio SPA via new `FeedbackPanel` component
- [x] All 1723 tests pass
- [x] Typecheck passes
- [x] Lint clean

Closes #809