### PR TITLE
fix(cli): union eval path globs

### DIFF
--- a/apps/cli/src/commands/eval/shared.ts
+++ b/apps/cli/src/commands/eval/shared.ts
@@ -25,7 +25,6 @@ export async function resolveEvalPaths(evalPaths: string[], cwd: string): Promis
     throw new Error('No eval paths provided (only negation patterns found).');
   }
 
-  const unmatched: string[] = [];
   const results = new Set<string>();
 
   for (const pattern of includePatterns) {
@@ -50,12 +49,8 @@ export async function resolveEvalPaths(evalPaths: string[], cwd: string): Promis
           followSymbolicLinks: true,
           ignore: ignorePatterns,
         });
-        if (dirMatches.length === 0) {
-          unmatched.push(pattern);
-        } else {
-          for (const filePath of dirMatches) {
-            results.add(path.normalize(filePath));
-          }
+        for (const filePath of dirMatches) {
+          results.add(path.normalize(filePath));
         }
         continue;
       }
@@ -75,19 +70,29 @@ export async function resolveEvalPaths(evalPaths: string[], cwd: string): Promis
     });
 
     const yamlMatches = matches.filter((filePath) => /\.(ya?ml|jsonl|json)$/i.test(filePath));
-    if (yamlMatches.length === 0) {
-      unmatched.push(pattern);
-      continue;
-    }
-
     for (const filePath of yamlMatches) {
       results.add(path.normalize(filePath));
     }
   }
 
-  if (unmatched.length > 0) {
+  if (ignorePatterns.length > 0 && results.size > 0) {
+    const ignoredMatches = await fg(ignorePatterns, {
+      cwd,
+      absolute: true,
+      onlyFiles: true,
+      unique: true,
+      dot: true,
+      followSymbolicLinks: true,
+    });
+
+    for (const filePath of ignoredMatches) {
+      results.delete(path.normalize(filePath));
+    }
+  }
+
+  if (results.size === 0) {
     throw new Error(
-      `No eval files matched: ${unmatched.join(
+      `No eval files matched any provided paths or globs: ${includePatterns.join(
         ', ',
       )}. Provide YAML, JSONL, or JSON paths or globs (e.g., "evals/**/*.yaml", "evals/**/*.jsonl", "evals.json").`,
     );

--- a/apps/cli/test/commands/eval/shared.test.ts
+++ b/apps/cli/test/commands/eval/shared.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { resolveEvalPaths } from '../../../src/commands/eval/shared.js';
+
+describe('resolveEvalPaths', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'agentv-resolve-eval-paths-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns matches from any include glob instead of requiring all includes to match', async () => {
+    const evalDir = path.join(tempDir, 'evals', 'suite-a');
+    mkdirSync(evalDir, { recursive: true });
+
+    const evalFile = path.join(evalDir, 'eval.yaml');
+    writeFileSync(evalFile, 'tests:\n  - id: sample\n    input: test\n');
+
+    const resolved = await resolveEvalPaths(
+      ['evals/**/*.eval.yaml', 'evals/**/eval.yaml'],
+      tempDir,
+    );
+
+    expect(resolved).toEqual([path.normalize(evalFile)]);
+  });
+
+  it('applies negation patterns to the combined match set', async () => {
+    const includedDir = path.join(tempDir, 'evals', 'included');
+    const excludedDir = path.join(tempDir, 'evals', 'excluded');
+    mkdirSync(includedDir, { recursive: true });
+    mkdirSync(excludedDir, { recursive: true });
+
+    const includedFile = path.join(includedDir, 'eval.yaml');
+    const excludedFile = path.join(excludedDir, 'eval.yaml');
+    writeFileSync(includedFile, 'tests:\n  - id: included\n    input: test\n');
+    writeFileSync(excludedFile, 'tests:\n  - id: excluded\n    input: test\n');
+
+    const resolved = await resolveEvalPaths(
+      ['evals/**/eval.yaml', '!evals/excluded/**'],
+      tempDir,
+    );
+
+    expect(resolved).toEqual([path.normalize(includedFile)]);
+  });
+
+  it('applies negation patterns to direct file references', async () => {
+    const evalDir = path.join(tempDir, 'evals', 'suite-a');
+    mkdirSync(evalDir, { recursive: true });
+
+    const evalFile = path.join(evalDir, 'eval.yaml');
+    writeFileSync(evalFile, 'tests:\n  - id: sample\n    input: test\n');
+
+    await expect(resolveEvalPaths([evalFile, '!evals/**'], tempDir)).rejects.toThrow(
+      'No eval files matched any provided paths or globs',
+    );
+  });
+
+  it('throws only when the combined include set is empty', async () => {
+    await expect(resolveEvalPaths(['evals/**/*.eval.yaml', 'evals/**/eval.yaml'], tempDir)).rejects
+      .toThrow('No eval files matched any provided paths or globs');
+  });
+});

--- a/apps/cli/test/commands/eval/shared.test.ts
+++ b/apps/cli/test/commands/eval/shared.test.ts
@@ -42,10 +42,7 @@ describe('resolveEvalPaths', () => {
     writeFileSync(includedFile, 'tests:\n  - id: included\n    input: test\n');
     writeFileSync(excludedFile, 'tests:\n  - id: excluded\n    input: test\n');
 
-    const resolved = await resolveEvalPaths(
-      ['evals/**/eval.yaml', '!evals/excluded/**'],
-      tempDir,
-    );
+    const resolved = await resolveEvalPaths(['evals/**/eval.yaml', '!evals/excluded/**'], tempDir);
 
     expect(resolved).toEqual([path.normalize(includedFile)]);
   });

--- a/apps/cli/test/commands/eval/shared.test.ts
+++ b/apps/cli/test/commands/eval/shared.test.ts
@@ -63,7 +63,8 @@ describe('resolveEvalPaths', () => {
   });
 
   it('throws only when the combined include set is empty', async () => {
-    await expect(resolveEvalPaths(['evals/**/*.eval.yaml', 'evals/**/eval.yaml'], tempDir)).rejects
-      .toThrow('No eval files matched any provided paths or globs');
+    await expect(
+      resolveEvalPaths(['evals/**/*.eval.yaml', 'evals/**/eval.yaml'], tempDir),
+    ).rejects.toThrow('No eval files matched any provided paths or globs');
   });
 });


### PR DESCRIPTION
## Summary
- change eval path resolution to treat multiple include globs as a union
- preserve negation support across combined results, including direct file references
- add regression tests for mixed include globs, negation handling, and empty-union failures

## Red/Green Evidence
Red on current main:
```text
bun apps/cli/src/cli.ts eval run "D:/GitHub/WiseTechGlobal/mcp-ediprod/evals/**/*.eval.yaml" "D:/GitHub/WiseTechGlobal/mcp-ediprod/evals/**/eval.yaml" --dry-run --target copilot
Error: No eval files matched: D:/GitHub/WiseTechGlobal/mcp-ediprod/evals/**/*.eval.yaml.
```

Green on this branch:
```text
bun apps/cli/src/cli.ts eval run "D:/GitHub/WiseTechGlobal/mcp-ediprod/evals/**/*.eval.yaml" "D:/GitHub/WiseTechGlobal/mcp-ediprod/evals/**/eval.yaml" --dry-run --target copilot
Using target: copilot
0/11   🔄 queue-no-requirements | copilot
...
```
The patched branch proceeds past path resolution into actual eval execution. Subsequent rubric failures are unrelated to eval path matching.

## Verification
- `bun run lint`
- `bun test apps/cli/test/commands/eval/shared.test.ts`