### PR TITLE
feat(studio): pass/fail icon in eval detail h1, remove duplicate header

### DIFF
--- a/apps/studio/src/components/EvalDetail.tsx
+++ b/apps/studio/src/components/EvalDetail.tsx
@@ -59,20 +59,6 @@ export function EvalDetail({ eval: result, runId, benchmarkId }: EvalDetailProps
 
   return (
     <div className="flex min-h-full flex-col">
-      {/* Compact header: test ID + metadata (no scores — scores live in Checks tab) */}
-      <div className="flex items-start justify-between border-b border-gray-800 px-4 py-3">
-        <div>
-          <h3 className="text-lg font-medium">{result.testId}</h3>
-          <p className="mt-0.5 text-sm text-gray-400">
-            {result.target && <span>Target: {result.target}</span>}
-            {result.durationMs != null && (
-              <span className="ml-4">{(result.durationMs / 1000).toFixed(1)}s</span>
-            )}
-            {result.costUsd != null && <span className="ml-4">${result.costUsd.toFixed(4)}</span>}
-          </p>
-        </div>
-      </div>
-
       {/* Tab navigation — at the top so Files tab editor fills maximum height */}
       <div className="border-b border-gray-800">
         <div className="flex gap-1 px-4">

--- a/apps/studio/src/routes/benchmarks/$benchmarkId_/evals/$runId.$evalId.tsx
+++ b/apps/studio/src/routes/benchmarks/$benchmarkId_/evals/$runId.$evalId.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react';
 
 import { EvalDetail } from '~/components/EvalDetail';
 import { RunEvalModal } from '~/components/RunEvalModal';
-import { useBenchmarkRunDetail, useStudioConfig } from '~/lib/api';
+import { isPassing, useBenchmarkRunDetail, useStudioConfig } from '~/lib/api';
 
 export const Route = createFileRoute('/benchmarks/$benchmarkId_/evals/$runId/$evalId')({
   component: BenchmarkEvalDetailPage,
@@ -50,6 +50,12 @@ function BenchmarkEvalDetailPage() {
     );
   }
 
+  const passThreshold = config?.threshold ?? config?.pass_threshold ?? 0.8;
+  const passed =
+    isPassing(result.score, passThreshold) &&
+    result.executionStatus !== 'error' &&
+    result.executionStatus !== 'failed';
+
   return (
     <div className="flex h-full flex-col gap-6">
       <div className="flex items-center justify-between">
@@ -57,7 +63,12 @@ function BenchmarkEvalDetailPage() {
           <p className="text-sm text-gray-400">
             Run: {runId} / Eval: {evalId}
           </p>
-          <h1 className="text-2xl font-semibold text-white">{evalId}</h1>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold text-white">
+            <span className={`text-2xl font-bold leading-none ${passed ? 'text-emerald-400' : 'text-red-400'}`}>
+              {passed ? '✓' : '✗'}
+            </span>
+            {evalId}
+          </h1>
         </div>
         {!isReadOnly && (
           <button

--- a/apps/studio/src/routes/evals/$runId.$evalId.tsx
+++ b/apps/studio/src/routes/evals/$runId.$evalId.tsx
@@ -11,7 +11,7 @@ import { useState } from 'react';
 
 import { EvalDetail } from '~/components/EvalDetail';
 import { RunEvalModal } from '~/components/RunEvalModal';
-import { useRunDetail, useStudioConfig } from '~/lib/api';
+import { isPassing, useRunDetail, useStudioConfig } from '~/lib/api';
 
 export const Route = createFileRoute('/evals/$runId/$evalId')({
   component: EvalDetailPage,
@@ -54,6 +54,12 @@ function EvalDetailPage() {
     );
   }
 
+  const passThreshold = config?.threshold ?? config?.pass_threshold ?? 0.8;
+  const passed =
+    isPassing(result.score, passThreshold) &&
+    result.executionStatus !== 'error' &&
+    result.executionStatus !== 'failed';
+
   return (
     <div className="flex h-full flex-col gap-6">
       <div className="flex items-center justify-between">
@@ -61,7 +67,12 @@ function EvalDetailPage() {
           <p className="text-sm text-gray-400">
             Run: {runId} / Eval: {evalId}
           </p>
-          <h1 className="text-2xl font-semibold text-white">{evalId}</h1>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold text-white">
+            <span className={`text-2xl font-bold leading-none ${passed ? 'text-emerald-400' : 'text-red-400'}`}>
+              {passed ? '✓' : '✗'}
+            </span>
+            {evalId}
+          </h1>
         </div>
         {!isReadOnly && (
           <button


### PR DESCRIPTION
Removes the compact header from EvalDetail.tsx (duplicate test ID + metadata) and adds a colored ✓/✗ status icon to the h1 heading in both route files.

Changes:
- **EvalDetail.tsx**: Remove compact header div (was duplicating testId + metadata already shown in h1)
- **evals/$runId.$evalId.tsx**: Add `isPassing` import, compute pass state, prepend ✓/✗ icon to h1
- **benchmarks/.../evals/$runId.$evalId.tsx**: Same change for benchmark route