### PR TITLE
feat(targets): remove workspace_template, add target-level hooks

### DIFF
--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -558,6 +558,7 @@ async function prepareFileMetadata(params: {
     // Determine target names: CLI --target flags override YAML
     const cliTargets = options.cliTargets;
     const suiteTargets = suite.targets;
+    const suiteTargetRefs = suite.targetRefs;
 
     // Resolve which target names to use (precedence: CLI > suite YAML targets > default)
     let targetNames: readonly string[];
@@ -582,6 +583,7 @@ async function prepareFileMetadata(params: {
         dryRunDelayMax: options.dryRunDelayMax,
         env: process.env,
         targetNames,
+        targetRefs: suiteTargetRefs,
       });
 
       selections = multiSelections.map((sel) => ({
@@ -603,12 +605,20 @@ async function prepareFileMetadata(params: {
         env: process.env,
       });
 
+      // Attach target hooks from eval file if available
+      const singleTargetHooks = suiteTargetRefs?.find(
+        (ref) => ref.name === selection.targetName,
+      )?.hooks;
+      const augmentedSelection: TargetSelection = singleTargetHooks
+        ? { ...selection, targetHooks: singleTargetHooks }
+        : selection;
+
       selections = [
         {
-          selection,
+          selection: augmentedSelection,
           inlineTargetLabel: resolveTargetLabel(
-            selection.targetName,
-            selection.resolvedTarget.name,
+            augmentedSelection.targetName,
+            augmentedSelection.resolvedTarget.name,
           ),
         },
       ];
@@ -777,6 +787,7 @@ async function runSingleEvalFile(params: {
     graderTarget: options.graderTarget,
     model: options.model,
     threshold: options.threshold,
+    targetHooks: resolvedTargetSelection.targetHooks,
     providerFactory,
     streamCallbacks: streamingObserver?.getStreamCallbacks(),
     onResult: async (result: EvaluationResult) => {

--- a/apps/cli/src/commands/eval/targets.ts
+++ b/apps/cli/src/commands/eval/targets.ts
@@ -86,6 +86,8 @@ export interface TargetSelection {
   readonly targetName: string;
   readonly targetSource: 'cli' | 'test-file' | 'default';
   readonly targetsFilePath: string;
+  /** Per-target hooks from eval file (eval-level customization) */
+  readonly targetHooks?: import('@agentv/core').TargetHooksConfig;
 }
 
 export interface TargetSelectionOptions {
@@ -219,7 +221,10 @@ export async function selectTarget(options: TargetSelectionOptions): Promise<Tar
  * Returns an array of TargetSelection, one per target name.
  */
 export async function selectMultipleTargets(
-  options: TargetSelectionOptions & { readonly targetNames: readonly string[] },
+  options: TargetSelectionOptions & {
+    readonly targetNames: readonly string[];
+    readonly targetRefs?: readonly import('@agentv/core').EvalTargetRef[];
+  },
 ): Promise<readonly TargetSelection[]> {
   const {
     testFilePath,
@@ -232,7 +237,18 @@ export async function selectMultipleTargets(
     dryRunDelayMax,
     env,
     targetNames,
+    targetRefs,
   } = options;
+
+  // Build a lookup for target hooks from eval target refs
+  const hooksMap = new Map<string, import('@agentv/core').TargetHooksConfig>();
+  if (targetRefs) {
+    for (const ref of targetRefs) {
+      if (ref.hooks) {
+        hooksMap.set(ref.name, ref.hooks);
+      }
+    }
+  }
 
   const targetsFilePath = await discoverTargetsFile({
     explicitPath: explicitTargetsPath,
@@ -267,11 +283,23 @@ export async function selectMultipleTargets(
     throw new Error(`Targets file validation failed with ${errors.length} error(s)`);
   }
 
-  const definitions = await readTargetDefinitions(targetsFilePath);
+  const fileDefinitions = await readTargetDefinitions(targetsFilePath);
+
+  // Inject synthetic definitions from eval target refs (for use_target delegation)
+  const definitions = [...fileDefinitions];
+  if (targetRefs) {
+    for (const ref of targetRefs) {
+      if (ref.use_target && !fileDefinitions.some((d) => d.name === ref.name)) {
+        definitions.push({ name: ref.name, use_target: ref.use_target } as TargetDefinition);
+      }
+    }
+  }
+
   const results: TargetSelection[] = [];
 
   for (const name of targetNames) {
     const targetDefinition = resolveUseTarget(name, definitions, env, targetsFilePath);
+    const hooks = hooksMap.get(name);
 
     if (dryRun) {
       const mockTarget: ResolvedTarget = {
@@ -291,6 +319,7 @@ export async function selectMultipleTargets(
         targetName: name,
         targetSource: 'cli',
         targetsFilePath,
+        ...(hooks && { targetHooks: hooks }),
       });
     } else {
       try {
@@ -303,6 +332,7 @@ export async function selectMultipleTargets(
           targetName: name,
           targetSource: 'cli',
           targetsFilePath,
+          ...(hooks && { targetHooks: hooks }),
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/apps/web/src/content/docs/docs/targets/coding-agents.mdx
+++ b/apps/web/src/content/docs/docs/targets/coding-agents.mdx
@@ -64,15 +64,13 @@ The preread block instructs the agent to read input files before processing the 
 targets:
   - name: claude_agent
     provider: claude
-    workspace_template: ./workspace-templates/my-project
     grader_target: azure-base
 ```
 
 | Field | Required | Description |
 |-------|----------|-------------|
 | `executable` | No | CLI binary name or path (default: `claude`). Accepts a bare name looked up on PATH (e.g. `claude-zai`) or an absolute/relative file path. |
-| `workspace_template` | No | Path to workspace template directory |
-| `cwd` | No | Working directory (mutually exclusive with workspace_template) |
+| `cwd` | No | Working directory |
 | `grader_target` | Yes | LLM target for evaluation |
 
 ## cc-mirror
@@ -97,8 +95,7 @@ targets:
 |-------|----------|-------------|
 | `executable` | No | CLI binary name or path. When set, used directly (skips variant.json lookup). |
 | `variant` | No | Variant name (directory under `~/.cc-mirror/`). Defaults to target `name`. Used to locate `variant.json` when `executable` is not set. |
-| `workspace_template` | No | Path to workspace template directory |
-| `cwd` | No | Working directory (mutually exclusive with workspace_template) |
+| `cwd` | No | Working directory |
 | `grader_target` | Yes | LLM target for evaluation |
 
 Setup a variant first, then reference it by name:
@@ -115,14 +112,12 @@ Since `cc-mirror` resolves to `claude-cli`, all Claude target fields (model, sys
 targets:
   - name: codex_target
     provider: codex
-    workspace_template: ./workspace-templates/my-project
     grader_target: azure-base
 ```
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `workspace_template` | No | Path to workspace template directory |
-| `cwd` | No | Working directory (mutually exclusive with workspace_template) |
+| `cwd` | No | Working directory |
 | `grader_target` | Yes | LLM target for evaluation |
 
 ## Copilot CLI
@@ -138,8 +133,7 @@ targets:
 | Field | Required | Description |
 |-------|----------|-------------|
 | `model` | No | Model to use (defaults to copilot's default) |
-| `workspace_template` | No | Path to workspace template directory |
-| `cwd` | No | Working directory (mutually exclusive with workspace_template) |
+| `cwd` | No | Working directory |
 | `grader_target` | Yes | LLM target for evaluation |
 
 ## Pi Coding Agent
@@ -148,14 +142,12 @@ targets:
 targets:
   - name: pi_target
     provider: pi-coding-agent
-    workspace_template: ./workspace-templates/my-project
     grader_target: azure-base
 ```
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `workspace_template` | No | Path to workspace template directory |
-| `cwd` | No | Working directory (mutually exclusive with workspace_template) |
+| `cwd` | No | Working directory |
 | `grader_target` | Yes | LLM target for evaluation |
 
 ## VS Code
@@ -164,14 +156,12 @@ targets:
 targets:
   - name: vscode_dev
     provider: vscode
-    workspace_template: ${{ WORKSPACE_PATH }}
     grader_target: azure-base
 ```
 
 | Field | Required | Description |
 |-------|----------|-------------|
 | `executable` | No | Path to VS Code binary. Supports `${{ ENV_VAR }}` syntax or literal paths. Defaults to `code` (or `code-insiders` for the insiders provider). |
-| `workspace_template` | No | Path to workspace template directory or `.code-workspace` file |
 | `grader_target` | Yes | LLM target for evaluation |
 
 Using a custom executable path:
@@ -181,7 +171,6 @@ targets:
   - name: vscode_dev
     provider: vscode
     executable: ${{ VSCODE_CMD }}
-    workspace_template: ${{ WORKSPACE_PATH }}
     grader_target: azure-base
 ```
 
@@ -191,7 +180,6 @@ targets:
 targets:
   - name: vscode_insiders
     provider: vscode-insiders
-    workspace_template: ${{ WORKSPACE_PATH }}
     grader_target: azure-base
 ```
 
@@ -206,15 +194,13 @@ targets:
   - name: local_agent
     provider: cli
     command: 'python agent.py --prompt-file {PROMPT_FILE} --output {OUTPUT_FILE}'
-    workspace_template: ./workspace-templates/my-project
     grader_target: azure-base
 ```
 
 | Field | Required | Description |
 |-------|----------|-------------|
 | `command` | Yes | Command to run. `{PROMPT}` is inline prompt text and `{PROMPT_FILE}` is a temp file path containing the prompt. |
-| `workspace_template` | No | Path to workspace template directory |
-| `cwd` | No | Working directory (mutually exclusive with workspace_template) |
+| `cwd` | No | Working directory |
 | `grader_target` | Yes | LLM target for evaluation |
 
 ## Mock Provider

--- a/apps/web/src/content/docs/docs/targets/configuration.mdx
+++ b/apps/web/src/content/docs/docs/targets/configuration.mdx
@@ -19,7 +19,6 @@ targets:
 
   - name: vscode_dev
     provider: vscode
-    workspace_template: ${{ WORKSPACE_PATH }}
     grader_target: azure-base
 
   - name: local_agent
@@ -89,23 +88,6 @@ targets:
     grader_target: azure-base  # LLM used for grading
 ```
 
-## Workspace Template
-
-For agent targets, `workspace_template` specifies a directory that gets copied to a temporary location before each test runs. This provides isolated, reproducible workspaces.
-
-```yaml
-targets:
-  - name: claude_agent
-    provider: claude
-    workspace_template: ./workspace-templates/my-project
-    grader_target: azure-base
-```
-
-When `workspace_template` is set:
-- The template directory is copied to `~/.agentv/workspaces/<eval-run-id>/shared/`
-- The `.git` directory is skipped during copy
-- Tests share the workspace; use `hooks.after_each` to reset state between tests
-
 ### Workspace Lifecycle Hooks
 
 Run commands and reset/cleanup policies at different lifecycle points using `workspace.hooks`. This can be defined at the suite level (applies to all tests) or per test (overrides suite-level).
@@ -129,7 +111,7 @@ workspace:
 
 | Field | Description |
 |-------|-------------|
-| `template` | Directory to copy as workspace (alternative to target-level `workspace_template`) |
+| `template` | Directory to copy as workspace |
 | `hooks.before_all` | Runs once after workspace creation, before the first test |
 | `hooks.after_all` | Runs once after the last test, before cleanup |
 | `hooks.before_each` | Runs before each test |
@@ -271,11 +253,61 @@ CLI overrides:
 - `--retain-on-success keep|cleanup`
 - `--retain-on-failure keep|cleanup`
 
-### cwd vs workspace_template
+### cwd
 
-| Option | Use Case |
-|--------|----------|
-| `cwd` | Run in an existing directory (shared across tests) |
-| `workspace_template` | Copy template to temp location (isolated per case) |
+Use `cwd` on a target to run in an existing directory (shared across tests). If not set, the eval file's directory is used as the working directory.
 
-These options are mutually exclusive. If neither is set, the eval file's directory is used as the working directory.
+## Target Hooks
+
+Eval files can define per-target hooks that run setup/teardown scripts to customize the workspace for each target variant. This enables comparing different harness configurations (e.g., baseline vs with-plugins) in a single eval file.
+
+Target hooks are defined in the eval file's `execution.targets` array using object form:
+
+```yaml
+execution:
+  targets:
+    - baseline                          # string shorthand (no hooks)
+    - name: with-skills                 # object form with hooks
+      use_target: default
+      hooks:
+        before_each:
+          command: ["setup-plugins.sh", "skills"]
+    - name: with-guidelines
+      use_target: default
+      hooks:
+        before_each:
+          command: ["sh", "-c", "cp guidelines.md $WORKSPACE_PATH/.claude/"]
+```
+
+### Hook execution order
+
+Target hooks run after workspace hooks on setup, before workspace hooks on teardown:
+
+1. Workspace `before_all`
+2. **Target `before_all`**
+3. For each test:
+   - Workspace `before_each`
+   - **Target `before_each`**
+   - Test executes
+   - **Target `after_each`**
+   - Workspace `after_each`
+4. **Target `after_all`**
+5. Workspace `after_all`
+
+### Hook schema
+
+Target hooks follow the same schema as workspace hooks:
+
+```yaml
+hooks:
+  before_all:
+    command: ["setup.sh"]       # Command array or shell string
+    timeout_ms: 60000           # Optional timeout
+    cwd: "./scripts"            # Optional working directory
+  before_each:
+    command: "echo setup"       # String shorthand (runs via sh -c)
+  after_each:
+    command: ["cleanup.sh"]
+  after_all:
+    command: ["teardown.sh"]
+```

--- a/packages/core/src/evaluation/evaluators/llm-grader.ts
+++ b/packages/core/src/evaluation/evaluators/llm-grader.ts
@@ -488,7 +488,7 @@ export class LlmGraderEvaluator implements Evaluator {
     const workspacePath = context.workspacePath;
     if (!workspacePath) {
       throw new Error(
-        'llm-grader built-in agent mode requires a workspace_template target (workspacePath is not set)',
+        'llm-grader built-in agent mode requires a workspace (workspacePath is not set)',
       );
     }
 

--- a/packages/core/src/evaluation/evaluators/types.ts
+++ b/packages/core/src/evaluation/evaluators/types.ts
@@ -53,9 +53,9 @@ export interface EvaluationContext {
   readonly targetResolver?: TargetResolver;
   /** List of available target names for code graders */
   readonly availableTargets?: readonly string[];
-  /** Unified diff of file changes from workspace (when workspace_template is configured) */
+  /** Unified diff of file changes from workspace */
   readonly fileChanges?: string;
-  /** Absolute path to the workspace directory (when workspace_template is configured) */
+  /** Absolute path to the workspace directory */
   readonly workspacePath?: string;
   /** Docker workspace config: when present, code-grader commands run inside a container */
   readonly dockerConfig?: DockerWorkspaceConfig;

--- a/packages/core/src/evaluation/loaders/config-loader.ts
+++ b/packages/core/src/evaluation/loaders/config-loader.ts
@@ -3,7 +3,15 @@ import path from 'node:path';
 import { parse } from 'yaml';
 
 import { interpolateEnv } from '../interpolation.js';
-import type { FailOnError, JsonObject, TrialStrategy, TrialsConfig } from '../types.js';
+import type {
+  EvalTargetRef,
+  FailOnError,
+  JsonObject,
+  TargetHooksConfig,
+  TrialStrategy,
+  TrialsConfig,
+  WorkspaceHookConfig,
+} from '../types.js';
 import { isJsonObject } from '../types.js';
 import { buildDirectoryChain, fileExists } from './file-resolver.js';
 
@@ -133,23 +141,113 @@ export function extractTargetFromSuite(suite: JsonObject): string | undefined {
 }
 
 /**
- * Extract targets array from parsed eval suite.
- * Precedence: execution.targets (array) > execution.target (singular).
+ * Extract target refs from parsed eval suite.
+ * Supports both string shorthand and object form with hooks.
  * Returns undefined when no targets array is specified.
  */
-export function extractTargetsFromSuite(suite: JsonObject): readonly string[] | undefined {
+export function extractTargetRefsFromSuite(
+  suite: JsonObject,
+): readonly EvalTargetRef[] | undefined {
   const execution = suite.execution;
   if (!execution || typeof execution !== 'object' || Array.isArray(execution)) {
     return undefined;
   }
 
   const targets = (execution as Record<string, unknown>).targets;
-  if (Array.isArray(targets)) {
-    const valid = targets.filter((t): t is string => typeof t === 'string' && t.trim().length > 0);
-    return valid.length > 0 ? valid.map((t) => t.trim()) : undefined;
+  if (!Array.isArray(targets)) {
+    return undefined;
   }
 
-  return undefined;
+  const refs: EvalTargetRef[] = [];
+  for (const t of targets) {
+    if (typeof t === 'string' && t.trim().length > 0) {
+      refs.push({ name: t.trim() });
+    } else if (t && typeof t === 'object' && !Array.isArray(t) && 'name' in t) {
+      const obj = t as Record<string, unknown>;
+      const name = typeof obj.name === 'string' ? obj.name.trim() : '';
+      if (name.length === 0) continue;
+      const useTarget = typeof obj.use_target === 'string' ? obj.use_target.trim() : undefined;
+      const hooks = parseTargetHooks(obj.hooks);
+      refs.push({
+        name,
+        ...(useTarget && { use_target: useTarget }),
+        ...(hooks && { hooks }),
+      });
+    }
+  }
+  return refs.length > 0 ? refs : undefined;
+}
+
+/**
+ * Extract target names from parsed eval suite (backward-compat wrapper).
+ * Precedence: execution.targets (array) > execution.target (singular).
+ * Returns undefined when no targets array is specified.
+ */
+export function extractTargetsFromSuite(suite: JsonObject): readonly string[] | undefined {
+  const refs = extractTargetRefsFromSuite(suite);
+  if (!refs) return undefined;
+  const names = refs.map((r) => r.name);
+  return names.length > 0 ? names : undefined;
+}
+
+/**
+ * Parse a single workspace hook config from a raw object.
+ * Accepts both string shorthand (shell command) and object form.
+ */
+function parseHookConfig(raw: unknown): WorkspaceHookConfig | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const obj = raw as Record<string, unknown>;
+
+  // Accept command as string (shell command) or array
+  let command: readonly string[] | undefined;
+  if (typeof obj.command === 'string') {
+    command = ['sh', '-c', obj.command];
+  } else if (Array.isArray(obj.command)) {
+    command = obj.command.filter((s): s is string => typeof s === 'string');
+  } else if (typeof obj.script === 'string') {
+    command = ['sh', '-c', obj.script];
+  } else if (Array.isArray(obj.script)) {
+    command = obj.script.filter((s): s is string => typeof s === 'string');
+  }
+
+  if (!command || command.length === 0) return undefined;
+
+  const timeoutMs =
+    typeof obj.timeout_ms === 'number'
+      ? obj.timeout_ms
+      : typeof obj.timeoutMs === 'number'
+        ? obj.timeoutMs
+        : undefined;
+  const cwd = typeof obj.cwd === 'string' ? obj.cwd : undefined;
+
+  return {
+    command,
+    ...(timeoutMs !== undefined && { timeout_ms: timeoutMs }),
+    ...(cwd && { cwd }),
+  };
+}
+
+/**
+ * Parse target hooks from a raw hooks object.
+ * Returns undefined if no valid hooks are found.
+ */
+function parseTargetHooks(raw: unknown): TargetHooksConfig | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const obj = raw as Record<string, unknown>;
+
+  const beforeAll = parseHookConfig(obj.before_all);
+  const beforeEach = parseHookConfig(obj.before_each);
+  const afterEach = parseHookConfig(obj.after_each);
+  const afterAll = parseHookConfig(obj.after_all);
+
+  if (!beforeAll && !beforeEach && !afterEach && !afterAll) return undefined;
+
+  return {
+    ...(beforeAll && { before_all: beforeAll }),
+    ...(beforeEach && { before_each: beforeEach }),
+    ...(afterEach && { after_each: afterEach }),
+    ...(afterAll && { after_all: afterAll }),
+  };
 }
 
 /**

--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -195,18 +195,6 @@ async function resetWorkspaceRoot(
 }
 
 /**
- * Extract workspaceTemplate from a resolved target's config.
- * Returns undefined if the target doesn't support workspace templates.
- */
-function getWorkspaceTemplate(target: ResolvedTarget): string | undefined {
-  const config = target.config as Record<string, unknown>;
-  if ('workspaceTemplate' in config && typeof config.workspaceTemplate === 'string') {
-    return config.workspaceTemplate;
-  }
-  return undefined;
-}
-
-/**
  * Validate the dependency DAG for a set of eval tests.
  * Rejects circular dependencies and references to missing test IDs.
  * Returns silently when the graph is valid.
@@ -379,6 +367,8 @@ export interface RunEvalCaseOptions {
   readonly threshold?: number;
   /** Results from dependency tests (only present when the test has depends_on) */
   readonly dependencyResults?: Readonly<Record<string, import('./types.js').DependencyResult>>;
+  /** Per-target hooks from eval file (before_all, before_each, after_each, after_all) */
+  readonly targetHooks?: import('./types.js').TargetHooksConfig;
 }
 
 export interface ProgressEvent {
@@ -448,6 +438,8 @@ export interface RunEvaluationOptions {
   readonly model?: string;
   /** Per-test score threshold for pass/fail (default: 0.8) */
   readonly threshold?: number;
+  /** Per-target hooks from eval file (before_all, before_each, after_each, after_all) */
+  readonly targetHooks?: import('./types.js').TargetHooksConfig;
 }
 
 export async function runEvaluation(
@@ -684,7 +676,7 @@ export async function runEvaluation(
   // If any test has workspace config, create shared workspace once.
   // Determine workspace config from first test (suite-level config propagates to all).
   const suiteWorkspace = filteredEvalCases[0]?.workspace;
-  const rawTemplate = suiteWorkspace?.template ?? getWorkspaceTemplate(target);
+  const rawTemplate = suiteWorkspace?.template;
   const resolvedTemplate = await resolveWorkspaceTemplate(rawTemplate);
   const workspaceTemplate = resolvedTemplate?.dir;
   let suiteWorkspaceFile = resolvedTemplate?.workspaceFile;
@@ -1015,6 +1007,57 @@ export async function runEvaluation(
       }
     }
 
+    // Execute target before_all (runs ONCE after workspace before_all)
+    const targetHooks = options.targetHooks;
+    const targetBeforeAllHook = targetHooks?.before_all;
+    if (sharedWorkspacePath && hasHookCommand(targetBeforeAllHook)) {
+      const beforeAllCommand = (targetBeforeAllHook.command ?? []).join(' ');
+      setupLog(`running target before_all command=${beforeAllCommand}`);
+      const scriptContext: ScriptExecutionContext = {
+        workspacePath: sharedWorkspacePath,
+        testId: '__target_before_all__',
+        evalRunId,
+        evalDir,
+        workspaceFileDir: suiteWorkspace?.workspaceFileDir,
+      };
+      try {
+        await executeWorkspaceScript(
+          toScriptConfig(targetBeforeAllHook, 'before_all', 'target hooks'),
+          scriptContext,
+        );
+        setupLog('target before_all completed');
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (sharedWorkspacePath && !useStaticWorkspace) {
+          await cleanupWorkspace(sharedWorkspacePath).catch(() => {});
+        }
+        throw new Error(`target before_all hook failed: ${message}`);
+      }
+    }
+
+    // Run target before_all on pool slots
+    if (availablePoolSlots.length > 0 && hasHookCommand(targetBeforeAllHook)) {
+      for (const slot of availablePoolSlots) {
+        setupLog(`running target before_all on pool slot ${slot.index}`);
+        const scriptContext: ScriptExecutionContext = {
+          workspacePath: slot.path,
+          testId: '__target_before_all__',
+          evalRunId,
+          evalDir,
+          workspaceFileDir: suiteWorkspace?.workspaceFileDir,
+        };
+        try {
+          await executeWorkspaceScript(
+            toScriptConfig(targetBeforeAllHook, 'before_all', 'target hooks'),
+            scriptContext,
+          );
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          throw new Error(`target before_all hook failed on pool slot ${slot.index}: ${message}`);
+        }
+      }
+    }
+
     // Initialize git baseline for shared workspace
     if (sharedWorkspacePath) {
       try {
@@ -1238,6 +1281,7 @@ export async function runEvaluation(
           evalDir,
           verbose,
           threshold: scoreThreshold,
+          targetHooks: options.targetHooks,
           ...(depResults && Object.keys(depResults).length > 0
             ? { dependencyResults: depResults }
             : {}),
@@ -1409,6 +1453,29 @@ export async function runEvaluation(
         : sharedWorkspacePath
           ? [sharedWorkspacePath]
           : [];
+
+    // Execute target after_all (runs ONCE before workspace after_all)
+    const targetAfterAllHook = targetHooks?.after_all;
+    if (afterAllWorkspaces.length > 0 && hasHookCommand(targetAfterAllHook)) {
+      for (const wsPath of afterAllWorkspaces) {
+        const scriptContext: ScriptExecutionContext = {
+          workspacePath: wsPath,
+          testId: '__target_after_all__',
+          evalRunId,
+          evalDir,
+          workspaceFileDir: suiteWorkspace?.workspaceFileDir,
+        };
+        try {
+          await executeWorkspaceScript(
+            toScriptConfig(targetAfterAllHook, 'after_all', 'target hooks'),
+            scriptContext,
+            'warn',
+          );
+        } catch {
+          // target after_all failures are non-fatal
+        }
+      }
+    }
 
     const suiteAfterAllHook = suiteWorkspace?.hooks?.after_all;
     if (afterAllWorkspaces.length > 0 && suiteHooksEnabled && hasHookCommand(suiteAfterAllHook)) {
@@ -1730,7 +1797,7 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
 
   if (!workspacePath) {
     // Per-case workspace creation (backwards compat for tests without shared workspace)
-    const rawCaseTemplate = evalCase.workspace?.template ?? getWorkspaceTemplate(target);
+    const rawCaseTemplate = evalCase.workspace?.template;
     const resolvedCaseTemplate = await resolveWorkspaceTemplate(rawCaseTemplate);
     const caseWorkspaceTemplate = resolvedCaseTemplate?.dir;
     caseWorkspaceFile = resolvedCaseTemplate?.workspaceFile;
@@ -1975,6 +2042,40 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
     }
   }
 
+  // Execute target before_each hook (runs after workspace before_each)
+  const targetBeforeEachHook = options.targetHooks?.before_each;
+  if (workspacePath && hasHookCommand(targetBeforeEachHook)) {
+    const scriptContext: ScriptExecutionContext = {
+      workspacePath,
+      testId: evalCase.id,
+      evalRunId: evalRunId ?? '',
+      caseInput: evalCase.question,
+      caseMetadata: evalCase.metadata,
+      evalDir,
+      workspaceFileDir: evalCase.workspace?.workspaceFileDir,
+    };
+    try {
+      await executeWorkspaceScript(
+        toScriptConfig(targetBeforeEachHook, 'before_each', `target hook for '${evalCase.id}'`),
+        scriptContext,
+      );
+      beforeEachNeedsFreshBaseline = true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return buildErrorResult(
+        evalCase,
+        target.name,
+        nowFn(),
+        new Error(`target before_each hook failed: ${message}`),
+        promptInputs,
+        provider,
+        'setup',
+        'script_error',
+        verbose,
+      );
+    }
+  }
+
   // Initialize git baseline for file-change tracking.
   // Runs git init + baseline commit before the agent, then diffs after.
   // Supports nested repos via --submodule=diff.
@@ -2171,6 +2272,29 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
   }
 
   const providerError = extractProviderError(providerResponse);
+
+  // Execute target after_each hook (runs before workspace after_each)
+  const targetAfterEachHook = options.targetHooks?.after_each;
+  if (workspacePath && hasHookCommand(targetAfterEachHook)) {
+    const scriptContext: ScriptExecutionContext = {
+      workspacePath,
+      testId: evalCase.id,
+      evalRunId: evalRunId ?? '',
+      caseInput: evalCase.question,
+      caseMetadata: evalCase.metadata,
+      evalDir,
+      workspaceFileDir: evalCase.workspace?.workspaceFileDir,
+    };
+    try {
+      await executeWorkspaceScript(
+        toScriptConfig(targetAfterEachHook, 'after_each', `target hook for '${evalCase.id}'`),
+        scriptContext,
+        'warn',
+      );
+    } catch {
+      // target after_each failures are non-fatal
+    }
+  }
 
   // Reset workspace state before after_each hook (if configured)
   if (
@@ -3420,7 +3544,7 @@ async function invokeProvider(
     readonly attempt: number;
     readonly agentTimeoutMs?: number;
     readonly signal?: AbortSignal;
-    /** Working directory override (e.g., from workspace_template) */
+    /** Working directory override (e.g., from eval-level workspace.template) */
     readonly cwd?: string;
     /** VS Code .code-workspace file (resolved from workspace.template) */
     readonly workspaceFile?: string;

--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -1007,7 +1007,7 @@ export async function runEvaluation(
       }
     }
 
-    // Execute target before_all (runs ONCE after workspace before_all)
+    // Execute target before_all (runs once per workspace — shared or per pool slot)
     const targetHooks = options.targetHooks;
     const targetBeforeAllHook = targetHooks?.before_all;
     if (sharedWorkspacePath && hasHookCommand(targetBeforeAllHook)) {

--- a/packages/core/src/evaluation/providers/codex-cli.ts
+++ b/packages/core/src/evaluation/providers/codex-cli.ts
@@ -131,7 +131,7 @@ export class CodexCliProvider implements Provider {
   }
 
   private resolveCwd(workspaceRoot: string, cwdOverride?: string): string {
-    // Request cwd override takes precedence (e.g., from workspace_template)
+    // Request cwd override takes precedence (e.g., from eval-level workspace.template)
     if (cwdOverride) {
       return path.resolve(cwdOverride);
     }

--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -96,9 +96,6 @@ export const CliTargetInputSchema = z
     // Working directory - optional
     cwd: z.string().optional(),
 
-    // Workspace template directory - optional (mutually exclusive with cwd)
-    workspace_template: z.string().optional(),
-
     // Timeout in seconds - optional
     timeout_seconds: z.number().positive().optional(),
 
@@ -183,7 +180,6 @@ export const CliTargetConfigSchema = z
     command: z.string().min(1),
     filesFormat: z.string().optional(),
     cwd: z.string().optional(),
-    workspaceTemplate: z.string().optional(),
     timeoutMs: z.number().positive().optional(),
     healthcheck: CliHealthcheckSchema.optional(),
     verbose: z.boolean().optional(),
@@ -286,23 +282,6 @@ export function normalizeCliTargetInput(
   const filesFormatSource = input.files_format ?? input.attachments_format;
   const filesFormat = resolveOptionalLiteralString(filesFormatSource);
 
-  // Resolve workspace template (mutually exclusive with cwd)
-  const workspaceTemplateSource = input.workspace_template;
-  let workspaceTemplate = resolveOptionalString(
-    workspaceTemplateSource,
-    env,
-    `${targetName} workspace template`,
-    {
-      allowLiteral: true,
-      optionalEnv: true,
-    },
-  );
-
-  // Resolve relative workspace template paths against eval file directory
-  if (workspaceTemplate && evalFilePath && !path.isAbsolute(workspaceTemplate)) {
-    workspaceTemplate = path.resolve(path.dirname(path.resolve(evalFilePath)), workspaceTemplate);
-  }
-
   // Resolve working directory
   let cwd = resolveOptionalString(input.cwd, env, `${targetName} working directory`, {
     allowLiteral: true,
@@ -314,15 +293,8 @@ export function normalizeCliTargetInput(
     cwd = path.resolve(path.dirname(path.resolve(evalFilePath)), cwd);
   }
 
-  // Validate mutual exclusivity of cwd and workspace_template
-  if (cwd && workspaceTemplate) {
-    throw new Error(
-      `${targetName}: 'cwd' and 'workspace_template' are mutually exclusive. Use 'cwd' to run in an existing directory, or 'workspace_template' to copy a template to a temp location.`,
-    );
-  }
-
-  // Fallback: if cwd is not set, workspace_template is not set, and we have an eval file path, use the eval directory
-  if (!cwd && !workspaceTemplate && evalFilePath) {
+  // Fallback: if cwd is not set and we have an eval file path, use the eval directory
+  if (!cwd && evalFilePath) {
     cwd = path.dirname(path.resolve(evalFilePath));
   }
 
@@ -345,7 +317,6 @@ export function normalizeCliTargetInput(
     command,
     filesFormat,
     cwd,
-    workspaceTemplate,
     timeoutMs,
     healthcheck,
     verbose,
@@ -453,7 +424,6 @@ export interface CodexResolvedConfig {
   readonly executable: string;
   readonly args?: readonly string[];
   readonly cwd?: string;
-  readonly workspaceTemplate?: string;
   readonly timeoutMs?: number;
   readonly logDir?: string;
   readonly logFormat?: 'summary' | 'json';
@@ -467,7 +437,6 @@ export interface CopilotCliResolvedConfig {
   readonly model?: string;
   readonly args?: readonly string[];
   readonly cwd?: string;
-  readonly workspaceTemplate?: string;
   readonly timeoutMs?: number;
   readonly logDir?: string;
   readonly logFormat?: 'summary' | 'json';
@@ -482,7 +451,6 @@ export interface CopilotSdkResolvedConfig {
   readonly githubToken?: string;
   readonly model?: string;
   readonly cwd?: string;
-  readonly workspaceTemplate?: string;
   readonly timeoutMs?: number;
   readonly logDir?: string;
   readonly logFormat?: 'summary' | 'json';
@@ -524,7 +492,6 @@ export interface PiCodingAgentResolvedConfig {
   readonly tools?: string;
   readonly thinking?: string;
   readonly cwd?: string;
-  readonly workspaceTemplate?: string;
   readonly timeoutMs?: number;
   readonly logDir?: string;
   readonly logFormat?: 'summary' | 'json';
@@ -543,7 +510,6 @@ export interface PiCliResolvedConfig {
   readonly thinking?: string;
   readonly args?: readonly string[];
   readonly cwd?: string;
-  readonly workspaceTemplate?: string;
   readonly timeoutMs?: number;
   readonly logDir?: string;
   readonly logFormat?: 'summary' | 'json';
@@ -557,7 +523,6 @@ export interface ClaudeResolvedConfig {
   readonly model?: string;
   readonly systemPrompt?: string;
   readonly cwd?: string;
-  readonly workspaceTemplate?: string;
   readonly timeoutMs?: number;
   readonly maxTurns?: number;
   readonly maxBudgetUsd?: number;
@@ -579,7 +544,6 @@ export interface VSCodeResolvedConfig {
   readonly waitForResponse: boolean;
   readonly dryRun: boolean;
   readonly subagentRoot?: string;
-  readonly workspaceTemplate?: string;
   readonly timeoutMs?: number;
 }
 
@@ -656,12 +620,6 @@ function collectDeprecatedCamelCaseWarnings(
 }
 
 function assertNoDeprecatedCamelCaseTargetFields(definition: TargetDefinition): void {
-  if (Object.prototype.hasOwnProperty.call(definition, 'workspaceTemplate')) {
-    throw new Error(
-      `${definition.name}: target-level workspace_template has been removed. Use eval-level workspace.template.`,
-    );
-  }
-
   const warning = findDeprecatedCamelCaseTargetWarnings(
     definition,
     `target "${definition.name}"`,
@@ -794,7 +752,6 @@ const BASE_TARGET_SCHEMA = z
     grader_target: z.string().optional(),
     judge_target: z.string().optional(), // backward compat
     workers: z.number().int().min(1).optional(),
-    workspace_template: z.string().optional(),
     subagent_mode_allowed: z.boolean().optional(),
     fallback_targets: z.array(z.string().min(1)).optional(),
   })
@@ -935,11 +892,6 @@ export function resolveTargetDefinition(
   assertNoDeprecatedCamelCaseTargetFields(definition);
 
   const parsed = BASE_TARGET_SCHEMA.parse(definition);
-  if (parsed.workspace_template !== undefined) {
-    throw new Error(
-      `${parsed.name}: target-level workspace_template has been removed. Use eval-level workspace.template.`,
-    );
-  }
   if (!parsed.provider) {
     throw new Error(
       `${parsed.name}: 'provider' is required (targets with use_target must be resolved before calling resolveTargetDefinition)`,
@@ -1291,13 +1243,12 @@ function resolveGeminiConfig(
 function resolveCodexConfig(
   target: z.infer<typeof BASE_TARGET_SCHEMA>,
   env: EnvLookup,
-  evalFilePath?: string,
+  _evalFilePath?: string,
 ): CodexResolvedConfig {
   const modelSource = target.model;
   const executableSource = target.executable ?? target.command ?? target.binary;
   const argsSource = target.args ?? target.arguments;
   const cwdSource = target.cwd;
-  const workspaceTemplateSource = target.workspace_template;
   const timeoutSource = target.timeout_seconds;
   const logDirSource = target.log_dir ?? target.log_directory;
   const logFormatSource =
@@ -1327,28 +1278,6 @@ function resolveCodexConfig(
     optionalEnv: true,
   });
 
-  let workspaceTemplate = resolveOptionalString(
-    workspaceTemplateSource,
-    env,
-    `${target.name} codex workspace template`,
-    {
-      allowLiteral: true,
-      optionalEnv: true,
-    },
-  );
-
-  // Resolve relative workspace template paths against eval file directory
-  if (workspaceTemplate && evalFilePath && !path.isAbsolute(workspaceTemplate)) {
-    workspaceTemplate = path.resolve(path.dirname(path.resolve(evalFilePath)), workspaceTemplate);
-  }
-
-  // Validate mutual exclusivity of cwd and workspace_template
-  if (cwd && workspaceTemplate) {
-    throw new Error(
-      `${target.name}: 'cwd' and 'workspace_template' are mutually exclusive. Use 'cwd' to run in an existing directory, or 'workspace_template' to copy a template to a temp location.`,
-    );
-  }
-
   const timeoutMs = resolveTimeoutMs(timeoutSource, `${target.name} codex timeout`);
   const logDir = resolveOptionalString(logDirSource, env, `${target.name} codex log directory`, {
     allowLiteral: true,
@@ -1366,7 +1295,6 @@ function resolveCodexConfig(
     executable,
     args,
     cwd,
-    workspaceTemplate,
     timeoutMs,
     logDir,
     logFormat,
@@ -1449,14 +1377,13 @@ function resolveStreamLog(
 function resolveCopilotSdkConfig(
   target: z.infer<typeof BASE_TARGET_SCHEMA>,
   env: EnvLookup,
-  evalFilePath?: string,
+  _evalFilePath?: string,
 ): CopilotSdkResolvedConfig {
   const cliUrlSource = target.cli_url;
   const cliPathSource = target.cli_path;
   const githubTokenSource = target.github_token;
   const modelSource = target.model;
   const cwdSource = target.cwd;
-  const workspaceTemplateSource = target.workspace_template;
   const timeoutSource = target.timeout_seconds;
   const logDirSource = target.log_dir ?? target.log_directory;
   const logFormatSource = target.log_format;
@@ -1496,28 +1423,6 @@ function resolveCopilotSdkConfig(
     allowLiteral: true,
     optionalEnv: true,
   });
-
-  let workspaceTemplate = resolveOptionalString(
-    workspaceTemplateSource,
-    env,
-    `${target.name} copilot-sdk workspace template`,
-    {
-      allowLiteral: true,
-      optionalEnv: true,
-    },
-  );
-
-  // Resolve relative workspace template paths against eval file directory
-  if (workspaceTemplate && evalFilePath && !path.isAbsolute(workspaceTemplate)) {
-    workspaceTemplate = path.resolve(path.dirname(path.resolve(evalFilePath)), workspaceTemplate);
-  }
-
-  // Validate mutual exclusivity of cwd and workspace_template
-  if (cwd && workspaceTemplate) {
-    throw new Error(
-      `${target.name}: 'cwd' and 'workspace_template' are mutually exclusive. Use 'cwd' to run in an existing directory, or 'workspace_template' to copy a template to a temp location.`,
-    );
-  }
 
   const timeoutMs = resolveTimeoutMs(timeoutSource, `${target.name} copilot-sdk timeout`);
 
@@ -1602,7 +1507,6 @@ function resolveCopilotSdkConfig(
     githubToken,
     model,
     cwd,
-    workspaceTemplate,
     timeoutMs,
     logDir,
     logFormat,
@@ -1620,13 +1524,12 @@ function resolveCopilotSdkConfig(
 function resolveCopilotCliConfig(
   target: z.infer<typeof BASE_TARGET_SCHEMA>,
   env: EnvLookup,
-  evalFilePath?: string,
+  _evalFilePath?: string,
 ): CopilotCliResolvedConfig {
   const executableSource = target.executable ?? target.command ?? target.binary;
   const modelSource = target.model;
   const argsSource = target.args ?? target.arguments;
   const cwdSource = target.cwd;
-  const workspaceTemplateSource = target.workspace_template;
   const timeoutSource = target.timeout_seconds;
   const logDirSource = target.log_dir ?? target.log_directory;
   const logFormatSource = target.log_format;
@@ -1655,28 +1558,6 @@ function resolveCopilotCliConfig(
     optionalEnv: true,
   });
 
-  let workspaceTemplate = resolveOptionalString(
-    workspaceTemplateSource,
-    env,
-    `${target.name} copilot-cli workspace template`,
-    {
-      allowLiteral: true,
-      optionalEnv: true,
-    },
-  );
-
-  // Resolve relative workspace template paths against eval file directory
-  if (workspaceTemplate && evalFilePath && !path.isAbsolute(workspaceTemplate)) {
-    workspaceTemplate = path.resolve(path.dirname(path.resolve(evalFilePath)), workspaceTemplate);
-  }
-
-  // Validate mutual exclusivity of cwd and workspace_template
-  if (cwd && workspaceTemplate) {
-    throw new Error(
-      `${target.name}: 'cwd' and 'workspace_template' are mutually exclusive. Use 'cwd' to run in an existing directory, or 'workspace_template' to copy a template to a temp location.`,
-    );
-  }
-
   const timeoutMs = resolveTimeoutMs(timeoutSource, `${target.name} copilot-cli timeout`);
 
   const logDir = resolveOptionalString(
@@ -1701,7 +1582,6 @@ function resolveCopilotCliConfig(
     model,
     args,
     cwd,
-    workspaceTemplate,
     timeoutMs,
     logDir,
     logFormat,
@@ -1721,7 +1601,7 @@ function normalizeCopilotLogFormat(value: unknown): 'summary' | 'json' | undefin
 function resolvePiCodingAgentConfig(
   target: z.infer<typeof BASE_TARGET_SCHEMA>,
   env: EnvLookup,
-  evalFilePath?: string,
+  _evalFilePath?: string,
 ): PiCodingAgentResolvedConfig {
   const subproviderSource = target.subprovider;
   const modelSource = target.model ?? target.pi_model;
@@ -1729,7 +1609,6 @@ function resolvePiCodingAgentConfig(
   const toolsSource = target.tools ?? target.pi_tools;
   const thinkingSource = target.thinking ?? target.pi_thinking;
   const cwdSource = target.cwd;
-  const workspaceTemplateSource = target.workspace_template;
   const timeoutSource = target.timeout_seconds;
   const logDirSource = target.log_dir ?? target.log_directory;
   const logFormatSource = target.log_format;
@@ -1781,28 +1660,6 @@ function resolvePiCodingAgentConfig(
     optionalEnv: true,
   });
 
-  let workspaceTemplate = resolveOptionalString(
-    workspaceTemplateSource,
-    env,
-    `${target.name} pi workspace template`,
-    {
-      allowLiteral: true,
-      optionalEnv: true,
-    },
-  );
-
-  // Resolve relative workspace template paths against eval file directory
-  if (workspaceTemplate && evalFilePath && !path.isAbsolute(workspaceTemplate)) {
-    workspaceTemplate = path.resolve(path.dirname(path.resolve(evalFilePath)), workspaceTemplate);
-  }
-
-  // Validate mutual exclusivity of cwd and workspace_template
-  if (cwd && workspaceTemplate) {
-    throw new Error(
-      `${target.name}: 'cwd' and 'workspace_template' are mutually exclusive. Use 'cwd' to run in an existing directory, or 'workspace_template' to copy a template to a temp location.`,
-    );
-  }
-
   const timeoutMs = resolveTimeoutMs(timeoutSource, `${target.name} pi timeout`);
 
   const logDir = resolveOptionalString(logDirSource, env, `${target.name} pi log directory`, {
@@ -1826,7 +1683,6 @@ function resolvePiCodingAgentConfig(
     tools,
     thinking,
     cwd,
-    workspaceTemplate,
     timeoutMs,
     logDir,
     logFormat,
@@ -1838,7 +1694,7 @@ function resolvePiCodingAgentConfig(
 function resolvePiCliConfig(
   target: z.infer<typeof BASE_TARGET_SCHEMA>,
   env: EnvLookup,
-  evalFilePath?: string,
+  _evalFilePath?: string,
 ): PiCliResolvedConfig {
   const executableSource = target.executable ?? target.command ?? target.binary;
   const subproviderSource = target.subprovider;
@@ -1847,7 +1703,6 @@ function resolvePiCliConfig(
   const toolsSource = target.tools ?? target.pi_tools;
   const thinkingSource = target.thinking ?? target.pi_thinking;
   const cwdSource = target.cwd;
-  const workspaceTemplateSource = target.workspace_template;
   const timeoutSource = target.timeout_seconds;
   const logDirSource = target.log_dir ?? target.log_directory;
   const logFormatSource = target.log_format;
@@ -1905,21 +1760,6 @@ function resolvePiCliConfig(
     optionalEnv: true,
   });
 
-  let workspaceTemplate = resolveOptionalString(
-    workspaceTemplateSource,
-    env,
-    `${target.name} pi-cli workspace template`,
-    { allowLiteral: true, optionalEnv: true },
-  );
-
-  if (workspaceTemplate && evalFilePath && !path.isAbsolute(workspaceTemplate)) {
-    workspaceTemplate = path.resolve(path.dirname(path.resolve(evalFilePath)), workspaceTemplate);
-  }
-
-  if (cwd && workspaceTemplate) {
-    throw new Error(`${target.name}: 'cwd' and 'workspace_template' are mutually exclusive.`);
-  }
-
   const timeoutMs = resolveTimeoutMs(timeoutSource, `${target.name} pi-cli timeout`);
 
   const logDir = resolveOptionalString(logDirSource, env, `${target.name} pi-cli log directory`, {
@@ -1945,7 +1785,6 @@ function resolvePiCliConfig(
     thinking,
     args,
     cwd,
-    workspaceTemplate,
     timeoutMs,
     logDir,
     logFormat,
@@ -1957,12 +1796,11 @@ function resolvePiCliConfig(
 function resolveClaudeConfig(
   target: z.infer<typeof BASE_TARGET_SCHEMA>,
   env: EnvLookup,
-  evalFilePath?: string,
+  _evalFilePath?: string,
 ): ClaudeResolvedConfig {
   const executableSource = target.executable ?? target.command ?? target.binary;
   const modelSource = target.model;
   const cwdSource = target.cwd;
-  const workspaceTemplateSource = target.workspace_template;
   const timeoutSource = target.timeout_seconds;
   const logDirSource = target.log_dir ?? target.log_directory;
   const logFormatSource =
@@ -1990,28 +1828,6 @@ function resolveClaudeConfig(
     optionalEnv: true,
   });
 
-  let workspaceTemplate = resolveOptionalString(
-    workspaceTemplateSource,
-    env,
-    `${target.name} claude workspace template`,
-    {
-      allowLiteral: true,
-      optionalEnv: true,
-    },
-  );
-
-  // Resolve relative workspace template paths against eval file directory
-  if (workspaceTemplate && evalFilePath && !path.isAbsolute(workspaceTemplate)) {
-    workspaceTemplate = path.resolve(path.dirname(path.resolve(evalFilePath)), workspaceTemplate);
-  }
-
-  // Validate mutual exclusivity of cwd and workspace_template
-  if (cwd && workspaceTemplate) {
-    throw new Error(
-      `${target.name}: 'cwd' and 'workspace_template' are mutually exclusive. Use 'cwd' to run in an existing directory, or 'workspace_template' to copy a template to a temp location.`,
-    );
-  }
-
   const timeoutMs = resolveTimeoutMs(timeoutSource, `${target.name} claude timeout`);
 
   const logDir = resolveOptionalString(logDirSource, env, `${target.name} claude log directory`, {
@@ -2036,7 +1852,6 @@ function resolveClaudeConfig(
     model,
     systemPrompt,
     cwd,
-    workspaceTemplate,
     timeoutMs,
     maxTurns,
     maxBudgetUsd,
@@ -2096,26 +1911,8 @@ function resolveVSCodeConfig(
   target: z.infer<typeof BASE_TARGET_SCHEMA>,
   env: EnvLookup,
   insiders: boolean,
-  evalFilePath?: string,
+  _evalFilePath?: string,
 ): VSCodeResolvedConfig {
-  const workspaceTemplateEnvVar = resolveOptionalLiteralString(target.workspace_template);
-  let workspaceTemplate = workspaceTemplateEnvVar
-    ? resolveOptionalString(
-        workspaceTemplateEnvVar,
-        env,
-        `${target.name} workspace template path`,
-        {
-          allowLiteral: true,
-          optionalEnv: true,
-        },
-      )
-    : undefined;
-
-  // Resolve relative workspace template paths against eval file directory
-  if (workspaceTemplate && evalFilePath && !path.isAbsolute(workspaceTemplate)) {
-    workspaceTemplate = path.resolve(path.dirname(path.resolve(evalFilePath)), workspaceTemplate);
-  }
-
   const executableSource = target.executable;
   const waitSource = target.wait;
   const dryRunSource = target.dry_run;
@@ -2139,7 +1936,6 @@ function resolveVSCodeConfig(
       allowLiteral: true,
       optionalEnv: true,
     }),
-    workspaceTemplate,
     timeoutMs,
   };
 }

--- a/packages/core/src/evaluation/providers/types.ts
+++ b/packages/core/src/evaluation/providers/types.ts
@@ -150,7 +150,7 @@ export interface ProviderRequest {
   readonly temperature?: number;
   readonly metadata?: JsonObject;
   readonly signal?: AbortSignal;
-  /** Working directory override (e.g., from workspace_template) */
+  /** Working directory override (e.g., from eval-level workspace.template) */
   readonly cwd?: string;
   /** VS Code .code-workspace file (resolved from workspace.template) */
   readonly workspaceFile?: string;
@@ -364,7 +364,6 @@ export interface TargetDefinition {
   readonly wait?: boolean | unknown | undefined;
   readonly dry_run?: boolean | unknown | undefined;
   readonly subagent_root?: string | unknown | undefined;
-  readonly workspace_template?: string | unknown | undefined;
   // CLI fields
   readonly files_format?: string | unknown | undefined;
   readonly attachments_format?: string | unknown | undefined;

--- a/packages/core/src/evaluation/providers/vscode-provider.ts
+++ b/packages/core/src/evaluation/providers/vscode-provider.ts
@@ -1,5 +1,5 @@
 import { exec } from 'node:child_process';
-import { constants, access, stat } from 'node:fs/promises';
+import { constants, access } from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import {
@@ -46,10 +46,8 @@ export class VSCodeProvider implements Provider {
     const inputFiles = normalizeAttachments(request.inputFiles);
     const promptContent = buildPromptDocument(request, inputFiles);
 
-    // Prefer workspace file resolved from eval-level workspace.template.
-    // Fall back to target-level config.workspaceTemplate (must be a file, not directory).
-    const workspaceTemplate =
-      request.workspaceFile ?? (await resolveWorkspaceTemplateFile(this.config.workspaceTemplate));
+    // Use workspace file resolved from eval-level workspace.template.
+    const workspaceTemplate = request.workspaceFile;
 
     // Measure wall-clock time for duration
     const startTime = Date.now();
@@ -116,11 +114,6 @@ export class VSCodeProvider implements Provider {
       buildPromptDocument(request, inputFiles),
     );
 
-    // For batch, we don't support per-request cwd override (would need separate workspaces)
-    const batchWorkspaceTemplate = await resolveWorkspaceTemplateFile(
-      this.config.workspaceTemplate,
-    );
-
     // Measure wall-clock time for batch duration
     const startTime = Date.now();
     const session = await dispatchBatchAgent({
@@ -131,7 +124,7 @@ export class VSCodeProvider implements Provider {
       dryRun: this.config.dryRun,
       vscodeCmd: this.config.executable,
       subagentRoot: this.config.subagentRoot,
-      workspaceTemplate: batchWorkspaceTemplate,
+      workspaceTemplate: undefined,
       silent: true,
       timeoutMs: this.config.timeoutMs,
     });
@@ -226,27 +219,6 @@ async function locateVSCodeExecutable(candidate: string): Promise<string> {
   throw new Error(
     `VS Code executable '${candidate}' was not found on PATH. Check the 'executable' setting in your target configuration.`,
   );
-}
-
-/**
- * Returns the workspace template path only if it points to a file (e.g. a .code-workspace).
- * When workspace_template is a directory, the orchestrator already copies it to a temp
- * location and passes that as request.cwd — so we drop the directory here and let the
- * cwd path handle folder injection into the .code-workspace file.
- */
-async function resolveWorkspaceTemplateFile(
-  template: string | undefined,
-): Promise<string | undefined> {
-  if (!template) {
-    return undefined;
-  }
-  try {
-    const stats = await stat(path.resolve(template));
-    return stats.isFile() ? template : undefined;
-  } catch {
-    // Path doesn't exist — let copyAgentConfig handle the error
-    return template;
-  }
 }
 
 // VS Code provider uses request.question (not chatPrompt) because VS Code handles

--- a/packages/core/src/evaluation/types.ts
+++ b/packages/core/src/evaluation/types.ts
@@ -290,6 +290,40 @@ export type WorkspaceHooksConfig = {
 };
 
 /**
+ * Per-target hook configuration defined in eval files.
+ * Target hooks run setup/teardown scripts to customize the workspace for each target variant.
+ *
+ * Execution order relative to workspace hooks:
+ * - Setup: workspace before_all → target before_all → (per test: workspace before_each → target before_each)
+ * - Teardown: (per test: target after_each → workspace after_each) → target after_all → workspace after_all
+ */
+export type TargetHooksConfig = {
+  /** Runs once before first test for this target */
+  readonly before_all?: WorkspaceHookConfig;
+  /** Runs before each test case for this target */
+  readonly before_each?: WorkspaceHookConfig;
+  /** Runs after each test case for this target */
+  readonly after_each?: WorkspaceHookConfig;
+  /** Runs once after final test for this target */
+  readonly after_all?: WorkspaceHookConfig;
+};
+
+/**
+ * Extended target reference from eval file.
+ * Allows eval files to define per-target hooks and delegation alongside target names.
+ *
+ * String targets are shorthand for `{ name: "target-name" }` (no hooks).
+ */
+export type EvalTargetRef = {
+  /** Target name (must match a target in targets.yaml or be defined inline with use_target) */
+  readonly name: string;
+  /** Delegate to another named target (same as use_target in targets.yaml) */
+  readonly use_target?: string;
+  /** Per-target hooks for workspace customization */
+  readonly hooks?: TargetHooksConfig;
+};
+
+/**
  * Docker-based workspace configuration.
  * When present, code-grader commands run inside a Docker container
  * instead of on the host.
@@ -1106,7 +1140,7 @@ export interface EvaluationResult {
   readonly afterAllOutput?: string;
   /** Captured output from workspace after_each script */
   readonly afterEachOutput?: string;
-  /** Unified diff of workspace file changes (when workspace_template is configured) */
+  /** Unified diff of workspace file changes */
   readonly fileChanges?: string;
   /** Individual trial results (only present when trials.count > 1) */
   readonly trials?: readonly TrialResult[];

--- a/packages/core/src/evaluation/validation/eval-file.schema.ts
+++ b/packages/core/src/evaluation/validation/eval-file.schema.ts
@@ -290,8 +290,8 @@ const RepoSchema = z.object({
 });
 
 const WorkspaceHookSchema = z.object({
-  command: z.array(z.string()).optional(),
-  script: z.array(z.string()).optional(),
+  command: z.union([z.string(), z.array(z.string())]).optional(),
+  script: z.union([z.string(), z.array(z.string())]).optional(),
   timeout_ms: z.number().optional(),
   timeoutMs: z.number().optional(),
   cwd: z.string().optional(),

--- a/packages/core/src/evaluation/validation/eval-file.schema.ts
+++ b/packages/core/src/evaluation/validation/eval-file.schema.ts
@@ -326,6 +326,24 @@ const WorkspaceSchema = z
   .strict();
 
 // ---------------------------------------------------------------------------
+// Target hooks (eval-level per-target customization)
+// ---------------------------------------------------------------------------
+
+const TargetHooksSchema = z.object({
+  before_all: WorkspaceHookSchema.optional(),
+  before_each: WorkspaceHookSchema.optional(),
+  after_each: WorkspaceHookSchema.optional(),
+  after_all: WorkspaceHookSchema.optional(),
+});
+
+/** Eval target reference: string shorthand or object with hooks */
+const EvalTargetRefSchema = z.object({
+  name: z.string().min(1),
+  use_target: z.string().optional(),
+  hooks: TargetHooksSchema.optional(),
+});
+
+// ---------------------------------------------------------------------------
 // Execution block
 // ---------------------------------------------------------------------------
 
@@ -341,7 +359,7 @@ const FailOnErrorSchema = z.boolean();
 
 const ExecutionSchema = z.object({
   target: z.string().optional(),
-  targets: z.array(z.string()).optional(),
+  targets: z.array(z.union([z.string(), EvalTargetRefSchema])).optional(),
   workers: z.number().int().min(1).max(50).optional(),
   assertions: z.array(EvaluatorSchema).optional(),
   evaluators: z.array(EvaluatorSchema).optional(),

--- a/packages/core/src/evaluation/validation/targets-validator.ts
+++ b/packages/core/src/evaluation/validation/targets-validator.ts
@@ -246,7 +246,19 @@ function validateUnknownSettings(
     'targets',
   ]);
 
+  const removedFields = new Set(['workspace_template', 'workspaceTemplate']);
+
   for (const key of Object.keys(target)) {
+    if (removedFields.has(key)) {
+      errors.push({
+        severity: 'warning',
+        filePath: absolutePath,
+        location: `${location}.${key}`,
+        message:
+          'workspace_template has been removed from targets. Use eval-level workspace.template instead.',
+      });
+      continue;
+    }
     if (!baseFields.has(key) && !knownSettings.has(key)) {
       errors.push({
         severity: 'warning',

--- a/packages/core/src/evaluation/validation/targets-validator.ts
+++ b/packages/core/src/evaluation/validation/targets-validator.ts
@@ -108,7 +108,6 @@ const CODEX_SETTINGS = new Set([
   'log_format',
   'log_output_format',
   'system_prompt',
-  'workspace_template',
 ]);
 
 const COPILOT_SDK_SETTINGS = new Set([
@@ -122,7 +121,6 @@ const COPILOT_SDK_SETTINGS = new Set([
   'log_dir',
   'log_format',
   'system_prompt',
-  'workspace_template',
   'byok',
 ]);
 
@@ -139,13 +137,11 @@ const COPILOT_CLI_SETTINGS = new Set([
   'log_dir',
   'log_format',
   'system_prompt',
-  'workspace_template',
 ]);
 
 const VSCODE_SETTINGS = new Set([
   ...COMMON_SETTINGS,
   'executable',
-  'workspace_template',
   'wait',
   'dry_run',
   'subagent_root',
@@ -174,7 +170,6 @@ const CLAUDE_SETTINGS = new Set([
   'log_format',
   'log_output_format',
   'system_prompt',
-  'workspace_template',
   'max_turns',
   'max_budget_usd',
 ]);
@@ -234,7 +229,6 @@ function validateUnknownSettings(
   location: string,
   errors: ValidationError[],
 ): void {
-  const removedTargetFields = new Set(['workspace_template', 'workspaceTemplate']);
   const knownSettings = getKnownSettings(provider);
   if (!knownSettings) {
     // Unknown provider, skip settings validation
@@ -253,17 +247,6 @@ function validateUnknownSettings(
   ]);
 
   for (const key of Object.keys(target)) {
-    if (removedTargetFields.has(key)) {
-      errors.push({
-        severity: 'error',
-        filePath: absolutePath,
-        location: `${location}.${key}`,
-        message:
-          'target-level workspace_template has been removed. Use eval-level workspace.template.',
-      });
-      continue;
-    }
-
     if (!baseFields.has(key) && !knownSettings.has(key)) {
       errors.push({
         severity: 'warning',

--- a/packages/core/src/evaluation/yaml-parser.ts
+++ b/packages/core/src/evaluation/yaml-parser.ts
@@ -11,6 +11,7 @@ import {
   extractCacheConfig,
   extractFailOnError,
   extractTargetFromSuite,
+  extractTargetRefsFromSuite,
   extractTargetsFromSuite,
   extractTargetsFromTestCase,
   extractThreshold,
@@ -64,6 +65,7 @@ export {
   extractCacheConfig,
   extractFailOnError,
   extractTargetFromSuite,
+  extractTargetRefsFromSuite,
   extractTargetsFromSuite,
   extractTargetsFromTestCase,
   extractThreshold,
@@ -157,9 +159,12 @@ function resolveTests(suite: RawTestSuite): JsonValue | undefined {
  * Read metadata from a test suite file (like target name).
  * This is a convenience function for CLI tools that need metadata without loading all tests.
  */
-export async function readTestSuiteMetadata(
-  testFilePath: string,
-): Promise<{ target?: string; targets?: readonly string[]; trials?: TrialsConfig }> {
+export async function readTestSuiteMetadata(testFilePath: string): Promise<{
+  target?: string;
+  targets?: readonly string[];
+  targetRefs?: readonly import('./types.js').EvalTargetRef[];
+  trials?: TrialsConfig;
+}> {
   try {
     const absolutePath = path.resolve(testFilePath);
     const content = await readFile(absolutePath, 'utf8');
@@ -172,6 +177,7 @@ export async function readTestSuiteMetadata(
     return {
       target: extractTargetFromSuite(parsed),
       targets: extractTargetsFromSuite(parsed),
+      targetRefs: extractTargetRefsFromSuite(parsed),
       trials: extractTrialsConfig(parsed),
     };
   } catch {
@@ -188,6 +194,8 @@ export type EvalSuiteResult = {
   readonly trials?: TrialsConfig;
   /** Suite-level targets from execution.targets (matrix evaluation) */
   readonly targets?: readonly string[];
+  /** Suite-level target refs with hooks from execution.targets (object form) */
+  readonly targetRefs?: readonly import('./types.js').EvalTargetRef[];
   /** Suite-level workers from execution.workers */
   readonly workers?: number;
   /** Suite-level cache config from execution.cache */
@@ -232,6 +240,7 @@ export async function loadTestSuite(
     tests,
     trials: extractTrialsConfig(parsed),
     targets: extractTargetsFromSuite(parsed),
+    targetRefs: extractTargetRefsFromSuite(parsed),
     workers: extractWorkersFromSuite(parsed),
     cacheConfig: extractCacheConfig(parsed),
     totalBudgetUsd: extractTotalBudgetUsd(parsed),

--- a/packages/core/test/evaluation/loaders/config-loader.test.ts
+++ b/packages/core/test/evaluation/loaders/config-loader.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'bun:test';
 import {
   extractFailOnError,
   extractTargetFromSuite,
+  extractTargetRefsFromSuite,
   extractTargetsFromSuite,
   extractTargetsFromTestCase,
   extractThreshold,
@@ -243,6 +244,116 @@ describe('extractTargetsFromSuite', () => {
       execution: { targets: 'copilot' },
     };
     expect(extractTargetsFromSuite(suite)).toBeUndefined();
+  });
+});
+
+describe('extractTargetRefsFromSuite', () => {
+  it('returns undefined when no execution block', () => {
+    const suite: JsonObject = { tests: [] };
+    expect(extractTargetRefsFromSuite(suite)).toBeUndefined();
+  });
+
+  it('returns refs for string targets', () => {
+    const suite: JsonObject = {
+      execution: { targets: ['copilot', 'claude'] },
+    };
+    expect(extractTargetRefsFromSuite(suite)).toEqual([{ name: 'copilot' }, { name: 'claude' }]);
+  });
+
+  it('returns refs for object targets with hooks', () => {
+    const suite: JsonObject = {
+      execution: {
+        targets: [
+          { name: 'baseline' },
+          {
+            name: 'with-skills',
+            use_target: 'default',
+            hooks: {
+              before_each: { command: ['setup.sh', 'skills'] },
+            },
+          },
+        ],
+      },
+    };
+    const refs = extractTargetRefsFromSuite(suite);
+    expect(refs).toHaveLength(2);
+    expect(refs?.[0]).toEqual({ name: 'baseline' });
+    expect(refs?.[1]).toEqual({
+      name: 'with-skills',
+      use_target: 'default',
+      hooks: {
+        before_each: { command: ['setup.sh', 'skills'] },
+      },
+    });
+  });
+
+  it('handles mixed string and object targets', () => {
+    const suite: JsonObject = {
+      execution: {
+        targets: [
+          'baseline',
+          {
+            name: 'with-hooks',
+            hooks: {
+              before_each: { command: ['echo', 'hello'] },
+              after_each: { command: ['echo', 'bye'] },
+            },
+          },
+        ],
+      },
+    };
+    const refs = extractTargetRefsFromSuite(suite);
+    expect(refs).toHaveLength(2);
+    expect(refs?.[0]).toEqual({ name: 'baseline' });
+    expect(refs?.[1].hooks?.before_each?.command).toEqual(['echo', 'hello']);
+    expect(refs?.[1].hooks?.after_each?.command).toEqual(['echo', 'bye']);
+  });
+
+  it('parses string command as shell command', () => {
+    const suite: JsonObject = {
+      execution: {
+        targets: [
+          {
+            name: 'test',
+            hooks: {
+              before_each: { command: 'setup-plugins.sh superpowers' },
+            },
+          },
+        ],
+      },
+    };
+    const refs = extractTargetRefsFromSuite(suite);
+    expect(refs?.[0].hooks?.before_each?.command).toEqual([
+      'sh',
+      '-c',
+      'setup-plugins.sh superpowers',
+    ]);
+  });
+
+  it('skips invalid entries', () => {
+    const suite: JsonObject = {
+      execution: {
+        targets: ['valid', 123, null, { name: '' }, { name: 'also-valid' }],
+      },
+    };
+    const refs = extractTargetRefsFromSuite(suite);
+    expect(refs).toEqual([{ name: 'valid' }, { name: 'also-valid' }]);
+  });
+
+  it('extractTargetsFromSuite derives names from refs', () => {
+    const suite: JsonObject = {
+      execution: {
+        targets: [
+          'baseline',
+          {
+            name: 'with-hooks',
+            use_target: 'default',
+            hooks: { before_each: { command: ['ls'] } },
+          },
+        ],
+      },
+    };
+    expect(extractTargetsFromSuite(suite)).toEqual(['baseline', 'with-hooks']);
   });
 });
 

--- a/packages/core/test/evaluation/providers/targets.test.ts
+++ b/packages/core/test/evaluation/providers/targets.test.ts
@@ -686,20 +686,6 @@ describe('resolveTargetDefinition', () => {
     expect(target.config.args).toEqual(['--profile', 'default', '--model', 'gpt-4']);
   });
 
-  it('rejects removed target-level workspace_template field', () => {
-    expect(() =>
-      resolveTargetDefinition(
-        {
-          name: 'cli-with-template',
-          provider: 'cli',
-          command: 'echo {PROMPT}',
-          workspace_template: '/templates/my-workspace',
-        },
-        {},
-      ),
-    ).toThrow(/workspace_template has been removed/i);
-  });
-
   it('resolves copilot alias to copilot-cli', () => {
     const target = resolveTargetDefinition(
       {
@@ -1032,20 +1018,6 @@ describe('resolveTargetDefinition', () => {
     expect(target.config.byokType).toBeUndefined();
     expect(target.config.byokBaseUrl).toBeUndefined();
     expect(target.config.byokApiKey).toBeUndefined();
-  });
-
-  it('rejects removed target-level workspaceTemplate camelCase field', () => {
-    expect(() =>
-      resolveTargetDefinition(
-        {
-          name: 'cli-camel-case',
-          provider: 'cli',
-          command: 'echo {PROMPT}',
-          workspaceTemplate: '/templates/camel-case-workspace',
-        },
-        {},
-      ),
-    ).toThrow(/workspace_template has been removed/i);
   });
 
   it('rejects camelCase target fields', () => {

--- a/packages/core/test/evaluation/validation/targets-validator.test.ts
+++ b/packages/core/test/evaluation/validation/targets-validator.test.ts
@@ -17,54 +17,6 @@ describe('validateTargetsFile', () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  it('rejects removed target-level workspace_template field', async () => {
-    const filePath = path.join(tempDir, 'removed-workspace-template.yaml');
-    await writeFile(
-      filePath,
-      `targets:
-  - name: test-target
-    provider: codex-cli
-    workspace_template: ./template
-`,
-    );
-
-    const result = await validateTargetsFile(filePath);
-
-    expect(result.valid).toBe(false);
-    expect(
-      result.errors.some(
-        (error) =>
-          error.severity === 'error' &&
-          error.location === 'targets[0].workspace_template' &&
-          error.message.includes('workspace_template has been removed'),
-      ),
-    ).toBe(true);
-  });
-
-  it('rejects removed target-level workspaceTemplate camelCase field', async () => {
-    const filePath = path.join(tempDir, 'removed-workspace-template-camel.yaml');
-    await writeFile(
-      filePath,
-      `targets:
-  - name: test-target
-    provider: codex-cli
-    workspaceTemplate: ./template
-`,
-    );
-
-    const result = await validateTargetsFile(filePath);
-
-    expect(result.valid).toBe(false);
-    expect(
-      result.errors.some(
-        (error) =>
-          error.severity === 'error' &&
-          error.location === 'targets[0].workspaceTemplate' &&
-          error.message.includes('workspace_template has been removed'),
-      ),
-    ).toBe(true);
-  });
-
   it('accepts openrouter as a known provider', async () => {
     const filePath = path.join(tempDir, 'openrouter-target.yaml');
     await writeFile(

--- a/plugins/agentv-dev/skills/agentv-eval-writer/SKILL.md
+++ b/plugins/agentv-dev/skills/agentv-eval-writer/SKILL.md
@@ -366,7 +366,7 @@ Configure via `assertions` array. Multiple graders produce a weighted average sc
 ```
 Contract: stdin JSON -> stdout JSON `{score, assertions: [{text, passed, evidence?}], reasoning}`
 Input includes: `question`, `criteria`, `answer`, `reference_answer`, `output`, `trace`, `token_usage`, `cost_usd`, `duration_ms`, `start_time`, `end_time`, `file_changes`, `workspace_path`, `config`
-When `workspace_template` is configured, `workspace_path` is the absolute path to the workspace dir (also available as `AGENTV_WORKSPACE_PATH` env var). Use this for functional grading (e.g., running `npm test` in the workspace).
+When a workspace is configured, `workspace_path` is the absolute path to the workspace dir (also available as `AGENTV_WORKSPACE_PATH` env var). Use this for functional grading (e.g., running `npm test` in the workspace).
 See docs at https://agentv.dev/evaluators/code-graders/
 
 ### llm_grader

--- a/plugins/agentv-dev/skills/agentv-eval-writer/references/eval-schema.json
+++ b/plugins/agentv-dev/skills/agentv-eval-writer/references/eval-schema.json
@@ -2496,7 +2496,155 @@
                       "targets": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "use_target": {
+                                  "type": "string"
+                                },
+                                "hooks": {
+                                  "type": "object",
+                                  "properties": {
+                                    "before_all": {
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "script": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "timeout_ms": {
+                                          "type": "number"
+                                        },
+                                        "timeoutMs": {
+                                          "type": "number"
+                                        },
+                                        "cwd": {
+                                          "type": "string"
+                                        },
+                                        "reset": {
+                                          "type": "string",
+                                          "enum": ["none", "fast", "strict"]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "before_each": {
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "script": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "timeout_ms": {
+                                          "type": "number"
+                                        },
+                                        "timeoutMs": {
+                                          "type": "number"
+                                        },
+                                        "cwd": {
+                                          "type": "string"
+                                        },
+                                        "reset": {
+                                          "type": "string",
+                                          "enum": ["none", "fast", "strict"]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "after_each": {
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "script": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "timeout_ms": {
+                                          "type": "number"
+                                        },
+                                        "timeoutMs": {
+                                          "type": "number"
+                                        },
+                                        "cwd": {
+                                          "type": "string"
+                                        },
+                                        "reset": {
+                                          "type": "string",
+                                          "enum": ["none", "fast", "strict"]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "after_all": {
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "script": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "timeout_ms": {
+                                          "type": "number"
+                                        },
+                                        "timeoutMs": {
+                                          "type": "number"
+                                        },
+                                        "cwd": {
+                                          "type": "string"
+                                        },
+                                        "reset": {
+                                          "type": "string",
+                                          "enum": ["none", "fast", "strict"]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": ["name"],
+                              "additionalProperties": false
+                            }
+                          ]
                         }
                       },
                       "workers": {
@@ -8764,7 +8912,155 @@
                       "targets": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "use_target": {
+                                  "type": "string"
+                                },
+                                "hooks": {
+                                  "type": "object",
+                                  "properties": {
+                                    "before_all": {
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "script": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "timeout_ms": {
+                                          "type": "number"
+                                        },
+                                        "timeoutMs": {
+                                          "type": "number"
+                                        },
+                                        "cwd": {
+                                          "type": "string"
+                                        },
+                                        "reset": {
+                                          "type": "string",
+                                          "enum": ["none", "fast", "strict"]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "before_each": {
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "script": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "timeout_ms": {
+                                          "type": "number"
+                                        },
+                                        "timeoutMs": {
+                                          "type": "number"
+                                        },
+                                        "cwd": {
+                                          "type": "string"
+                                        },
+                                        "reset": {
+                                          "type": "string",
+                                          "enum": ["none", "fast", "strict"]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "after_each": {
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "script": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "timeout_ms": {
+                                          "type": "number"
+                                        },
+                                        "timeoutMs": {
+                                          "type": "number"
+                                        },
+                                        "cwd": {
+                                          "type": "string"
+                                        },
+                                        "reset": {
+                                          "type": "string",
+                                          "enum": ["none", "fast", "strict"]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "after_all": {
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "script": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "timeout_ms": {
+                                          "type": "number"
+                                        },
+                                        "timeoutMs": {
+                                          "type": "number"
+                                        },
+                                        "cwd": {
+                                          "type": "string"
+                                        },
+                                        "reset": {
+                                          "type": "string",
+                                          "enum": ["none", "fast", "strict"]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": ["name"],
+                              "additionalProperties": false
+                            }
+                          ]
                         }
                       },
                       "workers": {
@@ -12643,7 +12939,155 @@
             "targets": {
               "type": "array",
               "items": {
-                "type": "string"
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "use_target": {
+                        "type": "string"
+                      },
+                      "hooks": {
+                        "type": "object",
+                        "properties": {
+                          "before_all": {
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "script": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "timeout_ms": {
+                                "type": "number"
+                              },
+                              "timeoutMs": {
+                                "type": "number"
+                              },
+                              "cwd": {
+                                "type": "string"
+                              },
+                              "reset": {
+                                "type": "string",
+                                "enum": ["none", "fast", "strict"]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "before_each": {
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "script": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "timeout_ms": {
+                                "type": "number"
+                              },
+                              "timeoutMs": {
+                                "type": "number"
+                              },
+                              "cwd": {
+                                "type": "string"
+                              },
+                              "reset": {
+                                "type": "string",
+                                "enum": ["none", "fast", "strict"]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "after_each": {
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "script": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "timeout_ms": {
+                                "type": "number"
+                              },
+                              "timeoutMs": {
+                                "type": "number"
+                              },
+                              "cwd": {
+                                "type": "string"
+                              },
+                              "reset": {
+                                "type": "string",
+                                "enum": ["none", "fast", "strict"]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "after_all": {
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "script": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "timeout_ms": {
+                                "type": "number"
+                              },
+                              "timeoutMs": {
+                                "type": "number"
+                              },
+                              "cwd": {
+                                "type": "string"
+                              },
+                              "reset": {
+                                "type": "string",
+                                "enum": ["none", "fast", "strict"]
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": ["name"],
+                    "additionalProperties": false
+                  }
+                ]
               }
             },
             "workers": {

--- a/plugins/agentv-dev/skills/agentv-eval-writer/references/eval-schema.json
+++ b/plugins/agentv-dev/skills/agentv-eval-writer/references/eval-schema.json
@@ -2517,16 +2517,30 @@
                                       "type": "object",
                                       "properties": {
                                         "command": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "script": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "timeout_ms": {
                                           "type": "number"
@@ -2548,16 +2562,30 @@
                                       "type": "object",
                                       "properties": {
                                         "command": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "script": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "timeout_ms": {
                                           "type": "number"
@@ -2579,16 +2607,30 @@
                                       "type": "object",
                                       "properties": {
                                         "command": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "script": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "timeout_ms": {
                                           "type": "number"
@@ -2610,16 +2652,30 @@
                                       "type": "object",
                                       "properties": {
                                         "command": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "script": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "timeout_ms": {
                                           "type": "number"
@@ -5086,16 +5142,30 @@
                             "type": "object",
                             "properties": {
                               "command": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "script": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "timeout_ms": {
                                 "type": "number"
@@ -5117,16 +5187,30 @@
                             "type": "object",
                             "properties": {
                               "command": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "script": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "timeout_ms": {
                                 "type": "number"
@@ -5148,16 +5232,30 @@
                             "type": "object",
                             "properties": {
                               "command": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "script": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "timeout_ms": {
                                 "type": "number"
@@ -5179,16 +5277,30 @@
                             "type": "object",
                             "properties": {
                               "command": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "script": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "timeout_ms": {
                                 "type": "number"
@@ -8933,16 +9045,30 @@
                                       "type": "object",
                                       "properties": {
                                         "command": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "script": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "timeout_ms": {
                                           "type": "number"
@@ -8964,16 +9090,30 @@
                                       "type": "object",
                                       "properties": {
                                         "command": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "script": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "timeout_ms": {
                                           "type": "number"
@@ -8995,16 +9135,30 @@
                                       "type": "object",
                                       "properties": {
                                         "command": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "script": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "timeout_ms": {
                                           "type": "number"
@@ -9026,16 +9180,30 @@
                                       "type": "object",
                                       "properties": {
                                         "command": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "script": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "timeout_ms": {
                                           "type": "number"
@@ -11502,16 +11670,30 @@
                             "type": "object",
                             "properties": {
                               "command": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "script": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "timeout_ms": {
                                 "type": "number"
@@ -11533,16 +11715,30 @@
                             "type": "object",
                             "properties": {
                               "command": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "script": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "timeout_ms": {
                                 "type": "number"
@@ -11564,16 +11760,30 @@
                             "type": "object",
                             "properties": {
                               "command": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "script": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "timeout_ms": {
                                 "type": "number"
@@ -11595,16 +11805,30 @@
                             "type": "object",
                             "properties": {
                               "command": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "script": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "timeout_ms": {
                                 "type": "number"
@@ -12960,16 +13184,30 @@
                             "type": "object",
                             "properties": {
                               "command": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "script": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "timeout_ms": {
                                 "type": "number"
@@ -12991,16 +13229,30 @@
                             "type": "object",
                             "properties": {
                               "command": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "script": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "timeout_ms": {
                                 "type": "number"
@@ -13022,16 +13274,30 @@
                             "type": "object",
                             "properties": {
                               "command": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "script": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "timeout_ms": {
                                 "type": "number"
@@ -13053,16 +13319,30 @@
                             "type": "object",
                             "properties": {
                               "command": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "script": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
                               },
                               "timeout_ms": {
                                 "type": "number"
@@ -16697,16 +16977,30 @@
                       "type": "object",
                       "properties": {
                         "command": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          ]
                         },
                         "script": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          ]
                         },
                         "timeout_ms": {
                           "type": "number"
@@ -16728,16 +17022,30 @@
                       "type": "object",
                       "properties": {
                         "command": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          ]
                         },
                         "script": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          ]
                         },
                         "timeout_ms": {
                           "type": "number"
@@ -16759,16 +17067,30 @@
                       "type": "object",
                       "properties": {
                         "command": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          ]
                         },
                         "script": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          ]
                         },
                         "timeout_ms": {
                           "type": "number"
@@ -16790,16 +17112,30 @@
                       "type": "object",
                       "properties": {
                         "command": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          ]
                         },
                         "script": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          ]
                         },
                         "timeout_ms": {
                           "type": "number"


### PR DESCRIPTION
Closes #1094

## Summary

- **Remove `workspace_template` from target schema** — unused field (zero references in any eval file). Removed from `BASE_TARGET_SCHEMA`, `TargetDefinition`, all provider resolved configs, orchestrator, validators, and docs.
- **Add target-level hooks** — eval files can now define per-target setup/teardown hooks in `execution.targets` using object form, enabling single-file harness variant comparison (e.g., baseline vs with-plugins vs with-guidelines).

## Target hooks example

```yaml
execution:
  targets:
    - baseline                          # string shorthand (no hooks)
    - name: with-skills                 # object form with hooks
      use_target: default
      hooks:
        before_each:
          command: ["setup-plugins.sh", "skills"]
```

## Hook execution order

Target hooks nest inside workspace hooks (standard setup/teardown nesting):

1. Workspace `before_all` → **Target `before_all`**
2. Per test: Workspace `before_each` → **Target `before_each`** → test → **Target `after_each`** → Workspace `after_each`
3. **Target `after_all`** → Workspace `after_all`

## Changes

- `packages/core/src/evaluation/types.ts` — new `TargetHooksConfig`, `EvalTargetRef` types
- `packages/core/src/evaluation/validation/eval-file.schema.ts` — `execution.targets` accepts `(string | EvalTargetRef)[]`
- `packages/core/src/evaluation/loaders/config-loader.ts` — new `extractTargetRefsFromSuite()`
- `packages/core/src/evaluation/orchestrator.ts` — 4 lifecycle hook execution points
- `apps/cli/src/commands/eval/targets.ts` — synthetic target injection, hooks threading
- `apps/cli/src/commands/eval/run-eval.ts` — pass `targetRefs` and `targetHooks` through
- Docs, tests, eval-schema.json updated

## Test plan

- [x] `bun run build` — passes
- [x] `bun run typecheck` — passes
- [x] `bun run lint` — passes
- [x] `bun run test` — 2157 tests pass (1642 core + 67 eval + 448 cli)
- [x] `bun run validate:examples` — 56/56 valid
- [ ] Manual UAT with real eval file using target hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)