### PR TITLE
feat(studio): expose eval resumability — API + Resume action on run detail

### DIFF
--- a/apps/cli/src/commands/results/eval-runner.ts
+++ b/apps/cli/src/commands/results/eval-runner.ts
@@ -123,7 +123,7 @@ function validateResumeOptions(req: RunEvalRequest): string | undefined {
   const modes: string[] = [];
   if (req.resume) modes.push('resume');
   if (req.rerun_failed) modes.push('rerun_failed');
-  if (req.retry_errors !== undefined && req.retry_errors !== null && req.retry_errors !== '') {
+  if (req.retry_errors?.trim()) {
     modes.push('retry_errors');
   }
   if (modes.length > 1) {

--- a/apps/cli/src/commands/results/eval-runner.ts
+++ b/apps/cli/src/commands/results/eval-runner.ts
@@ -105,6 +105,31 @@ interface RunEvalRequest {
   threshold?: number;
   workers?: number;
   dry_run?: boolean;
+  /** Resume an interrupted run: skip already-completed tests and append results to `output`. */
+  resume?: boolean;
+  /** Re-run failed/errored tests while keeping passing results. */
+  rerun_failed?: boolean;
+  /** Path to a previous run dir or index.jsonl — re-run only execution_error cases. */
+  retry_errors?: string;
+  /** Artifact directory for run output. Required when resume/rerun_failed are set without auto-detect. */
+  output?: string;
+}
+
+/**
+ * Validate mutually-exclusive resume modes.
+ * Returns an error message if invalid, or undefined if valid.
+ */
+function validateResumeOptions(req: RunEvalRequest): string | undefined {
+  const modes: string[] = [];
+  if (req.resume) modes.push('resume');
+  if (req.rerun_failed) modes.push('rerun_failed');
+  if (req.retry_errors !== undefined && req.retry_errors !== null && req.retry_errors !== '') {
+    modes.push('retry_errors');
+  }
+  if (modes.length > 1) {
+    return `resume, rerun_failed, and retry_errors are mutually exclusive (got: ${modes.join(', ')})`;
+  }
+  return undefined;
 }
 
 function buildCliArgs(req: RunEvalRequest): string[] {
@@ -146,6 +171,20 @@ function buildCliArgs(req: RunEvalRequest): string[] {
   // Dry run
   if (req.dry_run) {
     args.push('--dry-run');
+  }
+
+  // Resume / rerun-failed / retry-errors / output
+  if (req.output?.trim()) {
+    args.push('--output', req.output.trim());
+  }
+  if (req.resume) {
+    args.push('--resume');
+  }
+  if (req.rerun_failed) {
+    args.push('--rerun-failed');
+  }
+  if (req.retry_errors?.trim()) {
+    args.push('--retry-errors', req.retry_errors.trim());
   }
 
   return args;
@@ -253,6 +292,11 @@ export function registerEvalRoutes(
     // Validate: need at least a suite filter
     if (!body.suite_filter?.trim() && (!body.test_ids || body.test_ids.length === 0)) {
       return c.json({ error: 'Provide suite_filter or test_ids' }, 400);
+    }
+
+    const resumeError = validateResumeOptions(body);
+    if (resumeError) {
+      return c.json({ error: resumeError }, 400);
     }
 
     const cliPaths = resolveCliPath(cwd);
@@ -405,6 +449,9 @@ export function registerEvalRoutes(
   });
 
   app.post('/api/benchmarks/:benchmarkId/eval/run', async (c) => {
+    if (readOnly) {
+      return c.json({ error: 'Studio is running in read-only mode' }, 403);
+    }
     const cwd = getCwd(c);
 
     let body: RunEvalRequest;
@@ -416,6 +463,11 @@ export function registerEvalRoutes(
 
     if (!body.suite_filter?.trim() && (!body.test_ids || body.test_ids.length === 0)) {
       return c.json({ error: 'Provide suite_filter or test_ids' }, 400);
+    }
+
+    const resumeError = validateResumeOptions(body);
+    if (resumeError) {
+      return c.json({ error: resumeError }, 400);
     }
 
     const cliPaths = resolveCliPath(cwd);

--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -319,14 +319,51 @@ async function handleRunDetail(c: C, { searchDir }: DataContext) {
   if (!meta) return c.json({ error: 'Run not found' }, 404);
   try {
     const loaded = loadManifestResults(meta.path);
+    // Surface run_dir + suite_filter for local runs so the UI can launch a
+    // Studio-side resume against this exact run. Remote runs live in the
+    // results-repo cache and cannot be resumed in place, so omit both fields.
+    const resumeMeta = meta.source === 'local' ? deriveResumeMeta(searchDir, meta.path) : {};
     return c.json({
       results: stripHeavyFields(loaded),
       source: meta.source,
       source_label: meta.displayName,
+      ...resumeMeta,
     });
   } catch {
     return c.json({ error: 'Failed to load run' }, 500);
   }
+}
+
+/**
+ * Compute `run_dir` (relative to cwd, snake_case) and `suite_filter` (the
+ * eval file path stored in benchmark.json metadata) for a local run manifest.
+ * Returns whatever fields could be resolved — both are best-effort and only
+ * needed by the Studio "Resume run" / "Rerun failed" actions.
+ */
+function deriveResumeMeta(
+  cwd: string,
+  manifestPath: string,
+): { run_dir?: string; suite_filter?: string } {
+  const out: { run_dir?: string; suite_filter?: string } = {};
+  const runDir = path.dirname(manifestPath);
+  const relative = path.relative(cwd, runDir);
+  // If runDir is outside cwd, path.relative returns "../..." — keep absolute in that case.
+  out.run_dir = relative && !relative.startsWith('..') ? relative : runDir;
+  try {
+    const benchmarkPath = path.join(runDir, 'benchmark.json');
+    if (existsSync(benchmarkPath)) {
+      const parsed = JSON.parse(readFileSync(benchmarkPath, 'utf8')) as {
+        metadata?: { eval_file?: string };
+      };
+      const evalFile = parsed.metadata?.eval_file;
+      if (typeof evalFile === 'string' && evalFile.trim()) {
+        out.suite_filter = evalFile.trim();
+      }
+    }
+  } catch {
+    // benchmark.json missing / unreadable / malformed — leave suite_filter unset.
+  }
+  return out;
 }
 
 async function handleRunSuites(c: C, { searchDir, agentvDir }: DataContext) {

--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -347,8 +347,10 @@ function deriveResumeMeta(
   const out: { run_dir?: string; suite_filter?: string } = {};
   const runDir = path.dirname(manifestPath);
   const relative = path.relative(cwd, runDir);
-  // If runDir is outside cwd, path.relative returns "../..." — keep absolute in that case.
-  out.run_dir = relative && !relative.startsWith('..') ? relative : runDir;
+  // path.relative returns '..'-prefixed paths when runDir is outside cwd; keep
+  // those absolute so the CLI doesn't get confused. An empty string ('' = same
+  // dir as cwd) is unusual but valid — fall through to absolute in that case.
+  out.run_dir = relative !== '' && !relative.startsWith('..') ? relative : runDir;
   try {
     const benchmarkPath = path.join(runDir, 'benchmark.json');
     if (existsSync(benchmarkPath)) {

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -871,4 +871,261 @@ describe('serve app', () => {
       expect(data.error).toBe('Not found');
     });
   });
+
+  // ── POST /api/eval/run — resume / rerun-failed / retry-errors ─────────
+  //
+  // These tests assert the launch endpoint accepts the resume-family fields,
+  // translates them to CLI flags in the `command` preview returned to the
+  // client, validates mutual exclusivity, and respects the read-only guard.
+  // They do not depend on the spawned child process — once the request is
+  // accepted and the command is built, we have validated the contract.
+
+  describe('POST /api/eval/run (resume API)', () => {
+    function makeAppForRun(opts?: { readOnly?: boolean }) {
+      return createApp([], tempDir, undefined, undefined, {
+        studioDir,
+        readOnly: opts?.readOnly === true,
+      });
+    }
+
+    it('builds --resume + --output flags from the request', async () => {
+      const app = makeAppForRun();
+      const res = await app.request('/api/eval/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          suite_filter: 'examples/demo.eval.yaml',
+          target: 'gpt-4o',
+          output: '.agentv/results/runs/2026-05-06T00-00-00-000Z',
+          resume: true,
+        }),
+      });
+      // Either 202 (spawn succeeded) or 500 (no CLI on disk in test env).
+      expect([202, 500]).toContain(res.status);
+      const data = (await res.json()) as { command?: string; error?: string };
+      if (res.status === 202) {
+        expect(data.command).toContain('--resume');
+        expect(data.command).toContain('--output .agentv/results/runs/2026-05-06T00-00-00-000Z');
+      }
+    });
+
+    it('builds --rerun-failed + --output flags from the request', async () => {
+      const app = makeAppForRun();
+      const res = await app.request('/api/eval/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          suite_filter: 'examples/demo.eval.yaml',
+          target: 'gpt-4o',
+          output: 'runs/r1',
+          rerun_failed: true,
+        }),
+      });
+      expect([202, 500]).toContain(res.status);
+      if (res.status === 202) {
+        const data = (await res.json()) as { command: string };
+        expect(data.command).toContain('--rerun-failed');
+        expect(data.command).toContain('--output runs/r1');
+      }
+    });
+
+    it('builds --retry-errors <path> from the request', async () => {
+      const app = makeAppForRun();
+      const res = await app.request('/api/eval/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          suite_filter: 'examples/demo.eval.yaml',
+          retry_errors: 'runs/r0/index.jsonl',
+        }),
+      });
+      expect([202, 500]).toContain(res.status);
+      if (res.status === 202) {
+        const data = (await res.json()) as { command: string };
+        expect(data.command).toContain('--retry-errors runs/r0/index.jsonl');
+      }
+    });
+
+    it('rejects resume + rerun_failed combo with 400', async () => {
+      const app = makeAppForRun();
+      const res = await app.request('/api/eval/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          suite_filter: 'examples/demo.eval.yaml',
+          output: 'runs/r1',
+          resume: true,
+          rerun_failed: true,
+        }),
+      });
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as { error: string };
+      expect(data.error).toContain('mutually exclusive');
+    });
+
+    it('rejects resume + retry_errors combo with 400', async () => {
+      const app = makeAppForRun();
+      const res = await app.request('/api/eval/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          suite_filter: 'examples/demo.eval.yaml',
+          output: 'runs/r1',
+          resume: true,
+          retry_errors: 'runs/r0/index.jsonl',
+        }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 403 in read-only mode for unscoped /api/eval/run', async () => {
+      const app = makeAppForRun({ readOnly: true });
+      const res = await app.request('/api/eval/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          suite_filter: 'examples/demo.eval.yaml',
+          resume: true,
+          output: 'runs/r1',
+        }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 403 in read-only mode for benchmark-scoped /api/benchmarks/:id/eval/run', async () => {
+      const app = makeAppForRun({ readOnly: true });
+      const res = await app.request('/api/benchmarks/some-id/eval/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          suite_filter: 'examples/demo.eval.yaml',
+          resume: true,
+          output: 'runs/r1',
+        }),
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // ── POST /api/eval/preview — argument shaping for resume flags ─────────
+  //
+  // /api/eval/preview is a lightweight endpoint that returns the CLI
+  // command without spawning anything. Use it to assert the exact CLI
+  // surface produced by the new fields independent of test-host CLI state.
+
+  describe('POST /api/eval/preview (resume API)', () => {
+    it('emits --resume and --output for resume:true requests', async () => {
+      const app = createApp([], tempDir, undefined, undefined, { studioDir });
+      const res = await app.request('/api/eval/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          suite_filter: 'examples/demo.eval.yaml',
+          target: 'gpt-4o',
+          output: 'runs/r1',
+          resume: true,
+        }),
+      });
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { command: string };
+      expect(data.command).toContain('--resume');
+      expect(data.command).toContain('--output runs/r1');
+      expect(data.command).not.toContain('--rerun-failed');
+    });
+
+    it('emits --rerun-failed for rerun_failed:true requests', async () => {
+      const app = createApp([], tempDir, undefined, undefined, { studioDir });
+      const res = await app.request('/api/eval/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          suite_filter: 'examples/demo.eval.yaml',
+          output: 'runs/r1',
+          rerun_failed: true,
+        }),
+      });
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { command: string };
+      expect(data.command).toContain('--rerun-failed');
+      expect(data.command).not.toContain('--resume');
+    });
+
+    it('emits --retry-errors <path> for retry_errors requests', async () => {
+      const app = createApp([], tempDir, undefined, undefined, { studioDir });
+      const res = await app.request('/api/eval/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          suite_filter: 'examples/demo.eval.yaml',
+          retry_errors: 'runs/r0/index.jsonl',
+        }),
+      });
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { command: string };
+      expect(data.command).toContain('--retry-errors runs/r0/index.jsonl');
+    });
+  });
+
+  // ── GET /api/runs/:filename — run_dir + suite_filter for resume UI ─────
+  //
+  // The Studio "Resume run" / "Rerun failed cases" buttons need the run dir
+  // and the original eval file path to issue a launch request that targets
+  // the same run workspace. handleRunDetail reads benchmark.json's
+  // metadata.eval_file and reports the run dir relative to cwd.
+
+  describe('GET /api/runs/:filename (resume metadata)', () => {
+    it('includes run_dir and suite_filter for local runs with benchmark.json', async () => {
+      const runsDir = path.join(tempDir, '.agentv', 'results', 'runs');
+      mkdirSync(runsDir, { recursive: true });
+      const filename = '2026-05-06T00-00-00-000Z';
+      const runDir = path.join(runsDir, filename);
+      mkdirSync(runDir, { recursive: true });
+      writeFileSync(path.join(runDir, 'index.jsonl'), toJsonl(RESULT_A));
+      writeFileSync(
+        path.join(runDir, 'benchmark.json'),
+        JSON.stringify(
+          {
+            metadata: {
+              eval_file: 'examples/demo.eval.yaml',
+              timestamp: '2026-05-06T00:00:00.000Z',
+              targets: ['gpt-4o'],
+              tests_run: ['test-greeting'],
+            },
+            run_summary: {},
+            notes: [],
+          },
+          null,
+          2,
+        ),
+      );
+
+      const app = createApp([], tempDir, tempDir, undefined, { studioDir });
+      const res = await app.request(`/api/runs/${filename}`);
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as {
+        run_dir?: string;
+        suite_filter?: string;
+        source: 'local' | 'remote';
+      };
+      expect(data.source).toBe('local');
+      expect(data.run_dir).toBe(path.join('.agentv', 'results', 'runs', filename));
+      expect(data.suite_filter).toBe('examples/demo.eval.yaml');
+    });
+
+    it('omits suite_filter when benchmark.json is missing', async () => {
+      const runsDir = path.join(tempDir, '.agentv', 'results', 'runs');
+      mkdirSync(runsDir, { recursive: true });
+      const filename = '2026-05-06T00-00-01-000Z';
+      const runDir = path.join(runsDir, filename);
+      mkdirSync(runDir, { recursive: true });
+      writeFileSync(path.join(runDir, 'index.jsonl'), toJsonl(RESULT_A));
+
+      const app = createApp([], tempDir, tempDir, undefined, { studioDir });
+      const res = await app.request(`/api/runs/${filename}`);
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { run_dir?: string; suite_filter?: string };
+      expect(data.run_dir).toBeDefined();
+      expect(data.suite_filter).toBeUndefined();
+    });
+  });
 });

