### PR TITLE
fix(cli): detect global npm self-update installs

### DIFF
--- a/apps/cli/src/self-update.ts
+++ b/apps/cli/src/self-update.ts
@@ -51,8 +51,8 @@ export function detectPackageManager(): 'bun' | 'npm' {
  * Detect whether agentv was invoked from a local project install.
  * npm global installs can also live under a `node_modules` segment, so
  * the path alone is not enough. We treat `npx` cache paths as local and
- * otherwise require the package root to be the current project or one of
- * its ancestors before classifying it as local.
+ * otherwise require the current working directory to be inside the package
+ * root before classifying it as local.
  */
 export function detectInstallScopeFromPath(
   scriptPath: string,
@@ -82,8 +82,7 @@ export function detectInstallScopeFromPath(
 
   const projectOwnsPackage =
     cwdComparable === packageRootComparable ||
-    cwdComparable.startsWith(`${packageRootComparable}/`) ||
-    packageRootComparable.startsWith(`${cwdComparable}/`);
+    cwdComparable.startsWith(`${packageRootComparable}/`);
 
   return projectOwnsPackage ? 'local' : 'global';
 }

--- a/apps/cli/src/self-update.ts
+++ b/apps/cli/src/self-update.ts
@@ -49,16 +49,43 @@ export function detectPackageManager(): 'bun' | 'npm' {
 
 /**
  * Detect whether agentv was invoked from a local project install.
- * A path containing a `node_modules` segment indicates a local dependency;
- * anything else (system binary, `.bun/bin`, `.nvm/.../bin`) is treated as
- * global. Matches both POSIX and Windows path separators so a directory
- * that merely embeds the substring (e.g., `/opt/my_node_modules_tool/`)
- * isn't misclassified.
+ * npm global installs can also live under a `node_modules` segment, so
+ * the path alone is not enough. We treat `npx` cache paths as local and
+ * otherwise require the package root to be the current project or one of
+ * its ancestors before classifying it as local.
  */
-export function detectInstallScopeFromPath(scriptPath: string): 'local' | 'global' {
-  const hasSegment =
-    scriptPath.includes('/node_modules/') || scriptPath.includes('\\node_modules\\');
-  return hasSegment ? 'local' : 'global';
+export function detectInstallScopeFromPath(
+  scriptPath: string,
+  cwd = process.cwd(),
+): 'local' | 'global' {
+  const normalizedScriptPath = scriptPath.replace(/\\/g, '/');
+  const normalizedCwd = cwd.replace(/\\/g, '/');
+
+  if (!normalizedScriptPath.includes('/node_modules/')) {
+    return 'global';
+  }
+
+  if (normalizedScriptPath.includes('/.npm/_npx/') || normalizedScriptPath.includes('/npm-cache/_npx/')) {
+    return 'local';
+  }
+
+  const packageRoot = normalizedScriptPath.split('/node_modules/')[0];
+  if (!packageRoot) {
+    return 'global';
+  }
+
+  const scriptPathComparable = process.platform === 'win32'
+    ? normalizedScriptPath.toLowerCase()
+    : normalizedScriptPath;
+  const cwdComparable = process.platform === 'win32' ? normalizedCwd.toLowerCase() : normalizedCwd;
+  const packageRootComparable = process.platform === 'win32' ? packageRoot.toLowerCase() : packageRoot;
+
+  const projectOwnsPackage =
+    cwdComparable === packageRootComparable ||
+    cwdComparable.startsWith(`${packageRootComparable}/`) ||
+    packageRootComparable.startsWith(`${cwdComparable}/`);
+
+  return projectOwnsPackage ? 'local' : 'global';
 }
 
 export function detectInstallScope(): 'local' | 'global' {

--- a/apps/cli/test/self-update.test.ts
+++ b/apps/cli/test/self-update.test.ts
@@ -27,7 +27,12 @@ describe('detectPackageManagerFromPath', () => {
 
 describe('detectInstallScopeFromPath', () => {
   test('detects local for project node_modules path', () => {
-    expect(detectInstallScopeFromPath('/home/user/proj/node_modules/.bin/agentv')).toBe('local');
+    expect(
+      detectInstallScopeFromPath(
+        '/home/user/proj/node_modules/.bin/agentv',
+        '/home/user/proj',
+      ),
+    ).toBe('local');
   });
 
   test('detects local for nested npx cache path', () => {
@@ -51,9 +56,12 @@ describe('detectInstallScopeFromPath', () => {
   });
 
   test('detects local for Windows node_modules path', () => {
-    expect(detectInstallScopeFromPath('C:\\Users\\dev\\proj\\node_modules\\.bin\\agentv.cmd')).toBe(
-      'local',
-    );
+    expect(
+      detectInstallScopeFromPath(
+        'C:\\Users\\dev\\proj\\node_modules\\.bin\\agentv.cmd',
+        'C:\\Users\\dev\\proj',
+      ),
+    ).toBe('local');
   });
 
   test('detects global for Windows npm global install path', () => {

--- a/apps/cli/test/self-update.test.ts
+++ b/apps/cli/test/self-update.test.ts
@@ -56,6 +56,24 @@ describe('detectInstallScopeFromPath', () => {
     );
   });
 
+  test('detects global for Windows npm global install path', () => {
+    expect(
+      detectInstallScopeFromPath(
+        'C:\\Users\\dev\\AppData\\Roaming\\npm\\node_modules\\agentv\\dist\\cli.js',
+        'C:\\Users\\dev\\work\\repo',
+      ),
+    ).toBe('global');
+  });
+
+  test('detects local when cwd is inside the project using the dependency', () => {
+    expect(
+      detectInstallScopeFromPath(
+        'C:\\Users\\dev\\repo\\node_modules\\agentv\\dist\\cli.js',
+        'C:\\Users\\dev\\repo\\packages\\cli',
+      ),
+    ).toBe('local');
+  });
+
   test('treats unrelated directory containing node_modules substring as global', () => {
     // A path with the substring but no actual `node_modules` path segment
     // (e.g. a third-party tool installed under /opt/my_node_modules_tool/)

--- a/apps/cli/test/self-update.test.ts
+++ b/apps/cli/test/self-update.test.ts
@@ -73,6 +73,15 @@ describe('detectInstallScopeFromPath', () => {
     ).toBe('global');
   });
 
+  test('detects global for Windows npm global install path from home directory', () => {
+    expect(
+      detectInstallScopeFromPath(
+        'C:\\Users\\dev\\AppData\\Roaming\\npm\\node_modules\\agentv\\dist\\cli.js',
+        'C:\\Users\\dev',
+      ),
+    ).toBe('global');
+  });
+
   test('detects local when cwd is inside the project using the dependency', () => {
     expect(
       detectInstallScopeFromPath(


### PR DESCRIPTION
## Summary
Fix `agentv self update` misclassifying Windows global npm installs as local project installs.

## Root cause
Global npm installs on Windows commonly execute from a path like `AppData/Roaming/npm/node_modules/agentv/dist/cli.js`. The CLI treated any path containing `node_modules` as local, so self-update ran `npm install agentv@latest` instead of `npm install -g agentv@latest`.

## Changes
- detect local installs using project cwd rather than any `node_modules` segment
- preserve local classification for npx cache paths
- add regression coverage for Windows global npm installs and project-local node_modules cases
- align the existing local-install tests with the new cwd-aware behavior

## Validation
- `bun test apps/cli/test/self-update.test.ts`
  - passed: 22 tests, 0 failed
- direct executable check of `detectInstallScopeFromPath` for Windows global npm, project-local, and npx cache paths

Closes #1210