### PR TITLE
feat(providers): add cc-mirror provider alias

### DIFF
--- a/.agentv/targets.yaml
+++ b/.agentv/targets.yaml
@@ -63,6 +63,15 @@ targets:
     executable: claude-zai
     grader_target: grader
 
+  # Generic cc-mirror target. Set CC_MIRROR_VARIANT to the variant name
+  # (e.g., kimi, zai, minimax). Requires cc-mirror setup first:
+  #   npx cc-mirror quick --provider <provider> --api-key "$API_KEY"
+  # See https://github.com/numman-ali/cc-mirror
+  - name: cc-mirror
+    provider: cc-mirror
+    variant: ${{ CC_MIRROR_VARIANT }}
+    grader_target: grader
+
   - name: claude-sdk
     provider: claude-sdk
     grader_target: grader

--- a/.agentv/targets.yaml
+++ b/.agentv/targets.yaml
@@ -56,9 +56,10 @@ targets:
 
   # Claude via Z.ai provider (GLM models). Requires cc-mirror:
   #   npx cc-mirror quick --provider zai --api-key "$Z_AI_API_KEY"
+  # Alternative: set Z_AI_API_KEY in ~/.cc-mirror/claude-zai/config/settings.json
   # See https://github.com/numman-ali/cc-mirror
   - name: claude-zai
-    provider: claude-cli
+    provider: cc-mirror
     executable: claude-zai
     grader_target: grader
 

--- a/.agentv/targets.yaml
+++ b/.agentv/targets.yaml
@@ -63,9 +63,9 @@ targets:
     executable: claude-zai
     grader_target: grader
 
-  # Generic cc-mirror target. Set CC_MIRROR_VARIANT to the variant name
-  # (e.g., kimi, zai, minimax). Requires cc-mirror setup first:
-  #   npx cc-mirror quick --provider <provider> --api-key "$API_KEY"
+  # Generic cc-mirror target. Set CC_MIRROR_VARIANT to the installed variant
+  # name (the directory under ~/.cc-mirror/, e.g. claude-zai, my-kimi).
+  # Setup: npx cc-mirror quick --provider <provider> --name <variant-name> --api-key "$KEY"
   # See https://github.com/numman-ali/cc-mirror
   - name: cc-mirror
     provider: cc-mirror

--- a/apps/web/src/content/docs/docs/targets/coding-agents.mdx
+++ b/apps/web/src/content/docs/docs/targets/coding-agents.mdx
@@ -75,6 +75,40 @@ targets:
 | `cwd` | No | Working directory (mutually exclusive with workspace_template) |
 | `grader_target` | Yes | LLM target for evaluation |
 
