### PR TITLE
chore(studio): rename Re-run with Filters to Run evals

### DIFF
--- a/apps/studio/src/routes/benchmarks/$benchmarkId_/evals/$runId.$evalId.tsx
+++ b/apps/studio/src/routes/benchmarks/$benchmarkId_/evals/$runId.$evalId.tsx
@@ -64,7 +64,9 @@ function BenchmarkEvalDetailPage() {
             Run: {runId} / Eval: {evalId}
           </p>
           <h1 className="flex items-center gap-2 text-2xl font-semibold text-white">
-            <span className={`text-2xl font-bold leading-none ${passed ? 'text-emerald-400' : 'text-red-400'}`}>
+            <span
+              className={`text-2xl font-bold leading-none ${passed ? 'text-emerald-400' : 'text-red-400'}`}
+            >
               {passed ? '✓' : '✗'}
             </span>
             {evalId}

--- a/apps/studio/src/routes/benchmarks/$benchmarkId_/runs/$runId.tsx
+++ b/apps/studio/src/routes/benchmarks/$benchmarkId_/runs/$runId.tsx
@@ -84,7 +84,7 @@ function BenchmarkRunDetailPage() {
               onClick={() => setShowRunEval(true)}
               className="rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-500"
             >
-              ▶ Re-run with Filters
+              ▶ Run evals
             </button>
           )}
         </div>

--- a/apps/studio/src/routes/evals/$runId.$evalId.tsx
+++ b/apps/studio/src/routes/evals/$runId.$evalId.tsx
@@ -68,7 +68,9 @@ function EvalDetailPage() {
             Run: {runId} / Eval: {evalId}
           </p>
           <h1 className="flex items-center gap-2 text-2xl font-semibold text-white">
-            <span className={`text-2xl font-bold leading-none ${passed ? 'text-emerald-400' : 'text-red-400'}`}>
+            <span
+              className={`text-2xl font-bold leading-none ${passed ? 'text-emerald-400' : 'text-red-400'}`}
+            >
               {passed ? '✓' : '✗'}
             </span>
             {evalId}

--- a/apps/studio/src/routes/runs/$runId.tsx
+++ b/apps/studio/src/routes/runs/$runId.tsx
@@ -84,7 +84,7 @@ function RunDetailPage() {
               onClick={() => setShowRunEval(true)}
               className="rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-500"
             >
-              ▶ Re-run with Filters
+              ▶ Run evals
             </button>
           )}
         </div>


### PR DESCRIPTION
Renames the button to be user-centric. The with Filters part was implementation detail.

Closes nothing — drive-by rename.