### PR TITLE
feat(pipeline): add --target and --targets flags to pipeline run and pipeline input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -494,6 +494,10 @@ cp "$(git worktree list --porcelain | head -1 | sed 's/worktree //')/.env" .env 
 ```
 Both steps are required before running builds, tests, or evals in the worktree.
 
+### After Checking Out an Existing Branch or PR
+
+Whenever you `git checkout`, `gh pr checkout`, `git pull`, or otherwise switch to a ref that may have changed `package.json` / `bun.lock`, run `bun install` before building, testing, or pushing. The pre-push hook builds all workspaces — if dependencies are stale, the push fails with errors like `Cannot find module 'recharts'` even though the source change is unrelated. `bun install` is cheap when already up-to-date, so run it by default after any ref switch.
+
 ## Version Management
 
 This project uses a simple release script for version bumping. The git commit history serves as the changelog.

--- a/apps/cli/src/commands/pipeline/input.ts
+++ b/apps/cli/src/commands/pipeline/input.ts
@@ -65,8 +65,18 @@ export const evalInputCommand = command({
       long: 'experiment',
       description: 'Experiment label (e.g. with_skills, without_skills)',
     }),
+    target: option({
+      type: optional(string),
+      long: 'target',
+      description: 'Override target name from targets.yaml (mirrors eval run --target)',
+    }),
+    targets: option({
+      type: optional(string),
+      long: 'targets',
+      description: 'Path to targets.yaml (overrides discovery)',
+    }),
   },
-  handler: async ({ evalPath, out, experiment }) => {
+  handler: async ({ evalPath, out, experiment, target, targets }) => {
     const resolvedEvalPath = resolve(evalPath);
     const outDir = resolve(out ?? buildDefaultRunDir(process.cwd(), experiment));
     const repoRoot = await findRepoRoot(dirname(resolvedEvalPath));
@@ -94,6 +104,8 @@ export const evalInputCommand = command({
         testFilePath: resolvedEvalPath,
         repoRoot,
         cwd: evalDir,
+        cliTargetName: target,
+        explicitTargetsPath: targets,
         dryRun: false,
         dryRunDelay: 0,
         dryRunDelayMin: 0,

--- a/apps/cli/src/commands/pipeline/run.ts
+++ b/apps/cli/src/commands/pipeline/run.ts
@@ -27,7 +27,6 @@ import { selectTarget } from '../eval/targets.js';
 import type { GraderTask } from './grade.js';
 import { runCodeGraders } from './grade.js';
 
-
 /**
  * Convert a Message[] array to plain text.
  * Single message: returns content directly (no role prefix).

--- a/apps/cli/src/commands/pipeline/run.ts
+++ b/apps/cli/src/commands/pipeline/run.ts
@@ -27,6 +27,7 @@ import { selectTarget } from '../eval/targets.js';
 import type { GraderTask } from './grade.js';
 import { runCodeGraders } from './grade.js';
 
+
 /**
  * Convert a Message[] array to plain text.
  * Single message: returns content directly (no role prefix).
@@ -92,8 +93,18 @@ export const evalRunCommand = command({
       description:
         'Which grading phase to run: "code" runs code-graders inline, omit to skip grading (use pipeline grade separately)',
     }),
+    target: option({
+      type: optional(string),
+      long: 'target',
+      description: 'Override target name from targets.yaml (mirrors eval run --target)',
+    }),
+    targets: option({
+      type: optional(string),
+      long: 'targets',
+      description: 'Path to targets.yaml (overrides discovery)',
+    }),
   },
-  handler: async ({ evalPath, out, workers, experiment, graderType }) => {
+  handler: async ({ evalPath, out, workers, experiment, graderType, target, targets }) => {
     const resolvedEvalPath = resolve(evalPath);
     const outDir = resolve(out ?? buildDefaultRunDir(process.cwd(), experiment));
     const repoRoot = await findRepoRoot(dirname(resolvedEvalPath));
@@ -124,6 +135,8 @@ export const evalRunCommand = command({
         testFilePath: resolvedEvalPath,
         repoRoot,
         cwd: evalDir,
+        cliTargetName: target,
+        explicitTargetsPath: targets,
         dryRun: false,
         dryRunDelay: 0,
         dryRunDelayMin: 0,


### PR DESCRIPTION
## Summary

Adds `--target` and `--targets` flags to `agentv pipeline run` and `agentv pipeline input`, mirroring the options already available on `agentv eval run`.

## Problem

`agentv pipeline run <eval> --target wtalms` previously failed with `Unknown arguments` even though `agentv eval run <eval> --target wtalms` works fine. This made it impossible to reuse the same eval.yaml across different targets in pipeline mode without duplicating the file.

## Changes

Both `pipeline run` and `pipeline input` now accept:
- `--target <name>` — override the target name from targets.yaml
- `--targets <path>` — path to targets.yaml (overrides discovery)

These values are forwarded to `selectTarget()` via `cliTargetName` and `explicitTargetsPath`, the same pathway already used by `eval run`.

## Testing

```bash
# Previously failed, now works:
agentv pipeline run evals/ace-search-subset/n1.eval.yaml --target wtalms --grader-type code
agentv pipeline input evals/ace-search-subset/n1.eval.yaml --target wtalms
```

Closes #1107
