### PR TITLE
feat(cli): extend --retry-errors to resume missing cases from crashed runs

### DIFF
--- a/apps/cli/src/commands/eval/retry-errors.ts
+++ b/apps/cli/src/commands/eval/retry-errors.ts
@@ -7,6 +7,14 @@ async function loadRetrySourceResults(jsonlPath: string): Promise<readonly Evalu
 }
 
 /**
+ * Escape micromatch glob metacharacters in a string so it matches literally.
+ * Characters escaped: * ? [ ] { } ( ) ! @ # + |
+ */
+function escapeGlob(id: string): string {
+  return id.replace(/[*?[\]{}()!@#+|\\]/g, '\\$&');
+}
+
+/**
  * Load test IDs from an index/results source that have executionStatus === 'execution_error'.
  */
 export async function loadErrorTestIds(jsonlPath: string): Promise<readonly string[]> {
@@ -18,15 +26,35 @@ export async function loadErrorTestIds(jsonlPath: string): Promise<readonly stri
 }
 
 /**
- * Load test IDs from an index/results source that completed successfully (non-error).
- * Used for resume: any test NOT in this set needs to be re-run.
+ * Load test IDs that are fully completed (non-error) across ALL targets.
+ * A test ID is only considered "completed" if every result for that ID is non-error.
+ * This is conservative for matrix runs: if case-1 succeeded on target A but errored
+ * on target B, case-1 is NOT excluded (it will re-run on both targets).
  */
-export async function loadCompletedTestIds(jsonlPath: string): Promise<readonly string[]> {
-  const ids = (await loadRetrySourceResults(jsonlPath))
-    .filter((result) => result.testId && result.executionStatus !== 'execution_error')
-    .map((result) => result.testId);
+export async function loadFullyCompletedTestIds(jsonlPath: string): Promise<readonly string[]> {
+  const results = await loadRetrySourceResults(jsonlPath);
+  const allIds = new Set<string>();
+  const errorIds = new Set<string>();
 
-  return [...new Set(ids)];
+  for (const result of results) {
+    if (!result.testId) continue;
+    allIds.add(result.testId);
+    if (result.executionStatus === 'execution_error') {
+      errorIds.add(result.testId);
+    }
+  }
+
+  // Only IDs where every result is non-error
+  return [...allIds].filter((id) => !errorIds.has(id));
+}
+
+/**
+ * Build a micromatch negation pattern that excludes the given test IDs.
+ * Escapes glob metacharacters in IDs to ensure literal matching.
+ */
+export function buildExclusionFilter(completedIds: readonly string[]): string {
+  const escaped = completedIds.map(escapeGlob);
+  return escaped.length === 1 ? `!${escaped[0]}` : `!{${escaped.join(',')}}`;
 }
 
 /**

--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -34,7 +34,12 @@ import { loadEnvFromHierarchy } from './env.js';
 import { type OutputWriter, createOutputWriter, createWriterFromPath } from './output-writer.js';
 import { ProgressDisplay, type Verdict, type WorkerProgress } from './progress-display.js';
 import { buildDefaultRunDir } from './result-layout.js';
-import { loadCompletedTestIds, loadErrorTestIds, loadNonErrorResults } from './retry-errors.js';
+import {
+  buildExclusionFilter,
+  loadErrorTestIds,
+  loadFullyCompletedTestIds,
+  loadNonErrorResults,
+} from './retry-errors.js';
 import { saveRunCache } from './run-cache.js';
 import { findRepoRoot } from './shared.js';
 import {
@@ -904,19 +909,18 @@ export async function runEvalCommand(
   if (options.retryErrors) {
     const retryPath = path.resolve(options.retryErrors);
     await ensureFileExists(retryPath, 'Retry-errors JSONL file');
-    const completedIds = await loadCompletedTestIds(retryPath);
+    const completedIds = await loadFullyCompletedTestIds(retryPath);
     const errorIds = await loadErrorTestIds(retryPath);
     retryNonErrorResults = await loadNonErrorResults(retryPath);
 
     if (errorIds.length > 0) {
       console.log(`Found ${errorIds.length} execution-error test(s): ${errorIds.join(', ')}`);
     }
-    // Use a negation filter to exclude completed (non-error) cases.
-    // This re-runs both error cases and any cases missing from the previous output (crash recovery).
+    // Use a negation filter to exclude fully-completed (non-error across all targets) cases.
+    // This re-runs error cases, cases missing from the output (crash recovery), and cases
+    // that errored on some targets even if they succeeded on others (matrix safety).
     if (completedIds.length > 0) {
-      const excludePattern =
-        completedIds.length === 1 ? `!${completedIds[0]}` : `!{${completedIds.join(',')}}`;
-      options = { ...options, filter: excludePattern };
+      options = { ...options, filter: buildExclusionFilter(completedIds) };
       console.log(`Skipping ${completedIds.length} already-completed test(s).`);
     }
   }
@@ -1204,9 +1208,9 @@ export async function runEvalCommand(
   }
 
   if (totalEvalCount === 0) {
-    // When using --retry-errors, all tests being filtered means everything completed successfully
+    // When using --retry-errors, all tests being filtered means no errors or missing cases remain
     if (options.retryErrors && retryNonErrorResults && retryNonErrorResults.length > 0) {
-      console.log('All tests completed successfully in the previous run. Nothing to retry.');
+      console.log('No execution errors or missing cases in the previous run. Nothing to retry.');
       return;
     }
     throw new Error('No tests matched the provided filters.');

--- a/apps/cli/test/unit/retry-errors.test.ts
+++ b/apps/cli/test/unit/retry-errors.test.ts
@@ -4,8 +4,9 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import {
-  loadCompletedTestIds,
+  buildExclusionFilter,
   loadErrorTestIds,
+  loadFullyCompletedTestIds,
   loadNonErrorResults,
 } from '../../src/commands/eval/retry-errors.js';
 
@@ -135,7 +136,7 @@ describe('retry-errors', () => {
     expect(ids).toEqual(['case-2']);
   });
 
-  it('loadCompletedTestIds returns only non-error test IDs', async () => {
+  it('loadFullyCompletedTestIds returns only non-error test IDs', async () => {
     const filePath = createIndexFile([
       { test_id: 'case-1', execution_status: 'ok', score: 0.9 },
       { test_id: 'case-2', execution_status: 'execution_error', score: 0, error: 'timeout' },
@@ -148,28 +149,42 @@ describe('retry-errors', () => {
       },
     ]);
 
-    const ids = await loadCompletedTestIds(filePath);
+    const ids = await loadFullyCompletedTestIds(filePath);
     expect(ids).toEqual(['case-1', 'case-3']);
   });
 
-  it('loadCompletedTestIds returns empty array when all are errors', async () => {
+  it('loadFullyCompletedTestIds returns empty array when all are errors', async () => {
     const filePath = createIndexFile([
       { test_id: 'case-1', execution_status: 'execution_error', score: 0 },
       { test_id: 'case-2', execution_status: 'execution_error', score: 0 },
     ]);
 
-    const ids = await loadCompletedTestIds(filePath);
+    const ids = await loadFullyCompletedTestIds(filePath);
     expect(ids).toEqual([]);
   });
 
-  it('loadCompletedTestIds deduplicates IDs', async () => {
+  it('loadFullyCompletedTestIds excludes IDs that errored on any target (matrix safety)', async () => {
     const filePath = createIndexFile([
-      { test_id: 'case-1', execution_status: 'ok', score: 0.9 },
-      { test_id: 'case-1', execution_status: 'ok', score: 0.8 },
+      { test_id: 'case-1', execution_status: 'ok', score: 0.9, target: 'gpt-4' },
+      { test_id: 'case-1', execution_status: 'execution_error', score: 0, target: 'claude' },
+      { test_id: 'case-2', execution_status: 'ok', score: 0.8, target: 'gpt-4' },
+      { test_id: 'case-2', execution_status: 'ok', score: 0.7, target: 'claude' },
     ]);
 
-    const ids = await loadCompletedTestIds(filePath);
-    expect(ids).toEqual(['case-1']);
+    const ids = await loadFullyCompletedTestIds(filePath);
+    // case-1 errored on claude, so it should NOT be excluded from retry
+    expect(ids).toEqual(['case-2']);
+  });
+
+  it('buildExclusionFilter escapes glob metacharacters in test IDs', () => {
+    expect(buildExclusionFilter(['simple'])).toBe('!simple');
+    expect(buildExclusionFilter(['a', 'b'])).toBe('!{a,b}');
+    // Braces, brackets, stars, question marks should be escaped
+    expect(buildExclusionFilter(['test[1]'])).toBe('!test\\[1\\]');
+    expect(buildExclusionFilter(['test{a}'])).toBe('!test\\{a\\}');
+    expect(buildExclusionFilter(['test*'])).toBe('!test\\*');
+    expect(buildExclusionFilter(['test?'])).toBe('!test\\?');
+    expect(buildExclusionFilter(['!negated'])).toBe('!\\!negated');
   });
 
   it('throws on malformed index.jsonl lines', async () => {


### PR DESCRIPTION
Closes #975

## Summary
- Extends `--retry-errors` to also re-run test cases that are **missing** from the previous output (e.g., due to a crash or Ctrl+C mid-run), not just `execution_error` cases
- Uses a micromatch negation filter to exclude completed (non-error) test IDs, so any test not in the previous output runs naturally
- No new checkpoint system, CLI commands, or flags — reuses existing `index.jsonl` artifacts
- Matrix-safe: only excludes test IDs where ALL results across targets are non-error
- Escapes glob metacharacters in test IDs for correct literal matching

## How it works

Previously `--retry-errors` built an inclusion filter matching only error test IDs. Now it builds an exclusion filter (`!{completed-1,completed-2,...}`) that skips already-completed tests. This naturally includes:
1. Tests that errored (`execution_error`)
2. Tests that never ran (missing from output due to crash)

## Test plan
- [x] Unit tests for `loadFullyCompletedTestIds()`, `buildExclusionFilter()` (12 tests pass)
- [x] Build, typecheck, lint all pass
- [x] Manual e2e: partial run (2/5 completed) → `--retry-errors` runs 3 missing cases, merges 2 preserved
- [x] Manual e2e: all completed → prints "No execution errors or missing cases. Nothing to retry."
- [x] Manual e2e: matrix case (same test ID ok on one target, errored on another) → re-runs on all targets (conservative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)