+## cc-mirror
+
+[cc-mirror](https://github.com/numman-ali/cc-mirror) creates isolated Claude Code variants that route through alternative providers (Z.ai, Kimi, MiniMax, OpenRouter, etc.). The `cc-mirror` provider alias resolves to `claude-cli` and auto-discovers the binary path from `~/.cc-mirror/<variant>/variant.json`.
+
+```yaml
+targets:
+  # Explicit variant with known executable
+  - name: claude-zai
+    provider: cc-mirror
+    executable: claude-zai
+    grader_target: azure-base
+
+  # Auto-discover binary from variant.json
+  - name: my-kimi
+    provider: cc-mirror
+    grader_target: azure-base
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `executable` | No | CLI binary name or path. When set, used directly (skips variant.json lookup). |
+| `variant` | No | Variant name (directory under `~/.cc-mirror/`). Defaults to target `name`. Used to locate `variant.json` when `executable` is not set. |
+| `workspace_template` | No | Path to workspace template directory |
+| `cwd` | No | Working directory (mutually exclusive with workspace_template) |
+| `grader_target` | Yes | LLM target for evaluation |
+
+Setup a variant first, then reference it by name:
+
+```bash
+npx cc-mirror quick --provider zai --name claude-zai --api-key "$Z_AI_API_KEY"
+```
+
+Since `cc-mirror` resolves to `claude-cli`, all Claude target fields (model, system_prompt, timeout_seconds, etc.) are also supported.
+
 ## Codex CLI
 
 ```yaml

--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -1040,8 +1040,7 @@ export function resolveTargetDefinition(
         config: resolvePiCliConfig(parsed, env, evalFilePath),
       };
     case 'cc-mirror': {
-      const variantName =
-        typeof parsed.variant === 'string' ? parsed.variant : parsed.name;
+      const variantName = typeof parsed.variant === 'string' ? parsed.variant : parsed.name;
       // If executable is explicitly set, use it; otherwise auto-discover from variant.json
       if (!parsed.executable) {
         parsed.executable = resolveCcMirrorBinaryPath(variantName);
@@ -2051,8 +2050,7 @@ function resolveCcMirrorBinaryPath(variant: string): string {
   const variantJsonPath = path.join(homedir(), '.cc-mirror', variant, 'variant.json');
   if (!existsSync(variantJsonPath)) {
     throw new Error(
-      `cc-mirror variant "${variant}": ${variantJsonPath} not found. ` +
-        `Install the variant or set "executable" explicitly.`,
+      `cc-mirror variant "${variant}": ${variantJsonPath} not found. Install the variant or set "executable" explicitly.`,
     );
   }
   let parsed: { binaryPath?: string };

--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import path from 'node:path';
 import { z } from 'zod';
 
@@ -1037,6 +1039,19 @@ export function resolveTargetDefinition(
         ...base,
         config: resolvePiCliConfig(parsed, env, evalFilePath),
       };
+    case 'cc-mirror': {
+      const variantName =
+        typeof parsed.variant === 'string' ? parsed.variant : parsed.name;
+      // If executable is explicitly set, use it; otherwise auto-discover from variant.json
+      if (!parsed.executable) {
+        parsed.executable = resolveCcMirrorBinaryPath(variantName);
+      }
+      return {
+        kind: 'claude-cli',
+        ...base,
+        config: resolveClaudeConfig(parsed, env, evalFilePath),
+      };
+    }
     case 'claude':
     case 'claude-code':
     case 'claude-cli':
@@ -2026,6 +2041,34 @@ function resolveClaudeConfig(
     logFormat,
     streamLog: streamLogResult.streamLog,
   };
+}
+
+/**
+ * Resolve the binary path for a cc-mirror variant.
+ * Reads ~/.cc-mirror/<variant>/variant.json → binaryPath.
+ */
+function resolveCcMirrorBinaryPath(variant: string): string {
+  const variantJsonPath = path.join(homedir(), '.cc-mirror', variant, 'variant.json');
+  if (!existsSync(variantJsonPath)) {
+    throw new Error(
+      `cc-mirror variant "${variant}": ${variantJsonPath} not found. ` +
+        `Install the variant or set "executable" explicitly.`,
+    );
+  }
+  let parsed: { binaryPath?: string };
+  try {
+    parsed = JSON.parse(readFileSync(variantJsonPath, 'utf8'));
+  } catch (e) {
+    throw new Error(
+      `cc-mirror variant "${variant}": failed to parse ${variantJsonPath}: ${(e as Error).message}`,
+    );
+  }
+  if (typeof parsed.binaryPath !== 'string' || parsed.binaryPath.trim().length === 0) {
+    throw new Error(
+      `cc-mirror variant "${variant}": ${variantJsonPath} missing "binaryPath" field`,
+    );
+  }
+  return parsed.binaryPath;
 }
 
 function normalizeClaudeLogFormat(value: unknown): 'summary' | 'json' | undefined {

--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -1040,7 +1040,11 @@ export function resolveTargetDefinition(
         config: resolvePiCliConfig(parsed, env, evalFilePath),
       };
     case 'cc-mirror': {
-      const variantName = typeof parsed.variant === 'string' ? parsed.variant : parsed.name;
+      const variantName =
+        resolveOptionalString(parsed.variant, env, `${parsed.name} cc-mirror variant`, {
+          allowLiteral: true,
+          optionalEnv: true,
+        }) ?? parsed.name;
       // If executable is explicitly set, use it; otherwise auto-discover from variant.json
       if (!parsed.executable) {
         parsed.executable = resolveCcMirrorBinaryPath(variantName);

--- a/packages/core/src/evaluation/providers/types.ts
+++ b/packages/core/src/evaluation/providers/types.ts
@@ -114,6 +114,7 @@ export const PROVIDER_ALIASES: readonly string[] = [
 
   'pi', // alias for "pi-coding-agent"
   'claude-code', // alias for "claude" (legacy)
+  'cc-mirror', // alias for "claude-cli" (auto-discovers binary from ~/.cc-mirror/<variant>/)
   'bedrock', // legacy/future support
   'vertex', // legacy/future support
 ] as const;

--- a/packages/core/src/evaluation/validation/targets-validator.ts
+++ b/packages/core/src/evaluation/validation/targets-validator.ts
@@ -179,6 +179,8 @@ const CLAUDE_SETTINGS = new Set([
   'max_budget_usd',
 ]);
 
+const CC_MIRROR_SETTINGS = new Set([...CLAUDE_SETTINGS, 'variant']);
+
 function getKnownSettings(provider: string): Set<string> | null {
   const normalizedProvider = provider.toLowerCase();
   switch (normalizedProvider) {
@@ -204,6 +206,8 @@ function getKnownSettings(provider: string): Set<string> | null {
     case 'copilot':
     case 'copilot-cli':
       return COPILOT_CLI_SETTINGS;
+    case 'cc-mirror':
+      return CC_MIRROR_SETTINGS;
     case 'claude':
     case 'claude-code':
     case 'claude-cli':

--- a/packages/core/test/evaluation/providers/targets.test.ts
+++ b/packages/core/test/evaluation/providers/targets.test.ts
@@ -747,6 +747,43 @@ describe('resolveTargetDefinition', () => {
     expect(target.config.executable).toBe('claude-zai');
   });
 
+  it('cc-mirror with explicit executable resolves to claude-cli kind', () => {
+    const target = resolveTargetDefinition(
+      {
+        name: 'claude-zai',
+        provider: 'cc-mirror',
+        executable: '/usr/local/bin/claude-zai',
+      },
+      {},
+    );
+
+    expect(target.kind).toBe('claude-cli');
+    if (target.kind !== 'claude-cli') {
+      throw new Error('expected claude-cli target');
+    }
+
+    expect(target.config.executable).toBe('/usr/local/bin/claude-zai');
+  });
+
+  it('cc-mirror with explicit variant and executable', () => {
+    const target = resolveTargetDefinition(
+      {
+        name: 'my-mirror',
+        provider: 'cc-mirror',
+        variant: 'claude-zai',
+        executable: '/opt/bin/zai',
+      },
+      {},
+    );
+
+    expect(target.kind).toBe('claude-cli');
+    if (target.kind !== 'claude-cli') {
+      throw new Error('expected claude-cli target');
+    }
+
+    expect(target.config.executable).toBe('/opt/bin/zai');
+  });
+
   it('resolves copilot-cli as its own provider kind', () => {
     const target = resolveTargetDefinition(
       {


### PR DESCRIPTION
## Summary

- Adds `cc-mirror` as a provider alias that resolves to `claude-cli` kind
- Auto-discovers binary path from `~/.cc-mirror/<variant>/variant.json` when `executable` is not explicitly set
- If `executable` is set, uses it directly (skips variant.json lookup)
- Adds `variant` field support for cc-mirror targets (defaults to target `name`)
- Adds generic `cc-mirror` target in targets.yaml with `CC_MIRROR_VARIANT` env var

### Files changed
- `packages/core/src/evaluation/providers/targets.ts` — switch case + `resolveCcMirrorBinaryPath()` helper
- `packages/core/src/evaluation/providers/types.ts` — `'cc-mirror'` in `PROVIDER_ALIASES`
- `packages/core/src/evaluation/validation/targets-validator.ts` — `CC_MIRROR_SETTINGS` + validator case
- `packages/core/test/evaluation/providers/targets.test.ts` — 2 new tests
- `.agentv/targets.yaml` — updated claude-zai to use cc-mirror provider, added generic cc-mirror target

## Test plan
- [x] `bun run build` passes
- [x] All 1639 core tests pass (including 2 new cc-mirror tests)
- [x] `bun run validate:examples` — 56/56 valid
- [x] Pre-push hooks pass (build, typecheck, lint, test, validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)