### PR TITLE
feat(cli): add version check to studio/serve commands

### DIFF
--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -19,6 +19,10 @@
  * variants. They share handler functions via DataContext, differing only in
  * how searchDir is resolved.
  *
+ * Before starting the server, the command enforces `required_version` from
+ * the cwd's `.agentv/config.yaml` (single-project scope) via
+ * `enforceRequiredVersion()`, matching the behavior of `agentv eval`.
+ *
  * Exported functions (for testing):
  *   - resolveSourceFile(source, cwd) — resolves a run manifest path
  *   - loadResults(content) — parses JSONL into EvaluationResult[]
@@ -1455,9 +1459,9 @@ export const resultsServeCommand = command({
     // ── Version check ────────────────────────────────────────────────
     // Enforce `required_version` from .agentv/config.yaml so Studio/serve
     // match `agentv eval` behavior. Same prompt in TTY, warn+continue
-    // otherwise. Single-project scope only — multi-project deployments
-    // (one agentv serving repos with differing requirements) are not
-    // covered here (see GitHub #1127 for per-project local installs).
+    // otherwise. Single-project scope only — when one agentv instance
+    // serves multiple repos with differing version requirements, a
+    // per-project local install is required instead.
     const repoRoot = await findRepoRoot(cwd);
     const yamlConfig = await loadConfig(path.join(cwd, '_'), repoRoot);
     if (yamlConfig?.required_version) {

--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -37,14 +37,17 @@ import {
   discoverBenchmarks,
   getBenchmark,
   loadBenchmarkRegistry,
+  loadConfig,
   removeBenchmark,
 } from '@agentv/core';
 import type { Context } from 'hono';
 import { Hono } from 'hono';
 
+import { enforceRequiredVersion } from '../../version-check.js';
 import { parseJsonlResults } from '../eval/artifact-writer.js';
 import { resolveRunManifestPath } from '../eval/result-layout.js';
 import { loadRunCache, resolveRunCacheFile } from '../eval/run-cache.js';
+import { findRepoRoot } from '../eval/shared.js';
 import { listResultFiles } from '../inspect/utils.js';
 import { registerEvalRoutes } from './eval-runner.js';
 import {
@@ -1447,6 +1450,18 @@ export const resultsServeCommand = command({
       }
       console.log(`\nDiscovered ${discovered.length} project(s).`);
       return;
+    }
+
+    // ── Version check ────────────────────────────────────────────────
+    // Enforce `required_version` from .agentv/config.yaml so Studio/serve
+    // match `agentv eval` behavior. Same prompt in TTY, warn+continue
+    // otherwise. Single-project scope only — multi-project deployments
+    // (one agentv serving repos with differing requirements) are not
+    // covered here (see GitHub #1127 for per-project local installs).
+    const repoRoot = await findRepoRoot(cwd);
+    const yamlConfig = await loadConfig(path.join(cwd, '_'), repoRoot);
+    if (yamlConfig?.required_version) {
+      await enforceRequiredVersion(yamlConfig.required_version);
     }
 
     // ── Determine multi-project mode ────────────────────────────────


### PR DESCRIPTION
## Summary

- Enforce `required_version` from `.agentv/config.yaml` before starting AgentV Studio (`agentv studio` / `agentv serve`), matching the existing `agentv eval` behavior.
- Interactive (TTY) runs prompt "Update now? (Y/n)"; non-interactive runs warn to stderr and continue.
- Single-project scope only — multi-project server deployments remain out of scope (tracked in #1127).

## Implementation

`apps/cli/src/commands/results/serve.ts` — call `enforceRequiredVersion()` (from `version-check.ts`) before the server is started, using `loadConfig()` + `findRepoRoot()` to locate the project's `.agentv/config.yaml` (same pattern as `run-eval.ts:988-992`).

The check runs after benchmark-management subcommands (`--add` / `--remove` / `--discover`) so those paths aren't affected.

## Red/Green UAT

**Red (on `main`):** `agentv studio` with a mismatched `required_version: ">=99.0.0"` launched silently — no warning, no prompt. Output:

```
No results found. Dashboard will show an empty state.
Run an evaluation to see results: agentv eval <eval-file>
Dashboard: http://localhost:31170
Benchmarks API: http://localhost:31170/api/benchmarks
Press Ctrl+C to stop
```

**Green (this branch):**

1. Non-interactive (stdin redirected) with `required_version: ">=99.0.0"`:
   ```
   STDERR:
   Warning: This project requires agentv >=99.0.0 but you have 4.20.0.
     Run `agentv self update` to upgrade.
   ```
   Server starts normally after the warning.

2. Interactive TTY (via `script`), user answers `n`:
   ```
   Warning: This project requires agentv >=99.0.0 but you have 4.20.0.
   ? Update now? (Y/n) n
   ✔ Update now? No
   No results found. Dashboard will show an empty state.
   Dashboard: http://localhost:31172
   ```
   User declines; server starts as before.

3. Satisfying range (`required_version: ">=4.0.0"`): no warning, no prompt — server starts silently.

4. No `.agentv/config.yaml`: no warning, server starts silently.

## Test plan
- [x] Existing serve unit tests (39 tests) pass
- [x] Typecheck, build, lint, full test suite (via pre-push hooks)
- [x] Manual UAT: red/green above

Closes #1128