### PR TITLE
fix(workspace): allow git base_commit SHAs

### DIFF
--- a/packages/core/src/evaluation/workspace/repo-manager.ts
+++ b/packages/core/src/evaluation/workspace/repo-manager.ts
@@ -39,6 +39,10 @@ function getSourceUrl(source: RepoSource): string {
   return source.type === 'git' ? source.url : source.path;
 }
 
+function isFullCommitSha(ref: string | undefined): boolean {
+  return typeof ref === 'string' && /^[0-9a-f]{40}$/i.test(ref);
+}
+
 async function git(args: string[], opts?: { cwd?: string; timeout?: number }): Promise<string> {
   const { stdout } = await execFileAsync('git', args, {
     cwd: opts?.cwd,
@@ -169,9 +173,12 @@ export class RepoManager {
     // Resolve ref
     const ref = getRepoCheckoutRef(repo.checkout);
     const resolve = repo.checkout?.resolve ?? 'remote';
+    const baseCommit = repo.checkout?.base_commit;
+    const shouldResolveLocally =
+      resolve === 'local' || (repo.source.type === 'git' && isFullCommitSha(baseCommit));
 
     let resolvedSha: string;
-    if (resolve === 'remote' && repo.source.type === 'git') {
+    if (!shouldResolveLocally && repo.source.type === 'git') {
       // Resolve via ls-remote for remote refs
       const url = getSourceUrl(repo.source);
       try {

--- a/packages/core/test/evaluation/workspace/repo-manager.test.ts
+++ b/packages/core/test/evaluation/workspace/repo-manager.test.ts
@@ -99,6 +99,34 @@ describe('RepoManager', () => {
       expect(existsSync(path.join(targetDir, 'third.txt'))).toBe(false);
     }, 30_000);
 
+    it('checks out raw base_commit SHAs from git sources without resolve: local', async () => {
+      const repoDir = path.join(tmpDir, 'source-repo');
+      createTestRepo(repoDir);
+      writeFileSync(path.join(repoDir, 'second.txt'), 'second');
+      execSync('git add -A && git commit -m "second"', { cwd: repoDir, ...EXEC_OPTS });
+      const secondSha = gitExec('git rev-parse HEAD', repoDir);
+      writeFileSync(path.join(repoDir, 'third.txt'), 'third');
+      execSync('git add -A && git commit -m "third"', { cwd: repoDir, ...EXEC_OPTS });
+
+      const remoteDir = path.join(tmpDir, 'remote.git');
+      execSync(`git clone --bare "${repoDir}" "${remoteDir}"`, { env: cleanGitEnv() });
+
+      await manager.materialize(
+        {
+          path: './my-repo',
+          source: { type: 'git', url: remoteDir },
+          checkout: { base_commit: secondSha },
+        },
+        workspaceDir,
+      );
+
+      const targetDir = path.join(workspaceDir, 'my-repo');
+      const headSha = gitExec('git rev-parse HEAD', targetDir);
+      expect(headSha).toBe(secondSha);
+      expect(existsSync(path.join(targetDir, 'second.txt'))).toBe(true);
+      expect(existsSync(path.join(targetDir, 'third.txt'))).toBe(false);
+    }, 30_000);
+
     it('walks ancestor commits', async () => {
       const repoDir = path.join(tmpDir, 'source-repo');
       const firstSha = createTestRepo(repoDir);


### PR DESCRIPTION
Closes #1236

## What changed
- treat full `workspace.repos[].checkout.base_commit` SHAs as local checkout targets after clone for `source.type: git` repos
- keep remote `ls-remote` resolution for branch/tag-style refs
- add a regression test that reproduces the failure against a local bare git remote

## Verification
- `bun test ./test/evaluation/workspace/repo-manager.test.ts` in `packages/core`
- `bun run build`
- `bun run lint`
- `bun run test`

### Red
`bun apps/cli/src/cli.ts eval issue-1236-valid-repro.eval.yaml --dry-run --target default --targets issue-1236-targets.yaml` on `origin/main` failed during workspace setup with:

```text
Failed to materialize repos: Ref '6e446b722627e9df017b22e391fa63320362d8c7' not found on remote https://github.com/EntityProcess/agentv\n```\n\n### Green\nThe same command on this branch completed workspace setup and ran the test case instead of erroring; the run ended as a normal assertion failure from the mock target:\n\n```text\n1/1   ⚠️ noop | default → default-dry-run | 0% FAIL\n```\n\n### Note\nIssue claiming on the project board was blocked in this environment because the configured `gh` token is missing the `read:project` scope required by `gh project item-list`.\n