### PR TITLE
docs: clarify env var fallback for eval interpolation

### DIFF
--- a/apps/web/src/content/docs/docs/getting-started/quickstart.mdx
+++ b/apps/web/src/content/docs/docs/getting-started/quickstart.mdx
@@ -28,11 +28,14 @@ agentv init
 
 ## 3. Configure environment variables
 
-The init command creates a `.env.example` file in your project root.
+The init command creates a `.env.example` file in your project root. You can either export these
+variables in your shell/CI environment directly or copy `.env.example` to `.env` for local
+development.
 
 1. Copy `.env.example` to `.env`
 2. Fill in your API keys, endpoints, and other configuration values
-3. Update the environment variable names in `.agentv/targets.yaml` to match those defined in your `.env` file
+3. Update the environment variable names in `.agentv/targets.yaml` to match the variables you
+   exported or defined in `.env`
 
 ## 4. Create an eval
 

--- a/apps/web/src/content/docs/docs/targets/configuration.mdx
+++ b/apps/web/src/content/docs/docs/targets/configuration.mdx
@@ -30,7 +30,9 @@ targets:
 
 ## Environment Variables
 
-Use `${{ VARIABLE_NAME }}` syntax to reference values from your `.env` file:
+Use `${{ VARIABLE_NAME }}` syntax to reference values from your environment. AgentV reads
+exported process environment variables directly, and it also loads `.env` files from the
+eval directory hierarchy when present:
 
 ```yaml
 targets:
@@ -40,7 +42,8 @@ targets:
     model: ${{ ANTHROPIC_MODEL }}
 ```
 
-This keeps secrets out of version-controlled files.
+This keeps secrets out of version-controlled files and avoids requiring a CI step that rewrites
+already-exported secrets into `.env`.
 
 ## Supported Providers
 

--- a/packages/core/test/evaluation/interpolation-integration.test.ts
+++ b/packages/core/test/evaluation/interpolation-integration.test.ts
@@ -36,6 +36,33 @@ describe('env interpolation in YAML loading', () => {
     expect(cases[0].criteria).toBe('Must return correct answer');
   });
 
+  it('uses exported process.env values even when no .env file exists', async () => {
+    const evalFile = path.join(testDir, 'interp-process-env.eval.yaml');
+    await writeFile(
+      evalFile,
+      [
+        'workspace:',
+        '  repos:',
+        '    - path: ./RepoA',
+        '      source:',
+        '        type: local',
+        '        path: "${{ AGENTV_TEST_PATH }}"',
+        'tests:',
+        '  - id: test-1',
+        '    input: "hello"',
+        '    criteria: "${{ AGENTV_TEST_CRITERIA }}"',
+        '',
+      ].join('\n'),
+    );
+
+    const cases = await loadTests(evalFile, testDir);
+    expect(cases[0].criteria).toBe('Must return correct answer');
+    expect(cases[0].workspace?.repos?.[0]?.source).toEqual({
+      type: 'local',
+      path: '/abs/path/to/repo',
+    });
+  });
+
   it('interpolates ${{ VAR }} in workspace repo source path', async () => {
     const evalFile = path.join(testDir, 'interp-workspace.eval.yaml');
     await writeFile(


### PR DESCRIPTION
## Summary
- clarify in docs that `${{ VAR_NAME }}` resolution reads exported process environment variables directly
- note that `.env` files are optional and only augment the environment when present
- add an explicit regression test covering interpolation with no `.env` file

Closes #927.

## Red
Issue #927 described `.env` as required in CI. That matched the docs wording before this PR:
- `targets/configuration.mdx` said `${{ VARIABLE_NAME }}` reads values "from your .env file"
- `quickstart.mdx` instructed users to define target env names in `.env`

## Green
Verified on current `origin/main` and this branch that no `.env` file is required for interpolation:
```bash
CI_TEMPLATE_PATH=/tmp/template bun -e "import { loadTestSuite } from './packages/core/src/evaluation/yaml-parser.ts'; const suite = await loadTestSuite(process.argv[1], process.cwd()); console.log(suite.tests[0].workspace?.template);" /tmp/env-path.eval.yaml
```
This resolved `workspace.template` to the exported path directly.

## Verification
- `bun test packages/core/test/evaluation/interpolation-integration.test.ts`
- Manual repro: `loadTestSuite()` resolved `${{ CI_TEMPLATE_PATH }}` with no `.env` present
