### PR TITLE
fix(pi-coding-agent): validate subprovider model and detect SDK errors

### DIFF
--- a/packages/core/src/evaluation/providers/pi-coding-agent.ts
+++ b/packages/core/src/evaluation/providers/pi-coding-agent.ts
@@ -180,9 +180,7 @@ export class PiCodingAgentProvider implements Provider {
       const model = (sdk.getModel as any)(providerName, modelId);
       if (!model) {
         throw new Error(
-          `pi-coding-agent: getModel('${providerName}', '${modelId}') returned undefined. ` +
-            `The model '${modelId}' is not registered for provider '${providerName}' in pi-ai. ` +
-            `Check that subprovider and model are correct in your target config.`,
+          `pi-coding-agent: getModel('${providerName}', '${modelId}') returned undefined. The model '${modelId}' is not registered for provider '${providerName}' in pi-ai. Check that subprovider and model are correct in your target config.`,
         );
       }
 
@@ -350,8 +348,7 @@ export class PiCodingAgentProvider implements Provider {
               ? lastAssistant.errorMessage
               : 'unknown SDK error';
           throw new Error(
-            `pi-coding-agent SDK error (provider: ${lastAssistant.provider ?? providerName}, ` +
-              `model: ${lastAssistant.model ?? modelId}): ${errorMsg}`,
+            `pi-coding-agent SDK error (provider: ${lastAssistant.provider ?? providerName}, model: ${lastAssistant.model ?? modelId}): ${errorMsg}`,
           );
         }
 


### PR DESCRIPTION
## Summary
- **Validate `getModel()` result**: When `getModel(subprovider, model)` returns `undefined` (model not in pi-ai registry for that provider), throw a clear error instead of passing `undefined` to `createAgentSession` which silently falls back to `azure-openai-responses`
- **Detect SDK `stopReason: "error"`**: After `session.prompt()`, check if the last assistant message has `stopReason === "error"` and propagate the `errorMessage` as an execution error instead of silently returning empty/echoed content

Closes #878

## Test plan
- [x] Build passes
- [x] Typecheck passes
- [x] Lint passes (biome)
- [x] All 1731 unit tests pass
- [x] Run `multi-provider-skill-trigger.EVAL.yaml --target pi` with `subprovider: openrouter` to verify correct routing — all requests routed through `openrouter` with `openai/gpt-5.4`, score 1.000 PASS
- [x] Verify SDK errors now surface as execution errors in eval results — invalid model produces clear `provider_error` execution error instead of silent quality failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)