### PR TITLE
fix(copilot): consolidate chunk events in JSON log format

### DIFF
--- a/packages/core/src/evaluation/providers/copilot-utils.ts
+++ b/packages/core/src/evaluation/providers/copilot-utils.ts
@@ -323,13 +323,7 @@ export class CopilotStreamLogger {
   }
 
   handleEvent(eventType: string, data: unknown): void {
-    if (this.format === 'json') {
-      const elapsed = formatElapsed(this.startedAt);
-      this.stream.write(`${JSON.stringify({ time: elapsed, event: eventType, data })}\n`);
-      return;
-    }
-
-    // In summary mode, buffer chunk events and emit a single consolidated line.
+    // Buffer chunk events into a single consolidated entry (both formats).
     if (this.chunkExtractor) {
       const chunkText = this.chunkExtractor(eventType, data);
       if (chunkText === null) {
@@ -348,6 +342,12 @@ export class CopilotStreamLogger {
       this.flushPendingText();
     }
 
+    if (this.format === 'json') {
+      const elapsed = formatElapsed(this.startedAt);
+      this.stream.write(`${JSON.stringify({ time: elapsed, event: eventType, data })}\n`);
+      return;
+    }
+
     const elapsed = formatElapsed(this.startedAt);
     const summary = this.summarize(eventType, data);
     if (summary) {
@@ -358,14 +358,18 @@ export class CopilotStreamLogger {
   private flushPendingText(): void {
     if (!this.pendingText) return;
     const elapsed = formatElapsed(this.startedAt);
-    this.stream.write(`[+${elapsed}] [assistant_message] ${this.pendingText}\n`);
+    if (this.format === 'json') {
+      this.stream.write(
+        `${JSON.stringify({ time: elapsed, event: 'assistant_message', data: { content: this.pendingText } })}\n`,
+      );
+    } else {
+      this.stream.write(`[+${elapsed}] [assistant_message] ${this.pendingText}\n`);
+    }
     this.pendingText = '';
   }
 
   async close(): Promise<void> {
-    if (this.format !== 'json') {
-      this.flushPendingText();
-    }
+    this.flushPendingText();
     await new Promise<void>((resolve, reject) => {
       this.stream.once('error', reject);
       this.stream.end(() => resolve());

--- a/packages/core/test/evaluation/providers/copilot-stream-logger.test.ts
+++ b/packages/core/test/evaluation/providers/copilot-stream-logger.test.ts
@@ -100,7 +100,7 @@ describe('CopilotStreamLogger', () => {
     expect(content).toMatch(/\[assistant_message\] Final answer/);
   });
 
-  it('does not buffer in json format (keeps per-event for full fidelity)', async () => {
+  it('consolidates chunk events in json format as single assistant_message entry', async () => {
     const filePath = path.join(tempDir, 'test.log');
     const chunkExtractor = (type: string, data: unknown): string | null | undefined => {
       if (type !== 'agent_message_chunk') return undefined;
@@ -118,6 +118,7 @@ describe('CopilotStreamLogger', () => {
 
     logger.handleEvent('agent_message_chunk', { content: { type: 'text', text: 'chunk1' } });
     logger.handleEvent('agent_message_chunk', { content: { type: 'text', text: 'chunk2' } });
+    logger.handleEvent('tool_call', { title: 'read_file' });
     await logger.close();
 
     const content = await readFile(filePath, 'utf8');
@@ -125,8 +126,13 @@ describe('CopilotStreamLogger', () => {
       .split('\n')
       .filter((l) => l.trim().startsWith('{'))
       .map((l) => JSON.parse(l));
-    // Both chunks emitted individually as JSON
-    expect(jsonLines.filter((e) => e.event === 'agent_message_chunk')).toHaveLength(2);
+    // No raw chunk events — consolidated into one assistant_message
+    expect(jsonLines.filter((e) => e.event === 'agent_message_chunk')).toHaveLength(0);
+    const msg = jsonLines.find((e) => e.event === 'assistant_message');
+    expect(msg).toBeDefined();
+    expect(msg.data.content).toBe('chunk1chunk2');
+    // Non-chunk event still emitted
+    expect(jsonLines.find((e) => e.event === 'tool_call')).toBeDefined();
   });
 
   it('handles chunk events with no extractable text gracefully', async () => {


### PR DESCRIPTION
Closes the remaining gap from #1047.

## Problem

PR #1047 consolidated `agent_message_chunk` events into single `[assistant_message]` lines in **summary** log format, but left JSON mode unchanged — each chunk was still written as a separate JSON line. Users with `log_format: json` (the default in many targets) still saw dozens of fragmented chunk entries per assistant response.

## Solution

Apply the same chunk buffering logic to both formats. When a `chunkExtractor` is provided, chunk events are buffered regardless of format. On flush (next non-chunk event or `close()`), JSON mode emits a single `{"event": "assistant_message", "data": {"content": "..."}}` entry instead of N individual chunk entries.

## Changes

- **`copilot-utils.ts`**: Moved chunk extraction before the format branch so buffering applies to both `summary` and `json`. `flushPendingText()` now emits format-appropriate output. `close()` flushes unconditionally.
- **`copilot-stream-logger.test.ts`**: Updated the JSON format test to verify consolidation instead of asserting per-event passthrough.

## Test plan

- [x] 6 unit tests pass (`bun test copilot-stream-logger`)
- [x] All 1506 core tests pass
- [x] Biome lint + typecheck pass
- [x] Pre-push hooks pass (build, typecheck, lint, test, validate:examples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)