### PR TITLE
feat(studio): run evals from Studio with suite filter, test-id filter, and target override

### DIFF
--- a/apps/cli/src/commands/results/eval-runner.ts
+++ b/apps/cli/src/commands/results/eval-runner.ts
@@ -1,0 +1,493 @@
+/**
+ * Studio eval runner — discovery, launch, and status tracking for eval runs
+ * initiated from the Studio UI.
+ *
+ * Provides Hono route handlers for:
+ *   - GET  /api/eval/discover  — discover eval files in the project
+ *   - GET  /api/eval/targets   — list available target names
+ *   - POST /api/eval/run       — launch an eval run as a child process
+ *   - GET  /api/eval/status/:id — poll running eval status
+ *   - GET  /api/eval/runs      — list active and recent Studio-launched runs
+ *
+ * All handlers accept a `cwd` (project root) to resolve paths against.
+ * The module spawns `bun apps/cli/src/cli.ts eval run ...` and tracks
+ * process state in memory.
+ */
+
+import { type ChildProcess, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { listTargetNames, readTargetDefinitions } from '@agentv/core';
+import type { Context } from 'hono';
+import type { Hono } from 'hono';
+
+import { TARGET_FILE_CANDIDATES, discoverTargetsFile } from '../../utils/targets.js';
+import { discoverEvalFiles } from '../eval/discover.js';
+import { findRepoRoot } from '../eval/shared.js';
+
+// ── In-memory run tracker ────────────────────────────────────────────────
+
+interface StudioRun {
+  id: string;
+  status: 'starting' | 'running' | 'finished' | 'failed';
+  command: string;
+  startedAt: string;
+  finishedAt?: string;
+  exitCode?: number | null;
+  stdout: string;
+  stderr: string;
+  process?: ChildProcess;
+}
+
+const activeRuns = new Map<string, StudioRun>();
+
+function generateRunId(): string {
+  const now = new Date();
+  const pad = (n: number, w = 2) => String(n).padStart(w, '0');
+  const ts = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+  const rand = Math.random().toString(36).slice(2, 6);
+  return `studio-${ts}-${rand}`;
+}
+
+// Keep only last 20 finished runs to prevent unbounded memory growth
+function pruneFinishedRuns() {
+  const finished = [...activeRuns.entries()]
+    .filter(([, r]) => r.status === 'finished' || r.status === 'failed')
+    .sort((a, b) => (b[1].finishedAt ?? '').localeCompare(a[1].finishedAt ?? ''));
+  if (finished.length > 20) {
+    for (const [id] of finished.slice(20)) {
+      activeRuns.delete(id);
+    }
+  }
+}
+
+// ── Discover targets file from project root ──────────────────────────────
+
+async function discoverTargetsInProject(cwd: string): Promise<readonly string[]> {
+  const repoRoot = (await findRepoRoot(cwd)) ?? cwd;
+
+  // Try to find a targets file using the standard discovery
+  let targetsFilePath: string | undefined;
+  for (const candidate of TARGET_FILE_CANDIDATES) {
+    const fullPath = path.join(cwd, candidate);
+    if (existsSync(fullPath)) {
+      targetsFilePath = fullPath;
+      break;
+    }
+  }
+  if (!targetsFilePath) {
+    for (const candidate of TARGET_FILE_CANDIDATES) {
+      const fullPath = path.join(repoRoot, candidate);
+      if (existsSync(fullPath)) {
+        targetsFilePath = fullPath;
+        break;
+      }
+    }
+  }
+
+  if (!targetsFilePath) return [];
+
+  try {
+    const definitions = await readTargetDefinitions(targetsFilePath);
+    return listTargetNames(definitions);
+  } catch {
+    return [];
+  }
+}
+
+// ── Build CLI command from request body ──────────────────────────────────
+
+interface RunEvalRequest {
+  suite_filter?: string;
+  test_ids?: string[];
+  target?: string;
+  threshold?: number;
+  workers?: number;
+  dry_run?: boolean;
+}
+
+function buildCliArgs(req: RunEvalRequest): string[] {
+  const args: string[] = ['eval'];
+
+  // Suite filter (eval paths/globs)
+  if (req.suite_filter?.trim()) {
+    for (const part of req.suite_filter.split(',')) {
+      const trimmed = part.trim();
+      if (trimmed) args.push(trimmed);
+    }
+  }
+
+  // Test ID filters
+  if (req.test_ids && req.test_ids.length > 0) {
+    for (const id of req.test_ids) {
+      const trimmed = id.trim();
+      if (trimmed) {
+        args.push('--test-id', trimmed);
+      }
+    }
+  }
+
+  // Target override
+  if (req.target?.trim()) {
+    args.push('--target', req.target.trim());
+  }
+
+  // Threshold
+  if (req.threshold !== undefined && req.threshold !== null) {
+    args.push('--threshold', String(req.threshold));
+  }
+
+  // Workers
+  if (req.workers !== undefined && req.workers !== null) {
+    args.push('--workers', String(req.workers));
+  }
+
+  // Dry run
+  if (req.dry_run) {
+    args.push('--dry-run');
+  }
+
+  return args;
+}
+
+function buildCliPreview(args: string[]): string {
+  return `agentv ${args.map((a) => (a.includes(' ') || a.includes('*') ? `"${a}"` : a)).join(' ')}`;
+}
+
+// ── Resolve the bun + cli.ts path ────────────────────────────────────────
+
+function resolveCliPath(cwd: string): { bunPath: string; cliPath: string } | undefined {
+  // Try to find cli.ts in the project (monorepo dev context)
+  const candidates = [
+    path.join(cwd, 'apps/cli/src/cli.ts'),
+    path.join(cwd, 'apps/cli/dist/cli.js'),
+  ];
+  for (const c of candidates) {
+    if (existsSync(c)) {
+      return { bunPath: 'bun', cliPath: c };
+    }
+  }
+
+  // Try from the current running process location
+  const currentDir =
+    typeof __dirname !== 'undefined' ? __dirname : path.dirname(new URL(import.meta.url).pathname);
+  const fromSrc = path.resolve(currentDir, '../../../cli.ts');
+  const fromDist = path.resolve(currentDir, '../../cli.js');
+
+  if (existsSync(fromSrc)) return { bunPath: 'bun', cliPath: fromSrc };
+  if (existsSync(fromDist)) return { bunPath: 'bun', cliPath: fromDist };
+
+  return undefined;
+}
+
+// ── Route registration ───────────────────────────────────────────────────
+
+// biome-ignore lint/suspicious/noExplicitAny: Hono Context generic varies by route
+type C = Context<any, any, any>;
+
+export function registerEvalRoutes(app: Hono, getCwd: (c: C) => string) {
+  // ── Discovery: eval files ──────────────────────────────────────────────
+  app.get('/api/eval/discover', async (c) => {
+    const cwd = getCwd(c);
+    try {
+      const files = await discoverEvalFiles(cwd);
+      return c.json({
+        eval_files: files.map((f) => ({
+          path: f.path,
+          relative_path: f.relativePath,
+          category: f.category,
+        })),
+      });
+    } catch (err) {
+      return c.json({ error: (err as Error).message, eval_files: [] }, 500);
+    }
+  });
+
+  // ── Discovery: targets ─────────────────────────────────────────────────
+  app.get('/api/eval/targets', async (c) => {
+    const cwd = getCwd(c);
+    try {
+      const names = await discoverTargetsInProject(cwd);
+      return c.json({ targets: names });
+    } catch (err) {
+      return c.json({ error: (err as Error).message, targets: [] }, 500);
+    }
+  });
+
+  // ── Launch eval run ────────────────────────────────────────────────────
+  app.post('/api/eval/run', async (c) => {
+    const cwd = getCwd(c);
+
+    let body: RunEvalRequest;
+    try {
+      body = await c.req.json<RunEvalRequest>();
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400);
+    }
+
+    // Validate: need at least a suite filter
+    if (!body.suite_filter?.trim() && (!body.test_ids || body.test_ids.length === 0)) {
+      return c.json({ error: 'Provide suite_filter or test_ids' }, 400);
+    }
+
+    const cliPaths = resolveCliPath(cwd);
+    if (!cliPaths) {
+      return c.json({ error: 'Cannot locate agentv CLI entry point' }, 500);
+    }
+
+    const args = buildCliArgs(body);
+    const command = buildCliPreview(args);
+    const runId = generateRunId();
+
+    const run: StudioRun = {
+      id: runId,
+      status: 'starting',
+      command,
+      startedAt: new Date().toISOString(),
+      stdout: '',
+      stderr: '',
+    };
+    activeRuns.set(runId, run);
+
+    try {
+      const child = spawn(cliPaths.bunPath, [cliPaths.cliPath, ...args], {
+        cwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env },
+      });
+
+      run.process = child;
+      run.status = 'running';
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        run.stdout += chunk.toString();
+        // Cap buffer at 100KB
+        if (run.stdout.length > 100_000) {
+          run.stdout = run.stdout.slice(-80_000);
+        }
+      });
+
+      child.stderr?.on('data', (chunk: Buffer) => {
+        run.stderr += chunk.toString();
+        if (run.stderr.length > 100_000) {
+          run.stderr = run.stderr.slice(-80_000);
+        }
+      });
+
+      child.on('close', (code) => {
+        run.exitCode = code;
+        run.status = code === 0 ? 'finished' : 'failed';
+        run.finishedAt = new Date().toISOString();
+        run.process = undefined;
+        pruneFinishedRuns();
+      });
+
+      child.on('error', (err) => {
+        run.status = 'failed';
+        run.stderr += `\nProcess error: ${err.message}`;
+        run.finishedAt = new Date().toISOString();
+        run.process = undefined;
+      });
+
+      return c.json(
+        {
+          id: runId,
+          status: run.status,
+          command,
+        },
+        202,
+      );
+    } catch (err) {
+      run.status = 'failed';
+      run.stderr = (err as Error).message;
+      run.finishedAt = new Date().toISOString();
+      return c.json({ error: (err as Error).message }, 500);
+    }
+  });
+
+  // ── Run status ─────────────────────────────────────────────────────────
+  app.get('/api/eval/status/:id', (c) => {
+    const id = c.req.param('id');
+    const run = activeRuns.get(id ?? '');
+    if (!run) return c.json({ error: 'Run not found' }, 404);
+
+    return c.json({
+      id: run.id,
+      status: run.status,
+      command: run.command,
+      started_at: run.startedAt,
+      finished_at: run.finishedAt ?? null,
+      exit_code: run.exitCode ?? null,
+      stdout: run.stdout.slice(-10_000),
+      stderr: run.stderr.slice(-5_000),
+    });
+  });
+
+  // ── List runs ──────────────────────────────────────────────────────────
+  app.get('/api/eval/runs', (c) => {
+    const runs = [...activeRuns.values()].map((r) => ({
+      id: r.id,
+      status: r.status,
+      command: r.command,
+      started_at: r.startedAt,
+      finished_at: r.finishedAt ?? null,
+      exit_code: r.exitCode ?? null,
+    }));
+    runs.sort((a, b) => b.started_at.localeCompare(a.started_at));
+    return c.json({ runs });
+  });
+
+  // ── CLI preview (dry endpoint) ─────────────────────────────────────────
+  app.post('/api/eval/preview', async (c) => {
+    let body: RunEvalRequest;
+    try {
+      body = await c.req.json<RunEvalRequest>();
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400);
+    }
+
+    const args = buildCliArgs(body);
+    return c.json({ command: buildCliPreview(args) });
+  });
+
+  // ── Project-scoped variants ────────────────────────────────────────────
+  app.get('/api/projects/:projectId/eval/discover', async (c) => {
+    const cwd = getCwd(c);
+    try {
+      const files = await discoverEvalFiles(cwd);
+      return c.json({
+        eval_files: files.map((f) => ({
+          path: f.path,
+          relative_path: f.relativePath,
+          category: f.category,
+        })),
+      });
+    } catch (err) {
+      return c.json({ error: (err as Error).message, eval_files: [] }, 500);
+    }
+  });
+
+  app.get('/api/projects/:projectId/eval/targets', async (c) => {
+    const cwd = getCwd(c);
+    try {
+      const names = await discoverTargetsInProject(cwd);
+      return c.json({ targets: names });
+    } catch (err) {
+      return c.json({ error: (err as Error).message, targets: [] }, 500);
+    }
+  });
+
+  app.post('/api/projects/:projectId/eval/run', async (c) => {
+    const cwd = getCwd(c);
+
+    let body: RunEvalRequest;
+    try {
+      body = await c.req.json<RunEvalRequest>();
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400);
+    }
+
+    if (!body.suite_filter?.trim() && (!body.test_ids || body.test_ids.length === 0)) {
+      return c.json({ error: 'Provide suite_filter or test_ids' }, 400);
+    }
+
+    const cliPaths = resolveCliPath(cwd);
+    if (!cliPaths) {
+      return c.json({ error: 'Cannot locate agentv CLI entry point' }, 500);
+    }
+
+    const args = buildCliArgs(body);
+    const command = buildCliPreview(args);
+    const runId = generateRunId();
+
+    const run: StudioRun = {
+      id: runId,
+      status: 'starting',
+      command,
+      startedAt: new Date().toISOString(),
+      stdout: '',
+      stderr: '',
+    };
+    activeRuns.set(runId, run);
+
+    try {
+      const child = spawn(cliPaths.bunPath, [cliPaths.cliPath, ...args], {
+        cwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env },
+      });
+
+      run.process = child;
+      run.status = 'running';
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        run.stdout += chunk.toString();
+        if (run.stdout.length > 100_000) run.stdout = run.stdout.slice(-80_000);
+      });
+      child.stderr?.on('data', (chunk: Buffer) => {
+        run.stderr += chunk.toString();
+        if (run.stderr.length > 100_000) run.stderr = run.stderr.slice(-80_000);
+      });
+      child.on('close', (code) => {
+        run.exitCode = code;
+        run.status = code === 0 ? 'finished' : 'failed';
+        run.finishedAt = new Date().toISOString();
+        run.process = undefined;
+        pruneFinishedRuns();
+      });
+      child.on('error', (err) => {
+        run.status = 'failed';
+        run.stderr += `\nProcess error: ${err.message}`;
+        run.finishedAt = new Date().toISOString();
+        run.process = undefined;
+      });
+
+      return c.json({ id: runId, status: run.status, command }, 202);
+    } catch (err) {
+      run.status = 'failed';
+      run.stderr = (err as Error).message;
+      run.finishedAt = new Date().toISOString();
+      return c.json({ error: (err as Error).message }, 500);
+    }
+  });
+
+  app.get('/api/projects/:projectId/eval/status/:id', (c) => {
+    const id = c.req.param('id');
+    const run = activeRuns.get(id ?? '');
+    if (!run) return c.json({ error: 'Run not found' }, 404);
+    return c.json({
+      id: run.id,
+      status: run.status,
+      command: run.command,
+      started_at: run.startedAt,
+      finished_at: run.finishedAt ?? null,
+      exit_code: run.exitCode ?? null,
+      stdout: run.stdout.slice(-10_000),
+      stderr: run.stderr.slice(-5_000),
+    });
+  });
+
+  app.get('/api/projects/:projectId/eval/runs', (c) => {
+    const runs = [...activeRuns.values()].map((r) => ({
+      id: r.id,
+      status: r.status,
+      command: r.command,
+      started_at: r.startedAt,
+      finished_at: r.finishedAt ?? null,
+      exit_code: r.exitCode ?? null,
+    }));
+    runs.sort((a, b) => b.started_at.localeCompare(a.started_at));
+    return c.json({ runs });
+  });
+
+  app.post('/api/projects/:projectId/eval/preview', async (c) => {
+    let body: RunEvalRequest;
+    try {
+      body = await c.req.json<RunEvalRequest>();
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400);
+    }
+    const args = buildCliArgs(body);
+    return c.json({ command: buildCliPreview(args) });
+  });
+}

