### PR TITLE
feat(cli): skip self-update when already on latest version

### DIFF
--- a/apps/cli/src/commands/self/index.ts
+++ b/apps/cli/src/commands/self/index.ts
@@ -1,6 +1,6 @@
 import { command, flag, subcommands } from 'cmd-ts';
 import packageJson from '../../../package.json' with { type: 'json' };
-import { detectPackageManager, performSelfUpdate } from '../../self-update.js';
+import { detectPackageManager, fetchLatestVersion, performSelfUpdate } from '../../self-update.js';
 
 // Re-export for existing tests
 export { detectPackageManagerFromPath } from '../../self-update.js';
@@ -29,6 +29,17 @@ const updateCommand = command({
 
     const currentVersion = packageJson.version;
     console.log(`Current version: ${currentVersion}`);
+    console.log('Checking for updates...');
+
+    const latestVersion = await fetchLatestVersion();
+    if (latestVersion && latestVersion === currentVersion) {
+      console.log(`Already up to date (${currentVersion}).`);
+      return;
+    }
+
+    if (latestVersion) {
+      console.log(`Update available: ${currentVersion} → ${latestVersion}`);
+    }
     console.log(`Updating agentv using ${pm}...\n`);
 
     const result = await performSelfUpdate({ pm, currentVersion });

--- a/apps/cli/src/self-update.ts
+++ b/apps/cli/src/self-update.ts
@@ -16,6 +16,9 @@
  */
 
 import { spawn } from 'node:child_process';
+import { get } from 'node:https';
+
+const NPM_REGISTRY_URL = 'https://registry.npmjs.org/agentv/latest';
 
 /**
  * Detect package manager from the script path.
@@ -44,6 +47,39 @@ function runCommand(cmd: string, args: string[]): Promise<{ exitCode: number; st
     });
     child.on('error', reject);
     child.on('close', (code) => resolve({ exitCode: code ?? 1, stdout }));
+  });
+}
+
+/**
+ * Fetch the latest published version of agentv from the npm registry.
+ * Returns null on network errors or timeouts (best-effort).
+ */
+export function fetchLatestVersion(): Promise<string | null> {
+  return new Promise((resolve) => {
+    const req = get(NPM_REGISTRY_URL, { timeout: 5000 }, (res) => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        resolve(null);
+        return;
+      }
+      let body = '';
+      res.on('data', (chunk: Buffer) => {
+        body += chunk.toString();
+      });
+      res.on('end', () => {
+        try {
+          const version = JSON.parse(body).version;
+          resolve(typeof version === 'string' ? version : null);
+        } catch {
+          resolve(null);
+        }
+      });
+    });
+    req.on('error', () => resolve(null));
+    req.on('timeout', () => {
+      req.destroy();
+      resolve(null);
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

- Checks npm registry before running install in `agentv self update`
- If already on latest, prints "Already up to date (x.y.z)." and exits
- If registry is unreachable, falls through to normal update (best-effort)
- Shows available version before installing

## Test plan

- [x] `agentv self update` when already on latest: prints "Already up to date" and skips install
- [x] `agentv self update` when registry unreachable: falls through to install attempt (code review — timeout/error returns null, proceeds to install)
- [x] Version-check auto-update path unaffected
- [x] All existing tests pass (2,230 tests)

## E2E evidence

### Already on latest — skips install
```
$ agentv self update
Current version: 4.20.0
Checking for updates...
Already up to date (4.20.0).
```

### Version-check path unaffected
```
Warning: This project requires agentv >=99.0.0 but you have 4.20.0.
  Run `agentv self update` to upgrade.
Artifact directory: ...  ← eval continues
```

Closes #1129

🤖 Generated with [Claude Code](https://claude.com/claude-code)