--- a/apps/studio/src/components/ResumeRunActions.tsx
+++ b/apps/studio/src/components/ResumeRunActions.tsx
@@ -1,0 +1,106 @@
+/**
+ * ResumeRunActions — header buttons for resuming an interrupted run.
+ *
+ * Surfaces the existing CLI resume mechanics (`--resume`, `--rerun-failed`)
+ * via the launch endpoint when the loaded run contains at least one result
+ * with `executionStatus === 'execution_error'`. Hidden in read-only mode
+ * (the server also returns 403, but UI-level hiding avoids dead controls).
+ *
+ * On click, POSTs to /api/eval/run with `{ resume | rerun_failed: true,
+ * output: <runDir>, suite_filter, target }` and navigates to /jobs/:runId
+ * to surface progress.
+ *
+ * To extend with another resume verb (e.g. surfacing --retry-errors as a
+ * cross-run picker), add a third button calling `launch({ retryErrors:
+ * <path> })`. The launch helper already passes whichever fields are set
+ * straight through to the server, which forwards them to the CLI.
+ */
+
+import { useNavigate } from '@tanstack/react-router';
+import { useState } from 'react';
+
+import { launchEvalRun } from '~/lib/api';
+import type { EvalResult } from '~/lib/types';
+
+import {
+  type ResumeMode,
+  buildResumeRequestBody,
+  shouldShowResumeActions,
+} from './resume-run-helpers';
+
+export interface ResumeRunActionsProps {
+  results: EvalResult[];
+  runDir?: string;
+  suiteFilter?: string;
+  target?: string;
+  benchmarkId?: string;
+  isReadOnly: boolean;
+}
+
+export function ResumeRunActions({
+  results,
+  runDir,
+  suiteFilter,
+  target,
+  benchmarkId,
+  isReadOnly,
+}: ResumeRunActionsProps) {
+  const navigate = useNavigate();
+  const [busy, setBusy] = useState<ResumeMode | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!shouldShowResumeActions(results, isReadOnly)) return null;
+
+  // Both actions need the run dir + the original eval file. Without those
+  // we can't target the existing run workspace, so we render the buttons
+  // disabled with an explanatory title rather than hiding them — that way
+  // users can still see the affordance and understand why it's unavailable.
+  const ready = !!runDir && !!suiteFilter;
+  const disabledReason = !runDir
+    ? 'Run directory unavailable (remote run cannot be resumed in place)'
+    : !suiteFilter
+      ? 'Original eval file path missing from benchmark.json — cannot determine what to resume'
+      : '';
+
+  async function launch(mode: ResumeMode) {
+    if (!ready || !runDir || !suiteFilter) return;
+    setBusy(mode);
+    setError(null);
+    try {
+      const body = buildResumeRequestBody({ mode, runDir, suiteFilter, target });
+      const response = await launchEvalRun(body, benchmarkId);
+      navigate({ to: '/jobs/$runId', params: { runId: response.id } });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to launch resume');
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => launch('resume')}
+          disabled={!ready || busy !== null}
+          title={!ready ? disabledReason : 'Skip already-completed tests, run the rest'}
+          className="rounded-md bg-amber-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-50"
+          data-testid="resume-run-button"
+        >
+          {busy === 'resume' ? 'Resuming…' : '↻ Resume run'}
+        </button>
+        <button
+          type="button"
+          onClick={() => launch('rerun')}
+          disabled={!ready || busy !== null}
+          title={!ready ? disabledReason : 'Re-run failed/errored tests, keep passing results'}
+          className="rounded-md border border-amber-600/60 bg-transparent px-3 py-1.5 text-sm font-medium text-amber-300 hover:bg-amber-950/40 disabled:cursor-not-allowed disabled:opacity-50"
+          data-testid="rerun-failed-button"
+        >
+          {busy === 'rerun' ? 'Re-running…' : 'Rerun failed cases'}
+        </button>
+      </div>
+      {error && <p className="text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}

--- a/apps/studio/src/components/resume-run-helpers.test.ts
+++ b/apps/studio/src/components/resume-run-helpers.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { EvalResult } from '~/lib/types';
+
+import { buildResumeRequestBody, shouldShowResumeActions } from './resume-run-helpers';
+
+const ok = (testId: string): EvalResult => ({
+  testId,
+  score: 1,
+  executionStatus: 'ok',
+});
+
+const errored = (testId: string): EvalResult => ({
+  testId,
+  score: 0,
+  executionStatus: 'execution_error',
+});
+
+describe('shouldShowResumeActions', () => {
+  it('hides when no row has executionStatus=execution_error', () => {
+    expect(shouldShowResumeActions([ok('a'), ok('b')], false)).toBe(false);
+  });
+
+  it('shows when at least one row has executionStatus=execution_error', () => {
+    expect(shouldShowResumeActions([ok('a'), errored('b')], false)).toBe(true);
+  });
+
+  it('hides in read-only mode even when execution errors are present', () => {
+    expect(shouldShowResumeActions([errored('a')], true)).toBe(false);
+  });
+
+  it('hides on empty results', () => {
+    expect(shouldShowResumeActions([], false)).toBe(false);
+  });
+});
+
+describe('buildResumeRequestBody', () => {
+  it('builds a resume request with snake_case fields and resume:true', () => {
+    expect(
+      buildResumeRequestBody({
+        mode: 'resume',
+        runDir: '.agentv/results/runs/2026-05-06T00-00-00-000Z',
+        suiteFilter: 'examples/demo.eval.yaml',
+        target: 'gpt-4o',
+      }),
+    ).toEqual({
+      suite_filter: 'examples/demo.eval.yaml',
+      output: '.agentv/results/runs/2026-05-06T00-00-00-000Z',
+      target: 'gpt-4o',
+      resume: true,
+    });
+  });
+
+  it('builds a rerun-failed request with rerun_failed:true (and no resume key)', () => {
+    const body = buildResumeRequestBody({
+      mode: 'rerun',
+      runDir: 'runs/r1',
+      suiteFilter: 'examples/demo.eval.yaml',
+      target: 'gpt-4o',
+    });
+    expect(body).toEqual({
+      suite_filter: 'examples/demo.eval.yaml',
+      output: 'runs/r1',
+      target: 'gpt-4o',
+      rerun_failed: true,
+    });
+    expect(body.resume).toBeUndefined();
+  });
+
+  it('omits target when none is provided', () => {
+    expect(
+      buildResumeRequestBody({
+        mode: 'resume',
+        runDir: 'runs/r1',
+        suiteFilter: 'examples/demo.eval.yaml',
+      }),
+    ).toEqual({
+      suite_filter: 'examples/demo.eval.yaml',
+      output: 'runs/r1',
+      resume: true,
+    });
+  });
+});

--- a/apps/studio/src/components/resume-run-helpers.ts
+++ b/apps/studio/src/components/resume-run-helpers.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure helpers backing ResumeRunActions, isolated for unit testing.
+ *
+ * These are intentionally side-effect-free: visibility logic and request-body
+ * shaping live here so tests can pin the API contract without rendering React.
+ *
+ * To extend: add another `mode` to `ResumeMode` and handle it inside
+ * `buildResumeRequestBody` — the server already accepts the union of resume,
+ * rerun_failed, and retry_errors per the launch endpoint contract.
+ */
+
+import type { EvalResult, RunEvalRequest } from '~/lib/types';
+
+export type ResumeMode = 'resume' | 'rerun';
+
+export interface BuildResumeRequestParams {
+  mode: ResumeMode;
+  runDir: string;
+  suiteFilter: string;
+  target?: string;
+}
+
+/**
+ * Whether the resume actions should be visible. The button only makes sense
+ * when at least one row failed with an execution error and the user has
+ * write access (read-only mode hides the entire control rather than
+ * showing a disabled button — see issue acceptance criteria).
+ */
+export function shouldShowResumeActions(results: EvalResult[], isReadOnly: boolean): boolean {
+  if (isReadOnly) return false;
+  return results.some((r) => r.executionStatus === 'execution_error');
+}
+
+/**
+ * Build the POST /api/eval/run body for a resume / rerun-failed launch.
+ * Matches the wire-format contract: snake_case, with `output` pointing at
+ * the existing run dir so the CLI appends to that workspace.
+ */
+export function buildResumeRequestBody(params: BuildResumeRequestParams): RunEvalRequest {
+  const body: RunEvalRequest = {
+    suite_filter: params.suiteFilter,
+    output: params.runDir,
+  };
+  if (params.target) body.target = params.target;
+  if (params.mode === 'resume') {
+    body.resume = true;
+  } else {
+    body.rerun_failed = true;
+  }
+  return body;
+}

--- a/apps/studio/src/lib/types.ts
+++ b/apps/studio/src/lib/types.ts
@@ -76,6 +76,10 @@ export interface RunDetailResponse {
   results: EvalResult[];
   source: 'local' | 'remote';
   source_label?: string;
+  /** Path to the run workspace directory (relative to cwd when inside, otherwise absolute). Local runs only. */
+  run_dir?: string;
+  /** Eval file path the run was launched against, if recorded in benchmark.json. Local runs only. */
+  suite_filter?: string;
 }
 
 export interface SuiteSummary {
@@ -301,6 +305,14 @@ export interface RunEvalRequest {
   threshold?: number;
   workers?: number;
   dry_run?: boolean;
+  /** Resume an interrupted run: skip already-completed tests and append to `output`. */
+  resume?: boolean;
+  /** Re-run failed/errored tests while keeping passing results. */
+  rerun_failed?: boolean;
+  /** Path to a previous run dir or index.jsonl — re-run only execution_error cases. */
+  retry_errors?: string;
+  /** Artifact directory for run output — required to target an existing run dir. */
+  output?: string;
 }
 
 export interface EvalRunResponse {

--- a/apps/studio/src/routes/benchmarks/$benchmarkId_/runs/$runId.tsx
+++ b/apps/studio/src/routes/benchmarks/$benchmarkId_/runs/$runId.tsx
@@ -5,6 +5,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { useState } from 'react';
 
+import { ResumeRunActions } from '~/components/ResumeRunActions';
 import { RunDetail } from '~/components/RunDetail';
 import { RunEvalModal } from '~/components/RunEvalModal';
 import { useBenchmarkRunDetail, useStudioConfig } from '~/lib/api';
@@ -68,15 +69,25 @@ function BenchmarkRunDetailPage() {
           <h1 className="text-2xl font-semibold text-white">{heading}</h1>
           <p className="mt-1 text-sm text-gray-500">{meta}</p>
         </div>
-        {!isReadOnly && (
-          <button
-            type="button"
-            onClick={() => setShowRunEval(true)}
-            className="rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-500"
-          >
-            ▶ Re-run with Filters
-          </button>
-        )}
+        <div className="flex items-center gap-3">
+          <ResumeRunActions
+            results={data?.results ?? []}
+            runDir={data?.run_dir}
+            suiteFilter={data?.suite_filter}
+            target={target ?? undefined}
+            benchmarkId={benchmarkId}
+            isReadOnly={isReadOnly}
+          />
+          {!isReadOnly && (
+            <button
+              type="button"
+              onClick={() => setShowRunEval(true)}
+              className="rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-500"
+            >
+              ▶ Re-run with Filters
+            </button>
+          )}
+        </div>
       </div>
       <RunDetail results={data?.results ?? []} runId={runId} benchmarkId={benchmarkId} />
       {!isReadOnly && (

--- a/apps/studio/src/routes/runs/$runId.tsx
+++ b/apps/studio/src/routes/runs/$runId.tsx
@@ -5,6 +5,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { useState } from 'react';
 
+import { ResumeRunActions } from '~/components/ResumeRunActions';
 import { RunDetail } from '~/components/RunDetail';
 import { RunEvalModal } from '~/components/RunEvalModal';
 import { useRunDetail, useStudioConfig } from '~/lib/api';
@@ -69,15 +70,24 @@ function RunDetailPage() {
           <h1 className="text-2xl font-semibold text-white">{heading}</h1>
           <p className="mt-1 text-sm text-gray-500">{meta}</p>
         </div>
-        {!isReadOnly && (
-          <button
-            type="button"
-            onClick={() => setShowRunEval(true)}
-            className="rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-500"
-          >
-            ▶ Re-run with Filters
-          </button>
-        )}
+        <div className="flex items-center gap-3">
+          <ResumeRunActions
+            results={data?.results ?? []}
+            runDir={data?.run_dir}
+            suiteFilter={data?.suite_filter}
+            target={target ?? undefined}
+            isReadOnly={isReadOnly}
+          />
+          {!isReadOnly && (
+            <button
+              type="button"
+              onClick={() => setShowRunEval(true)}
+              className="rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-500"
+            >
+              ▶ Re-run with Filters
+            </button>
+          )}
+        </div>
       </div>
       <RunDetail results={data?.results ?? []} runId={runId} />
       {!isReadOnly && (


### PR DESCRIPTION
Closes #1219

## Summary

Surfaces the existing CLI resume mechanics (`--resume`, `--rerun-failed`, `--retry-errors`, `--output`) in Studio so users can finish an interrupted or partially-errored run from the web UI instead of dropping to a terminal.

## Changes

### Server (`apps/cli/src/commands/results/`)

- `RunEvalRequest` accepts `resume` / `rerun_failed` / `retry_errors` / `output` (snake_case wire format).
- `buildCliArgs` translates these into `--resume`, `--rerun-failed`, `--retry-errors <path>`, `--output <dir>`.
- New `validateResumeOptions` returns 400 with a usable message when the three modes are combined.
- Read-only guard now also covers `/api/benchmarks/:id/eval/run` (was missing before).
- `handleRunDetail` reads `benchmark.json` for the run and exposes `run_dir` (relative to cwd) and `suite_filter` (from `metadata.eval_file`) so the UI can target the same workspace. Local runs only — remote runs in the results-repo cache cannot be resumed in place.

### UI (`apps/studio/src/`)

- New `ResumeRunActions` component renders **"↻ Resume run"** + **"Rerun failed cases"** buttons on `/runs/:runId` and `/benchmarks/:id/runs/:runId` when at least one row has `executionStatus === 'execution_error'`.
- Hidden in read-only mode; disabled with an explanatory tooltip when `run_dir` or `suite_filter` cannot be resolved.
- After POSTing to `/api/eval/run`, navigates to `/jobs/:runId` for live progress.
- Pure helpers (`shouldShowResumeActions`, `buildResumeRequestBody`) are unit-tested without rendering React.

## Tests added

- `apps/cli/test/commands/results/serve.test.ts` — request/preview shaping for resume / rerun_failed / retry_errors, mutual-exclusivity 400s, read-only 403 (unscoped + benchmark-scoped), `run_dir` + `suite_filter` exposure on `/api/runs/:filename`. 53 tests in this file.
- `apps/studio/src/components/resume-run-helpers.test.ts` — visibility logic and request-body shape for both modes (incl. read-only hides, missing target omitted). 7 tests.

## Test plan

- [x] `bun run test` — 2337 tests pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] Manual red/green UAT (synthetic fixture)
- [x] **Live e2e against Azure OpenAI** (real provider, real `execution_error`, click-through)

## Red / Green UAT — synthetic fixture

Hand-crafted run workspace with one `execution_status: execution_error` row + a `benchmark.json` whose `metadata.eval_file` points at a known eval YAML. Confirms wire contract + UI surface across `main`, this branch, and `--read-only`.

### Red — `main`

`GET /api/runs/:filename` does **not** include `run_dir` / `suite_filter`. Run detail page exposes only "▶ Re-run with Filters":

```
- heading "gpt-4o" [level=1]
- button "▶ Re-run with Filters"
```

### Green — this branch

`GET /api/runs/:filename` returns:
```
"run_dir":".agentv/results/runs/2026-05-06T00-00-00-000Z",
"suite_filter":"examples/features/basic/evals/dataset.eval.yaml"
```

UI renders the new actions:
```
- button "↻ Resume run"
- button "Rerun failed cases"
- button "▶ Re-run with Filters"
```

`/api/eval/preview` produces the expected CLI invocations and validation rejects mode combos with 400. Read-only mode hides both buttons and the API still returns 403.

## Live e2e UAT — real Azure OpenAI run

Built a 2-test eval, ran it with `--budget-usd 0.000001 --workers 1` to deliberately trigger one `execution_error` (budget_exceeded on the second test). Then opened the run in Studio and clicked **Rerun failed cases**.

**Eval definition** (`tiny.eval.yaml`):
```yaml
tests:
  - id: cheap-greet
    criteria: Assistant says hello.
    input: "Say hello in one short sentence."
    expected_output: "Hello!"
  - id: also-cheap-greet
    criteria: Assistant says goodbye.
    input: "Say goodbye in one short sentence."
    expected_output: "Goodbye!"
```

**Initial state** (`index.jsonl`, before button click):
```
{"test_id":"cheap-greet",      "execution_status":"ok",              "score":1, "timestamp":"05:36:23.544Z"}
{"test_id":"also-cheap-greet", "execution_status":"execution_error", "score":0, "timestamp":"05:36:23.553Z"}
```

**UI snapshot at `/runs/2026-05-06T05-36-19-075Z`** — both new buttons visible, header shows 50% pass rate:
```
- heading "azure" [level=1]
- button "↻ Resume run"
- button "Rerun failed cases"
- button "▶ Re-run with Filters"
- cell "✓"   - cell "cheap-greet"      - cell "100%"  (1.5s)
- cell "!"   - cell "also-cheap-greet" - cell "ERR"   (0.0s)
```

**Click "Rerun failed cases"** → browser navigated to `/jobs/studio-20260506-074017-xatb`. The Studio job tracker showed status `running` then `finished` with exit code 0. Spawned CLI command (returned in the launch response):
```
agentv eval /tmp/agentv-e2e-oVjxrS/tiny.eval.yaml --target azure --output .agentv/results/runs/default/2026-05-06T05-36-19-075Z --rerun-failed
```

**Final state** (`index.jsonl`, after rerun finished):
```
{"test_id":"cheap-greet",      "execution_status":"ok", "score":1, "timestamp":"05:36:23.544Z"}  ← unchanged
{"test_id":"also-cheap-greet", "execution_status":"execution_error", "score":0, "timestamp":"05:36:23.553Z"}  ← original error row preserved
{"test_id":"also-cheap-greet", "execution_status":"ok", "score":1, "timestamp":"05:40:22.003Z"}  ← re-run, now passing
```

Acceptance: **previously-passing test was skipped** (timestamp on `cheap-greet` unchanged); **errored test was re-run and now passes**; pass rate updated from 50% → 67% in the Studio header.

## Pre-existing bug discovered

The live e2e surfaced an unrelated bug in `resolveCliPath` (off-by-one in the `currentDir` fallback path) which prevents Studio from spawning the CLI when run from source against a foreign cwd. Filed as #1221 and worked around in this UAT with an `agentv` PATH shim. Not in scope for this PR — the global-install path used by end users is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