--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -46,6 +46,7 @@ import { parseJsonlResults } from '../eval/artifact-writer.js';
 import { resolveRunManifestPath } from '../eval/result-layout.js';
 import { loadRunCache, resolveRunCacheFile } from '../eval/run-cache.js';
 import { listResultFiles } from '../trace/utils.js';
+import { registerEvalRoutes } from './eval-runner.js';
 import {
   loadLightweightResults,
   loadManifestResults,
@@ -891,6 +892,18 @@ export function createApp(
   app.get('/api/projects/:projectId/experiments', (c) => withProject(c, handleExperiments));
   app.get('/api/projects/:projectId/targets', (c) => withProject(c, handleTargets));
   app.get('/api/projects/:projectId/feedback', (c) => withProject(c, handleFeedbackRead));
+
+  // ── Eval runner routes (discovery, launch, status) ────────────────────
+
+  registerEvalRoutes(app, (c) => {
+    // For project-scoped routes, resolve to project path; otherwise use searchDir
+    const projectId = c.req.param('projectId');
+    if (projectId) {
+      const project = getProject(projectId);
+      if (project) return project.path;
+    }
+    return searchDir;
+  });
 
   // ── Static file serving for Studio SPA ────────────────────────────────
 

--- a/apps/studio/src/components/RunEvalModal.tsx
+++ b/apps/studio/src/components/RunEvalModal.tsx
@@ -1,0 +1,457 @@
+/**
+ * RunEvalModal — a compact wizard for launching eval runs from Studio.
+ *
+ * Two-step flow:
+ *   Step 1: What to run (suite filter, test-id pills, target override)
+ *   Step 2: Advanced options (threshold, workers) — collapsed by default
+ *
+ * Shows a CLI preview before launch, then tracks run status.
+ *
+ * Entry points pass optional prefill props (e.g., from a run detail page
+ * or eval detail page) so the modal opens pre-populated.
+ */
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  launchEvalRun,
+  previewEvalCommand,
+  useEvalDiscover,
+  useEvalRunStatus,
+  useEvalTargets,
+} from '~/lib/api';
+import type { RunEvalRequest } from '~/lib/types';
+
+// ── Props ────────────────────────────────────────────────────────────────
+
+export interface RunEvalModalProps {
+  open: boolean;
+  onClose: () => void;
+  projectId?: string;
+  prefill?: {
+    suiteFilter?: string;
+    testIds?: string[];
+    target?: string;
+  };
+}
+
+// ── Component ────────────────────────────────────────────────────────────
+
+export function RunEvalModal({ open, onClose, projectId, prefill }: RunEvalModalProps) {
+  const queryClient = useQueryClient();
+
+  // Form state
+  const [suiteFilter, setSuiteFilter] = useState(prefill?.suiteFilter ?? '');
+  const [testIdInput, setTestIdInput] = useState('');
+  const [testIds, setTestIds] = useState<string[]>(prefill?.testIds ?? []);
+  const [target, setTarget] = useState(prefill?.target ?? '');
+  const [threshold, setThreshold] = useState('');
+  const [workers, setWorkers] = useState('');
+  const [dryRun, setDryRun] = useState(false);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  // Run state
+  const [activeRunId, setActiveRunId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [launching, setLaunching] = useState(false);
+  const [cliPreview, setCliPreview] = useState<string | null>(null);
+
+  // Data
+  const { data: discoverData } = useEvalDiscover(projectId);
+  const { data: targetsData } = useEvalTargets(projectId);
+  const { data: runStatus } = useEvalRunStatus(activeRunId);
+
+  const evalFiles = useMemo(() => discoverData?.eval_files ?? [], [discoverData]);
+  const targetNames = useMemo(() => targetsData?.targets ?? [], [targetsData]);
+
+  // Reset form when opening with new prefill
+  useEffect(() => {
+    if (open) {
+      setSuiteFilter(prefill?.suiteFilter ?? '');
+      setTestIds(prefill?.testIds ?? []);
+      setTarget(prefill?.target ?? '');
+      setTestIdInput('');
+      setThreshold('');
+      setWorkers('');
+      setDryRun(false);
+      setShowAdvanced(false);
+      setActiveRunId(null);
+      setError(null);
+      setLaunching(false);
+      setCliPreview(null);
+    }
+  }, [open, prefill]);
+
+  // When run finishes, refresh the runs list
+  useEffect(() => {
+    if (runStatus?.status === 'finished' || runStatus?.status === 'failed') {
+      queryClient.invalidateQueries({ queryKey: ['runs'] });
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
+    }
+  }, [runStatus?.status, queryClient]);
+
+  // Build request body from form state
+  const buildRequest = useCallback((): RunEvalRequest => {
+    const req: RunEvalRequest = {};
+    if (suiteFilter.trim()) req.suite_filter = suiteFilter.trim();
+    if (testIds.length > 0) req.test_ids = testIds;
+    if (target) req.target = target;
+    if (threshold) req.threshold = Number.parseFloat(threshold);
+    if (workers) req.workers = Number.parseInt(workers, 10);
+    if (dryRun) req.dry_run = true;
+    return req;
+  }, [suiteFilter, testIds, target, threshold, workers, dryRun]);
+
+  // Update CLI preview when form changes
+  useEffect(() => {
+    const req = buildRequest();
+    if (!req.suite_filter && (!req.test_ids || req.test_ids.length === 0)) {
+      setCliPreview(null);
+      return;
+    }
+    previewEvalCommand(req, projectId)
+      .then((r) => setCliPreview(r.command))
+      .catch(() => setCliPreview(null));
+  }, [buildRequest, projectId]);
+
+  // Add a test ID pill
+  function addTestId() {
+    const trimmed = testIdInput.trim();
+    if (trimmed && !testIds.includes(trimmed)) {
+      setTestIds([...testIds, trimmed]);
+    }
+    setTestIdInput('');
+  }
+
+  function removeTestId(id: string) {
+    setTestIds(testIds.filter((t) => t !== id));
+  }
+
+  // Launch
+  async function handleLaunch() {
+    setError(null);
+    setLaunching(true);
+    try {
+      const req = buildRequest();
+      const result = await launchEvalRun(req, projectId);
+      setActiveRunId(result.id);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLaunching(false);
+    }
+  }
+
+  if (!open) return null;
+
+  // ── Active run view ────────────────────────────────────────────────────
+
+  if (activeRunId && runStatus) {
+    return (
+      <ModalShell onClose={onClose} title="Eval Run">
+        <RunStatusView status={runStatus} onClose={onClose} />
+      </ModalShell>
+    );
+  }
+
+  // ── Form view ──────────────────────────────────────────────────────────
+
+  const canLaunch = !!(suiteFilter.trim() || testIds.length > 0);
+
+  return (
+    <ModalShell onClose={onClose} title="Run Eval">
+      <div className="space-y-4">
+        {/* Suite filter */}
+        <div>
+          <label htmlFor="suite-filter" className="mb-1 block text-sm font-medium text-gray-300">
+            Suite Filter
+          </label>
+          <input
+            id="suite-filter"
+            type="text"
+            value={suiteFilter}
+            onChange={(e) => setSuiteFilter(e.target.value)}
+            placeholder="evals/**/*.eval.yaml"
+            className="w-full rounded-md border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-white placeholder-gray-500 focus:border-cyan-600 focus:outline-none"
+          />
+          {evalFiles.length > 0 && !suiteFilter && (
+            <div className="mt-1.5 flex flex-wrap gap-1">
+              {evalFiles.slice(0, 5).map((f) => (
+                <button
+                  key={f.relative_path}
+                  type="button"
+                  onClick={() =>
+                    setSuiteFilter((prev) =>
+                      prev ? `${prev}, ${f.relative_path}` : f.relative_path,
+                    )
+                  }
+                  className="rounded bg-gray-800 px-2 py-0.5 text-xs text-gray-400 hover:bg-gray-700 hover:text-gray-200"
+                >
+                  {f.relative_path}
+                </button>
+              ))}
+              {evalFiles.length > 5 && (
+                <span className="px-1 text-xs text-gray-500">+{evalFiles.length - 5} more</span>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Test ID filter */}
+        <div>
+          <label htmlFor="test-id-input" className="mb-1 block text-sm font-medium text-gray-300">
+            Test ID Filter
+          </label>
+          <div className="flex gap-2">
+            <input
+              id="test-id-input"
+              type="text"
+              value={testIdInput}
+              onChange={(e) => setTestIdInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  addTestId();
+                }
+              }}
+              placeholder="auth-*, retrieval-basic"
+              className="flex-1 rounded-md border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-white placeholder-gray-500 focus:border-cyan-600 focus:outline-none"
+            />
+            <button
+              type="button"
+              onClick={addTestId}
+              disabled={!testIdInput.trim()}
+              className="rounded-md bg-gray-700 px-3 py-2 text-sm text-white hover:bg-gray-600 disabled:opacity-50"
+            >
+              Add
+            </button>
+          </div>
+          {testIds.length > 0 && (
+            <div className="mt-1.5 flex flex-wrap gap-1">
+              {testIds.map((id) => (
+                <span
+                  key={id}
+                  className="inline-flex items-center gap-1 rounded-full bg-cyan-900/40 px-2.5 py-0.5 text-xs text-cyan-300"
+                >
+                  {id}
+                  <button
+                    type="button"
+                    onClick={() => removeTestId(id)}
+                    className="text-cyan-400 hover:text-white"
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Target override */}
+        <div>
+          <label htmlFor="target-override" className="mb-1 block text-sm font-medium text-gray-300">
+            Target Override
+          </label>
+          <select
+            id="target-override"
+            value={target}
+            onChange={(e) => setTarget(e.target.value)}
+            className="w-full rounded-md border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-white focus:border-cyan-600 focus:outline-none"
+          >
+            <option value="">Use eval's configured target</option>
+            {targetNames.map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Advanced options */}
+        <div>
+          <button
+            type="button"
+            onClick={() => setShowAdvanced(!showAdvanced)}
+            className="text-sm text-gray-400 hover:text-gray-200"
+          >
+            {showAdvanced ? '▾' : '▸'} Advanced Options
+          </button>
+          {showAdvanced && (
+            <div className="mt-2 grid grid-cols-2 gap-3">
+              <div>
+                <label htmlFor="threshold-input" className="mb-1 block text-xs text-gray-400">
+                  Threshold (0–1)
+                </label>
+                <input
+                  id="threshold-input"
+                  type="number"
+                  value={threshold}
+                  onChange={(e) => setThreshold(e.target.value)}
+                  min="0"
+                  max="1"
+                  step="0.1"
+                  placeholder="0.8"
+                  className="w-full rounded-md border border-gray-700 bg-gray-800 px-3 py-1.5 text-sm text-white placeholder-gray-500 focus:border-cyan-600 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label htmlFor="workers-input" className="mb-1 block text-xs text-gray-400">
+                  Workers
+                </label>
+                <input
+                  id="workers-input"
+                  type="number"
+                  value={workers}
+                  onChange={(e) => setWorkers(e.target.value)}
+                  min="1"
+                  max="50"
+                  placeholder="3"
+                  className="w-full rounded-md border border-gray-700 bg-gray-800 px-3 py-1.5 text-sm text-white placeholder-gray-500 focus:border-cyan-600 focus:outline-none"
+                />
+              </div>
+              <div className="col-span-2">
+                <label className="flex items-center gap-2 text-sm text-gray-400">
+                  <input
+                    type="checkbox"
+                    checked={dryRun}
+                    onChange={(e) => setDryRun(e.target.checked)}
+                    className="rounded border-gray-600 bg-gray-800"
+                  />
+                  Dry run (mock provider responses)
+                </label>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* CLI preview */}
+        {cliPreview && (
+          <div className="rounded-md border border-gray-700 bg-gray-950 p-3">
+            <div className="mb-1 text-xs text-gray-500">CLI Preview</div>
+            <code className="block break-all text-xs text-cyan-300">{cliPreview}</code>
+          </div>
+        )}
+
+        {/* Error */}
+        {error && (
+          <div className="rounded-md border border-red-900/50 bg-red-950/20 p-2 text-sm text-red-400">
+            {error}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md bg-gray-700 px-4 py-2 text-sm text-white hover:bg-gray-600"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleLaunch}
+            disabled={!canLaunch || launching}
+            className="rounded-md bg-cyan-600 px-4 py-2 text-sm font-medium text-white hover:bg-cyan-500 disabled:opacity-50"
+          >
+            {launching ? 'Launching…' : 'Run Now'}
+          </button>
+        </div>
+      </div>
+    </ModalShell>
+  );
+}
+
+// ── Sub-components ───────────────────────────────────────────────────────
+
+function ModalShell({
+  children,
+  onClose,
+  title,
+}: {
+  children: React.ReactNode;
+  onClose: () => void;
+  title: string;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 pt-[10vh]">
+      <div className="w-full max-w-lg rounded-lg border border-gray-700 bg-gray-900 shadow-xl">
+        <div className="flex items-center justify-between border-b border-gray-800 px-5 py-3">
+          <h2 className="text-lg font-semibold text-white">{title}</h2>
+          <button type="button" onClick={onClose} className="text-gray-400 hover:text-white">
+            ✕
+          </button>
+        </div>
+        <div className="px-5 py-4">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+function RunStatusView({
+  status,
+  onClose,
+}: {
+  status: import('~/lib/types').EvalRunStatus;
+  onClose: () => void;
+}) {
+  const isTerminal = status.status === 'finished' || status.status === 'failed';
+
+  const statusColors: Record<string, string> = {
+    starting: 'text-yellow-400',
+    running: 'text-cyan-400',
+    finished: 'text-emerald-400',
+    failed: 'text-red-400',
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-3">
+        <span className={`text-sm font-medium ${statusColors[status.status] ?? 'text-gray-400'}`}>
+          {status.status === 'running' && '●'}{' '}
+          {status.status.charAt(0).toUpperCase() + status.status.slice(1)}
+        </span>
+        {!isTerminal && (
+          <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-cyan-400 border-t-transparent" />
+        )}
+      </div>
+
+      <div className="rounded-md border border-gray-700 bg-gray-950 p-3">
+        <code className="block break-all text-xs text-cyan-300">{status.command}</code>
+      </div>
+
+      {status.stdout && (
+        <div className="max-h-48 overflow-y-auto rounded-md bg-gray-950 p-3">
+          <pre className="whitespace-pre-wrap text-xs text-gray-300">
+            {status.stdout.slice(-3000)}
+          </pre>
+        </div>
+      )}
+
+      {status.stderr && (
+        <div className="max-h-24 overflow-y-auto rounded-md bg-red-950/20 p-3">
+          <pre className="whitespace-pre-wrap text-xs text-red-300">
+            {status.stderr.slice(-2000)}
+          </pre>
+        </div>
+      )}
+
+      {isTerminal && (
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-gray-500">
+            Exit code: {status.exit_code}
+            {status.finished_at && ` · ${new Date(status.finished_at).toLocaleTimeString()}`}
+          </span>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md bg-gray-700 px-4 py-2 text-sm text-white hover:bg-gray-600"
+          >
+            Close
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/studio/src/lib/api.ts
+++ b/apps/studio/src/lib/api.ts
@@ -10,6 +10,11 @@ import { queryOptions, useQuery } from '@tanstack/react-query';
 import type {
   CategoriesResponse,
   EvalDetailResponse,
+  EvalDiscoverResponse,
+  EvalPreviewResponse,
+  EvalRunResponse,
+  EvalRunStatus,
+  EvalTargetsResponse,
   ExperimentsResponse,
   FeedbackData,
   FileContentResponse,
@@ -18,6 +23,7 @@ import type {
   ProjectEntry,
   ProjectListResponse,
   RunDetailResponse,
+  RunEvalRequest,
   RunListResponse,
   StudioConfigResponse,
   SuitesResponse,
@@ -395,4 +401,80 @@ export async function saveStudioConfig(
     throw new Error(`Failed to save config: ${res.status}`);
   }
   return res.json() as Promise<StudioConfigResponse>;
+}
+
+// ── Eval runner queries & mutations ──────────────────────────────────────
+
+export function evalDiscoverOptions(projectId?: string) {
+  const url = projectId ? `${projectApiBase(projectId)}/eval/discover` : '/api/eval/discover';
+  return queryOptions({
+    queryKey: ['eval-discover', projectId ?? ''],
+    queryFn: () => fetchJson<EvalDiscoverResponse>(url),
+    staleTime: 30_000,
+  });
+}
+
+export function useEvalDiscover(projectId?: string) {
+  return useQuery(evalDiscoverOptions(projectId));
+}
+
+export function evalTargetsOptions(projectId?: string) {
+  const url = projectId ? `${projectApiBase(projectId)}/eval/targets` : '/api/eval/targets';
+  return queryOptions({
+    queryKey: ['eval-targets', projectId ?? ''],
+    queryFn: () => fetchJson<EvalTargetsResponse>(url),
+    staleTime: 30_000,
+  });
+}
+
+export function useEvalTargets(projectId?: string) {
+  return useQuery(evalTargetsOptions(projectId));
+}
+
+export async function launchEvalRun(
+  body: RunEvalRequest,
+  projectId?: string,
+): Promise<EvalRunResponse> {
+  const url = projectId ? `${projectApiBase(projectId)}/eval/run` : '/api/eval/run';
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }));
+    throw new Error((err as { error?: string }).error ?? `Failed: ${res.status}`);
+  }
+  return res.json() as Promise<EvalRunResponse>;
+}
+
+export function evalRunStatusOptions(runId: string | null) {
+  return queryOptions({
+    queryKey: ['eval-status', runId],
+    queryFn: () => fetchJson<EvalRunStatus>(`/api/eval/status/${runId}`),
+    enabled: !!runId,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      if (status === 'finished' || status === 'failed') return false;
+      return 2_000;
+    },
+  });
+}
+
+export function useEvalRunStatus(runId: string | null) {
+  return useQuery(evalRunStatusOptions(runId));
+}
+
+export async function previewEvalCommand(
+  body: RunEvalRequest,
+  projectId?: string,
+): Promise<EvalPreviewResponse> {
+  const url = projectId ? `${projectApiBase(projectId)}/eval/preview` : '/api/eval/preview';
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`Preview failed: ${res.status}`);
+  return res.json() as Promise<EvalPreviewResponse>;
 }

--- a/apps/studio/src/lib/types.ts
+++ b/apps/studio/src/lib/types.ts
@@ -195,3 +195,60 @@ export interface ProjectEntry {
   added_at: string;
   last_opened_at: string;
 }
+
+// ── Eval runner types ────────────────────────────────────────────────────
+
+export interface DiscoveredEvalFile {
+  path: string;
+  relative_path: string;
+  category: string;
+}
+
+export interface EvalDiscoverResponse {
+  eval_files: DiscoveredEvalFile[];
+}
+
+export interface EvalTargetsResponse {
+  targets: string[];
+}
+
+export interface RunEvalRequest {
+  suite_filter?: string;
+  test_ids?: string[];
+  target?: string;
+  threshold?: number;
+  workers?: number;
+  dry_run?: boolean;
+}
+
+export interface EvalRunResponse {
+  id: string;
+  status: string;
+  command: string;
+}
+
+export interface EvalRunStatus {
+  id: string;
+  status: 'starting' | 'running' | 'finished' | 'failed';
+  command: string;
+  started_at: string;
+  finished_at: string | null;
+  exit_code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+export interface EvalRunListResponse {
+  runs: Array<{
+    id: string;
+    status: string;
+    command: string;
+    started_at: string;
+    finished_at: string | null;
+    exit_code: number | null;
+  }>;
+}
+
+export interface EvalPreviewResponse {
+  command: string;
+}

--- a/apps/studio/src/routes/evals/$runId.$evalId.tsx
+++ b/apps/studio/src/routes/evals/$runId.$evalId.tsx
@@ -7,8 +7,10 @@
  */
 
 import { createFileRoute } from '@tanstack/react-router';
+import { useState } from 'react';
 
 import { EvalDetail } from '~/components/EvalDetail';
+import { RunEvalModal } from '~/components/RunEvalModal';
 import { useRunDetail } from '~/lib/api';
 
 export const Route = createFileRoute('/evals/$runId/$evalId')({
@@ -18,6 +20,7 @@ export const Route = createFileRoute('/evals/$runId/$evalId')({
 function EvalDetailPage() {
   const { runId, evalId } = Route.useParams();
   const { data, isLoading, error } = useRunDetail(runId);
+  const [showRunEval, setShowRunEval] = useState(false);
 
   if (isLoading) {
     return (
@@ -51,13 +54,30 @@ function EvalDetailPage() {
 
   return (
     <div className="flex h-full flex-col gap-6">
-      <div>
-        <p className="text-sm text-gray-400">
-          Run: {runId} / Eval: {evalId}
-        </p>
-        <h1 className="text-2xl font-semibold text-white">{evalId}</h1>
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm text-gray-400">
+            Run: {runId} / Eval: {evalId}
+          </p>
+          <h1 className="text-2xl font-semibold text-white">{evalId}</h1>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowRunEval(true)}
+          className="rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-500"
+        >
+          ▶ Run this Test
+        </button>
       </div>
       <EvalDetail eval={result} runId={runId} />
+      <RunEvalModal
+        open={showRunEval}
+        onClose={() => setShowRunEval(false)}
+        prefill={{
+          testIds: [evalId],
+          target: result.target,
+        }}
+      />
     </div>
   );
 }

--- a/apps/studio/src/routes/index.tsx
+++ b/apps/studio/src/routes/index.tsx
@@ -12,6 +12,7 @@ import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { ExperimentsTab } from '~/components/ExperimentsTab';
 import { ProjectCard } from '~/components/ProjectCard';
+import { RunEvalModal } from '~/components/RunEvalModal';
 import { RunList } from '~/components/RunList';
 import { TargetsTab } from '~/components/TargetsTab';
 import { addProjectApi, discoverProjectsApi, useProjectList, useRunList } from '~/lib/api';
@@ -52,6 +53,7 @@ function ProjectsDashboard() {
   const [discoverPath, setDiscoverPath] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
+  const [showRunEval, setShowRunEval] = useState(false);
 
   const projects = data?.projects ?? [];
 
@@ -89,13 +91,22 @@ function ProjectsDashboard() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold text-white">Projects</h1>
-        <button
-          type="button"
-          onClick={() => setShowAddForm(!showAddForm)}
-          className="rounded-md bg-cyan-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-cyan-500"
-        >
-          {showAddForm ? 'Cancel' : 'Add Project'}
-        </button>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => setShowRunEval(true)}
+            className="rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-500"
+          >
+            ▶ Run Eval
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowAddForm(!showAddForm)}
+            className="rounded-md bg-cyan-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-cyan-500"
+          >
+            {showAddForm ? 'Cancel' : 'Add Project'}
+          </button>
+        </div>
       </div>
 
       {error && (
@@ -144,6 +155,8 @@ function ProjectsDashboard() {
           <ProjectCard key={project.id} project={project} />
         ))}
       </div>
+
+      <RunEvalModal open={showRunEval} onClose={() => setShowRunEval(false)} />
     </div>
   );
 }
@@ -156,12 +169,22 @@ function SingleProjectHome() {
   const tab = searchParams.tab as TabId | undefined;
   const navigate = useNavigate();
   const { data, isLoading, error } = useRunList();
+  const [showRunEval, setShowRunEval] = useState(false);
 
   const activeTab: TabId = tabs.some((t) => t.id === tab) ? (tab as TabId) : 'runs';
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-semibold text-white">Evaluation Runs</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-white">Evaluation Runs</h1>
+        <button
+          type="button"
+          onClick={() => setShowRunEval(true)}
+          className="rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-500"
+        >
+          ▶ Run Eval
+        </button>
+      </div>
 
       {/* Tab navigation */}
       <div className="border-b border-gray-800">
@@ -187,6 +210,8 @@ function SingleProjectHome() {
       {activeTab === 'runs' && <RunsTabContent data={data} isLoading={isLoading} error={error} />}
       {activeTab === 'experiments' && <ExperimentsTab />}
       {activeTab === 'targets' && <TargetsTab />}
+
+      <RunEvalModal open={showRunEval} onClose={() => setShowRunEval(false)} />
     </div>
   );
 }

--- a/apps/studio/src/routes/projects/$projectId.tsx
+++ b/apps/studio/src/routes/projects/$projectId.tsx
@@ -5,8 +5,10 @@
  */
 
 import { createFileRoute, useNavigate, useRouterState } from '@tanstack/react-router';
+import { useState } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
+import { RunEvalModal } from '~/components/RunEvalModal';
 import { RunList } from '~/components/RunList';
 import { useProjectRunList } from '~/lib/api';
 import { projectExperimentsOptions, projectTargetsOptions } from '~/lib/api';
@@ -30,12 +32,22 @@ function ProjectHomePage() {
   const searchParams = routerState.location.search as Record<string, string>;
   const tab = searchParams.tab as TabId | undefined;
   const navigate = useNavigate();
+  const [showRunEval, setShowRunEval] = useState(false);
 
   const activeTab: TabId = tabs.some((t) => t.id === tab) ? (tab as TabId) : 'runs';
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-semibold text-white">{projectId}</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-white">{projectId}</h1>
+        <button
+          type="button"
+          onClick={() => setShowRunEval(true)}
+          className="rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-500"
+        >
+          ▶ Run Eval
+        </button>
+      </div>
 
       {/* Tab navigation */}
       <div className="border-b border-gray-800">
@@ -66,6 +78,12 @@ function ProjectHomePage() {
       {activeTab === 'runs' && <ProjectRunsTab projectId={projectId} />}
       {activeTab === 'experiments' && <ProjectExperimentsTab projectId={projectId} />}
       {activeTab === 'targets' && <ProjectTargetsTab projectId={projectId} />}
+
+      <RunEvalModal
+        open={showRunEval}
+        onClose={() => setShowRunEval(false)}
+        projectId={projectId}
+      />
     </div>
   );
 }

--- a/apps/studio/src/routes/projects/$projectId_/evals/$runId.$evalId.tsx
+++ b/apps/studio/src/routes/projects/$projectId_/evals/$runId.$evalId.tsx
@@ -3,8 +3,10 @@
  */
 
 import { createFileRoute } from '@tanstack/react-router';
+import { useState } from 'react';
 
 import { EvalDetail } from '~/components/EvalDetail';
+import { RunEvalModal } from '~/components/RunEvalModal';
 import { useProjectRunDetail } from '~/lib/api';
 
 export const Route = createFileRoute('/projects/$projectId_/evals/$runId/$evalId')({
@@ -14,6 +16,7 @@ export const Route = createFileRoute('/projects/$projectId_/evals/$runId/$evalId
 function ProjectEvalDetailPage() {
   const { projectId, runId, evalId } = Route.useParams();
   const { data, isLoading, error } = useProjectRunDetail(projectId, runId);
+  const [showRunEval, setShowRunEval] = useState(false);
 
   if (isLoading) {
     return (
@@ -47,13 +50,31 @@ function ProjectEvalDetailPage() {
 
   return (
     <div className="flex h-full flex-col gap-6">
-      <div>
-        <p className="text-sm text-gray-400">
-          Run: {runId} / Eval: {evalId}
-        </p>
-        <h1 className="text-2xl font-semibold text-white">{evalId}</h1>
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm text-gray-400">
+            Run: {runId} / Eval: {evalId}
+          </p>
+          <h1 className="text-2xl font-semibold text-white">{evalId}</h1>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowRunEval(true)}
+          className="rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-500"
+        >
+          ▶ Run this Test
+        </button>
       </div>
       <EvalDetail eval={result} runId={runId} projectId={projectId} />
+      <RunEvalModal
+        open={showRunEval}
+        onClose={() => setShowRunEval(false)}
+        projectId={projectId}
+        prefill={{
+          testIds: [evalId],
+          target: result.target,
+        }}
+      />
     </div>
   );
 }

--- a/apps/studio/src/routes/projects/$projectId_/runs/$runId.tsx
+++ b/apps/studio/src/routes/projects/$projectId_/runs/$runId.tsx
@@ -3,8 +3,10 @@
  */
 
 import { createFileRoute } from '@tanstack/react-router';
+import { useState } from 'react';
 
 import { RunDetail } from '~/components/RunDetail';
+import { RunEvalModal } from '~/components/RunEvalModal';
 import { useProjectRunDetail } from '~/lib/api';
 
 export const Route = createFileRoute('/projects/$projectId_/runs/$runId')({
@@ -14,6 +16,7 @@ export const Route = createFileRoute('/projects/$projectId_/runs/$runId')({
 function ProjectRunDetailPage() {
   const { projectId, runId } = Route.useParams();
   const { data, isLoading, error } = useProjectRunDetail(projectId, runId);
+  const [showRunEval, setShowRunEval] = useState(false);
 
   if (isLoading) {
     return (
@@ -36,13 +39,31 @@ function ProjectRunDetailPage() {
     );
   }
 
+  const firstResult = data?.results?.[0];
+  const prefill = firstResult?.target ? { target: firstResult.target } : undefined;
+
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold text-white">Run: {runId}</h1>
-        <p className="mt-1 text-sm text-gray-400">Source: {data?.source}</p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-white">Run: {runId}</h1>
+          <p className="mt-1 text-sm text-gray-400">Source: {data?.source}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowRunEval(true)}
+          className="rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-500"
+        >
+          ▶ Re-run with Filters
+        </button>
       </div>
       <RunDetail results={data?.results ?? []} runId={runId} projectId={projectId} />
+      <RunEvalModal
+        open={showRunEval}
+        onClose={() => setShowRunEval(false)}
+        projectId={projectId}
+        prefill={prefill}
+      />
     </div>
   );
 }

--- a/apps/studio/src/routes/runs/$runId.tsx
+++ b/apps/studio/src/routes/runs/$runId.tsx
@@ -3,8 +3,10 @@
  */
 
 import { createFileRoute } from '@tanstack/react-router';
+import { useState } from 'react';
 
 import { RunDetail } from '~/components/RunDetail';
+import { RunEvalModal } from '~/components/RunEvalModal';
 import { useRunDetail } from '~/lib/api';
 
 export const Route = createFileRoute('/runs/$runId')({
@@ -14,6 +16,7 @@ export const Route = createFileRoute('/runs/$runId')({
 function RunDetailPage() {
   const { runId } = Route.useParams();
   const { data, isLoading, error } = useRunDetail(runId);
+  const [showRunEval, setShowRunEval] = useState(false);
 
   if (isLoading) {
     return (
@@ -36,13 +39,27 @@ function RunDetailPage() {
     );
   }
 
+  // Derive prefill from run data
+  const firstResult = data?.results?.[0];
+  const prefill = firstResult?.target ? { target: firstResult.target } : undefined;
+
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold text-white">Run: {runId}</h1>
-        <p className="mt-1 text-sm text-gray-400">Source: {data?.source}</p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-white">Run: {runId}</h1>
+          <p className="mt-1 text-sm text-gray-400">Source: {data?.source}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowRunEval(true)}
+          className="rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-500"
+        >
+          ▶ Re-run with Filters
+        </button>
       </div>
       <RunDetail results={data?.results ?? []} runId={runId} />
+      <RunEvalModal open={showRunEval} onClose={() => setShowRunEval(false)} prefill={prefill} />
     </div>
   );
 }


### PR DESCRIPTION
## feat: Run Evals from Studio (#945)

Adds a lightweight "Run Eval" flow to Studio that maps to existing CLI args, so users can launch evals without switching to the terminal.

### What's New

**Backend (`apps/cli/src/commands/results/eval-runner.ts`)**
- `GET /api/eval/discover` — finds eval files in the project via glob
- `GET /api/eval/targets` — discovers target definitions from targets.yaml
- `POST /api/eval/run` — spawns `agentv eval ...` as a child process
- `GET /api/eval/status/:id` — polls process state (stdout/stderr streaming)
- `POST /api/eval/preview` — returns the CLI command that would be executed
- `GET /api/eval/runs` — lists active and recent runs
- All endpoints also project-scoped under `/api/projects/:projectId/eval/*`

**Frontend (`apps/studio/src/components/RunEvalModal.tsx`)**
- Two-step wizard modal:
  - **Step 1:** Suite filter (with file discovery suggestions), test-id pill input, target dropdown (auto-populated)
  - **Step 2:** Advanced options (threshold, workers, dry-run)
- CLI command preview before launch
- Live status view with stdout/stderr streaming, exit code display
- Auto-refreshes runs list on completion

**Entry Points (3 pages × 2 scopes = 6 route files)**
- Home page → **"▶ Run Eval"** button
- Run detail → **"▶ Re-run with Filters"** (prefills target from current run)
- Eval detail → **"▶ Run this Test"** (prefills test-id and target)

### E2E Validation (agent-browser)

All flows validated in headless Chrome:
1. ✅ "Run Eval" button visible on home page
2. ✅ Modal opens with suite filter, test-id input, target dropdown (18 targets discovered)
3. ✅ Eval file suggestions clickable, test-id pills work
4. ✅ CLI preview renders correctly
5. ✅ Advanced options expand/collapse
6. ✅ Failed run (bad filter) shows error with exit code 1
7. ✅ Successful dry-run shows "Finished" with stdout streaming, exit code 0
8. ✅ Runs list auto-refreshes with new run visible
9. ✅ "Re-run with Filters" button on run detail page
10. ✅ "Run this Test" button on eval detail page

### Files Changed
- **New:** `apps/cli/src/commands/results/eval-runner.ts`
- **New:** `apps/studio/src/components/RunEvalModal.tsx`
- **Modified:** `apps/cli/src/commands/results/serve.ts` (route registration)
- **Modified:** `apps/studio/src/lib/types.ts` (eval runner types)
- **Modified:** `apps/studio/src/lib/api.ts` (query hooks + mutations)
- **Modified:** 6 route files (entry point buttons)

Closes #945