### PR TITLE
fix(test): raise pipeline-e2e timeout to 30s (#1169)

### DIFF
--- a/apps/cli/test/commands/eval/pipeline/pipeline-e2e.test.ts
+++ b/apps/cli/test/commands/eval/pipeline/pipeline-e2e.test.ts
@@ -62,5 +62,5 @@ describe('eval pipeline e2e', () => {
 
     const benchmark = JSON.parse(await readFile(join(OUT_DIR, 'benchmark.json'), 'utf8'));
     expect(benchmark.run_summary).toBeDefined();
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
Closes #1169

## Problem

`apps/cli/test/commands/eval/pipeline/pipeline-e2e.test.ts` (`eval pipeline e2e > runs full input → grade → bench pipeline`) flakes under suite contention from `bun --filter agentv test`, timing out at the 5000 ms per-test default. The test passes in isolation in ~7-12s — it's a real end-to-end test that spawns three sequential `bun apps/cli/src/cli.ts pipeline ...` subprocesses (input → grade → bench), so 5s is too tight when the suite is busy.

## Fix

Raise the per-test timeout to 30 s using Bun's `it(name, fn, timeout)` numeric-third-arg form. One-line change, no scope creep. The pipeline plumbing assertion ("the wiring works") is preserved as-is — fixture not trimmed because the existing fixture is already minimal and the timeout bump alone fully solves the flake.

## Red / green evidence

- **Red (before):** suite-context run produced `(fail) eval pipeline e2e > runs full input → grade → bench pipeline ... ^ this test timed out after 5000ms.`
- **Green (after):**
  - Isolated: `bun test apps/cli/test/commands/eval/pipeline/pipeline-e2e.test.ts` → `1 pass, 0 fail` in ~12 s.
  - Suite context: `bun --filter agentv test` ran multiple times; the pipeline-e2e test no longer appears in any failure output. Pre-push hook (which runs the full suite) passed cleanly on the green push.

## Notes

- A few neighbouring `pipeline input` tests in `apps/cli/test/commands/eval/pipeline/input.test.ts` exhibit the same 5s-timeout-under-contention pattern and flake intermittently. They are out of scope for #1169 and would benefit from the same treatment in a follow-up.