### PR TITLE
fix(core): accept content object shorthands in eval validator

### DIFF
--- a/packages/core/src/evaluation/validation/eval-validator.ts
+++ b/packages/core/src/evaluation/validation/eval-validator.ts
@@ -486,6 +486,12 @@ function validateMessages(
       continue;
     }
 
+    // Content object shorthand: items with 'type' (e.g., {type: "file", value: "..."})
+    // but no 'role' are valid content shorthands — the runtime wraps them implicitly.
+    if (!('role' in message) && 'type' in message) {
+      continue; // Accept silently — runtime handles expansion
+    }
+
     // Validate role field
     const role = message.role;
     const validRoles = ['system', 'user', 'assistant'];


### PR DESCRIPTION
## Summary
- Fix `validateMessages()` in eval-validator to accept content object shorthands (items with `type` but no `role`) that the runtime already handles via `shorthand-expansion.ts`
- Previously, input arrays containing `{type: "file", value: "..."}` objects would produce spurious validation errors about invalid role `undefined`
- Closes #915

## Changes
In `packages/core/src/evaluation/validation/eval-validator.ts`, added an early-continue check in `validateMessages()` after the `isObject` guard: if a message has a `type` field but no `role` field, it is treated as a content object shorthand and skipped, since the runtime wraps these implicitly.

## Test plan
- [x] All 1318 existing tests pass (`bun test` in packages/core)
- [x] Pre-push hooks pass (Build, Typecheck, Lint, Test, Validate eval YAML files)
- [ ] Verify that eval files with content object shorthands in input arrays no longer produce validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)