### PR TITLE
fix(cli): add --dangerously-skip-permissions to ClaudeCliProvider

### DIFF
--- a/packages/core/src/evaluation/providers/claude-cli.ts
+++ b/packages/core/src/evaluation/providers/claude-cli.ts
@@ -182,6 +182,10 @@ export class ClaudeCliProvider implements Provider {
       '--verbose',
     ];
 
+    if (this.config.bypassPermissions !== false) {
+      args.push('--dangerously-skip-permissions');
+    }
+
     if (this.config.model) {
       args.push('--model', this.config.model);
     }

--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -533,6 +533,8 @@ export interface ClaudeResolvedConfig {
   readonly logFormat?: 'summary' | 'json';
   /** New stream_log field. false=no stream log (default), 'raw'=per-event, 'summary'=consolidated. */
   readonly streamLog?: false | 'raw' | 'summary';
+  /** When true (default), passes --dangerously-skip-permissions to the Claude CLI. Matches ClaudeSdkProvider behavior. */
+  readonly bypassPermissions?: boolean;
 }
 
 export interface MockResolvedConfig {
@@ -1853,6 +1855,11 @@ function resolveClaudeConfig(
   const maxBudgetUsd =
     typeof target.max_budget_usd === 'number' ? target.max_budget_usd : undefined;
 
+  const bypassPermissions =
+    target.bypass_permissions !== undefined
+      ? resolveOptionalBoolean(target.bypass_permissions)
+      : undefined;
+
   return {
     executable,
     model,
@@ -1864,6 +1871,7 @@ function resolveClaudeConfig(
     logDir,
     logFormat,
     streamLog: streamLogResult.streamLog,
+    bypassPermissions,
   };
 }
 

--- a/packages/core/test/evaluation/providers/claude-provider-aliases.test.ts
+++ b/packages/core/test/evaluation/providers/claude-provider-aliases.test.ts
@@ -6,6 +6,7 @@ import { ClaudeProvider } from '../../../src/evaluation/providers/claude.js';
 import { createBuiltinProviderRegistry } from '../../../src/evaluation/providers/index.js';
 
 const mockClaudeConfig = {
+  executable: 'claude',
   model: undefined,
   cwd: undefined,
   timeoutMs: undefined,
@@ -59,5 +60,28 @@ describe('Claude provider alias resolution', () => {
     expect(sdkProvider).toBeInstanceOf(ClaudeProvider);
     expect(cliProvider.kind).toBe('claude-cli');
     expect(sdkProvider.kind).toBe('claude');
+  });
+});
+
+describe('ClaudeCliProvider buildArgs', () => {
+  it('includes --dangerously-skip-permissions by default', () => {
+    const provider = new ClaudeCliProvider('target', mockClaudeConfig);
+    // biome-ignore lint/suspicious/noExplicitAny: testing private method
+    const args: string[] = (provider as any).buildArgs();
+    expect(args).toContain('--dangerously-skip-permissions');
+  });
+
+  it('includes --dangerously-skip-permissions when bypassPermissions is true', () => {
+    const provider = new ClaudeCliProvider('target', { ...mockClaudeConfig, bypassPermissions: true });
+    // biome-ignore lint/suspicious/noExplicitAny: testing private method
+    const args: string[] = (provider as any).buildArgs();
+    expect(args).toContain('--dangerously-skip-permissions');
+  });
+
+  it('omits --dangerously-skip-permissions when bypassPermissions is false', () => {
+    const provider = new ClaudeCliProvider('target', { ...mockClaudeConfig, bypassPermissions: false });
+    // biome-ignore lint/suspicious/noExplicitAny: testing private method
+    const args: string[] = (provider as any).buildArgs();
+    expect(args).not.toContain('--dangerously-skip-permissions');
   });
 });

--- a/packages/core/test/evaluation/providers/claude-provider-aliases.test.ts
+++ b/packages/core/test/evaluation/providers/claude-provider-aliases.test.ts
@@ -72,14 +72,20 @@ describe('ClaudeCliProvider buildArgs', () => {
   });
 
   it('includes --dangerously-skip-permissions when bypassPermissions is true', () => {
-    const provider = new ClaudeCliProvider('target', { ...mockClaudeConfig, bypassPermissions: true });
+    const provider = new ClaudeCliProvider('target', {
+      ...mockClaudeConfig,
+      bypassPermissions: true,
+    });
     // biome-ignore lint/suspicious/noExplicitAny: testing private method
     const args: string[] = (provider as any).buildArgs();
     expect(args).toContain('--dangerously-skip-permissions');
   });
 
   it('omits --dangerously-skip-permissions when bypassPermissions is false', () => {
-    const provider = new ClaudeCliProvider('target', { ...mockClaudeConfig, bypassPermissions: false });
+    const provider = new ClaudeCliProvider('target', {
+      ...mockClaudeConfig,
+      bypassPermissions: false,
+    });
     // biome-ignore lint/suspicious/noExplicitAny: testing private method
     const args: string[] = (provider as any).buildArgs();
     expect(args).not.toContain('--dangerously-skip-permissions');


### PR DESCRIPTION
## Summary

- `ClaudeCliProvider` was missing permission bypass flags, causing permission prompts on every tool call during evals
- Added `bypassPermissions` option to `ClaudeResolvedConfig` (optional, defaults to `true` in `buildArgs`)
- When `bypassPermissions !== false`, appends `--dangerously-skip-permissions` to the Claude CLI args — matching `ClaudeSdkProvider`'s unconditional `permissionMode: 'bypassPermissions'`
- Added `bypass_permissions` YAML field support in `resolveClaudeConfig`

## Red/Green

**Red (before):** `ClaudeCliProvider.buildArgs()` returned `['-p', '--output-format', 'stream-json', '--include-partial-messages', '--verbose']` — no permission bypass flags, causing interactive prompts in evals.

**Green (after):** `buildArgs()` now includes `--dangerously-skip-permissions` by default. Setting `bypass_permissions: false` in the target YAML omits it.

## Test plan

- [x] `ClaudeCliProvider.buildArgs()` includes `--dangerously-skip-permissions` by default
- [x] `ClaudeCliProvider.buildArgs()` includes the flag when `bypassPermissions: true`
- [x] `ClaudeCliProvider.buildArgs()` omits the flag when `bypassPermissions: false`
- [x] All pre-push hooks pass (build, typecheck, lint, test, validate)

Closes #1238

🤖 Generated with [Claude Code](https://claude.com/claude-code)