### PR TITLE
feat(cli): show eval progress durations in ms

### DIFF
--- a/apps/cli/src/commands/eval/progress-display.ts
+++ b/apps/cli/src/commands/eval/progress-display.ts
@@ -49,11 +49,11 @@ function formatDurations(
 
   if (durationMs !== undefined && totalDurationMs !== undefined) {
     const normalizedTotalMs = Math.max(durationMs, totalDurationMs);
-    return ` | τ ${durationMs}/${normalizedTotalMs}ms`;
+    return ` | ${durationMs}/${normalizedTotalMs}ms`;
   }
 
   const singleDurationMs = durationMs ?? totalDurationMs;
-  return singleDurationMs !== undefined ? ` | τ ${singleDurationMs}ms` : '';
+  return singleDurationMs !== undefined ? ` | ${singleDurationMs}ms` : '';
 }
 
 /**

--- a/apps/cli/src/commands/eval/progress-display.ts
+++ b/apps/cli/src/commands/eval/progress-display.ts
@@ -10,6 +10,8 @@ export interface WorkerProgress {
   targetLabel?: string;
   score?: number;
   verdict?: Verdict;
+  durationMs?: number;
+  totalDurationMs?: number;
 }
 
 const ANSI_BOLD = '\x1b[1m';
@@ -35,6 +37,20 @@ function formatVerdict(score: number | undefined, verdict: Verdict | undefined):
   const color = verdict === 'PASS' ? ANSI_GREEN : verdict === 'FAIL' ? ANSI_RED : ANSI_YELLOW;
 
   return ` | ${color}${ANSI_BOLD}${verdictLabel}${ANSI_RESET}`;
+}
+
+function formatDurations(
+  durationMs: number | undefined,
+  totalDurationMs: number | undefined,
+): string {
+  const segments: string[] = [];
+  if (durationMs !== undefined) {
+    segments.push(`agent ${durationMs}ms`);
+  }
+  if (totalDurationMs !== undefined) {
+    segments.push(`total ${totalDurationMs}ms`);
+  }
+  return segments.length > 0 ? ` | ${segments.join(' | ')}` : '';
 }
 
 /**
@@ -99,14 +115,14 @@ export class ProgressDisplay {
         // Pick icon based on verdict: ✅ PASS, ⚠️ FAIL, ❌ ERROR
         const icon = progress.verdict === 'FAIL' ? '⚠️' : progress.verdict === 'ERROR' ? '❌' : '✅';
         console.log(
-          `${countPrefix}   ${icon} ${progress.testId}${targetSuffix}${formatVerdict(progress.score, progress.verdict)}`,
+          `${countPrefix}   ${icon} ${progress.testId}${targetSuffix}${formatVerdict(progress.score, progress.verdict)}${formatDurations(progress.durationMs, progress.totalDurationMs)}`,
         );
         break;
       }
       case 'failed': {
         const failIcon = progress.verdict === 'ERROR' ? '❌' : '⚠️';
         console.log(
-          `${countPrefix}   ${failIcon} ${progress.testId}${targetSuffix}${formatVerdict(progress.score, progress.verdict)}${progress.error ? `: ${progress.error}` : ''}`,
+          `${countPrefix}   ${failIcon} ${progress.testId}${targetSuffix}${formatVerdict(progress.score, progress.verdict)}${formatDurations(progress.durationMs, progress.totalDurationMs)}${progress.error ? `: ${progress.error}` : ''}`,
         );
         break;
       }

--- a/apps/cli/src/commands/eval/progress-display.ts
+++ b/apps/cli/src/commands/eval/progress-display.ts
@@ -49,11 +49,11 @@ function formatDurations(
 
   if (durationMs !== undefined && totalDurationMs !== undefined) {
     const normalizedTotalMs = Math.max(durationMs, totalDurationMs);
-    return ` | ⏱ ${durationMs}/${normalizedTotalMs}ms`;
+    return ` | τ ${durationMs}/${normalizedTotalMs}ms`;
   }
 
   const singleDurationMs = durationMs ?? totalDurationMs;
-  return singleDurationMs !== undefined ? ` | ⏱ ${singleDurationMs}ms` : '';
+  return singleDurationMs !== undefined ? ` | τ ${singleDurationMs}ms` : '';
 }
 
 /**

--- a/apps/cli/src/commands/eval/progress-display.ts
+++ b/apps/cli/src/commands/eval/progress-display.ts
@@ -43,14 +43,17 @@ function formatDurations(
   durationMs: number | undefined,
   totalDurationMs: number | undefined,
 ): string {
-  const segments: string[] = [];
-  if (durationMs !== undefined) {
-    segments.push(`agent ${durationMs}ms`);
+  if (durationMs === undefined && totalDurationMs === undefined) {
+    return '';
   }
-  if (totalDurationMs !== undefined) {
-    segments.push(`total ${totalDurationMs}ms`);
+
+  if (durationMs !== undefined && totalDurationMs !== undefined) {
+    const normalizedTotalMs = Math.max(durationMs, totalDurationMs);
+    return ` | ⏱ ${durationMs}/${normalizedTotalMs}ms`;
   }
-  return segments.length > 0 ? ` | ${segments.join(' | ')}` : '';
+
+  const singleDurationMs = durationMs ?? totalDurationMs;
+  return singleDurationMs !== undefined ? ` | ⏱ ${singleDurationMs}ms` : '';
 }
 
 /**

--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -932,6 +932,8 @@ async function runSingleEvalFile(params: {
         targetLabel: inlineTargetLabel,
         score: event.score,
         verdict,
+        durationMs: event.durationMs,
+        totalDurationMs: event.evalRunDurationMs,
       });
     },
   });

--- a/apps/cli/test/commands/eval/progress-display.test.ts
+++ b/apps/cli/test/commands/eval/progress-display.test.ts
@@ -11,7 +11,7 @@ describe('ProgressDisplay', () => {
 
   afterEach(() => {
     if (originalNoColor === undefined) {
-      delete process.env.NO_COLOR;
+      process.env.NO_COLOR = undefined;
     } else {
       process.env.NO_COLOR = originalNoColor;
     }

--- a/apps/cli/test/commands/eval/progress-display.test.ts
+++ b/apps/cli/test/commands/eval/progress-display.test.ts
@@ -44,7 +44,7 @@ describe('ProgressDisplay', () => {
     }
 
     expect(logs).toEqual([
-      '1/1   ✅ test-42-billing-negative-margin | wtalms-stg | 94% PASS | ⏱ 18342/22109ms',
+      '1/1   ✅ test-42-billing-negative-margin | wtalms-stg | 94% PASS | τ 18342/22109ms',
     ]);
   });
 
@@ -75,7 +75,7 @@ describe('ProgressDisplay', () => {
     }
 
     expect(logs).toEqual([
-      '1/1   ✅ simple-thresholds-pass | mock_metrics_agent | 100% PASS | ⏱ 245/245ms',
+      '1/1   ✅ simple-thresholds-pass | mock_metrics_agent | 100% PASS | τ 245/245ms',
     ]);
   });
 

--- a/apps/cli/test/commands/eval/progress-display.test.ts
+++ b/apps/cli/test/commands/eval/progress-display.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+import { ProgressDisplay } from '../../../src/commands/eval/progress-display.js';
+
+describe('ProgressDisplay', () => {
+  const originalNoColor = process.env.NO_COLOR;
+
+  beforeEach(() => {
+    process.env.NO_COLOR = '1';
+  });
+
+  afterEach(() => {
+    if (originalNoColor === undefined) {
+      delete process.env.NO_COLOR;
+    } else {
+      process.env.NO_COLOR = originalNoColor;
+    }
+  });
+
+  it('prints agent and total durations after the verdict', () => {
+    const display = new ProgressDisplay(1);
+    const logs: string[] = [];
+    const logSpy = mock((message?: unknown) => {
+      logs.push(String(message ?? ''));
+    });
+    const originalLog = console.log;
+    console.log = logSpy as typeof console.log;
+
+    try {
+      display.start();
+      display.setTotalTests(1);
+      display.updateWorker({
+        workerId: 1,
+        testId: 'test-42-billing-negative-margin',
+        status: 'completed',
+        targetLabel: 'wtalms-stg',
+        score: 0.94,
+        verdict: 'PASS',
+        durationMs: 18342,
+        totalDurationMs: 22109,
+      });
+    } finally {
+      console.log = originalLog;
+    }
+
+    expect(logs).toEqual([
+      '1/1   ✅ test-42-billing-negative-margin | wtalms-stg | 94% PASS | agent 18342ms | total 22109ms',
+    ]);
+  });
+
+  it('omits duration segments when metrics are unavailable', () => {
+    const display = new ProgressDisplay(1);
+    const logs: string[] = [];
+    const logSpy = mock((message?: unknown) => {
+      logs.push(String(message ?? ''));
+    });
+    const originalLog = console.log;
+    console.log = logSpy as typeof console.log;
+
+    try {
+      display.start();
+      display.setTotalTests(1);
+      display.updateWorker({
+        workerId: 1,
+        testId: 'test-01-biosecurity',
+        status: 'completed',
+        targetLabel: 'wtalms-stg',
+        score: 0.98,
+        verdict: 'PASS',
+      });
+    } finally {
+      console.log = originalLog;
+    }
+
+    expect(logs).toEqual(['1/1   ✅ test-01-biosecurity | wtalms-stg | 98% PASS']);
+  });
+});

--- a/apps/cli/test/commands/eval/progress-display.test.ts
+++ b/apps/cli/test/commands/eval/progress-display.test.ts
@@ -17,7 +17,7 @@ describe('ProgressDisplay', () => {
     }
   });
 
-  it('prints agent and total durations after the verdict', () => {
+  it('prints compact agent/total durations after the verdict', () => {
     const display = new ProgressDisplay(1);
     const logs: string[] = [];
     const logSpy = mock((message?: unknown) => {
@@ -44,7 +44,38 @@ describe('ProgressDisplay', () => {
     }
 
     expect(logs).toEqual([
-      '1/1   ✅ test-42-billing-negative-margin | wtalms-stg | 94% PASS | agent 18342ms | total 22109ms',
+      '1/1   ✅ test-42-billing-negative-margin | wtalms-stg | 94% PASS | ⏱ 18342/22109ms',
+    ]);
+  });
+
+  it('normalizes total duration when reported agent time is higher', () => {
+    const display = new ProgressDisplay(1);
+    const logs: string[] = [];
+    const logSpy = mock((message?: unknown) => {
+      logs.push(String(message ?? ''));
+    });
+    const originalLog = console.log;
+    console.log = logSpy as typeof console.log;
+
+    try {
+      display.start();
+      display.setTotalTests(1);
+      display.updateWorker({
+        workerId: 1,
+        testId: 'simple-thresholds-pass',
+        status: 'completed',
+        targetLabel: 'mock_metrics_agent',
+        score: 1,
+        verdict: 'PASS',
+        durationMs: 245,
+        totalDurationMs: 78,
+      });
+    } finally {
+      console.log = originalLog;
+    }
+
+    expect(logs).toEqual([
+      '1/1   ✅ simple-thresholds-pass | mock_metrics_agent | 100% PASS | ⏱ 245/245ms',
     ]);
   });
 

--- a/apps/cli/test/commands/eval/progress-display.test.ts
+++ b/apps/cli/test/commands/eval/progress-display.test.ts
@@ -44,7 +44,7 @@ describe('ProgressDisplay', () => {
     }
 
     expect(logs).toEqual([
-      '1/1   ✅ test-42-billing-negative-margin | wtalms-stg | 94% PASS | τ 18342/22109ms',
+      '1/1   ✅ test-42-billing-negative-margin | wtalms-stg | 94% PASS | 18342/22109ms',
     ]);
   });
 
@@ -75,7 +75,7 @@ describe('ProgressDisplay', () => {
     }
 
     expect(logs).toEqual([
-      '1/1   ✅ simple-thresholds-pass | mock_metrics_agent | 100% PASS | τ 245/245ms',
+      '1/1   ✅ simple-thresholds-pass | mock_metrics_agent | 100% PASS | 245/245ms',
     ]);
   });
 

--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -384,6 +384,10 @@ export interface ProgressEvent {
   readonly score?: number;
   /** Execution status classification for completed/failed tests */
   readonly executionStatus?: ExecutionStatus;
