### PR TITLE
fix(cli): resolveCliPath off-by-one in src + dist fallback paths

### DIFF
--- a/apps/cli/src/commands/results/eval-runner.ts
+++ b/apps/cli/src/commands/results/eval-runner.ts
@@ -209,11 +209,16 @@ function resolveCliPath(cwd: string): { binPath: string; args: string[] } | unde
   }
 
   // 2. Try from the current running process location (handles both CJS __dirname
-  //    and ESM import.meta.url; fileURLToPath works correctly on Windows)
+  //    and ESM import.meta.url; fileURLToPath works correctly on Windows).
+  //    Layouts we can be loaded from:
+  //      - dev/source: this module sits at apps/cli/src/commands/results/eval-runner.ts,
+  //        so cli.ts is two dirs up at apps/cli/src/cli.ts.
+  //      - bundled dist: tsup emits the chunk into apps/cli/dist/, alongside cli.js,
+  //        so the entry is in the same directory as currentDir.
   const currentDir =
     typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
-  const fromSrc = path.resolve(currentDir, '../../../cli.ts');
-  const fromDist = path.resolve(currentDir, '../../cli.js');
+  const fromSrc = path.resolve(currentDir, '../../cli.ts');
+  const fromDist = path.resolve(currentDir, 'cli.js');
 
   if (existsSync(fromSrc)) return { binPath: 'bun', args: [fromSrc] };
   if (existsSync(fromDist)) return { binPath: 'bun', args: [fromDist] };

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -900,13 +900,13 @@ describe('serve app', () => {
           resume: true,
         }),
       });
-      // Either 202 (spawn succeeded) or 500 (no CLI on disk in test env).
-      expect([202, 500]).toContain(res.status);
-      const data = (await res.json()) as { command?: string; error?: string };
-      if (res.status === 202) {
-        expect(data.command).toContain('--resume');
-        expect(data.command).toContain('--output .agentv/results/runs/2026-05-06T00-00-00-000Z');
-      }
+      // resolveCliPath must resolve in the test env via the running-process
+      // fallback (apps/cli/src/cli.ts is two dirs up from this module). A
+      // 500 here would mean the off-by-one regression from #1221 came back.
+      expect(res.status).toBe(202);
+      const data = (await res.json()) as { command: string };
+      expect(data.command).toContain('--resume');
+      expect(data.command).toContain('--output .agentv/results/runs/2026-05-06T00-00-00-000Z');
     });
 
     it('builds --rerun-failed + --output flags from the request', async () => {
@@ -921,12 +921,10 @@ describe('serve app', () => {
           rerun_failed: true,
         }),
       });
-      expect([202, 500]).toContain(res.status);
-      if (res.status === 202) {
-        const data = (await res.json()) as { command: string };
-        expect(data.command).toContain('--rerun-failed');
-        expect(data.command).toContain('--output runs/r1');
-      }
+      expect(res.status).toBe(202);
+      const data = (await res.json()) as { command: string };
+      expect(data.command).toContain('--rerun-failed');
+      expect(data.command).toContain('--output runs/r1');
     });
 
     it('builds --retry-errors <path> from the request', async () => {
@@ -939,11 +937,9 @@ describe('serve app', () => {
           retry_errors: 'runs/r0/index.jsonl',
         }),
       });
-      expect([202, 500]).toContain(res.status);
-      if (res.status === 202) {
-        const data = (await res.json()) as { command: string };
-        expect(data.command).toContain('--retry-errors runs/r0/index.jsonl');
-      }
+      expect(res.status).toBe(202);
+      const data = (await res.json()) as { command: string };
+      expect(data.command).toContain('--retry-errors runs/r0/index.jsonl');
     });
 
     it('rejects resume + rerun_failed combo with 400', async () => {


### PR DESCRIPTION
Closes #1221

## Summary

Two off-by-one errors in `resolveCliPath` (added in the original eval-runner introduction, surfaced during PR #1220 e2e UAT) prevented Studio from spawning the CLI when run from a source checkout against any cwd that isn't the agentv repo itself.

## Bug

`apps/cli/src/commands/results/eval-runner.ts:215-216` resolved fallback paths from `currentDir` (where the eval-runner module is loaded from) using:

```ts
const fromSrc = path.resolve(currentDir, '../../../cli.ts');  // ❌ apps/cli/cli.ts (no src/)
const fromDist = path.resolve(currentDir, '../../cli.js');    // ❌ apps/cli.js (one too high)
```

For a dev-from-source run, `currentDir = .../apps/cli/src/commands/results/` and we want `apps/cli/src/cli.ts` — so it's two `..` not three. For a tsup-bundled dist run, `currentDir = .../apps/cli/dist/` (chunks live alongside `cli.js`) and we want `cli.js` in the same dir — no `..` at all.

End users with `agentv` installed globally hit the third fallback (global PATH lookup) and were unaffected. Developers running Studio from a worktree against a project outside the agentv repo got `{"error":"Cannot locate agentv CLI entry point"}`.

## Fix

```diff
- const fromSrc = path.resolve(currentDir, '../../../cli.ts');
- const fromDist = path.resolve(currentDir, '../../cli.js');
+ const fromSrc = path.resolve(currentDir, '../../cli.ts');
+ const fromDist = path.resolve(currentDir, 'cli.js');
```

Plus a comment block explaining the two layouts so the next person doesn't have to re-derive them.

## Tests

The resume-API request-shaping tests in `apps/cli/test/commands/results/serve.test.ts` previously tolerated `[202, 500]` because of this exact bug ("either spawn succeeded or no CLI on disk in test env"). With the fix, the running-process fallback always succeeds in the test runner, so tightened those assertions to **exactly 202**. A regression of this off-by-one will now fail CI.

## Red / Green UAT

Foreign cwd: `/tmp/agentv-1221-aXeco4` (random scratch dir, not the agentv repo).

### Red — `main`
```
$ POST /api/eval/run {"resume":true,"output":"runs/r","suite_filter":"x"}
→ 500 {"error":"Cannot locate agentv CLI entry point"}
```

### Green — this branch
```
$ POST /api/eval/run {"resume":true,"output":"runs/r","suite_filter":"x.eval.yaml","target":"y"}
→ 202 {"id":"studio-20260506-140143-gfjn","status":"running","command":"agentv eval x.eval.yaml --target y --output runs/r --resume"}

$ POST /api/eval/preview {"rerun_failed":true,...}
→ 200 {"command":"agentv eval x.eval.yaml --target y --output runs/r --rerun-failed"}
```

## Test plan

- [x] `bun test apps/cli/test/commands/results/serve.test.ts` — 53 tests pass with strict 202 assertions
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] Manual red/green UAT (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
