### PR TITLE
fix: remove before_session hook startup color

### DIFF
--- a/packages/core/src/evaluation/hooks.ts
+++ b/packages/core/src/evaluation/hooks.ts
@@ -27,9 +27,6 @@
 
 import { spawnSync } from 'node:child_process';
 
-const ANSI_YELLOW = '[33m';
-const ANSI_RESET = '[0m';
-
 /**
  * Parse env var lines from hook stdout.
  *
@@ -86,7 +83,7 @@ export function runBeforeSessionHook(command: string): void {
   const shell = isWindows ? 'cmd' : 'sh';
   const shellFlag = isWindows ? '/c' : '-c';
 
-  console.log(`${ANSI_YELLOW}Running before_session hook: ${command}${ANSI_RESET}`);
+  console.log(`Running before_session hook: ${command}`);
 
   const result = spawnSync(shell, [shellFlag, command], {
     encoding: 'utf8',

--- a/packages/core/test/evaluation/hooks.test.ts
+++ b/packages/core/test/evaluation/hooks.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, spyOn } from 'bun:test';
 
-import { parseEnvOutput } from '../../src/evaluation/hooks.js';
+import { parseEnvOutput, runBeforeSessionHook } from '../../src/evaluation/hooks.js';
 
 describe('parseEnvOutput', () => {
   it('parses dotenv KEY=value lines', () => {
@@ -60,5 +60,31 @@ describe('parseEnvOutput', () => {
 
   it('accepts keys with underscores and digits', () => {
     expect(parseEnvOutput('MY_KEY_123=hello')).toEqual({ MY_KEY_123: 'hello' });
+  });
+});
+
+describe('runBeforeSessionHook', () => {
+  it('logs hook startup without ANSI color codes', () => {
+    const envKey = 'AGENTV_TEST_BEFORE_SESSION_HOOK_COLOR';
+    const originalValue = process.env[envKey];
+    const command = `bun -e "process.stdout.write('${envKey}=plain\\n')"`;
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+
+    delete process.env[envKey];
+
+    try {
+      runBeforeSessionHook(command);
+
+      expect(logSpy.mock.calls[0]?.[0]).toBe(`Running before_session hook: ${command}`);
+      expect(process.env[envKey]).toBe('plain');
+    } finally {
+      logSpy.mockRestore();
+
+      if (originalValue === undefined) {
+        delete process.env[envKey];
+      } else {
+        process.env[envKey] = originalValue;
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary
- remove yellow ANSI styling from the `before_session` startup log line
- add a regression test that runs the hook and asserts the startup log is plain text

## Red/Green evidence
### Red (`origin/main`)
```text
"\u001b[33mRunning before_session hook: bun -e \"process.stdout.write('HOOK_VAR=ok\\n')\"\u001b[0m"
```

### Green (this branch)
```text
"Running before_session hook: bun -e \"process.stdout.write('HOOK_VAR=ok\\n')\""
```

## Test Plan
- [x] `bun test packages/core/test/evaluation/hooks.test.ts`
- [x] `bun run build`
- [x] `git push -u origin fix/before-session-hook-color` (pre-push hooks)
