### PR TITLE
fix(studio): correct studio dist path for published package

### DIFF
--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -733,8 +733,8 @@ function resolveStudioDistDir(): string | undefined {
     path.resolve(currentDir, '../../../../studio/dist'),
     // From dist/ → sibling apps/studio/dist (monorepo dev)
     path.resolve(currentDir, '../../studio/dist'),
-    // Bundled inside CLI dist (published package)
-    path.resolve(currentDir, '../studio'),
+    // Bundled inside CLI dist (published package: dist/studio/)
+    path.resolve(currentDir, 'studio'),
     // From dist/ in monorepo root context
     path.resolve(currentDir, '../../../apps/studio/dist'),
   ];


### PR DESCRIPTION
## Summary
- Fixed `resolveStudioDistDir()` using wrong relative path (`../studio` instead of `./studio`) for the bundled studio dist in published npm packages
- This caused `agentv studio` to fail with "Studio dist not found" when installed globally

## Test plan
- [x] All 351 CLI tests pass
- [x] `agentv studio` works from built dist (`bun apps/cli/dist/cli.js studio`)
- [x] Studio dist is correctly bundled at `dist/studio/` during build

🤖 Generated with [Claude Code](https://claude.com/claude-code)