### PR TITLE
chore(ci): add release and promote GitHub workflows

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,31 @@
+name: Promote to latest
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to promote (e.g. 2.18.0). Leave empty to use version from package.json."
+        required: false
+        type: string
+
+jobs:
+  promote:
+    name: Promote npm dist-tag to latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Configure npm auth
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Promote to latest
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            bun run promote:latest "${{ inputs.version }}"
+          else
+            bun run promote:latest
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Build
+        run: bun run build
+
+      - name: Configure npm auth
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm (next)
+        run: bun run publish:next
+
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: publish
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          # Get the previous tag
+          PREV_TAG=$(git tag --sort=-version:refname | grep -v "$(git describe --tags --exact-match)" | head -1)
+          if [ -z "$PREV_TAG" ]; then
+            echo "body=Initial release" >> "$GITHUB_OUTPUT"
+          else
+            NOTES=$(git log --pretty=format:"- %s" "${PREV_TAG}..HEAD" --no-merges)
+            {
+              echo "body<<EOF"
+              echo "$NOTES"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: ${{ steps.notes.outputs.body }}
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- **Release workflow** (`release.yml`): Triggers on `v*` tag push. Builds, publishes all packages to npm `next` channel, then creates a GitHub Release with auto-generated release notes.
- **Promote workflow** (`promote.yml`): Manual dispatch. Promotes a version from `next` to `latest` dist-tag. Accepts optional version input (defaults to package.json version).

Both workflows use `NPM_TOKEN` secret for npm auth (generated dynamically as `.npmrc` — not committed).

## Setup required
1. Add `NPM_TOKEN` to GitHub repo secrets (Settings > Secrets > Actions)
   - Generate from npmjs.com: Access Tokens > Generate New Token > Automation

## Release flow
```
bun run release          # bumps version, creates v* tag, pushes
# → release.yml triggers automatically → publishes to npm next
# verify on npm, then:
gh workflow run promote.yml   # or use Actions UI to promote to latest
```

## Test plan
- [ ] Add `NPM_TOKEN` secret to the repo
- [ ] Run `bun run release` to create a tag and verify the release workflow triggers
- [ ] Verify packages appear on npm with `next` tag
- [ ] Run promote workflow from Actions UI and verify `latest` tag updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)