### PR TITLE
fix(core): accept string items in message content arrays

### DIFF
--- a/packages/core/src/evaluation/input-message-utils.ts
+++ b/packages/core/src/evaluation/input-message-utils.ts
@@ -53,6 +53,14 @@ export function extractContentSegments(content: TestMessageContent): JsonObject[
   const segments: JsonObject[] = [];
 
   for (const segment of content) {
+    // Plain string items inside a content array are treated as text segments.
+    // This matches the validator, which accepts string items in content arrays.
+    if (typeof segment === 'string') {
+      if (segment.trim().length > 0) {
+        segments.push({ type: 'text', value: segment });
+      }
+      continue;
+    }
     if (!isJsonObject(segment)) {
       continue;
     }

--- a/packages/core/src/evaluation/loaders/message-processor.ts
+++ b/packages/core/src/evaluation/loaders/message-processor.ts
@@ -79,6 +79,18 @@ export async function processMessages(options: ProcessMessagesOptions): Promise<
     const processedContent: JsonObject[] = [];
 
     for (const rawSegment of content) {
+      // Plain string items inside a content array are treated as inline text segments.
+      // This matches the validator, which accepts string items alongside structured blocks.
+      if (typeof rawSegment === 'string') {
+        if (rawSegment.length > 0) {
+          processedContent.push({ type: 'text', value: rawSegment });
+          if (textParts) {
+            textParts.push(rawSegment);
+          }
+        }
+        continue;
+      }
+
       if (!isJsonObject(rawSegment)) {
         continue;
       }
@@ -334,6 +346,14 @@ export async function processExpectedMessages(
       // Process content array, resolving file references
       const processedContent: JsonObject[] = [];
       for (const rawSegment of content) {
+        // Plain string items are treated as inline text segments (matches validator).
+        if (typeof rawSegment === 'string') {
+          if (rawSegment.length > 0) {
+            processedContent.push({ type: 'text', value: rawSegment });
+          }
+          continue;
+        }
+
         if (!isJsonObject(rawSegment)) {
           continue;
         }

--- a/packages/core/src/evaluation/types.ts
+++ b/packages/core/src/evaluation/types.ts
@@ -40,8 +40,12 @@ const TEST_MESSAGE_ROLE_SET: ReadonlySet<string> = new Set(TEST_MESSAGE_ROLE_VAL
 
 /**
  * Text or structured payload attached to a message.
+ *
+ * Content arrays may mix plain string items with structured content blocks
+ * (e.g. `{ type: 'text' | 'file' | 'image', value: ... }`). Plain string items
+ * are treated as text segments by the loader and prompt builder.
  */
-export type TestMessageContent = string | JsonObject | readonly JsonObject[];
+export type TestMessageContent = string | JsonObject | readonly (string | JsonObject)[];
 
 /**
  * System-authored instruction message.
@@ -140,7 +144,12 @@ export function isTestMessage(value: unknown): value is TestMessage {
   if (typeof candidate.content === 'string') {
     return true;
   }
-  if (Array.isArray(candidate.content) && candidate.content.every(isJsonObject)) {
+  // Content arrays may mix plain string items with structured content blocks.
+  // The loader treats string items as text segments (see message-processor.ts).
+  if (
+    Array.isArray(candidate.content) &&
+    candidate.content.every((item) => typeof item === 'string' || isJsonObject(item))
+  ) {
     return true;
   }
   // Allow messages with tool_calls but no content (for expected_output format)

--- a/packages/core/test/evaluation/loaders/message-processor.test.ts
+++ b/packages/core/test/evaluation/loaders/message-processor.test.ts
@@ -162,6 +162,39 @@ describe('processMessages – image content', () => {
     }
   });
 
+  it('converts plain string items in content arrays into text segments', async () => {
+    await setupFixtures();
+    try {
+      const messages: TestMessage[] = [
+        {
+          role: 'user',
+          content: ['Use the local file.', { type: 'file', value: './test-file.txt' }],
+        },
+      ];
+
+      const textParts: string[] = [];
+      const result = await processMessages({
+        messages,
+        searchRoots: [FIXTURE_DIR],
+        repoRootPath: FIXTURE_DIR,
+        textParts,
+        messageType: 'input',
+        verbose: false,
+      });
+
+      const items = result[0].content as Record<string, unknown>[];
+      expect(items).toHaveLength(2);
+      expect(items[0].type).toBe('text');
+      expect(items[0].value).toBe('Use the local file.');
+      expect(items[1].type).toBe('file');
+      expect(items[1].text).toBe('hello world');
+      // Inline string was also surfaced through textParts for prompt building.
+      expect(textParts).toContain('Use the local file.');
+    } finally {
+      await cleanupFixtures();
+    }
+  });
+
   it('preserves existing type: text and type: file behavior', async () => {
     await setupFixtures();
     try {

--- a/packages/core/test/evaluation/loaders/shorthand-expansion.test.ts
+++ b/packages/core/test/evaluation/loaders/shorthand-expansion.test.ts
@@ -61,6 +61,25 @@ describe('expandInputShorthand', () => {
     const messages = [{ invalid: 'message' }, { also: 'invalid' }];
     expect(expandInputShorthand(messages)).toBeUndefined();
   });
+
+  it('accepts messages whose content array mixes plain strings and structured blocks', () => {
+    const messages = [
+      {
+        role: 'user',
+        content: ['Use the local file.', { type: 'file', value: '/README.md' }],
+      },
+    ];
+
+    const result = expandInputShorthand(messages);
+
+    expect(result).toHaveLength(1);
+    const content = result?.[0].content;
+    expect(Array.isArray(content)).toBe(true);
+    const items = content as Array<unknown>;
+    expect(items).toHaveLength(2);
+    expect(items[0]).toBe('Use the local file.');
+    expect(items[1]).toEqual({ type: 'file', value: '/README.md' });
+  });
 });
 
 describe('expandExpectedOutputShorthand', () => {


### PR DESCRIPTION
Closes #1034

## Summary

`agentv validate` accepted message `content` arrays mixing inline strings with structured blocks like `{type: file, value: ...}`, but `agentv eval run` skipped the same test as "incomplete". The validator and the runtime loader disagreed on what a valid `TestMessage` looked like.

This PR makes the loader, prompt builder, and `isTestMessage` guard agree with the validator: plain string items inside a content array are treated as inline text segments alongside structured blocks.

## Changes

- `packages/core/src/evaluation/types.ts`
  - Widen `TestMessageContent` to `string | JsonObject | (string | JsonObject)[]`.
  - `isTestMessage` accepts content arrays whose items are strings or JSON objects.
- `packages/core/src/evaluation/input-message-utils.ts`
  - `extractContentSegments` converts string items into `{type:'text',value:...}` segments (drops empty strings).
- `packages/core/src/evaluation/loaders/message-processor.ts`
  - Both `processMessages` and `processExpectedMessages` convert string items to text segments. `processMessages` also surfaces them through `textParts` for prompt building.
- Tests
  - `shorthand-expansion.test.ts`: lock in that mixed string + structured-block content arrays survive `expandInputShorthand`.
  - `message-processor.test.ts`: cover the mixed-content shape end to end (resulting segments + `textParts`).

## Red / Green UAT

Reproduction file:

```yaml
description: red repro with inline string block in content array
tests:
  - id: red-inline-string-block
    criteria: Returns a short answer
    input:
      - role: user
        content:
          - |-
            Use the local file.
          - type: file
            value: /README.md
```

**Red (origin/main):**

```
$ agentv validate red-inline-string-block.eval.yaml
✓ red-inline-string-block.eval.yaml

$ agentv eval run red-inline-string-block.eval.yaml --test-id red-inline-string-block --dry-run
Error: Skipping incomplete test: red-inline-string-block. Missing required fields: id, input, and at least one of criteria/expected_output/assertions
Error: No tests matched the provided filters.
```

**Green (this branch):**

```
$ bun apps/cli/src/cli.ts eval run .tmp/agentv-repro/red-inline-string-block.eval.yaml --test-id red-inline-string-block --dry-run
...
Top performing tests:
  1. red-inline-string-block: 0.000
Results written to: .agentv/results/runs/.../index.jsonl
```

The generated `input.md` shows the inline string and the resolved file content interleaved correctly:

```
@[user]:
Use the local file.

<file path="README.md">
# AgentV
...
</file>
```

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` (1976 tests pass)
- [x] `bunx prek run --all-files --hook-stage pre-push` (Build / Typecheck / Lint / Test / Validate eval YAML files all green)
- [x] Manual red/green eval run on the reproduction file from issue #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)