### PR TITLE
feat(providers): add executable field to claude-cli provider

### DIFF
--- a/.agentv/targets.yaml
+++ b/.agentv/targets.yaml
@@ -53,12 +53,18 @@ targets:
   - name: claude
     provider: claude-cli
     grader_target: grader
-    log_format: json
+
+  # Claude via Z.ai provider (GLM models). Requires cc-mirror:
+  #   npx cc-mirror quick --provider zai --api-key "$Z_AI_API_KEY"
+  # See https://github.com/numman-ali/cc-mirror
+  - name: claude-zai
+    provider: claude-cli
+    executable: claude-zai
+    grader_target: grader
 
   - name: claude-sdk
     provider: claude-sdk
     grader_target: grader
-    log_format: json
 
   - name: pi
     provider: pi-cli

--- a/apps/web/src/content/docs/docs/targets/coding-agents.mdx
+++ b/apps/web/src/content/docs/docs/targets/coding-agents.mdx
@@ -70,6 +70,7 @@ targets:
 
 | Field | Required | Description |
 |-------|----------|-------------|
+| `executable` | No | CLI binary name or path (default: `claude`). Accepts a bare name looked up on PATH (e.g. `claude-zai`) or an absolute/relative file path. |
 | `workspace_template` | No | Path to workspace template directory |
 | `cwd` | No | Working directory (mutually exclusive with workspace_template) |
 | `grader_target` | Yes | LLM target for evaluation |

--- a/packages/core/src/evaluation/providers/claude-cli.ts
+++ b/packages/core/src/evaluation/providers/claude-cli.ts
@@ -269,7 +269,7 @@ export class ClaudeCliProvider implements Provider {
         spawnOptions.cwd = options.cwd;
       }
 
-      const child = spawn('claude', options.args, spawnOptions);
+      const child = spawn(this.config.executable, options.args, spawnOptions);
 
       let stdout = '';
       let stderr = '';
@@ -339,7 +339,7 @@ export class ClaudeCliProvider implements Provider {
         if (err.code === 'ENOENT') {
           reject(
             new Error(
-              `Claude CLI executable 'claude' was not found on PATH. Install claude-code or ensure it is in PATH.`,
+              `Claude CLI executable '${this.config.executable}' was not found on PATH. Install claude-code or ensure it is in PATH.`,
             ),
           );
         } else {

--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -551,6 +551,7 @@ export interface PiCliResolvedConfig {
 }
 
 export interface ClaudeResolvedConfig {
+  readonly executable: string;
   readonly model?: string;
   readonly systemPrompt?: string;
   readonly cwd?: string;
@@ -1940,6 +1941,7 @@ function resolveClaudeConfig(
   env: EnvLookup,
   evalFilePath?: string,
 ): ClaudeResolvedConfig {
+  const executableSource = target.executable ?? target.command ?? target.binary;
   const modelSource = target.model;
   const cwdSource = target.cwd;
   const workspaceTemplateSource = target.workspace_template;
@@ -1953,6 +1955,12 @@ function resolveClaudeConfig(
   if (streamLogResult.deprecationWarning) {
     process.stderr.write(`[agentv] ⚠ ${streamLogResult.deprecationWarning}\n`);
   }
+
+  const executable =
+    resolveOptionalString(executableSource, env, `${target.name} claude-cli executable`, {
+      allowLiteral: true,
+      optionalEnv: true,
+    }) ?? 'claude';
 
   const model = resolveOptionalString(modelSource, env, `${target.name} claude model`, {
     allowLiteral: true,
@@ -2006,6 +2014,7 @@ function resolveClaudeConfig(
     typeof target.max_budget_usd === 'number' ? target.max_budget_usd : undefined;
 
   return {
+    executable,
     model,
     systemPrompt,
     cwd,

--- a/packages/core/src/evaluation/validation/targets-validator.ts
+++ b/packages/core/src/evaluation/validation/targets-validator.ts
@@ -163,6 +163,9 @@ const MOCK_SETTINGS = new Set([
 
 const CLAUDE_SETTINGS = new Set([
   ...COMMON_SETTINGS,
+  'executable',
+  'command',
+  'binary',
   'model',
   'cwd',
   'timeout_seconds',

--- a/packages/core/test/evaluation/providers/targets.test.ts
+++ b/packages/core/test/evaluation/providers/targets.test.ts
@@ -712,6 +712,41 @@ describe('resolveTargetDefinition', () => {
     expect(target.kind).toBe('copilot-cli');
   });
 
+  it('claude-cli defaults executable to claude', () => {
+    const target = resolveTargetDefinition(
+      {
+        name: 'claude-default',
+        provider: 'claude-cli',
+      },
+      {},
+    );
+
+    expect(target.kind).toBe('claude-cli');
+    if (target.kind !== 'claude-cli') {
+      throw new Error('expected claude-cli target');
+    }
+
+    expect(target.config.executable).toBe('claude');
+  });
+
+  it('claude-cli accepts custom executable', () => {
+    const target = resolveTargetDefinition(
+      {
+        name: 'claude-zai',
+        provider: 'claude-cli',
+        executable: 'claude-zai',
+      },
+      {},
+    );
+
+    expect(target.kind).toBe('claude-cli');
+    if (target.kind !== 'claude-cli') {
+      throw new Error('expected claude-cli target');
+    }
+
+    expect(target.config.executable).toBe('claude-zai');
+  });
+
   it('resolves copilot-cli as its own provider kind', () => {
     const target = resolveTargetDefinition(
       {


### PR DESCRIPTION
## Summary

- Add `executable` field to `ClaudeResolvedConfig`, defaulting to `'claude'`
- Resolve `executable` from target YAML (`executable`, `command`, or `binary` aliases) following the same pattern as `copilot-cli` and `pi-cli` providers
- Use `this.config.executable` in `spawn()` call and ENOENT error message instead of hardcoded `'claude'`

This enables targeting alternate Claude Code installations (e.g. `claude-zai`) while retaining all Claude-specific features (stream parsing, token tracking, cost reporting, workspace_template).

### Usage

```yaml
targets:
  - name: claude-zai
    provider: claude-cli
    executable: claude-zai
    grader_target: grader
```

## Test plan

- [x] Existing 1635 core tests pass
- [x] New tests: `claude-cli defaults executable to claude` and `claude-cli accepts custom executable`
- [x] Build succeeds
- [x] Pre-push hooks pass (build, typecheck, lint, test, validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)