+  /** Candidate/agent execution duration in milliseconds */
+  readonly durationMs?: number;
+  /** Full eval duration in milliseconds, including grading/orchestration */
+  readonly evalRunDurationMs?: number;
 }
 
 export interface RunEvaluationOptions {
@@ -1386,6 +1390,8 @@ export async function runEvaluation(
             error: result.error,
             score: result.score,
             executionStatus: result.executionStatus,
+            durationMs: result.durationMs,
+            evalRunDurationMs: result.evalRun?.durationMs,
           });
         }
 
@@ -1768,6 +1774,7 @@ async function runBatchEvaluation(options: {
           error: error instanceof Error ? error.message : String(error),
           score: errorResult.score,
           executionStatus: errorResult.executionStatus,
+          evalRunDurationMs: errorResult.evalRun?.durationMs,
         });
       }
       continue;
@@ -1788,6 +1795,8 @@ async function runBatchEvaluation(options: {
         error: result.error,
         score: result.score,
         executionStatus: result.executionStatus,
+        durationMs: result.durationMs,
+        evalRunDurationMs: result.evalRun?.durationMs,
       });
     }
   }


### PR DESCRIPTION
## Summary
- show compact timing on completed/failed eval progress lines as `agent/totalms` when both metrics are available
- thread `durationMs` and `evalRun.durationMs` through core progress events into the CLI progress display
- normalize the displayed total so it never renders lower than the displayed agent duration
- add focused progress display tests for compact formatting, normalization, and missing-metrics behavior

