### PR TITLE
fix(test): raise input.test.ts pipeline timeouts to 30s

### DIFF
--- a/apps/cli/test/commands/eval/pipeline/input.test.ts
+++ b/apps/cli/test/commands/eval/pipeline/input.test.ts
@@ -19,7 +19,7 @@ describe('pipeline input', () => {
     const manifest = JSON.parse(await readFile(join(OUT_DIR, 'manifest.json'), 'utf8'));
     expect(manifest.test_ids).toEqual(['test-01']);
     expect(manifest.eval_file).toContain('input-test.eval.yaml');
-  });
+  }, 30_000);
 
   it('writes per-test input.json with input and input_files', async () => {
     const { execa } = await import('execa');
@@ -30,7 +30,7 @@ describe('pipeline input', () => {
     );
     expect(input.input).toHaveLength(1);
     expect(input.input[0].content).toBe('hello world');
-  });
+  }, 30_000);
 
   it('writes code_graders/<name>.json with resolved command', async () => {
     const { execa } = await import('execa');
@@ -44,7 +44,7 @@ describe('pipeline input', () => {
     );
     expect(grader.command).toBeDefined();
     expect(grader.name).toBe('contains_hello');
-  });
+  }, 30_000);
 
   it('writes llm_graders/<name>.json with prompt content', async () => {
     const { execa } = await import('execa');
@@ -58,7 +58,7 @@ describe('pipeline input', () => {
     );
     expect(grader.prompt_content).toBeDefined();
     expect(grader.name).toBe('relevance');
-  });
+  }, 30_000);
 
   it('writes criteria.md', async () => {
     const { execa } = await import('execa');
@@ -66,7 +66,7 @@ describe('pipeline input', () => {
 
     const criteria = await readFile(join(OUT_DIR, 'input-test', 'test-01', 'criteria.md'), 'utf8');
     expect(criteria).toContain('Response echoes the input');
-  });
+  }, 30_000);
 
   it('writes invoke.json', async () => {
     const { execa } = await import('execa');
@@ -76,7 +76,7 @@ describe('pipeline input', () => {
       await readFile(join(OUT_DIR, 'input-test', 'test-01', 'invoke.json'), 'utf8'),
     );
     expect(invoke.kind).toBeDefined();
-  });
+  }, 30_000);
 
   it('writes experiment to manifest when --experiment is provided', async () => {
     const { execa } = await import('execa');
@@ -93,7 +93,7 @@ describe('pipeline input', () => {
 
     const manifest = JSON.parse(await readFile(join(OUT_DIR, 'manifest.json'), 'utf8'));
     expect(manifest.experiment).toBe('without_skills');
-  });
+  }, 30_000);
 
   it('omits experiment from manifest when --experiment is not provided', async () => {
     const { execa } = await import('execa');
@@ -101,7 +101,7 @@ describe('pipeline input', () => {
 
     const manifest = JSON.parse(await readFile(join(OUT_DIR, 'manifest.json'), 'utf8'));
     expect(manifest.experiment).toBeUndefined();
-  });
+  }, 30_000);
 
   it('writes code_graders/<name>.json for deterministic assertions', async () => {
     const { execa } = await import('execa');
@@ -127,7 +127,7 @@ describe('pipeline input', () => {
     expect(regexGrader.name).toBe('matches_pattern');
     expect(regexGrader.type).toBe('regex');
     expect(regexGrader.value).toBe('h[aeiou]llo');
-  });
+  }, 30_000);
 
   it('falls back to eval file basename for suite directory when name is absent', async () => {
     const { execa } = await import('execa');
@@ -141,5 +141,5 @@ describe('pipeline input', () => {
 
     const manifest = JSON.parse(await readFile(join(OUT_DIR, 'manifest.json'), 'utf8'));
     expect(manifest.suite).toBe('no-name');
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
Follow-up to #1170. Same 5s-default timeout flake observed in the `pipeline input` describe block in `apps/cli/test/commands/eval/pipeline/input.test.ts` during repeated `bun --filter agentv test` runs after the #1166/#1167/#1168 land.

Each test in the block spawns a `bun apps/cli/src/cli.ts pipeline input ...` subprocess that completes in ~1-2s in isolation but routinely overshoots 5s under suite contention.

The user brief named three sibling tests (`writes code_graders/<name>.json for deterministic assertions`, `omits experiment from manifest...`, `falls back to eval file basename...`); the remaining seven exhibited identical SIGTERM-at-5s failures in the same suite run, so the per-test bump is applied uniformly to all 10 tests in the block to prevent partial-coverage churn.

Same one-line treatment per the #1170 precedent (`it(name, fn, 30_000)` — Bun test's numeric third-arg form).

## Test plan
- [x] `bun test apps/cli/test/commands/eval/pipeline/input.test.ts` — passes (10/10)
- [x] `bun --filter agentv test` — no `pipeline input >` failures (verified across 3 consecutive suite runs)
- [x] Pre-push hook (full suite) passed