### PR TITLE
fix(core): allow mode=static with no repos and no path

### DIFF
--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -731,10 +731,22 @@ export async function runEvaluation(
   if (cliWorkspacePath && workspaceMode && workspaceMode !== 'static') {
     throw new Error('--workspace-path requires --workspace-mode static when both are provided');
   }
-  const configuredMode = cliWorkspacePath
+  let configuredMode = cliWorkspacePath
     ? 'static'
     : (workspaceMode ?? suiteWorkspace?.mode ?? (yamlWorkspacePath ? 'static' : 'pooled'));
   const configuredStaticPath = cliWorkspacePath ?? yamlWorkspacePath;
+
+  // When mode=static with no path and no repos, the static mode is a no-op (nothing to
+  // skip cloning). Fall back to temp mode so agentv creates a temp directory automatically.
+  if (configuredMode === 'static' && !configuredStaticPath) {
+    if (!suiteWorkspace?.repos?.length) {
+      setupLog('workspace.mode=static with no path and no repos — falling back to temp mode');
+      configuredMode = 'temp';
+    } else {
+      throw new Error('workspace.mode=static requires workspace.path or --workspace-path');
+    }
+  }
+
   const useStaticWorkspace = configuredMode === 'static';
 
   // static workspace is incompatible with per_test isolation
@@ -742,9 +754,6 @@ export async function runEvaluation(
     throw new Error(
       'static workspace mode is incompatible with isolation: per_test. Use isolation: shared (default).',
     );
-  }
-  if (configuredMode === 'static' && !configuredStaticPath) {
-    throw new Error('workspace.mode=static requires workspace.path or --workspace-path');
   }
   if (configuredMode !== 'static' && configuredStaticPath) {
     throw new Error('workspace.path requires workspace.mode=static');

--- a/packages/core/test/evaluation/orchestrator.test.ts
+++ b/packages/core/test/evaluation/orchestrator.test.ts
@@ -3126,10 +3126,36 @@ fs.writeFileSync(path.join(payload.workspace_path, 'hook.txt'), payload.test_id 
     expect(results[0].error).toBeUndefined();
   });
 
-  it('errors when workspaceMode is static without workspace path', async () => {
+  it('falls back to temp mode when workspaceMode is static with no path and no repos', async () => {
     const provider = new SequenceProvider('mock', {
       responses: [{ output: [{ role: 'assistant', content: [{ type: 'text', text: 'answer' }] }] }],
     });
+
+    const results = await runEvaluation({
+      testFilePath: 'in-memory.yaml',
+      repoRoot: 'in-memory',
+      target: baseTarget,
+      providerFactory: () => provider,
+      evaluators: evaluatorRegistry,
+      evalCases: [baseTestCase],
+      workspaceMode: 'static',
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].error).toBeUndefined();
+  });
+
+  it('errors when workspaceMode is static without workspace path but with repos', async () => {
+    const provider = new SequenceProvider('mock', {
+      responses: [{ output: [{ role: 'assistant', content: [{ type: 'text', text: 'answer' }] }] }],
+    });
+
+    const evalCase = {
+      ...baseTestCase,
+      workspace: {
+        repos: [{ source: { type: 'git' as const, url: 'https://example.com/repo.git' } }],
+      },
+    };
 
     await expect(
       runEvaluation({
@@ -3138,7 +3164,7 @@ fs.writeFileSync(path.join(payload.workspace_path, 'hook.txt'), payload.test_id 
         target: baseTarget,
         providerFactory: () => provider,
         evaluators: evaluatorRegistry,
-        evalCases: [baseTestCase],
+        evalCases: [evalCase],
         workspaceMode: 'static',
       }),
     ).rejects.toThrow('workspace.mode=static requires workspace.path or --workspace-path');


### PR DESCRIPTION
## Summary
- When `workspace.mode=static` is set without `workspace.path` and there are no `repos`, fall back to `temp` mode instead of erroring
- The `static` mode's purpose is to skip repo cloning, which is already a no-op when there are no repos — so the path requirement is unnecessary in this case

## Changes
- `packages/core/src/evaluation/orchestrator.ts`: Move the `useStaticWorkspace` derivation after the new fallback check. When `mode=static` + no path + no repos, downgrade `configuredMode` to `temp` so a temp directory is created automatically
- `packages/core/test/evaluation/orchestrator.test.ts`: Updated existing test to verify the error still fires when repos are present; added new test verifying the fallback succeeds with no repos

## Test plan
- [x] Existing test updated: `mode=static` without path **with repos** still errors
- [x] New test: `mode=static` without path and without repos falls back to temp mode and succeeds
- [x] All 1618 core tests pass
- [x] Pre-push hooks pass (build, typecheck, lint, test, validate examples)

Closes #1082

🤖 Generated with [Claude Code](https://claude.com/claude-code)