### PR TITLE
feat(cli): add --keep-workspaces flag and improve workspace summary

### DIFF
--- a/apps/cli/src/commands/eval/commands/run.ts
+++ b/apps/cli/src/commands/eval/commands/run.ts
@@ -126,6 +126,11 @@ export const evalRunCommand = command({
       long: 'workspace-path',
       description: 'Static workspace directory path (used when workspace mode is static)',
     }),
+    keepWorkspaces: flag({
+      long: 'keep-workspaces',
+      description:
+        'Preserve per-test workspaces after eval (default: keep on failure, cleanup on success)',
+    }),
     otelFile: option({
       type: optional(string),
       long: 'otel-file',
@@ -241,6 +246,7 @@ export const evalRunCommand = command({
       verbose: args.verbose,
       workspaceMode: args.workspaceMode,
       workspacePath: args.workspacePath,
+      keepWorkspaces: args.keepWorkspaces,
       trace: false,
       otelFile: args.otelFile,
       exportOtel: args.exportOtel,

--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -87,6 +87,7 @@ interface NormalizedOptions {
   readonly retryErrors?: string;
   readonly workspaceMode?: 'pooled' | 'temp' | 'static';
   readonly workspacePath?: string;
+  readonly keepWorkspaces: boolean;
   /** Deprecated: benchmark.json is always written to artifact dir */
   readonly benchmarkJson?: string;
   /** Deprecated: use --output instead */
@@ -357,6 +358,11 @@ function normalizeOptions(
     retryErrors: normalizeString(rawOptions.retryErrors),
     workspaceMode,
     workspacePath,
+    // Precedence: CLI > YAML config > TS config
+    keepWorkspaces:
+      normalizeBoolean(rawOptions.keepWorkspaces) ||
+      yamlExecution?.keep_workspaces === true ||
+      config?.execution?.keepWorkspaces === true,
     benchmarkJson: normalizeString(rawOptions.benchmarkJson),
     artifacts: normalizeString(rawOptions.artifacts),
     graderTarget: normalizeString(rawOptions.graderTarget),
@@ -754,6 +760,7 @@ async function runSingleEvalFile(params: {
     maxConcurrency: resolvedWorkers,
     workspaceMode: options.workspaceMode,
     workspacePath: options.workspacePath,
+    keepWorkspaces: options.keepWorkspaces,
     trials: trialsConfig,
     totalBudgetUsd,
     failOnError,
@@ -1455,15 +1462,25 @@ export async function runEvalCommand(
       );
     }
 
-    // Print workspace paths for failed cases (when preserved for debugging)
-    const failedWithWorkspaces = allResults.filter(
-      (r) => r.workspacePath && (r.error || r.score < 0.5),
-    );
-    if (failedWithWorkspaces.length > 0) {
-      console.log('\nWorkspaces preserved for debugging:');
-      for (const result of failedWithWorkspaces) {
-        console.log(`  ${result.testId}: ${result.workspacePath}`);
+    // Print workspace paths summary
+    const resultsWithWorkspaces = allResults.filter((r) => r.workspacePath);
+    const preservedWorkspaces = options.keepWorkspaces
+      ? resultsWithWorkspaces
+      : resultsWithWorkspaces.filter((r) => r.error || r.score < 0.5);
+
+    if (preservedWorkspaces.length > 0) {
+      console.log('\nPreserved workspaces:');
+      for (const result of preservedWorkspaces) {
+        console.log(`  ${result.testId} -> ${result.workspacePath}`);
       }
+    }
+
+    // Hint about --keep-workspaces when workspaces were used but some cleaned up
+    const usedWorkspaces =
+      resultsWithWorkspaces.length > 0 ||
+      (options.workspaceMode && options.workspaceMode !== 'static');
+    if (!options.keepWorkspaces && usedWorkspaces) {
+      console.log('Use --keep-workspaces to preserve all workspaces for inspection.');
     }
 
     if (allResults.length > 0) {

--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -2324,6 +2324,8 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
         }
       } else if ((retainOnSuccess ?? (keepWorkspaces ? 'keep' : 'cleanup')) !== 'keep') {
         await cleanupWorkspace(workspacePath).catch(() => {});
+      } else {
+        return { ...finalResult, workspacePath };
       }
     }
 


### PR DESCRIPTION
## Summary

- Add `--keep-workspaces` CLI flag to `agentv eval run`, wiring the existing orchestrator `keepWorkspaces` plumbing through the CLI
- Normalize with CLI > YAML config > TS config precedence (same pattern as `--verbose`)
- Improve end-of-run workspace summary: show preserved paths for all tests when `--keep-workspaces` is set, show hint when workspaces used without the flag
- Fix orchestrator bug: return `workspacePath` on result for successfully preserved workspaces (previously only failures included the path)

## Red/Green UAT

**Red (main):**
- `--keep-workspaces` → `Unknown arguments` error
- Successful workspace paths never shown (orchestrator bug: workspace kept but path not in result)

**Green (branch):**
- `--keep-workspaces` accepted, workspaces preserved, paths shown for all tests
- Without `--keep-workspaces`: failed workspace paths shown + hint `Use --keep-workspaces to preserve all workspaces for inspection.`
- No hint when workspaces aren't used at all

## Test plan

- [x] Build passes
- [x] All 2117 unit tests pass (0 failures)
- [x] `--keep-workspaces` appears in `--help` output
- [x] Red test: flag rejected on main
- [x] Green test: flag accepted, workspace paths displayed, hint shown

Closes #1066

🤖 Generated with [Claude Code](https://claude.com/claude-code)