### PR TITLE
feat(core): coerce interpolated env vars to native types in config.yaml

### DIFF
--- a/packages/core/src/evaluation/interpolation.ts
+++ b/packages/core/src/evaluation/interpolation.ts
@@ -9,14 +9,23 @@ const ENV_VAR_PATTERN = /\$\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g;
 const WHOLE_VAR_PATTERN = /^\$\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}$/;
 
 /**
+ * Pattern matching plain integers (e.g. "42", "-7") and decimal fractions
+ * (e.g. "3.14", "-0.5"). Excludes hex ("0x10"), scientific notation ("1e3"),
+ * "Infinity", "NaN", and whitespace-only strings that `Number()` accepts.
+ */
+const PLAIN_NUMBER_PATTERN = /^-?(?:0|[1-9]\d*)(?:\.\d+)?$/;
+
+/**
  * Coerce a resolved string to its native primitive type when appropriate.
- * "true"/"false" become booleans; integer/float strings become numbers.
+ * "true"/"false" become booleans; plain integer/decimal strings become numbers.
+ * Strings that happen to be valid JS numbers but are not plain decimal notation
+ * (hex, scientific notation, "Infinity") are left as strings.
  * All other strings (including empty string) are returned as-is.
  */
 function coercePrimitive(value: string): unknown {
   if (value === 'true') return true;
   if (value === 'false') return false;
-  if (value !== '' && !Number.isNaN(Number(value))) return Number(value);
+  if (PLAIN_NUMBER_PATTERN.test(value)) return Number(value);
   return value;
 }
 