Closes #1186.

## Root Cause
The eval runner already computed both per-agent duration (`result.durationMs`) and full eval duration (`result.evalRun.durationMs`), but the progress event shape and CLI formatter dropped those values before rendering the completed result line. Once surfaced, the raw numbers could still be misleading because provider-reported agent duration can exceed local wall-clock eval timing for mock or remote targets.

## Validation
- `bun test apps/cli/test/commands/eval/progress-display.test.ts`
- `bun test apps/cli/test/commands/eval/statistics-inconclusive.test.ts`
- `bun --filter @agentv/core typecheck`
- `bun --filter agentv typecheck`
- `git push` pre-push hook passed: build, typecheck, lint, test, validate example evals

## Red/Green UAT
Command used in both cases:

```bash
NO_COLOR=1 bun apps/cli/dist/cli.js eval examples/features/execution-metrics/evals/dataset.eval.yaml --target mock_metrics_agent --test-id simple-thresholds-pass --workers 1
```

Before (`main`):

```text
0/1   🔄 simple-thresholds-pass | mock_metrics_agent
1/1   ✅ simple-thresholds-pass | mock_metrics_agent | 100% PASS
```

After (`feat/1186-progress-durations-ms`):

```text
0/1   🔄 simple-thresholds-pass | mock_metrics_agent
1/1   ✅ simple-thresholds-pass | mock_metrics_agent | 100% PASS | 245/245ms
```


