### PR TITLE
docs(agents): note Studio stale-dist trap under Functional Testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,14 @@ When functionally testing changes to the AgentV CLI, **NEVER** use `agentv` dire
 
 **Prefer running from source** (`src/cli.ts`) during development. The dist build can silently serve stale code if you forget to rebuild after changes.
 
+**Studio frontend exception — rebuild `apps/studio/dist/` before UAT.** Running `agentv studio` from source (`bun apps/cli/src/cli.ts studio ...`) only reloads the CLI and backend routes from source. The Studio web UI (React/Tailwind bundle) is served as static assets from `apps/studio/dist/`, which is build output and does **not** recompile on change. If you are testing Studio UI changes — especially post-merge on `main` or after pulling — rebuild the frontend first:
+
+```bash
+cd apps/studio && bun run build
+```
+
+Skipping this step silently serves the previous bundle, so you'll see the old UI even though your source edits and the backend API are live. This has burned at least one post-merge UAT; always rebuild before screenshotting or driving Studio with `agent-browser`.
+
 ### Browser E2E Testing (Docs Site)
 
 Use `agent-browser` for visual verification of docs site changes. Environment-specific rules:


### PR DESCRIPTION
## Summary

- Adds a paragraph to \`AGENTS.md\` under **Functional Testing (CLI)** explaining that \`bun apps/cli/src/cli.ts studio\` only hot-reloads the CLI / backend routes — the Studio web UI is served as a static bundle from \`apps/studio/dist/\` and does **not** rebuild on change.
- Tells contributors (and agents) to run \`cd apps/studio && bun run build\` before screenshotting or driving Studio with \`agent-browser\`.

## Why

During the post-merge UAT on #1040, my first attempt to verify the new \`TagsEditor\` rendered an older version of the Compare tab entirely — no mode toggle, wrong cell styling, no \`PassRatePill\`. Spent time convincing myself the merge had broken something before realizing \`apps/studio/dist/\` was from 2026-04-09 (before the work) and my source-mode invocation never touched it. The component code was correct all along; the bundle just hadn't been rebuilt.

This is the kind of thing that's easy to miss on the first run and obvious in hindsight. One paragraph in \`AGENTS.md\` prevents the next agent / contributor from the same confusion.

## Test plan

- [x] \`bun run lint\` — clean
- [x] \`git push\` runs the prek pre-push hook (Build / Typecheck / Lint / Test / Validate eval YAML) — all passed on push
- [x] \`AGENTS.md\` renders correctly on GitHub (verified by re-opening the PR view)
- [ ] Reviewer spot-checks the wording fits the tone of the surrounding "Functional Testing (CLI)" section

## Related

- Follow-up observation from #1040 ([post-UAT comment](https://github.com/EntityProcess/agentv/pull/1040#issuecomment-4228534494))

🤖 Generated with [Claude Code](https://claude.com/claude-code)