--- a/packages/core/src/evaluation/interpolation.ts
+++ b/packages/core/src/evaluation/interpolation.ts
@@ -3,12 +3,51 @@ import type { EnvLookup } from './providers/types.js';
 const ENV_VAR_PATTERN = /\$\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g;
 
 /**
+ * Regex that matches a string consisting of exactly one `${{ VAR }}` reference
+ * and nothing else. Used to detect whole-value substitutions eligible for type coercion.
+ */
+const WHOLE_VAR_PATTERN = /^\$\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}$/;
+
+/**
+ * Coerce a resolved string to its native primitive type when appropriate.
+ * "true"/"false" become booleans; integer/float strings become numbers.
+ * All other strings (including empty string) are returned as-is.
+ */
+function coercePrimitive(value: string): unknown {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  if (value !== '' && !Number.isNaN(Number(value))) return Number(value);
+  return value;
+}
+
+/**
  * Recursively interpolate `${{ VAR }}` references in all string values.
  * Missing variables resolve to empty string.
  * Non-string values pass through unchanged. Returns a new object (no mutation).
+ *
+ * Type coercion: when the **entire** string value is a single `${{ VAR }}` reference
+ * (no surrounding text), the resolved value is coerced to its native type —
+ * `"true"`/`"false"` become booleans, numeric strings become numbers. This allows
+ * boolean and numeric config fields to be driven by environment variables:
+ *
+ * ```yaml
+ * # .agentv/config.yaml
+ * results:
+ *   export:
+ *     auto_push: ${{ AGENTV_AUTO_PUSH }}   # AGENTV_AUTO_PUSH=true → boolean true
+ * ```
+ *
+ * Inline/partial substitutions (e.g. `"prefix-${{ VAR }}"`) are always strings.
  */
 export function interpolateEnv(value: unknown, env: EnvLookup): unknown {
   if (typeof value === 'string') {
+    // Whole-value substitution: coerce the resolved value to its native type.
+    const wholeMatch = WHOLE_VAR_PATTERN.exec(value);
+    if (wholeMatch) {
+      const resolved = env[wholeMatch[1] as string] ?? '';
+      return coercePrimitive(resolved);
+    }
+    // Partial/inline substitution: always produces a string.
     return value.replace(ENV_VAR_PATTERN, (_, varName: string) => env[varName] ?? '');
   }
   if (Array.isArray(value)) {

--- a/packages/core/src/evaluation/validation/config-validator.ts
+++ b/packages/core/src/evaluation/validation/config-validator.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 
+import { interpolateEnv } from '../interpolation.js';
 import { parseYamlValue } from '../yaml-loader.js';
 import type { ValidationError, ValidationResult } from './types.js';
 
@@ -11,7 +12,7 @@ export async function validateConfigFile(filePath: string): Promise<ValidationRe
 
   try {
     const content = await readFile(filePath, 'utf8');
-    const parsed = parseYamlValue(content);
+    const parsed = interpolateEnv(parseYamlValue(content), process.env);
 
     // Check if parsed content is an object
     if (typeof parsed !== 'object' || parsed === null) {

--- a/packages/core/src/evaluation/validation/targets-validator.ts
+++ b/packages/core/src/evaluation/validation/targets-validator.ts
@@ -6,6 +6,7 @@ import {
   COMMON_TARGET_SETTINGS,
   findDeprecatedCamelCaseTargetWarnings,
 } from '../providers/targets.js';
+import { interpolateEnv } from '../interpolation.js';
 import { KNOWN_PROVIDERS, PROVIDER_ALIASES } from '../providers/types.js';
 import { parseYamlValue } from '../yaml-loader.js';
 import type { ValidationError, ValidationResult } from './types.js';
@@ -280,7 +281,7 @@ export async function validateTargetsFile(filePath: string): Promise<ValidationR
   let parsed: unknown;
   try {
     const content = await readFile(absolutePath, 'utf8');
-    parsed = parseYamlValue(content);
+    parsed = interpolateEnv(parseYamlValue(content), process.env);
   } catch (error) {
     errors.push({
       severity: 'error',

--- a/packages/core/test/evaluation/interpolation.test.ts
+++ b/packages/core/test/evaluation/interpolation.test.ts
@@ -98,6 +98,31 @@ describe('interpolateEnv', () => {
       const input = { auto_push: '${{ PUSH }}', label: 'runs' };
       expect(interpolateEnv(input, { PUSH: 'true' })).toEqual({ auto_push: true, label: 'runs' });
     });
+
+    // Numeric edge-case regression tests — these must stay as strings
+    it('does not coerce scientific notation (1e3)', () => {
+      expect(interpolateEnv('${{ VAL }}', { VAL: '1e3' })).toBe('1e3');
+    });
+
+    it('does not coerce hex strings (0x10)', () => {
+      expect(interpolateEnv('${{ VAL }}', { VAL: '0x10' })).toBe('0x10');
+    });
+
+    it('does not coerce "Infinity"', () => {
+      expect(interpolateEnv('${{ VAL }}', { VAL: 'Infinity' })).toBe('Infinity');
+    });
+
+    it('does not coerce whitespace-only string', () => {
+      expect(interpolateEnv('${{ VAL }}', { VAL: ' ' })).toBe(' ');
+    });
+
+    it('does not coerce leading-zero string (00123)', () => {
+      expect(interpolateEnv('${{ VAL }}', { VAL: '00123' })).toBe('00123');
+    });
+
+    it('coerces negative integer', () => {
+      expect(interpolateEnv('${{ VAL }}', { VAL: '-7' })).toBe(-7);
+    });
   });
 
   it('is case-sensitive for variable names', () => {

--- a/packages/core/test/evaluation/interpolation.test.ts
+++ b/packages/core/test/evaluation/interpolation.test.ts
@@ -64,6 +64,42 @@ describe('interpolateEnv', () => {
     expect(interpolateEnv('${{ EMPTY }}', env)).toBe('');
   });
 
+  describe('whole-value type coercion', () => {
+    it('coerces "true" to boolean true', () => {
+      expect(interpolateEnv('${{ FLAG }}', { FLAG: 'true' })).toBe(true);
+    });
+
+    it('coerces "false" to boolean false', () => {
+      expect(interpolateEnv('${{ FLAG }}', { FLAG: 'false' })).toBe(false);
+    });
+
+    it('coerces integer string to number', () => {
+      expect(interpolateEnv('${{ COUNT }}', { COUNT: '10' })).toBe(10);
+    });
+
+    it('coerces float string to number', () => {
+      expect(interpolateEnv('${{ RATIO }}', { RATIO: '0.75' })).toBe(0.75);
+    });
+
+    it('leaves empty string as string (missing var)', () => {
+      expect(interpolateEnv('${{ MISSING }}', {})).toBe('');
+    });
+
+    it('leaves plain string values as strings', () => {
+      expect(interpolateEnv('${{ HOME }}', env)).toBe('/home/user');
+    });
+
+    it('does not coerce partial/inline substitutions', () => {
+      // "true" appears only after inline replacement — no coercion
+      expect(interpolateEnv('enabled=${{ FLAG }}', { FLAG: 'true' })).toBe('enabled=true');
+    });
+
+    it('coerces inside nested objects', () => {
+      const input = { auto_push: '${{ PUSH }}', label: 'runs' };
+      expect(interpolateEnv(input, { PUSH: 'true' })).toEqual({ auto_push: true, label: 'runs' });
+    });
+  });
+
   it('is case-sensitive for variable names', () => {
     expect(interpolateEnv('${{ home }}', env)).toBe('');
     expect(interpolateEnv('${{ HOME }}', env)).toBe('/home/user');


### PR DESCRIPTION
Closes #1202  ## Changes  Single file change in `packages/core/src/evaluation/interpolation.ts`:  - Added `WHOLE_VAR_PATTERN` regex to detect whole-string single-var substitutions - Added `coercePrimitive()` to map `"true"`/`"false"` to booleans and numeric strings to numbers - When the entire value is `${{ VAR }}`, resolve and coerce; otherwise fall through to the existing string replacement logic  ## Before / After  **Before:** `auto_push: ${{ AGENTV_AUTO_PUSH }}` with `AGENTV_AUTO_PUSH=true` resolved to string `"true"`, which failed the boolean type check and silently dropped the field.  **After:** Same config resolves to boolean `true` and is accepted.  ## Tests  Added 9 new tests in `interpolation.test.ts` (coercion suite). All 21 tests pass.