### PR TITLE
ci: manually exchange OIDC token for npm dist-tag auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,19 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: true
 
+      - name: Configure npm auth via OIDC (promote only)
+        if: inputs.action == 'promote-latest'
+        run: |
+          OIDC_TOKEN=$(curl -sS \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm:registry.npmjs.org" \
+            | jq -r '.value')
+          NPM_TOKEN=$(curl -sS -X POST \
+            "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/%40agentv%2Fcore" \
+            -H "Authorization: Bearer ${OIDC_TOKEN}" \
+            | jq -r '.token')
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+
       - name: Promote to latest
         if: inputs.action == 'promote-latest'
         run: |


### PR DESCRIPTION
`npm dist-tag` doesn't support `--provenance`, so it can't use the automatic OIDC exchange. This manually:
1. Requests a GitHub OIDC token with `npm:registry.npmjs.org` audience
2. Exchanges it for a short-lived npm token via `/-/npm/v1/oidc/token/exchange/package/...`
3. Writes the token to `~/.npmrc` before running `promote:latest`

No web UI changes or stored secrets needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)