### PR TITLE
fix(pi-cli): recover assistant text from message updates

### DIFF
--- a/packages/core/src/evaluation/providers/pi-cli.ts
+++ b/packages/core/src/evaluation/providers/pi-cli.ts
@@ -638,17 +638,9 @@ function extractMessages(events: unknown[]): readonly Message[] {
   if (messages) {
     for (let i = messages.length - 1; i >= 0; i--) {
       if (messages[i].role === 'assistant' && !messages[i].content) {
-        // Try to find content from the last message_end event
-        for (let j = events.length - 1; j >= 0; j--) {
-          const evt = events[j] as Record<string, unknown> | null;
-          if (!evt || evt.type !== 'message_end') continue;
-          const msg = evt.message as Record<string, unknown> | undefined;
-          if (msg?.role !== 'assistant') continue;
-          const text = extractPiTextContent(msg.content);
-          if (text) {
-            messages[i] = { ...messages[i], content: text };
-            break;
-          }
+        const recoveredContent = extractAssistantContentFromEvents(events);
+        if (recoveredContent) {
+          messages[i] = { ...messages[i], content: recoveredContent };
         }
         break;
       }
@@ -665,6 +657,42 @@ function extractMessages(events: unknown[]): readonly Message[] {
   }
 
   return messages;
+}
+
+function extractAssistantContentFromEvents(events: unknown[]): string | undefined {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const evt = events[i] as Record<string, unknown> | null;
+    if (!evt || typeof evt !== 'object') continue;
+
+    if (evt.type === 'message_end') {
+      const msg = evt.message as Record<string, unknown> | undefined;
+      if (msg?.role !== 'assistant') continue;
+      const text = extractPiTextContent(msg.content);
+      if (text) return text;
+      continue;
+    }
+
+    if (evt.type !== 'message_update') continue;
+
+    const msg = evt.message as Record<string, unknown> | undefined;
+    if (msg?.role !== 'assistant') continue;
+
+    const deltaEvent = evt.assistantMessageEvent as Record<string, unknown> | undefined;
+    const partial = deltaEvent?.partial as Record<string, unknown> | undefined;
+
+    const partialText = extractPiTextContent(partial?.content);
+    if (partialText) return partialText;
+
+    if (typeof deltaEvent?.content === 'string' && deltaEvent.content.length > 0) {
+      return deltaEvent.content;
+    }
+
+    if (typeof deltaEvent?.delta === 'string' && deltaEvent.delta.length > 0) {
+      return deltaEvent.delta;
+    }
+  }
+
+  return undefined;
 }
 
 /**

--- a/packages/core/test/evaluation/providers/pi-cli-tool-extraction.test.ts
+++ b/packages/core/test/evaluation/providers/pi-cli-tool-extraction.test.ts
@@ -228,4 +228,44 @@ describe('pi-cli tool call extraction from events', () => {
       path: '.agents/skills/csv-analyzer/SKILL.md',
     });
   });
+
+  it('should recover assistant text from message_update deltas when agent_end content is empty', () => {
+    const events = [
+      {
+        type: 'message_update',
+        message: { role: 'assistant', content: [] },
+        assistantMessageEvent: {
+          type: 'text_delta',
+          contentIndex: 0,
+          delta: '2 + 2',
+          partial: { role: 'assistant', content: [{ type: 'text', text: '2 + 2' }] },
+        },
+      },
+      {
+        type: 'message_update',
+        message: { role: 'assistant', content: [] },
+        assistantMessageEvent: {
+          type: 'text_delta',
+          contentIndex: 0,
+          delta: ' = 4',
+          partial: { role: 'assistant', content: [{ type: 'text', text: '2 + 2 = 4' }] },
+        },
+      },
+      {
+        type: 'agent_end',
+        messages: [
+          { role: 'user', content: [{ type: 'text', text: 'What is 2+2?' }] },
+          { role: 'assistant', content: [] },
+        ],
+      },
+    ];
+
+    const messages = extractMessages(events);
+
+    expect(messages).toHaveLength(2);
+    expect(messages[1]).toMatchObject({
+      role: 'assistant',
+      content: '2 + 2 = 4',
+    });
+  });
 });


### PR DESCRIPTION
Closes #922

## Summary
- recover assistant content from pi `message_update` streaming events when `agent_end.messages[].content` is empty
- keep the existing `message_end` fallback and add regression coverage for the streamed-delta case

## Red
- On `main`, running a synthetic pi JSON stream with `message_update` text deltas and an empty `agent_end` assistant message returned an assistant message with no content
- Repro command used locally:
  `bun --eval 'import { _internal } from "./packages/core/src/evaluation/providers/pi-cli.ts"; /* synthetic message_update + empty agent_end */'`\n\n## Green\n- The same synthetic stream now returns assistant content `2 + 2 = 4`\n- Regression test added in `packages/core/test/evaluation/providers/pi-cli-tool-extraction.test.ts`\n\n## Verification\n- `bun test packages/core/test/evaluation/providers/pi-cli-tool-extraction.test.ts`\n- `bun test packages/core/test/evaluation/providers/targets.test.ts --test-name-pattern "pi-cli with azure subprovider and base_url"`\n- `bunx biome check packages/core/src/evaluation/providers/pi-cli.ts packages/core/test/evaluation/providers/pi-cli-tool-extraction.test.ts`\n- pre-push hook passed: build, typecheck, lint, test, validate:examples\n