### PR TITLE
fix(dry-run): return schema-valid mock responses to prevent grader crashes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,7 +284,7 @@ Unit tests alone are insufficient for evaluator changes. After implementing or m
 
 4. **Update baseline files** if output format changes (e.g., type name renames). Baseline files live alongside eval YAML files as `*.baseline.jsonl` and contain expected `scores[].type` values. There are 30+ baseline files across `examples/`.
 
-5. **Note:** `--dry-run` returns mock responses that don't match evaluator output schemas. Use it only for testing harness flow, not evaluator logic.
+5. **Note:** `--dry-run` returns schema-valid mock responses (`{}` as output, zeroed `tokenUsage`). Built-in graders will not crash, but scores are meaningless. Use it for testing harness flow, not evaluator logic.
 
 ### Completing Work — E2E Checklist
 

--- a/packages/core/src/evaluation/providers/vscode-provider.ts
+++ b/packages/core/src/evaluation/providers/vscode-provider.ts
@@ -75,8 +75,9 @@ export class VSCodeProvider implements Provider {
 
     if (this.config.dryRun) {
       return {
-        output: [],
+        output: [{ role: 'assistant' as const, content: '{}' }],
         durationMs,
+        tokenUsage: { input: 0, output: 0 },
         raw: {
           session,
           inputFiles,
@@ -146,8 +147,9 @@ export class VSCodeProvider implements Provider {
 
     if (this.config.dryRun) {
       return normalizedRequests.map(({ inputFiles }) => ({
-        output: [],
+        output: [{ role: 'assistant' as const, content: '{}' }],
         durationMs: perRequestDurationMs,
+        tokenUsage: { input: 0, output: 0 },
         raw: {
           session,
           inputFiles,

--- a/packages/core/test/evaluation/providers/vscode-provider-dry-run.test.ts
+++ b/packages/core/test/evaluation/providers/vscode-provider-dry-run.test.ts
@@ -1,0 +1,89 @@
+import os from 'node:os';
+import path from 'node:path';
+import { rm, mkdir, writeFile } from 'node:fs/promises';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+// Mock vscode dispatch to skip actual VS Code invocation
+vi.mock('../../../src/evaluation/providers/vscode/index.js', () => ({
+  dispatchAgentSession: vi.fn().mockResolvedValue({
+    exitCode: 0,
+    subagentName: 'subagent-1',
+    responseFile: '/fake/response.md',
+    tempFile: '/fake/response.tmp.md',
+  }),
+  dispatchBatchAgent: vi.fn().mockResolvedValue({
+    exitCode: 0,
+    responseFiles: ['/fake/response1.md'],
+  }),
+  getSubagentRoot: vi.fn().mockReturnValue('/fake/subagents'),
+  provisionSubagents: vi.fn().mockResolvedValue({ created: [], skippedExisting: [] }),
+}));
+
+import { VSCodeProvider } from '../../../src/evaluation/providers/vscode-provider.js';
+
+let tmpDir: string;
+let fakeExecutable: string;
+
+beforeAll(async () => {
+  const dir = path.join(os.tmpdir(), `agentv-test-dry-run-${Date.now()}`);
+  await mkdir(dir, { recursive: true });
+  fakeExecutable = path.join(dir, 'code');
+  await writeFile(fakeExecutable, '#!/bin/sh\n');
+  tmpDir = dir;
+});
+
+afterAll(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('VSCodeProvider dry-run response shape', () => {
+  it('returns non-empty output so graders do not crash', async () => {
+    const provider = new VSCodeProvider(
+      'test',
+      { executable: fakeExecutable, waitForResponse: true, dryRun: true },
+      'vscode',
+    );
+    const response = await provider.invoke({ question: 'ping' });
+
+    expect(response.output).toHaveLength(1);
+    expect(response.output![0]!.role).toBe('assistant');
+  });
+
+  it('returns valid JSON content so is-json grader passes', async () => {
+    const provider = new VSCodeProvider(
+      'test',
+      { executable: fakeExecutable, waitForResponse: true, dryRun: true },
+      'vscode',
+    );
+    const response = await provider.invoke({ question: 'ping' });
+
+    const content = response.output![0]!.content;
+    expect(() => JSON.parse(content as string)).not.toThrow();
+  });
+
+  it('returns zeroed tokenUsage so execution-metrics grader does not report missing data', async () => {
+    const provider = new VSCodeProvider(
+      'test',
+      { executable: fakeExecutable, waitForResponse: true, dryRun: true },
+      'vscode',
+    );
+    const response = await provider.invoke({ question: 'ping' });
+
+    expect(response.tokenUsage).toEqual({ input: 0, output: 0 });
+  });
+
+  it('batch invoke returns the same schema-valid shape per response', async () => {
+    const provider = new VSCodeProvider(
+      'test',
+      { executable: fakeExecutable, waitForResponse: true, dryRun: true },
+      'vscode',
+    );
+    const responses = await provider.invokeBatch!([{ question: 'ping' }]);
+
+    expect(responses).toHaveLength(1);
+    expect(responses[0]!.output).toHaveLength(1);
+    expect(responses[0]!.output![0]!.role).toBe('assistant');
+    expect(() => JSON.parse(responses[0]!.output![0]!.content as string)).not.toThrow();
+    expect(responses[0]!.tokenUsage).toEqual({ input: 0, output: 0 });
+  });
+});

--- a/packages/core/test/evaluation/providers/vscode-provider-dry-run.test.ts
+++ b/packages/core/test/evaluation/providers/vscode-provider-dry-run.test.ts
@@ -1,6 +1,6 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { rm, mkdir, writeFile } from 'node:fs/promises';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 // Mock vscode dispatch to skip actual VS Code invocation
@@ -46,7 +46,7 @@ describe('VSCodeProvider dry-run response shape', () => {
     const response = await provider.invoke({ question: 'ping' });
 
     expect(response.output).toHaveLength(1);
-    expect(response.output![0]!.role).toBe('assistant');
+    expect(response.output?.at(0)?.role).toBe('assistant');
   });
 
   it('returns valid JSON content so is-json grader passes', async () => {
@@ -57,7 +57,7 @@ describe('VSCodeProvider dry-run response shape', () => {
     );
     const response = await provider.invoke({ question: 'ping' });
 
-    const content = response.output![0]!.content;
+    const content = response.output?.at(0)?.content;
     expect(() => JSON.parse(content as string)).not.toThrow();
   });
 
@@ -78,12 +78,13 @@ describe('VSCodeProvider dry-run response shape', () => {
       { executable: fakeExecutable, waitForResponse: true, dryRun: true },
       'vscode',
     );
-    const responses = await provider.invokeBatch!([{ question: 'ping' }]);
+    const responses = await provider.invokeBatch?.([{ question: 'ping' }]);
 
     expect(responses).toHaveLength(1);
-    expect(responses[0]!.output).toHaveLength(1);
-    expect(responses[0]!.output![0]!.role).toBe('assistant');
-    expect(() => JSON.parse(responses[0]!.output![0]!.content as string)).not.toThrow();
-    expect(responses[0]!.tokenUsage).toEqual({ input: 0, output: 0 });
+    const first = responses?.at(0);
+    expect(first?.output).toHaveLength(1);
+    expect(first?.output?.at(0)?.role).toBe('assistant');
+    expect(() => JSON.parse(first?.output?.at(0)?.content as string)).not.toThrow();
+    expect(first?.tokenUsage).toEqual({ input: 0, output: 0 });
   });
 });


### PR DESCRIPTION
## Summary

- VSCode provider dry-run mode returned `output: []`, which produced an empty candidate string that caused all built-in graders to fail or report errors
- Fixed both `invoke()` and `invokeBatch()` to return `output: [{ role: 'assistant', content: '{}' }]` plus zeroed `tokenUsage: { input: 0, output: 0 }`
- Updated AGENTS.md to reflect that dry-run now returns schema-valid responses

## Before / After

**Red (before fix):** Dry-run response has `output: []`, so `extractLastAssistantContent` returns `''`:
- `is-json` grader: fails — `''` is not valid JSON
- `execution-metrics` with `max_tokens`: fails — "Token usage data not available"
- `contains`/`equals`/`regex`: trivially fail on empty string

**Green (after fix):** Dry-run returns `output: [{ role: 'assistant', content: '{}' }]` with `tokenUsage: { input: 0, output: 0 }`:
- `is-json` grader: passes — `'{}'` is valid JSON
- `execution-metrics`: has zeroed token data, so it evaluates normally
- `contains`/`equals`/`regex`: operate on a non-empty string, no crash

## Test plan

- [ ] 4 regression tests added in `vscode-provider-dry-run.test.ts` covering `invoke()` and `invokeBatch()` for all three properties: non-empty output, valid JSON content, zeroed tokenUsage
- [ ] `@agentv/core` test suite: 1635 pass, 0 fail
- [ ] Lint passes

Closes #1088

🤖 Generated with [Claude Code](https://claude.com/claude-code)