### PR TITLE
refactor(studio): rename Studio frontend benchmark → project (3/4)

### DIFF
--- a/apps/studio/src/components/AnalyticsCharts.tsx
+++ b/apps/studio/src/components/AnalyticsCharts.tsx
@@ -33,7 +33,7 @@ import {
   YAxis,
 } from 'recharts';
 
-import { benchmarkCompareOptions, compareOptionsWithBaseline } from '~/lib/api';
+import { compareOptionsWithBaseline, projectCompareOptions } from '~/lib/api';
 import type { CompareResponse, CompareRunEntry } from '~/lib/types';
 
 // ── Color palette matching Studio DESIGN.md ────────────────────────────
@@ -71,21 +71,21 @@ function targetColor(idx: number): string {
 interface AnalyticsChartsProps {
   /** Unfiltered compare response (no baseline). Used for tag heatmap, histogram, etc. */
   data: CompareResponse;
-  /** Benchmark scope. Undefined for unscoped root view. */
-  benchmarkId?: string;
+  /** Project scope. Undefined for unscoped root view. */
+  projectId?: string;
 }
 
 // ── Main component ─────────────────────────────────────────────────────
 
-export function AnalyticsCharts({ data, benchmarkId }: AnalyticsChartsProps) {
+export function AnalyticsCharts({ data, projectId }: AnalyticsChartsProps) {
   const [collapsed, setCollapsed] = useState(true);
   const [baseline, setBaseline] = useState<string>('');
   const targets = data.targets;
 
   // Fetch compare data with baseline param when a baseline is selected
   const baselineQuery = useQuery(
-    benchmarkId
-      ? benchmarkCompareOptions(benchmarkId, baseline || undefined)
+    projectId
+      ? projectCompareOptions(projectId, baseline || undefined)
       : compareOptionsWithBaseline(baseline || undefined),
   );
   const baselineData = baseline ? baselineQuery.data : undefined;

--- a/apps/studio/src/components/AnalyticsTab.tsx
+++ b/apps/studio/src/components/AnalyticsTab.tsx
@@ -37,8 +37,8 @@ interface AnalyticsTabProps {
   isLoading: boolean;
   isError?: boolean;
   error?: Error | null;
-  /** Benchmark scope. Undefined for the unscoped (root) compare view. */
-  benchmarkId?: string;
+  /** Project scope. Undefined for the unscoped (root) compare view. */
+  projectId?: string;
   /** Read-only mode disables tag editing. */
   readOnly?: boolean;
 }
@@ -52,7 +52,7 @@ export function AnalyticsTab({
   isLoading,
   isError,
   error,
-  benchmarkId,
+  projectId,
   readOnly,
 }: AnalyticsTabProps) {
   const [mode, setMode] = useState<ViewMode>('aggregated');
@@ -180,12 +180,12 @@ export function AnalyticsTab({
             filteredData && (
               <>
                 {mode === 'aggregated' && (
-                  <AggregatedView data={filteredData} benchmarkId={benchmarkId} />
+                  <AggregatedView data={filteredData} projectId={projectId} />
                 )}
                 {mode === 'per-run' && (
                   <PerRunView
                     data={filteredData}
-                    benchmarkId={benchmarkId}
+                    projectId={projectId}
                     readOnly={readOnly ?? false}
                   />
                 )}
@@ -358,7 +358,7 @@ function ModeButton({
 
 // ── Aggregated (matrix) view ────────────────────────────────────────────
 
-function AggregatedView({ data, benchmarkId }: { data: CompareResponse; benchmarkId?: string }) {
+function AggregatedView({ data, projectId }: { data: CompareResponse; projectId?: string }) {
   const { experiments, targets, cells } = data;
 
   // Hooks must run on every render regardless of the early-return below,
@@ -410,7 +410,7 @@ function AggregatedView({ data, benchmarkId }: { data: CompareResponse; benchmar
           </tbody>
         </table>
       </div>
-      <AnalyticsCharts data={data} benchmarkId={benchmarkId} />
+      <AnalyticsCharts data={data} projectId={projectId} />
     </div>
   );
 }
@@ -500,11 +500,11 @@ function TestBreakdown({ tests }: { tests: CompareTestResult[] }) {
 
 function PerRunView({
   data,
-  benchmarkId,
+  projectId,
   readOnly,
 }: {
   data: CompareResponse;
-  benchmarkId?: string;
+  projectId?: string;
   readOnly: boolean;
 }) {
   const runs = data.runs ?? [];
@@ -566,7 +566,7 @@ function PerRunView({
                 editing={editingRunId === run.run_id}
                 onStartEdit={() => setEditingRunId(run.run_id)}
                 onEndEdit={() => setEditingRunId(null)}
-                benchmarkId={benchmarkId}
+                projectId={projectId}
                 readOnly={readOnly}
               />
             ))}
@@ -615,7 +615,7 @@ function PerRunRow({
   editing,
   onStartEdit,
   onEndEdit,
-  benchmarkId,
+  projectId,
   readOnly,
 }: {
   run: CompareRunEntry;
@@ -624,7 +624,7 @@ function PerRunRow({
   editing: boolean;
   onStartEdit: () => void;
   onEndEdit: () => void;
-  benchmarkId?: string;
+  projectId?: string;
   readOnly: boolean;
 }) {
   const avgPct = Math.round(run.avg_score * 100);
@@ -726,7 +726,7 @@ function PerRunRow({
             <TagsEditor
               runId={run.run_id}
               currentTags={tags}
-              benchmarkId={benchmarkId}
+              projectId={projectId}
               onClose={onEndEdit}
             />
           </td>
@@ -751,12 +751,12 @@ function PerRunRow({
 function TagsEditor({
   runId,
   currentTags,
-  benchmarkId,
+  projectId,
   onClose,
 }: {
   runId: string;
   currentTags: string[];
-  benchmarkId?: string;
+  projectId?: string;
   onClose: () => void;
 }) {
   const [tags, setTags] = useState<string[]>(currentTags);
@@ -770,13 +770,13 @@ function TagsEditor({
   }, []);
 
   const saveMut = useMutation({
-    mutationFn: () => saveRunTagsApi(runId, tags, benchmarkId),
+    mutationFn: () => saveRunTagsApi(runId, tags, projectId),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['compare'] });
       qc.invalidateQueries({ queryKey: ['runs'] });
-      if (benchmarkId) {
-        qc.invalidateQueries({ queryKey: ['benchmarks', benchmarkId, 'compare'] });
-        qc.invalidateQueries({ queryKey: ['benchmarks', benchmarkId, 'runs'] });
+      if (projectId) {
+        qc.invalidateQueries({ queryKey: ['projects', projectId, 'compare'] });
+        qc.invalidateQueries({ queryKey: ['projects', projectId, 'runs'] });
       }
       onClose();
     },
@@ -784,13 +784,13 @@ function TagsEditor({
   });
 
   const clearMut = useMutation({
-    mutationFn: () => deleteRunTagsApi(runId, benchmarkId),
+    mutationFn: () => deleteRunTagsApi(runId, projectId),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['compare'] });
       qc.invalidateQueries({ queryKey: ['runs'] });
-      if (benchmarkId) {
-        qc.invalidateQueries({ queryKey: ['benchmarks', benchmarkId, 'compare'] });
-        qc.invalidateQueries({ queryKey: ['benchmarks', benchmarkId, 'runs'] });
+      if (projectId) {
+        qc.invalidateQueries({ queryKey: ['projects', projectId, 'compare'] });
+        qc.invalidateQueries({ queryKey: ['projects', projectId, 'runs'] });
       }
       onClose();
     },

--- a/apps/studio/src/components/EvalDetail.tsx
+++ b/apps/studio/src/components/EvalDetail.tsx
@@ -11,9 +11,9 @@ import { useState } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
 import {
-  benchmarkEvalFileContentOptions,
-  benchmarkEvalFilesOptions,
   isPassing,
+  projectEvalFileContentOptions,
+  projectEvalFilesOptions,
   useEvalFileContent,
   useEvalFiles,
   useStudioConfig,
@@ -29,7 +29,7 @@ import { ScoreBar } from './ScoreBar';
 interface EvalDetailProps {
   eval: EvalResult;
   runId: string;
-  benchmarkId?: string;
+  projectId?: string;
 }
 
 type Tab = 'checks' | 'files' | 'feedback';
@@ -46,7 +46,7 @@ function findFirstFile(nodes: FileNode[]): string | null {
   return null;
 }
 
-export function EvalDetail({ eval: result, runId, benchmarkId }: EvalDetailProps) {
+export function EvalDetail({ eval: result, runId, projectId }: EvalDetailProps) {
   const [activeTab, setActiveTab] = useState<Tab>('checks');
   const { data: config } = useStudioConfig();
   const isReadOnly = config?.read_only === true;
@@ -88,7 +88,7 @@ export function EvalDetail({ eval: result, runId, benchmarkId }: EvalDetailProps
         )}
         {activeTab === 'files' && (
           <div className="h-full p-4">
-            <FilesTab result={result} runId={runId} benchmarkId={benchmarkId} />
+            <FilesTab result={result} runId={runId} projectId={projectId} />
           </div>
         )}
         {!isReadOnly && activeTab === 'feedback' && (
@@ -253,13 +253,13 @@ function ChecksTab({ result }: { result: EvalResult }) {
 function FilesTab({
   result,
   runId,
-  benchmarkId,
-}: { result: EvalResult; runId: string; benchmarkId?: string }) {
+  projectId,
+}: { result: EvalResult; runId: string; projectId?: string }) {
   const evalId = result.testId;
 
-  // Use benchmark-scoped API hooks when benchmarkId is present
-  const { data: filesData } = benchmarkId
-    ? useQuery(benchmarkEvalFilesOptions(benchmarkId, runId, evalId))
+  // Use project-scoped API hooks when projectId is present
+  const { data: filesData } = projectId
+    ? useQuery(projectEvalFilesOptions(projectId, runId, evalId))
     : useEvalFiles(runId, evalId);
   const files = filesData?.files ?? [];
 
@@ -267,8 +267,8 @@ function FilesTab({
 
   const effectivePath = selectedPath ?? (files.length > 0 ? findFirstFile(files) : null);
 
-  const { data: fileContentData, isLoading: isLoadingContent } = benchmarkId
-    ? useQuery(benchmarkEvalFileContentOptions(benchmarkId, runId, evalId, effectivePath ?? ''))
+  const { data: fileContentData, isLoading: isLoadingContent } = projectId
+    ? useQuery(projectEvalFileContentOptions(projectId, runId, evalId, effectivePath ?? ''))
     : useEvalFileContent(runId, evalId, effectivePath ?? '');
 
   if (files.length === 0) {

--- a/apps/studio/src/components/ProjectCard.tsx
+++ b/apps/studio/src/components/ProjectCard.tsx
@@ -1,13 +1,13 @@
 /**
- * Benchmark card for the multi-benchmark dashboard.
+ * Project card for the multi-project dashboard.
  *
- * Shows benchmark name, path, run count, pass rate, and last run time.
- * Click navigates to the benchmark's run list.
+ * Shows project name, path, run count, pass rate, and last run time.
+ * Click navigates to the project's run list.
  */
 
 import { Link } from '@tanstack/react-router';
 
-import type { BenchmarkSummary } from '~/lib/types';
+import type { ProjectSummary } from '~/lib/types';
 
 function formatTimeAgo(timestamp: string | null): string {
   if (!timestamp) return 'No runs';
@@ -23,34 +23,34 @@ function formatTimeAgo(timestamp: string | null): string {
   return `${days}d ago`;
 }
 
-export function BenchmarkCard({ benchmark }: { benchmark: BenchmarkSummary }) {
-  const passPercent = Math.round(benchmark.pass_rate * 100);
+export function ProjectCard({ project }: { project: ProjectSummary }) {
+  const passPercent = Math.round(project.pass_rate * 100);
 
   return (
     <Link
-      to="/benchmarks/$benchmarkId"
-      params={{ benchmarkId: benchmark.id }}
+      to="/projects/$projectId"
+      params={{ projectId: project.id }}
       className="group block rounded-lg border border-gray-800 bg-gray-900/50 p-5 transition-colors hover:border-cyan-800 hover:bg-gray-900"
     >
       <div className="flex items-start justify-between">
         <div className="min-w-0 flex-1">
           <h3 className="truncate text-lg font-semibold text-white group-hover:text-cyan-400">
-            {benchmark.name}
+            {project.name}
           </h3>
-          <p className="mt-1 truncate text-xs text-gray-500">{benchmark.path}</p>
+          <p className="mt-1 truncate text-xs text-gray-500">{project.path}</p>
         </div>
       </div>
 
       <div className="mt-4 grid grid-cols-3 gap-3">
         <div>
           <p className="text-xs text-gray-500">Runs</p>
-          <p className="text-lg font-semibold text-white">{benchmark.run_count}</p>
+          <p className="text-lg font-semibold text-white">{project.run_count}</p>
         </div>
         <div>
           <p className="text-xs text-gray-500">Pass Rate</p>
           <p
             className={`text-lg font-semibold ${
-              benchmark.run_count === 0
+              project.run_count === 0
                 ? 'text-gray-500'
                 : passPercent >= 80
                   ? 'text-emerald-400'
@@ -59,12 +59,12 @@ export function BenchmarkCard({ benchmark }: { benchmark: BenchmarkSummary }) {
                     : 'text-red-400'
             }`}
           >
-            {benchmark.run_count > 0 ? `${passPercent}%` : '--'}
+            {project.run_count > 0 ? `${passPercent}%` : '--'}
           </p>
         </div>
         <div>
           <p className="text-xs text-gray-500">Last Run</p>
-          <p className="text-sm text-gray-300">{formatTimeAgo(benchmark.last_run)}</p>
+          <p className="text-sm text-gray-300">{formatTimeAgo(project.last_run)}</p>
         </div>
       </div>
     </Link>

--- a/apps/studio/src/components/ResumeRunActions.tsx
+++ b/apps/studio/src/components/ResumeRunActions.tsx
@@ -33,7 +33,7 @@ export interface ResumeRunActionsProps {
   runDir?: string;
   suiteFilter?: string;
   target?: string;
-  benchmarkId?: string;
+  projectId?: string;
   isReadOnly: boolean;
   plannedTestCount?: number;
 }
@@ -43,7 +43,7 @@ export function ResumeRunActions({
   runDir,
   suiteFilter,
   target,
-  benchmarkId,
+  projectId,
   isReadOnly,
   plannedTestCount,
 }: ResumeRunActionsProps) {
@@ -70,7 +70,7 @@ export function ResumeRunActions({
     setError(null);
     try {
       const body = buildResumeRequestBody({ mode, runDir, suiteFilter, target });
-      const response = await launchEvalRun(body, benchmarkId);
+      const response = await launchEvalRun(body, projectId);
       navigate({ to: '/jobs/$runId', params: { runId: response.id } });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to launch resume');

--- a/apps/studio/src/components/RunDetail.tsx
+++ b/apps/studio/src/components/RunDetail.tsx
@@ -25,7 +25,7 @@ import { StatsCards } from './StatsCards';
 interface RunDetailProps {
   results: EvalResult[];
   runId: string;
-  benchmarkId?: string;
+  projectId?: string;
 }
 
 interface SuiteStats {
@@ -92,7 +92,7 @@ function buildCategoryGroups(results: EvalResult[], passThreshold: number): Cate
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export function RunDetail({ results, runId, benchmarkId }: RunDetailProps) {
+export function RunDetail({ results, runId, projectId }: RunDetailProps) {
   const { data: config } = useStudioConfig();
   const passThreshold = config?.threshold ?? config?.pass_threshold ?? 0.8;
 
@@ -198,10 +198,10 @@ export function RunDetail({ results, runId, benchmarkId }: RunDetailProps) {
                       )}
                     </td>
                     <td className="px-4 py-3">
-                      {benchmarkId ? (
+                      {projectId ? (
                         <Link
-                          to="/benchmarks/$benchmarkId/evals/$runId/$evalId"
-                          params={{ benchmarkId, runId, evalId: result.testId }}
+                          to="/projects/$projectId/evals/$runId/$evalId"
+                          params={{ projectId, runId, evalId: result.testId }}
                           className="font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
                         >
                           {result.testId}
@@ -242,14 +242,14 @@ export function RunDetail({ results, runId, benchmarkId }: RunDetailProps) {
         </div>
       </div>
 
-      <ConsoleLogSection runId={runId} benchmarkId={benchmarkId} />
+      <ConsoleLogSection runId={runId} projectId={projectId} />
     </div>
   );
 }
 
-function ConsoleLogSection({ runId, benchmarkId }: { runId: string; benchmarkId?: string }) {
+function ConsoleLogSection({ runId, projectId }: { runId: string; projectId?: string }) {
   const [open, setOpen] = useState(false);
-  const { data: log, isLoading, error } = useRunLog(runId, benchmarkId);
+  const { data: log, isLoading, error } = useRunLog(runId, projectId);
 
   // Hide the section entirely when no log was captured (remote runs, or
   // local runs from before this feature shipped). The 404 path resolves

--- a/apps/studio/src/components/RunEvalModal.tsx
+++ b/apps/studio/src/components/RunEvalModal.tsx
@@ -35,7 +35,7 @@ import {
 export interface RunEvalModalProps {
   open: boolean;
   onClose: () => void;
-  benchmarkId?: string;
+  projectId?: string;
   prefill?: {
     suiteFilter?: string;
     testIds?: string[];
@@ -45,7 +45,7 @@ export interface RunEvalModalProps {
 
 // ── Component ────────────────────────────────────────────────────────────
 
-export function RunEvalModal({ open, onClose, benchmarkId, prefill }: RunEvalModalProps) {
+export function RunEvalModal({ open, onClose, projectId, prefill }: RunEvalModalProps) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
@@ -67,10 +67,10 @@ export function RunEvalModal({ open, onClose, benchmarkId, prefill }: RunEvalMod
   const [cliPreview, setCliPreview] = useState<string | null>(null);
 
   // Data
-  const { data: discoverData } = useEvalDiscover(benchmarkId);
-  const { data: targetsData } = useEvalTargets(benchmarkId);
+  const { data: discoverData } = useEvalDiscover(projectId);
+  const { data: targetsData } = useEvalTargets(projectId);
   const { data: runStatus } = useEvalRunStatus(activeRunId);
-  const { data: studioConfig } = useStudioConfig(benchmarkId);
+  const { data: studioConfig } = useStudioConfig(projectId);
 
   const evalFiles = useMemo(() => discoverData?.eval_files ?? [], [discoverData]);
   const targetNames = useMemo(() => targetsData?.targets ?? [], [targetsData]);
@@ -106,7 +106,7 @@ export function RunEvalModal({ open, onClose, benchmarkId, prefill }: RunEvalMod
   useEffect(() => {
     if (runStatus?.status === 'finished' || runStatus?.status === 'failed') {
       queryClient.invalidateQueries({ queryKey: ['runs'] });
-      queryClient.invalidateQueries({ queryKey: ['benchmarks'] });
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
     }
   }, [runStatus?.status, queryClient]);
 
@@ -130,10 +130,10 @@ export function RunEvalModal({ open, onClose, benchmarkId, prefill }: RunEvalMod
       setCliPreview(null);
       return;
     }
-    previewEvalCommand(req, benchmarkId)
+    previewEvalCommand(req, projectId)
       .then((r) => setCliPreview(r.command))
       .catch(() => setCliPreview(null));
-  }, [buildRequest, benchmarkId]);
+  }, [buildRequest, projectId]);
 
   // Add a test ID pill
   function addTestId() {
@@ -154,7 +154,7 @@ export function RunEvalModal({ open, onClose, benchmarkId, prefill }: RunEvalMod
     setLaunching(true);
     try {
       const req = buildRequest();
-      const result = await launchEvalRun(req, benchmarkId);
+      const result = await launchEvalRun(req, projectId);
       setActiveRunId(result.id);
     } catch (err) {
       setError((err as Error).message);

--- a/apps/studio/src/components/RunList.tsx
+++ b/apps/studio/src/components/RunList.tsx
@@ -24,7 +24,7 @@ import { PassRatePill } from './PassRatePill';
 
 interface RunListProps {
   runs: RunMeta[];
-  benchmarkId?: string;
+  projectId?: string;
   emptyMessage?: React.ReactNode;
 }
 
@@ -48,7 +48,7 @@ function formatDate(ts: string | undefined | null): { date: string; full: string
   }
 }
 
-export function RunList({ runs, benchmarkId, emptyMessage }: RunListProps) {
+export function RunList({ runs, projectId, emptyMessage }: RunListProps) {
   const { data: config } = useStudioConfig();
   const passThreshold = config?.threshold ?? DEFAULT_PASS_THRESHOLD;
 
@@ -113,10 +113,10 @@ export function RunList({ runs, benchmarkId, emptyMessage }: RunListProps) {
 
                 {/* Run name */}
                 <td className="px-4 py-3">
-                  {benchmarkId ? (
+                  {projectId ? (
                     <Link
-                      to="/benchmarks/$benchmarkId/runs/$runId"
-                      params={{ benchmarkId, runId: run.filename }}
+                      to="/projects/$projectId/runs/$runId"
+                      params={{ projectId, runId: run.filename }}
                       className="font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
                     >
                       {label}

--- a/apps/studio/src/components/Sidebar.tsx
+++ b/apps/studio/src/components/Sidebar.tsx
@@ -18,13 +18,13 @@ import { Link, useLocation, useMatchRoute } from '@tanstack/react-router';
 
 import {
   isPassing,
-  useAllBenchmarkRuns,
-  useBenchmarkList,
-  useBenchmarkRunDetail,
-  useBenchmarkRunList,
+  useAllProjectRuns,
   useCategorySuites,
   useEvalRuns,
   useExperiments,
+  useProjectList,
+  useProjectRunDetail,
+  useProjectRunList,
   useRunDetail,
   useRunList,
   useStudioConfig,
@@ -71,48 +71,40 @@ function SidebarShell({ children }: { children: ReactNode }) {
 export function Sidebar() {
   const matchRoute = useMatchRoute();
 
-  // ── Benchmark-scoped route matching ──────────────────────────────────
-  const benchmarkEvalMatch = matchRoute({
-    to: '/benchmarks/$benchmarkId/evals/$runId/$evalId',
+  // ── Project-scoped route matching ──────────────────────────────────
+  const projectEvalMatch = matchRoute({
+    to: '/projects/$projectId/evals/$runId/$evalId',
     fuzzy: true,
   });
-  const benchmarkRunMatch = matchRoute({
-    to: '/benchmarks/$benchmarkId/runs/$runId',
+  const projectRunMatch = matchRoute({
+    to: '/projects/$projectId/runs/$runId',
     fuzzy: true,
   });
-  const benchmarkMatch = matchRoute({
-    to: '/benchmarks/$benchmarkId',
+  const projectMatch = matchRoute({
+    to: '/projects/$projectId',
     fuzzy: true,
   });
 
-  // Benchmark-scoped eval detail
-  if (
-    benchmarkEvalMatch &&
-    typeof benchmarkEvalMatch === 'object' &&
-    'benchmarkId' in benchmarkEvalMatch
-  ) {
-    const { benchmarkId, runId, evalId } = benchmarkEvalMatch as {
-      benchmarkId: string;
+  // Project-scoped eval detail
+  if (projectEvalMatch && typeof projectEvalMatch === 'object' && 'projectId' in projectEvalMatch) {
+    const { projectId, runId, evalId } = projectEvalMatch as {
+      projectId: string;
       runId: string;
       evalId: string;
     };
-    return <BenchmarkEvalSidebar benchmarkId={benchmarkId} runId={runId} currentEvalId={evalId} />;
+    return <ProjectEvalSidebar projectId={projectId} runId={runId} currentEvalId={evalId} />;
   }
 
-  // Benchmark-scoped run detail
-  if (
-    benchmarkRunMatch &&
-    typeof benchmarkRunMatch === 'object' &&
-    'benchmarkId' in benchmarkRunMatch
-  ) {
-    const { benchmarkId, runId } = benchmarkRunMatch as { benchmarkId: string; runId: string };
-    return <BenchmarkRunDetailSidebar benchmarkId={benchmarkId} currentRunId={runId} />;
+  // Project-scoped run detail
+  if (projectRunMatch && typeof projectRunMatch === 'object' && 'projectId' in projectRunMatch) {
+    const { projectId, runId } = projectRunMatch as { projectId: string; runId: string };
+    return <ProjectRunDetailSidebar projectId={projectId} currentRunId={runId} />;
   }
 
-  // Benchmark home (runs/experiments/targets)
-  if (benchmarkMatch && typeof benchmarkMatch === 'object' && 'benchmarkId' in benchmarkMatch) {
-    const { benchmarkId } = benchmarkMatch as { benchmarkId: string };
-    return <BenchmarkRunDetailSidebar benchmarkId={benchmarkId} />;
+  // Project home (runs/experiments/targets)
+  if (projectMatch && typeof projectMatch === 'object' && 'projectId' in projectMatch) {
+    const { projectId } = projectMatch as { projectId: string };
+    return <ProjectRunDetailSidebar projectId={projectId} />;
   }
 
   // ── Unscoped route matching ──────────────────────────────────────────
@@ -159,17 +151,17 @@ export function Sidebar() {
 
 function RunSidebar() {
   const matchRoute = useMatchRoute();
-  const { data: benchmarkData } = useBenchmarkList();
-  const hasBenchmarks = (benchmarkData?.benchmarks.length ?? 0) > 0;
+  const { data: projectData } = useProjectList();
+  const hasProjects = (projectData?.projects.length ?? 0) > 0;
 
   const isHome = matchRoute({ to: '/' });
   const runMatch = matchRoute({ to: '/runs/$runId', fuzzy: true });
 
-  // On the benchmarks landing page, show aggregated runs from all benchmarks
-  const useAggregated = hasBenchmarks && isHome !== false;
+  // On the projects landing page, show aggregated runs from all projects
+  const useAggregated = hasProjects && isHome !== false;
 
   const { data: localData } = useRunList();
-  const { data: aggregatedData } = useAllBenchmarkRuns();
+  const { data: aggregatedData } = useAllProjectRuns();
   const data = useAggregated ? aggregatedData : localData;
 
   const { data: evalRunsData } = useEvalRuns();
@@ -204,15 +196,15 @@ function RunSidebar() {
             'runId' in runMatch &&
             (runMatch as { runId: string }).runId === run.filename;
 
-          // Aggregated runs link to their benchmark's run detail
-          if (run.benchmark_id) {
+          // Aggregated runs link to their project's run detail
+          if (run.project_id) {
             return (
               <Link
-                key={`${run.benchmark_id}/${run.filename}`}
-                to="/benchmarks/$benchmarkId/runs/$runId"
-                params={{ benchmarkId: run.benchmark_id, runId: run.filename }}
+                key={`${run.project_id}/${run.filename}`}
+                to="/projects/$projectId/runs/$runId"
+                params={{ projectId: run.project_id, runId: run.filename }}
                 className="mb-0.5 block rounded-md px-2 py-1.5 text-sm text-gray-400 transition-colors hover:bg-gray-800/50 hover:text-gray-200"
-                title={run.benchmark_name}
+                title={run.project_name}
               >
                 <span className="block truncate">{formatRunLabel(run)}</span>
                 <span className="block text-xs text-gray-600">{timeAgo(run.timestamp)}</span>
@@ -411,16 +403,16 @@ function CategorySidebar({ runId, category }: { runId: string; category: string 
   );
 }
 
-// ── Benchmark-scoped sidebars ────────────────────────────────────────────
+// ── Project-scoped sidebars ────────────────────────────────────────────
 
-function BenchmarkRunDetailSidebar({
-  benchmarkId,
+function ProjectRunDetailSidebar({
+  projectId,
   currentRunId,
 }: {
-  benchmarkId: string;
+  projectId: string;
   currentRunId?: string;
 }) {
-  const { data } = useBenchmarkRunList(benchmarkId);
+  const { data } = useProjectRunList(projectId);
 
   return (
     <SidebarShell>
@@ -432,9 +424,9 @@ function BenchmarkRunDetailSidebar({
 
       <div className="border-b border-gray-800 px-4 py-2">
         <Link to="/" className="text-xs text-gray-400 hover:text-cyan-400">
-          &larr; All Benchmarks
+          &larr; All Projects
         </Link>
-        <p className="mt-1 truncate text-sm font-medium text-gray-300">{benchmarkId}</p>
+        <p className="mt-1 truncate text-sm font-medium text-gray-300">{projectId}</p>
       </div>
 
       <nav className="flex-1 overflow-y-auto px-2 py-3">
@@ -446,8 +438,8 @@ function BenchmarkRunDetailSidebar({
           return (
             <Link
               key={run.filename}
-              to="/benchmarks/$benchmarkId/runs/$runId"
-              params={{ benchmarkId, runId: run.filename }}
+              to="/projects/$projectId/runs/$runId"
+              params={{ projectId, runId: run.filename }}
               className={`mb-0.5 block rounded-md px-2 py-1.5 text-sm transition-colors ${
                 isActive
                   ? 'bg-gray-800 text-cyan-400'
@@ -464,16 +456,16 @@ function BenchmarkRunDetailSidebar({
   );
 }
 
-function BenchmarkEvalSidebar({
-  benchmarkId,
+function ProjectEvalSidebar({
+  projectId,
   runId,
   currentEvalId,
 }: {
-  benchmarkId: string;
+  projectId: string;
   runId: string;
   currentEvalId: string;
 }) {
-  const { data } = useBenchmarkRunDetail(benchmarkId, runId);
+  const { data } = useProjectRunDetail(projectId, runId);
   const { data: config } = useStudioConfig();
   const passThreshold = config?.threshold ?? config?.pass_threshold ?? 0.8;
 
@@ -487,8 +479,8 @@ function BenchmarkEvalSidebar({
 
       <div className="border-b border-gray-800 px-4 py-2">
         <Link
-          to="/benchmarks/$benchmarkId/runs/$runId"
-          params={{ benchmarkId, runId }}
+          to="/projects/$projectId/runs/$runId"
+          params={{ projectId, runId }}
           className="text-xs text-gray-400 hover:text-cyan-400"
         >
           &larr; Back to run
@@ -506,8 +498,8 @@ function BenchmarkEvalSidebar({
           return (
             <Link
               key={result.testId}
-              to="/benchmarks/$benchmarkId/evals/$runId/$evalId"
-              params={{ benchmarkId, runId, evalId: result.testId }}
+              to="/projects/$projectId/evals/$runId/$evalId"
+              params={{ projectId, runId, evalId: result.testId }}
               className={`mb-0.5 flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${
                 isActive
                   ? 'bg-gray-800 text-cyan-400'

--- a/apps/studio/src/components/StopRunButton.tsx
+++ b/apps/studio/src/components/StopRunButton.tsx
@@ -4,7 +4,7 @@
  * workflow, not a destructive cancel: the partial index.jsonl is
  * preserved and can be resumed in one click from the run-detail page.
  *
- * Calls POST /api/eval/run/:id/stop (or the benchmark-scoped variant).
+ * Calls POST /api/eval/run/:id/stop (or the project-scoped variant).
  * Optimistically flips the local label to "Stopping…" until the next
  * poll of /api/eval/status/:id observes a terminal state — at which
  * point the button hides via `shouldShowStopButton`.
@@ -23,10 +23,10 @@ export interface StopRunButtonProps {
   runId: string;
   status: RunStatus | undefined;
   isReadOnly: boolean;
-  benchmarkId?: string;
+  projectId?: string;
 }
 
-export function StopRunButton({ runId, status, isReadOnly, benchmarkId }: StopRunButtonProps) {
+export function StopRunButton({ runId, status, isReadOnly, projectId }: StopRunButtonProps) {
   const [stopping, setStopping] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -36,7 +36,7 @@ export function StopRunButton({ runId, status, isReadOnly, benchmarkId }: StopRu
     setStopping(true);
     setError(null);
     try {
-      await stopEvalRun(runId, benchmarkId);
+      await stopEvalRun(runId, projectId);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to stop run');
       setStopping(false);

--- a/apps/studio/src/components/TargetsTab.tsx
+++ b/apps/studio/src/components/TargetsTab.tsx
@@ -10,8 +10,8 @@ import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
 
 import {
-  benchmarkRunListOptions,
-  benchmarkTargetsOptions,
+  projectRunListOptions,
+  projectTargetsOptions,
   runListOptions,
   targetsOptions,
 } from '~/lib/api';
@@ -21,7 +21,7 @@ import { PassRatePill } from './PassRatePill';
 import { RunList } from './RunList';
 
 interface TargetsTabProps {
-  benchmarkId?: string;
+  projectId?: string;
 }
 
 interface ExperimentRunGroup {
@@ -33,12 +33,10 @@ interface ExperimentRunGroup {
   passRate: number;
 }
 
-export function TargetsTab({ benchmarkId }: TargetsTabProps = {}) {
+export function TargetsTab({ projectId }: TargetsTabProps = {}) {
   const [selectedTargetName, setSelectedTargetName] = useState<string | null>(null);
-  const targetsQuery = useQuery(
-    benchmarkId ? benchmarkTargetsOptions(benchmarkId) : targetsOptions,
-  );
-  const runsQuery = useQuery(benchmarkId ? benchmarkRunListOptions(benchmarkId) : runListOptions);
+  const targetsQuery = useQuery(projectId ? projectTargetsOptions(projectId) : targetsOptions);
+  const runsQuery = useQuery(projectId ? projectRunListOptions(projectId) : runListOptions);
   const targets = (targetsQuery.data as TargetsResponse | undefined)?.targets ?? [];
   const runs = runsQuery.data?.runs ?? [];
   const error = targetsQuery.error ?? runsQuery.error;
@@ -213,7 +211,7 @@ export function TargetsTab({ benchmarkId }: TargetsTabProps = {}) {
                   <PassRatePill rate={group.passRate} />
                 </div>
               </div>
-              <RunList runs={group.runs} benchmarkId={benchmarkId} />
+              <RunList runs={group.runs} projectId={projectId} />
             </section>
           ))}
         </div>

--- a/apps/studio/src/lib/api.ts
+++ b/apps/studio/src/lib/api.ts
@@ -8,8 +8,6 @@
 import { queryOptions, useQuery } from '@tanstack/react-query';
 
 import type {
-  BenchmarkEntry,
-  BenchmarkListResponse,
   CategoriesResponse,
   CompareResponse,
   EvalDetailResponse,
@@ -24,6 +22,8 @@ import type {
   FileContentResponse,
   FileTreeResponse,
   IndexResponse,
+  ProjectEntry,
+  ProjectListResponse,
   RemoteStatusResponse,
   RunDetailResponse,
   RunEvalRequest,
@@ -73,12 +73,12 @@ export function runDetailOptions(filename: string) {
   });
 }
 
-export function runLogOptions(filename: string, benchmarkId?: string) {
-  const url = benchmarkId
-    ? `${benchmarkApiBase(benchmarkId)}/runs/${encodeURIComponent(filename)}/log`
+export function runLogOptions(filename: string, projectId?: string) {
+  const url = projectId
+    ? `${projectApiBase(projectId)}/runs/${encodeURIComponent(filename)}/log`
     : `/api/runs/${encodeURIComponent(filename)}/log`;
   return queryOptions({
-    queryKey: ['runs', filename, 'log', benchmarkId ?? ''],
+    queryKey: ['runs', filename, 'log', projectId ?? ''],
     queryFn: () => fetchText(url),
     enabled: !!filename,
     // Re-fetch while a run is still capturing output so the viewer streams in.
@@ -86,8 +86,8 @@ export function runLogOptions(filename: string, benchmarkId?: string) {
   });
 }
 
-export function useRunLog(filename: string, benchmarkId?: string) {
-  return useQuery(runLogOptions(filename, benchmarkId));
+export function useRunLog(filename: string, projectId?: string) {
+  return useQuery(runLogOptions(filename, projectId));
 }
 
 export function runSuitesOptions(runId: string) {
@@ -191,10 +191,10 @@ export const studioConfigOptions = queryOptions({
   staleTime: 5_000,
 });
 
-export function remoteStatusOptions(benchmarkId?: string) {
-  const url = benchmarkId ? `${benchmarkApiBase(benchmarkId)}/remote/status` : '/api/remote/status';
+export function remoteStatusOptions(projectId?: string) {
+  const url = projectId ? `${projectApiBase(projectId)}/remote/status` : '/api/remote/status';
   return queryOptions({
-    queryKey: ['remote-status', benchmarkId ?? ''],
+    queryKey: ['remote-status', projectId ?? ''],
     queryFn: () => fetchJson<RemoteStatusResponse>(url),
     staleTime: 5_000,
   });
@@ -254,12 +254,12 @@ export function useCategorySuites(runId: string, category: string) {
   return useQuery(categorySuitesOptions(runId, category));
 }
 
-export function useStudioConfig(benchmarkId?: string) {
-  return useQuery(benchmarkId ? benchmarkConfigOptions(benchmarkId) : studioConfigOptions);
+export function useStudioConfig(projectId?: string) {
+  return useQuery(projectId ? projectConfigOptions(projectId) : studioConfigOptions);
 }
 
-export function useRemoteStatus(benchmarkId?: string) {
-  return useQuery(remoteStatusOptions(benchmarkId));
+export function useRemoteStatus(projectId?: string) {
+  return useQuery(remoteStatusOptions(projectId));
 }
 
 /** Default pass threshold matching @agentv/core DEFAULT_THRESHOLD */
@@ -269,201 +269,197 @@ export function isPassing(score: number, passThreshold: number = DEFAULT_PASS_TH
   return score >= passThreshold;
 }
 
-// ── Benchmark API ────────────────────────────────────────────────────────
+// ── Project API ────────────────────────────────────────────────────────
 
-export const benchmarkListOptions = queryOptions({
-  queryKey: ['benchmarks'],
-  queryFn: () => fetchJson<BenchmarkListResponse>('/api/benchmarks'),
+export const projectListOptions = queryOptions({
+  queryKey: ['projects'],
+  queryFn: () => fetchJson<ProjectListResponse>('/api/projects'),
   refetchInterval: 10_000,
 });
 
-export function useBenchmarkList() {
-  return useQuery(benchmarkListOptions);
+export function useProjectList() {
+  return useQuery(projectListOptions);
 }
 
-export const allBenchmarkRunsOptions = queryOptions({
-  queryKey: ['benchmarks', 'all-runs'],
-  queryFn: () => fetchJson<RunListResponse>('/api/benchmarks/all-runs'),
+export const allProjectRunsOptions = queryOptions({
+  queryKey: ['projects', 'all-runs'],
+  queryFn: () => fetchJson<RunListResponse>('/api/projects/all-runs'),
   refetchInterval: 5_000,
 });
 
-export function useAllBenchmarkRuns() {
-  return useQuery(allBenchmarkRunsOptions);
+export function useAllProjectRuns() {
+  return useQuery(allProjectRunsOptions);
 }
 
-export async function addBenchmarkApi(benchmarkPath: string): Promise<BenchmarkEntry> {
-  const res = await fetch('/api/benchmarks', {
+export async function addProjectApi(projectPath: string): Promise<ProjectEntry> {
+  const res = await fetch('/api/projects', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ path: benchmarkPath }),
+    body: JSON.stringify({ path: projectPath }),
   });
   if (!res.ok) {
     const err = (await res.json()) as { error: string };
-    throw new Error(err.error || `Failed to add benchmark: ${res.status}`);
+    throw new Error(err.error || `Failed to add project: ${res.status}`);
   }
-  return res.json() as Promise<BenchmarkEntry>;
+  return res.json() as Promise<ProjectEntry>;
 }
 
-export async function removeBenchmarkApi(benchmarkId: string): Promise<void> {
-  const res = await fetch(`/api/benchmarks/${encodeURIComponent(benchmarkId)}`, {
+export async function removeProjectApi(projectId: string): Promise<void> {
+  const res = await fetch(`/api/projects/${encodeURIComponent(projectId)}`, {
     method: 'DELETE',
   });
   if (!res.ok) {
-    throw new Error(`Failed to remove benchmark: ${res.status}`);
+    throw new Error(`Failed to remove project: ${res.status}`);
   }
 }
 
-/** Build the API base URL for a benchmark-scoped request. */
-function benchmarkApiBase(benchmarkId: string): string {
-  return `/api/benchmarks/${encodeURIComponent(benchmarkId)}`;
+/** Build the API base URL for a project-scoped request. */
+function projectApiBase(projectId: string): string {
+  return `/api/projects/${encodeURIComponent(projectId)}`;
 }
 
-export function benchmarkRunListOptions(benchmarkId: string) {
+export function projectRunListOptions(projectId: string) {
   return queryOptions({
-    queryKey: ['benchmarks', benchmarkId, 'runs'],
-    queryFn: () => fetchJson<RunListResponse>(`${benchmarkApiBase(benchmarkId)}/runs`),
-    enabled: !!benchmarkId,
+    queryKey: ['projects', projectId, 'runs'],
+    queryFn: () => fetchJson<RunListResponse>(`${projectApiBase(projectId)}/runs`),
+    enabled: !!projectId,
     refetchInterval: 5_000,
   });
 }
 
-export function useBenchmarkRunList(benchmarkId: string) {
-  return useQuery(benchmarkRunListOptions(benchmarkId));
+export function useProjectRunList(projectId: string) {
+  return useQuery(projectRunListOptions(projectId));
 }
 
-export function benchmarkRunDetailOptions(benchmarkId: string, filename: string) {
+export function projectRunDetailOptions(projectId: string, filename: string) {
   return queryOptions({
-    queryKey: ['benchmarks', benchmarkId, 'runs', filename],
+    queryKey: ['projects', projectId, 'runs', filename],
     queryFn: () =>
       fetchJson<RunDetailResponse>(
-        `${benchmarkApiBase(benchmarkId)}/runs/${encodeURIComponent(filename)}`,
+        `${projectApiBase(projectId)}/runs/${encodeURIComponent(filename)}`,
       ),
-    enabled: !!benchmarkId && !!filename,
+    enabled: !!projectId && !!filename,
   });
 }
 
-export function useBenchmarkRunDetail(benchmarkId: string, filename: string) {
-  return useQuery(benchmarkRunDetailOptions(benchmarkId, filename));
+export function useProjectRunDetail(projectId: string, filename: string) {
+  return useQuery(projectRunDetailOptions(projectId, filename));
 }
 
-export function benchmarkRunSuitesOptions(benchmarkId: string, runId: string) {
+export function projectRunSuitesOptions(projectId: string, runId: string) {
   return queryOptions({
-    queryKey: ['benchmarks', benchmarkId, 'runs', runId, 'suites'],
+    queryKey: ['projects', projectId, 'runs', runId, 'suites'],
     queryFn: () =>
       fetchJson<SuitesResponse>(
-        `${benchmarkApiBase(benchmarkId)}/runs/${encodeURIComponent(runId)}/suites`,
+        `${projectApiBase(projectId)}/runs/${encodeURIComponent(runId)}/suites`,
       ),
-    enabled: !!benchmarkId && !!runId,
+    enabled: !!projectId && !!runId,
   });
 }
 
-export function benchmarkRunCategoriesOptions(benchmarkId: string, runId: string) {
+export function projectRunCategoriesOptions(projectId: string, runId: string) {
   return queryOptions({
-    queryKey: ['benchmarks', benchmarkId, 'runs', runId, 'categories'],
+    queryKey: ['projects', projectId, 'runs', runId, 'categories'],
     queryFn: () =>
       fetchJson<CategoriesResponse>(
-        `${benchmarkApiBase(benchmarkId)}/runs/${encodeURIComponent(runId)}/categories`,
+        `${projectApiBase(projectId)}/runs/${encodeURIComponent(runId)}/categories`,
       ),
-    enabled: !!benchmarkId && !!runId,
+    enabled: !!projectId && !!runId,
   });
 }
 
-export function benchmarkCategorySuitesOptions(
-  benchmarkId: string,
-  runId: string,
-  category: string,
-) {
+export function projectCategorySuitesOptions(projectId: string, runId: string, category: string) {
   return queryOptions({
-    queryKey: ['benchmarks', benchmarkId, 'runs', runId, 'categories', category, 'suites'],
+    queryKey: ['projects', projectId, 'runs', runId, 'categories', category, 'suites'],
     queryFn: () =>
       fetchJson<SuitesResponse>(
-        `${benchmarkApiBase(benchmarkId)}/runs/${encodeURIComponent(runId)}/categories/${encodeURIComponent(category)}/suites`,
+        `${projectApiBase(projectId)}/runs/${encodeURIComponent(runId)}/categories/${encodeURIComponent(category)}/suites`,
       ),
-    enabled: !!benchmarkId && !!runId && !!category,
+    enabled: !!projectId && !!runId && !!category,
   });
 }
 
-export function benchmarkEvalDetailOptions(benchmarkId: string, runId: string, evalId: string) {
+export function projectEvalDetailOptions(projectId: string, runId: string, evalId: string) {
   return queryOptions({
-    queryKey: ['benchmarks', benchmarkId, 'runs', runId, 'evals', evalId],
+    queryKey: ['projects', projectId, 'runs', runId, 'evals', evalId],
     queryFn: () =>
       fetchJson<EvalDetailResponse>(
-        `${benchmarkApiBase(benchmarkId)}/runs/${encodeURIComponent(runId)}/evals/${encodeURIComponent(evalId)}`,
+        `${projectApiBase(projectId)}/runs/${encodeURIComponent(runId)}/evals/${encodeURIComponent(evalId)}`,
       ),
-    enabled: !!benchmarkId && !!runId && !!evalId,
+    enabled: !!projectId && !!runId && !!evalId,
   });
 }
 
-export function benchmarkEvalFilesOptions(benchmarkId: string, runId: string, evalId: string) {
+export function projectEvalFilesOptions(projectId: string, runId: string, evalId: string) {
   return queryOptions({
-    queryKey: ['benchmarks', benchmarkId, 'runs', runId, 'evals', evalId, 'files'],
+    queryKey: ['projects', projectId, 'runs', runId, 'evals', evalId, 'files'],
     queryFn: () =>
       fetchJson<FileTreeResponse>(
-        `${benchmarkApiBase(benchmarkId)}/runs/${encodeURIComponent(runId)}/evals/${encodeURIComponent(evalId)}/files`,
+        `${projectApiBase(projectId)}/runs/${encodeURIComponent(runId)}/evals/${encodeURIComponent(evalId)}/files`,
       ),
-    enabled: !!benchmarkId && !!runId && !!evalId,
+    enabled: !!projectId && !!runId && !!evalId,
   });
 }
 
-export function benchmarkEvalFileContentOptions(
-  benchmarkId: string,
+export function projectEvalFileContentOptions(
+  projectId: string,
   runId: string,
   evalId: string,
   filePath: string,
 ) {
   return queryOptions({
-    queryKey: ['benchmarks', benchmarkId, 'runs', runId, 'evals', evalId, 'files', filePath],
+    queryKey: ['projects', projectId, 'runs', runId, 'evals', evalId, 'files', filePath],
     queryFn: () =>
       fetchJson<FileContentResponse>(
-        `${benchmarkApiBase(benchmarkId)}/runs/${encodeURIComponent(runId)}/evals/${encodeURIComponent(evalId)}/files/${filePath}`,
+        `${projectApiBase(projectId)}/runs/${encodeURIComponent(runId)}/evals/${encodeURIComponent(evalId)}/files/${filePath}`,
       ),
-    enabled: !!benchmarkId && !!runId && !!evalId && !!filePath,
+    enabled: !!projectId && !!runId && !!evalId && !!filePath,
   });
 }
 
-export function benchmarkExperimentsOptions(benchmarkId: string) {
+export function projectExperimentsOptions(projectId: string) {
   return queryOptions({
-    queryKey: ['benchmarks', benchmarkId, 'experiments'],
-    queryFn: () => fetchJson<ExperimentsResponse>(`${benchmarkApiBase(benchmarkId)}/experiments`),
-    enabled: !!benchmarkId,
+    queryKey: ['projects', projectId, 'experiments'],
+    queryFn: () => fetchJson<ExperimentsResponse>(`${projectApiBase(projectId)}/experiments`),
+    enabled: !!projectId,
   });
 }
 
-export function benchmarkCompareOptions(benchmarkId: string, baseline?: string) {
-  const base = `${benchmarkApiBase(benchmarkId)}/compare`;
+export function projectCompareOptions(projectId: string, baseline?: string) {
+  const base = `${projectApiBase(projectId)}/compare`;
   if (baseline) {
     return queryOptions({
-      queryKey: ['benchmarks', benchmarkId, 'compare', 'baseline', baseline],
+      queryKey: ['projects', projectId, 'compare', 'baseline', baseline],
       queryFn: () => fetchJson<CompareResponse>(`${base}?baseline=${encodeURIComponent(baseline)}`),
-      enabled: !!benchmarkId,
+      enabled: !!projectId,
     });
   }
   return queryOptions({
-    queryKey: ['benchmarks', benchmarkId, 'compare'],
+    queryKey: ['projects', projectId, 'compare'],
     queryFn: () => fetchJson<CompareResponse>(base),
-    enabled: !!benchmarkId,
+    enabled: !!projectId,
   });
 }
 
-export function benchmarkTargetsOptions(benchmarkId: string) {
+export function projectTargetsOptions(projectId: string) {
   return queryOptions({
-    queryKey: ['benchmarks', benchmarkId, 'targets'],
-    queryFn: () => fetchJson<TargetsResponse>(`${benchmarkApiBase(benchmarkId)}/targets`),
-    enabled: !!benchmarkId,
+    queryKey: ['projects', projectId, 'targets'],
+    queryFn: () => fetchJson<TargetsResponse>(`${projectApiBase(projectId)}/targets`),
+    enabled: !!projectId,
   });
 }
 
-export function benchmarkConfigOptions(benchmarkId: string) {
+export function projectConfigOptions(projectId: string) {
   return queryOptions({
-    queryKey: ['benchmarks', benchmarkId, 'config'],
-    queryFn: () => fetchJson<StudioConfigResponse>(`${benchmarkApiBase(benchmarkId)}/config`),
-    enabled: !!benchmarkId,
+    queryKey: ['projects', projectId, 'config'],
+    queryFn: () => fetchJson<StudioConfigResponse>(`${projectApiBase(projectId)}/config`),
+    enabled: !!projectId,
     staleTime: 5_000,
   });
 }
 
-export async function syncRemoteResultsApi(benchmarkId?: string): Promise<RemoteStatusResponse> {
-  const url = benchmarkId ? `${benchmarkApiBase(benchmarkId)}/remote/sync` : '/api/remote/sync';
+export async function syncRemoteResultsApi(projectId?: string): Promise<RemoteStatusResponse> {
+  const url = projectId ? `${projectApiBase(projectId)}/remote/sync` : '/api/remote/sync';
   const res = await fetch(url, {
     method: 'POST',
   });
@@ -483,10 +479,10 @@ export async function syncRemoteResultsApi(benchmarkId?: string): Promise<Remote
 export async function saveRunTagsApi(
   runId: string,
   tags: string[],
-  benchmarkId?: string,
+  projectId?: string,
 ): Promise<RunTagsResponse> {
-  const url = benchmarkId
-    ? `${benchmarkApiBase(benchmarkId)}/runs/${encodeURIComponent(runId)}/tags`
+  const url = projectId
+    ? `${projectApiBase(projectId)}/runs/${encodeURIComponent(runId)}/tags`
     : `/api/runs/${encodeURIComponent(runId)}/tags`;
   const res = await fetch(url, {
     method: 'PUT',
@@ -501,9 +497,9 @@ export async function saveRunTagsApi(
 }
 
 /** Remove the tags sidecar for a run. */
-export async function deleteRunTagsApi(runId: string, benchmarkId?: string): Promise<void> {
-  const url = benchmarkId
-    ? `${benchmarkApiBase(benchmarkId)}/runs/${encodeURIComponent(runId)}/tags`
+export async function deleteRunTagsApi(runId: string, projectId?: string): Promise<void> {
+  const url = projectId
+    ? `${projectApiBase(projectId)}/runs/${encodeURIComponent(runId)}/tags`
     : `/api/runs/${encodeURIComponent(runId)}/tags`;
   const res = await fetch(url, { method: 'DELETE' });
   if (!res.ok) {
@@ -528,37 +524,37 @@ export async function saveStudioConfig(
 
 // ── Eval runner queries & mutations ──────────────────────────────────────
 
-export function evalDiscoverOptions(benchmarkId?: string) {
-  const url = benchmarkId ? `${benchmarkApiBase(benchmarkId)}/eval/discover` : '/api/eval/discover';
+export function evalDiscoverOptions(projectId?: string) {
+  const url = projectId ? `${projectApiBase(projectId)}/eval/discover` : '/api/eval/discover';
   return queryOptions({
-    queryKey: ['eval-discover', benchmarkId ?? ''],
+    queryKey: ['eval-discover', projectId ?? ''],
     queryFn: () => fetchJson<EvalDiscoverResponse>(url),
     staleTime: 30_000,
   });
 }
 
-export function useEvalDiscover(benchmarkId?: string) {
-  return useQuery(evalDiscoverOptions(benchmarkId));
+export function useEvalDiscover(projectId?: string) {
+  return useQuery(evalDiscoverOptions(projectId));
 }
 
-export function evalTargetsOptions(benchmarkId?: string) {
-  const url = benchmarkId ? `${benchmarkApiBase(benchmarkId)}/eval/targets` : '/api/eval/targets';
+export function evalTargetsOptions(projectId?: string) {
+  const url = projectId ? `${projectApiBase(projectId)}/eval/targets` : '/api/eval/targets';
   return queryOptions({
-    queryKey: ['eval-targets', benchmarkId ?? ''],
+    queryKey: ['eval-targets', projectId ?? ''],
     queryFn: () => fetchJson<EvalTargetsResponse>(url),
     staleTime: 30_000,
   });
 }
 
-export function useEvalTargets(benchmarkId?: string) {
-  return useQuery(evalTargetsOptions(benchmarkId));
+export function useEvalTargets(projectId?: string) {
+  return useQuery(evalTargetsOptions(projectId));
 }
 
 export async function launchEvalRun(
   body: RunEvalRequest,
-  benchmarkId?: string,
+  projectId?: string,
 ): Promise<EvalRunResponse> {
-  const url = benchmarkId ? `${benchmarkApiBase(benchmarkId)}/eval/run` : '/api/eval/run';
+  const url = projectId ? `${projectApiBase(projectId)}/eval/run` : '/api/eval/run';
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -573,10 +569,10 @@ export async function launchEvalRun(
 
 export async function stopEvalRun(
   runId: string,
-  benchmarkId?: string,
+  projectId?: string,
 ): Promise<{ stopped: boolean; reason?: string; status?: string }> {
-  const url = benchmarkId
-    ? `${benchmarkApiBase(benchmarkId)}/eval/run/${runId}/stop`
+  const url = projectId
+    ? `${projectApiBase(projectId)}/eval/run/${runId}/stop`
     : `/api/eval/run/${runId}/stop`;
   const res = await fetch(url, { method: 'POST' });
   if (!res.ok) {
@@ -603,24 +599,24 @@ export function useEvalRunStatus(runId: string | null) {
   return useQuery(evalRunStatusOptions(runId));
 }
 
-export function evalRunsOptions(benchmarkId?: string) {
-  const url = benchmarkId ? `${benchmarkApiBase(benchmarkId)}/eval/runs` : '/api/eval/runs';
+export function evalRunsOptions(projectId?: string) {
+  const url = projectId ? `${projectApiBase(projectId)}/eval/runs` : '/api/eval/runs';
   return queryOptions({
-    queryKey: ['eval-runs', benchmarkId ?? ''],
+    queryKey: ['eval-runs', projectId ?? ''],
     queryFn: () => fetchJson<EvalRunListResponse>(url),
     refetchInterval: 3_000,
   });
 }
 
-export function useEvalRuns(benchmarkId?: string) {
-  return useQuery(evalRunsOptions(benchmarkId));
+export function useEvalRuns(projectId?: string) {
+  return useQuery(evalRunsOptions(projectId));
 }
 
 export async function previewEvalCommand(
   body: RunEvalRequest,
-  benchmarkId?: string,
+  projectId?: string,
 ): Promise<EvalPreviewResponse> {
-  const url = benchmarkId ? `${benchmarkApiBase(benchmarkId)}/eval/preview` : '/api/eval/preview';
+  const url = projectId ? `${projectApiBase(projectId)}/eval/preview` : '/api/eval/preview';
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/apps/studio/src/lib/types.ts
+++ b/apps/studio/src/lib/types.ts
@@ -17,8 +17,8 @@ export interface RunMeta {
   target?: string;
   experiment?: string;
   source: 'local' | 'remote';
-  benchmark_id?: string;
-  benchmark_name?: string;
+  project_id?: string;
+  project_name?: string;
   /** Optional user-assigned tags from the run's sidecar tags.json. */
   tags?: string[];
   /**
@@ -249,8 +249,8 @@ export interface StudioConfigResponse {
   /** @deprecated Use threshold */
   pass_threshold?: number;
   read_only?: boolean;
-  benchmark_name?: string;
-  multi_benchmark_dashboard?: boolean;
+  project_name?: string;
+  multi_project_dashboard?: boolean;
 }
 
 export interface RemoteStatusResponse {
@@ -266,9 +266,9 @@ export interface RemoteStatusResponse {
   last_error?: string;
 }
 
-// ── Benchmark types ──────────────────────────────────────────────────────
+// ── Project types ──────────────────────────────────────────────────────
 
-export interface BenchmarkSummary {
+export interface ProjectSummary {
   id: string;
   name: string;
   path: string;
@@ -279,11 +279,11 @@ export interface BenchmarkSummary {
   last_run: string | null;
 }
 
-export interface BenchmarkListResponse {
-  benchmarks: BenchmarkSummary[];
+export interface ProjectListResponse {
+  projects: ProjectSummary[];
 }
 
-export interface BenchmarkEntry {
+export interface ProjectEntry {
   id: string;
   name: string;
   path: string;

--- a/apps/studio/src/routeTree.gen.ts
+++ b/apps/studio/src/routeTree.gen.ts
@@ -12,14 +12,14 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as RunsRunIdRouteImport } from './routes/runs/$runId'
+import { Route as ProjectsProjectIdRouteImport } from './routes/projects/$projectId'
 import { Route as JobsRunIdRouteImport } from './routes/jobs/$runId'
 import { Route as ExperimentsExperimentNameRouteImport } from './routes/experiments/$experimentName'
-import { Route as BenchmarksBenchmarkIdRouteImport } from './routes/benchmarks/$benchmarkId'
 import { Route as EvalsRunIdEvalIdRouteImport } from './routes/evals/$runId.$evalId'
 import { Route as RunsRunIdSuiteSuiteRouteImport } from './routes/runs/$runId_.suite.$suite'
 import { Route as RunsRunIdCategoryCategoryRouteImport } from './routes/runs/$runId_.category.$category'
-import { Route as BenchmarksBenchmarkIdRunsRunIdRouteImport } from './routes/benchmarks/$benchmarkId_/runs/$runId'
-import { Route as BenchmarksBenchmarkIdEvalsRunIdEvalIdRouteImport } from './routes/benchmarks/$benchmarkId_/evals/$runId.$evalId'
+import { Route as ProjectsProjectIdRunsRunIdRouteImport } from './routes/projects/$projectId_/runs/$runId'
+import { Route as ProjectsProjectIdEvalsRunIdEvalIdRouteImport } from './routes/projects/$projectId_/evals/$runId.$evalId'
 
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
@@ -36,6 +36,11 @@ const RunsRunIdRoute = RunsRunIdRouteImport.update({
   path: '/runs/$runId',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ProjectsProjectIdRoute = ProjectsProjectIdRouteImport.update({
+  id: '/projects/$projectId',
+  path: '/projects/$projectId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const JobsRunIdRoute = JobsRunIdRouteImport.update({
   id: '/jobs/$runId',
   path: '/jobs/$runId',
@@ -47,11 +52,6 @@ const ExperimentsExperimentNameRoute =
     path: '/experiments/$experimentName',
     getParentRoute: () => rootRouteImport,
   } as any)
-const BenchmarksBenchmarkIdRoute = BenchmarksBenchmarkIdRouteImport.update({
-  id: '/benchmarks/$benchmarkId',
-  path: '/benchmarks/$benchmarkId',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const EvalsRunIdEvalIdRoute = EvalsRunIdEvalIdRouteImport.update({
   id: '/evals/$runId/$evalId',
   path: '/evals/$runId/$evalId',
@@ -68,113 +68,113 @@ const RunsRunIdCategoryCategoryRoute =
     path: '/runs/$runId/category/$category',
     getParentRoute: () => rootRouteImport,
   } as any)
-const BenchmarksBenchmarkIdRunsRunIdRoute =
-  BenchmarksBenchmarkIdRunsRunIdRouteImport.update({
-    id: '/benchmarks/$benchmarkId_/runs/$runId',
-    path: '/benchmarks/$benchmarkId/runs/$runId',
+const ProjectsProjectIdRunsRunIdRoute =
+  ProjectsProjectIdRunsRunIdRouteImport.update({
+    id: '/projects/$projectId_/runs/$runId',
+    path: '/projects/$projectId/runs/$runId',
     getParentRoute: () => rootRouteImport,
   } as any)
-const BenchmarksBenchmarkIdEvalsRunIdEvalIdRoute =
-  BenchmarksBenchmarkIdEvalsRunIdEvalIdRouteImport.update({
-    id: '/benchmarks/$benchmarkId_/evals/$runId/$evalId',
-    path: '/benchmarks/$benchmarkId/evals/$runId/$evalId',
+const ProjectsProjectIdEvalsRunIdEvalIdRoute =
+  ProjectsProjectIdEvalsRunIdEvalIdRouteImport.update({
+    id: '/projects/$projectId_/evals/$runId/$evalId',
+    path: '/projects/$projectId/evals/$runId/$evalId',
     getParentRoute: () => rootRouteImport,
   } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/settings': typeof SettingsRoute
-  '/benchmarks/$benchmarkId': typeof BenchmarksBenchmarkIdRoute
   '/experiments/$experimentName': typeof ExperimentsExperimentNameRoute
   '/jobs/$runId': typeof JobsRunIdRoute
+  '/projects/$projectId': typeof ProjectsProjectIdRoute
   '/runs/$runId': typeof RunsRunIdRoute
   '/evals/$runId/$evalId': typeof EvalsRunIdEvalIdRoute
-  '/benchmarks/$benchmarkId/runs/$runId': typeof BenchmarksBenchmarkIdRunsRunIdRoute
+  '/projects/$projectId/runs/$runId': typeof ProjectsProjectIdRunsRunIdRoute
   '/runs/$runId/category/$category': typeof RunsRunIdCategoryCategoryRoute
   '/runs/$runId/suite/$suite': typeof RunsRunIdSuiteSuiteRoute
-  '/benchmarks/$benchmarkId/evals/$runId/$evalId': typeof BenchmarksBenchmarkIdEvalsRunIdEvalIdRoute
+  '/projects/$projectId/evals/$runId/$evalId': typeof ProjectsProjectIdEvalsRunIdEvalIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/settings': typeof SettingsRoute
-  '/benchmarks/$benchmarkId': typeof BenchmarksBenchmarkIdRoute
   '/experiments/$experimentName': typeof ExperimentsExperimentNameRoute
   '/jobs/$runId': typeof JobsRunIdRoute
+  '/projects/$projectId': typeof ProjectsProjectIdRoute
   '/runs/$runId': typeof RunsRunIdRoute
   '/evals/$runId/$evalId': typeof EvalsRunIdEvalIdRoute
-  '/benchmarks/$benchmarkId/runs/$runId': typeof BenchmarksBenchmarkIdRunsRunIdRoute
+  '/projects/$projectId/runs/$runId': typeof ProjectsProjectIdRunsRunIdRoute
   '/runs/$runId/category/$category': typeof RunsRunIdCategoryCategoryRoute
   '/runs/$runId/suite/$suite': typeof RunsRunIdSuiteSuiteRoute
-  '/benchmarks/$benchmarkId/evals/$runId/$evalId': typeof BenchmarksBenchmarkIdEvalsRunIdEvalIdRoute
+  '/projects/$projectId/evals/$runId/$evalId': typeof ProjectsProjectIdEvalsRunIdEvalIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/settings': typeof SettingsRoute
-  '/benchmarks/$benchmarkId': typeof BenchmarksBenchmarkIdRoute
   '/experiments/$experimentName': typeof ExperimentsExperimentNameRoute
   '/jobs/$runId': typeof JobsRunIdRoute
+  '/projects/$projectId': typeof ProjectsProjectIdRoute
   '/runs/$runId': typeof RunsRunIdRoute
   '/evals/$runId/$evalId': typeof EvalsRunIdEvalIdRoute
-  '/benchmarks/$benchmarkId_/runs/$runId': typeof BenchmarksBenchmarkIdRunsRunIdRoute
+  '/projects/$projectId_/runs/$runId': typeof ProjectsProjectIdRunsRunIdRoute
   '/runs/$runId_/category/$category': typeof RunsRunIdCategoryCategoryRoute
   '/runs/$runId_/suite/$suite': typeof RunsRunIdSuiteSuiteRoute
-  '/benchmarks/$benchmarkId_/evals/$runId/$evalId': typeof BenchmarksBenchmarkIdEvalsRunIdEvalIdRoute
+  '/projects/$projectId_/evals/$runId/$evalId': typeof ProjectsProjectIdEvalsRunIdEvalIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
     | '/settings'
-    | '/benchmarks/$benchmarkId'
     | '/experiments/$experimentName'
     | '/jobs/$runId'
+    | '/projects/$projectId'
     | '/runs/$runId'
     | '/evals/$runId/$evalId'
-    | '/benchmarks/$benchmarkId/runs/$runId'
+    | '/projects/$projectId/runs/$runId'
     | '/runs/$runId/category/$category'
     | '/runs/$runId/suite/$suite'
-    | '/benchmarks/$benchmarkId/evals/$runId/$evalId'
+    | '/projects/$projectId/evals/$runId/$evalId'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/settings'
-    | '/benchmarks/$benchmarkId'
     | '/experiments/$experimentName'
     | '/jobs/$runId'
+    | '/projects/$projectId'
     | '/runs/$runId'
     | '/evals/$runId/$evalId'
-    | '/benchmarks/$benchmarkId/runs/$runId'
+    | '/projects/$projectId/runs/$runId'
     | '/runs/$runId/category/$category'
     | '/runs/$runId/suite/$suite'
-    | '/benchmarks/$benchmarkId/evals/$runId/$evalId'
+    | '/projects/$projectId/evals/$runId/$evalId'
   id:
     | '__root__'
     | '/'
     | '/settings'
-    | '/benchmarks/$benchmarkId'
     | '/experiments/$experimentName'
     | '/jobs/$runId'
+    | '/projects/$projectId'
     | '/runs/$runId'
     | '/evals/$runId/$evalId'
-    | '/benchmarks/$benchmarkId_/runs/$runId'
+    | '/projects/$projectId_/runs/$runId'
     | '/runs/$runId_/category/$category'
     | '/runs/$runId_/suite/$suite'
-    | '/benchmarks/$benchmarkId_/evals/$runId/$evalId'
+    | '/projects/$projectId_/evals/$runId/$evalId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   SettingsRoute: typeof SettingsRoute
-  BenchmarksBenchmarkIdRoute: typeof BenchmarksBenchmarkIdRoute
   ExperimentsExperimentNameRoute: typeof ExperimentsExperimentNameRoute
   JobsRunIdRoute: typeof JobsRunIdRoute
+  ProjectsProjectIdRoute: typeof ProjectsProjectIdRoute
   RunsRunIdRoute: typeof RunsRunIdRoute
   EvalsRunIdEvalIdRoute: typeof EvalsRunIdEvalIdRoute
-  BenchmarksBenchmarkIdRunsRunIdRoute: typeof BenchmarksBenchmarkIdRunsRunIdRoute
+  ProjectsProjectIdRunsRunIdRoute: typeof ProjectsProjectIdRunsRunIdRoute
   RunsRunIdCategoryCategoryRoute: typeof RunsRunIdCategoryCategoryRoute
   RunsRunIdSuiteSuiteRoute: typeof RunsRunIdSuiteSuiteRoute
-  BenchmarksBenchmarkIdEvalsRunIdEvalIdRoute: typeof BenchmarksBenchmarkIdEvalsRunIdEvalIdRoute
+  ProjectsProjectIdEvalsRunIdEvalIdRoute: typeof ProjectsProjectIdEvalsRunIdEvalIdRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -200,6 +200,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof RunsRunIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/projects/$projectId': {
+      id: '/projects/$projectId'
+      path: '/projects/$projectId'
+      fullPath: '/projects/$projectId'
+      preLoaderRoute: typeof ProjectsProjectIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/jobs/$runId': {
       id: '/jobs/$runId'
       path: '/jobs/$runId'
@@ -212,13 +219,6 @@ declare module '@tanstack/react-router' {
       path: '/experiments/$experimentName'
       fullPath: '/experiments/$experimentName'
       preLoaderRoute: typeof ExperimentsExperimentNameRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/benchmarks/$benchmarkId': {
-      id: '/benchmarks/$benchmarkId'
-      path: '/benchmarks/$benchmarkId'
-      fullPath: '/benchmarks/$benchmarkId'
-      preLoaderRoute: typeof BenchmarksBenchmarkIdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/evals/$runId/$evalId': {
@@ -242,18 +242,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof RunsRunIdCategoryCategoryRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/benchmarks/$benchmarkId_/runs/$runId': {
-      id: '/benchmarks/$benchmarkId_/runs/$runId'
-      path: '/benchmarks/$benchmarkId/runs/$runId'
-      fullPath: '/benchmarks/$benchmarkId/runs/$runId'
-      preLoaderRoute: typeof BenchmarksBenchmarkIdRunsRunIdRouteImport
+    '/projects/$projectId_/runs/$runId': {
+      id: '/projects/$projectId_/runs/$runId'
+      path: '/projects/$projectId/runs/$runId'
+      fullPath: '/projects/$projectId/runs/$runId'
+      preLoaderRoute: typeof ProjectsProjectIdRunsRunIdRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/benchmarks/$benchmarkId_/evals/$runId/$evalId': {
-      id: '/benchmarks/$benchmarkId_/evals/$runId/$evalId'
-      path: '/benchmarks/$benchmarkId/evals/$runId/$evalId'
-      fullPath: '/benchmarks/$benchmarkId/evals/$runId/$evalId'
-      preLoaderRoute: typeof BenchmarksBenchmarkIdEvalsRunIdEvalIdRouteImport
+    '/projects/$projectId_/evals/$runId/$evalId': {
+      id: '/projects/$projectId_/evals/$runId/$evalId'
+      path: '/projects/$projectId/evals/$runId/$evalId'
+      fullPath: '/projects/$projectId/evals/$runId/$evalId'
+      preLoaderRoute: typeof ProjectsProjectIdEvalsRunIdEvalIdRouteImport
       parentRoute: typeof rootRouteImport
     }
   }
@@ -262,16 +262,16 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   SettingsRoute: SettingsRoute,
-  BenchmarksBenchmarkIdRoute: BenchmarksBenchmarkIdRoute,
   ExperimentsExperimentNameRoute: ExperimentsExperimentNameRoute,
   JobsRunIdRoute: JobsRunIdRoute,
+  ProjectsProjectIdRoute: ProjectsProjectIdRoute,
   RunsRunIdRoute: RunsRunIdRoute,
   EvalsRunIdEvalIdRoute: EvalsRunIdEvalIdRoute,
-  BenchmarksBenchmarkIdRunsRunIdRoute: BenchmarksBenchmarkIdRunsRunIdRoute,
+  ProjectsProjectIdRunsRunIdRoute: ProjectsProjectIdRunsRunIdRoute,
   RunsRunIdCategoryCategoryRoute: RunsRunIdCategoryCategoryRoute,
   RunsRunIdSuiteSuiteRoute: RunsRunIdSuiteSuiteRoute,
-  BenchmarksBenchmarkIdEvalsRunIdEvalIdRoute:
-    BenchmarksBenchmarkIdEvalsRunIdEvalIdRoute,
+  ProjectsProjectIdEvalsRunIdEvalIdRoute:
+    ProjectsProjectIdEvalsRunIdEvalIdRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/studio/src/routes/index.tsx
+++ b/apps/studio/src/routes/index.tsx
@@ -1,7 +1,7 @@
 /**
- * Home route: shows the multi-benchmark dashboard when the server enables it,
+ * Home route: shows the multi-project dashboard when the server enables it,
  * or the existing tabbed landing page (Runs, Experiments, Analytics, Targets)
- * in single-benchmark mode.
+ * in single-project mode.
  *
  * Uses URL search param `?tab=` for tab persistence.
  */
@@ -11,18 +11,18 @@ import { useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
 import { AnalyticsTab } from '~/components/AnalyticsTab';
-import { BenchmarkCard } from '~/components/BenchmarkCard';
 import { ExperimentsTab } from '~/components/ExperimentsTab';
+import { ProjectCard } from '~/components/ProjectCard';
 import { RunEvalModal } from '~/components/RunEvalModal';
 import { RunList } from '~/components/RunList';
 import { type RunSourceFilter, RunSourceToolbar } from '~/components/RunSourceToolbar';
 import { TargetsTab } from '~/components/TargetsTab';
 import {
-  addBenchmarkApi,
+  addProjectApi,
   syncRemoteResultsApi,
-  useBenchmarkList,
   useCompare,
   useEvalRuns,
+  useProjectList,
   useRemoteStatus,
   useRunList,
   useStudioConfig,
@@ -42,29 +42,26 @@ export const Route = createFileRoute('/')({
 });
 
 function HomePage() {
-  const { data: benchmarkData, isLoading: benchmarksLoading } = useBenchmarkList();
+  const { data: projectData, isLoading: projectsLoading } = useProjectList();
   const { data: config, isLoading: configLoading } = useStudioConfig();
-  const hasBenchmarks = (benchmarkData?.benchmarks.length ?? 0) > 0;
-  const multiBenchmarkDashboard = config?.multi_benchmark_dashboard;
+  const hasProjects = (projectData?.projects.length ?? 0) > 0;
+  const multiProjectDashboard = config?.multi_project_dashboard;
 
-  if (benchmarksLoading || configLoading) {
+  if (projectsLoading || configLoading) {
     return <LoadingSkeleton />;
   }
 
-  if (
-    multiBenchmarkDashboard === true ||
-    (multiBenchmarkDashboard === undefined && hasBenchmarks)
-  ) {
-    return <BenchmarksDashboard />;
+  if (multiProjectDashboard === true || (multiProjectDashboard === undefined && hasProjects)) {
+    return <ProjectsDashboard />;
   }
 
-  return <SingleBenchmarkHome />;
+  return <SingleProjectHome />;
 }
 
-// ── Benchmarks Dashboard ────────────────────────────────────────────────
+// ── Projects Dashboard ────────────────────────────────────────────────
 
-function BenchmarksDashboard() {
-  const { data } = useBenchmarkList();
+function ProjectsDashboard() {
+  const { data } = useProjectList();
   const { data: config } = useStudioConfig();
   const queryClient = useQueryClient();
   const [addPath, setAddPath] = useState('');
@@ -72,18 +69,18 @@ function BenchmarksDashboard() {
   const [showAddForm, setShowAddForm] = useState(false);
   const [showRunEval, setShowRunEval] = useState(false);
 
-  const benchmarks = data?.benchmarks ?? [];
+  const projects = data?.projects ?? [];
   const isReadOnly = config?.read_only === true;
 
-  async function handleAddBenchmark(e: React.FormEvent) {
+  async function handleAddProject(e: React.FormEvent) {
     e.preventDefault();
     if (!addPath.trim()) return;
     setError(null);
     try {
-      await addBenchmarkApi(addPath.trim());
+      await addProjectApi(addPath.trim());
       setAddPath('');
       setShowAddForm(false);
-      queryClient.invalidateQueries({ queryKey: ['benchmarks'] });
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
     } catch (err) {
       setError((err as Error).message);
     }
@@ -92,7 +89,7 @@ function BenchmarksDashboard() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold text-white">Benchmarks</h1>
+        <h1 className="text-2xl font-semibold text-white">Projects</h1>
         <div className="flex gap-2">
           {!isReadOnly && (
             <>
@@ -108,7 +105,7 @@ function BenchmarksDashboard() {
                 onClick={() => setShowAddForm(!showAddForm)}
                 className="rounded-md bg-cyan-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-cyan-500"
               >
-                {showAddForm ? 'Cancel' : 'Add Benchmark'}
+                {showAddForm ? 'Cancel' : 'Add Project'}
               </button>
             </>
           )}
@@ -123,12 +120,12 @@ function BenchmarksDashboard() {
 
       {!isReadOnly && showAddForm && (
         <div className="space-y-3 rounded-lg border border-gray-800 bg-gray-900/50 p-4">
-          <form onSubmit={handleAddBenchmark} className="flex gap-2">
+          <form onSubmit={handleAddProject} className="flex gap-2">
             <input
               type="text"
               value={addPath}
               onChange={(e) => setAddPath(e.target.value)}
-              placeholder="Benchmark path (e.g., /home/user/projects/my-evals)"
+              placeholder="Project path (e.g., /home/user/projects/my-evals)"
               className="flex-1 rounded-md border border-gray-700 bg-gray-800 px-3 py-1.5 text-sm text-white placeholder-gray-500 focus:border-cyan-600 focus:outline-none"
             />
             <button
@@ -142,8 +139,8 @@ function BenchmarksDashboard() {
       )}
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {benchmarks.map((benchmark) => (
-          <BenchmarkCard key={benchmark.id} benchmark={benchmark} />
+        {projects.map((project) => (
+          <ProjectCard key={project.id} project={project} />
         ))}
       </div>
 
@@ -152,9 +149,9 @@ function BenchmarksDashboard() {
   );
 }
 
-// ── Single-benchmark home (existing behavior) ───────────────────────────
+// ── Single-project home (existing behavior) ───────────────────────────
 
-function SingleBenchmarkHome() {
+function SingleProjectHome() {
   const routerState = useRouterState();
   const searchParams = routerState.location.search as Record<string, string>;
   const tab = searchParams.tab as TabId | undefined;
@@ -195,8 +192,8 @@ function SingleBenchmarkHome() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-semibold text-white">Evaluation Runs</h1>
-          {config?.benchmark_name && (
-            <p className="mt-0.5 text-sm text-gray-500">{config.benchmark_name}</p>
+          {config?.project_name && (
+            <p className="mt-0.5 text-sm text-gray-500">{config.project_name}</p>
           )}
         </div>
         {!isReadOnly && (

--- a/apps/studio/src/routes/projects/$projectId.tsx
+++ b/apps/studio/src/routes/projects/$projectId.tsx
@@ -1,7 +1,7 @@
 /**
- * Benchmark home route: tabbed view (Runs, Experiments, Analytics, Targets) scoped to a benchmark.
+ * Project home route: tabbed view (Runs, Experiments, Analytics, Targets) scoped to a project.
  *
- * Mirrors the single-benchmark home page but fetches from benchmark-scoped API endpoints.
+ * Mirrors the single-project home page but fetches from project-scoped API endpoints.
  */
 
 import { createFileRoute, useNavigate, useRouterState } from '@tanstack/react-router';
@@ -14,10 +14,10 @@ import { RunList } from '~/components/RunList';
 import { type RunSourceFilter, RunSourceToolbar } from '~/components/RunSourceToolbar';
 import { TargetsTab } from '~/components/TargetsTab';
 import {
-  benchmarkCompareOptions,
-  benchmarkExperimentsOptions,
+  projectCompareOptions,
+  projectExperimentsOptions,
   syncRemoteResultsApi,
-  useBenchmarkRunList,
+  useProjectRunList,
   useRemoteStatus,
   useStudioConfig,
 } from '~/lib/api';
@@ -32,12 +32,12 @@ const tabs: { id: TabId; label: string }[] = [
   { id: 'targets', label: 'Targets' },
 ];
 
-export const Route = createFileRoute('/benchmarks/$benchmarkId')({
-  component: BenchmarkHomePage,
+export const Route = createFileRoute('/projects/$projectId')({
+  component: ProjectHomePage,
 });
 
-function BenchmarkHomePage() {
-  const { benchmarkId } = Route.useParams();
+function ProjectHomePage() {
+  const { projectId } = Route.useParams();
   const routerState = useRouterState();
   const searchParams = routerState.location.search as Record<string, string>;
   const tab = searchParams.tab as TabId | undefined;
@@ -51,7 +51,7 @@ function BenchmarkHomePage() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold text-white">{benchmarkId}</h1>
+        <h1 className="text-2xl font-semibold text-white">{projectId}</h1>
         {!isReadOnly && (
           <button
             type="button"
@@ -72,8 +72,8 @@ function BenchmarkHomePage() {
               key={t.id}
               onClick={() =>
                 navigate({
-                  to: '/benchmarks/$benchmarkId',
-                  params: { benchmarkId },
+                  to: '/projects/$projectId',
+                  params: { projectId },
                   search: { tab: t.id } as Record<string, string>,
                 })
               }
@@ -89,28 +89,28 @@ function BenchmarkHomePage() {
         </div>
       </div>
 
-      {activeTab === 'runs' && <BenchmarkRunsTab benchmarkId={benchmarkId} />}
-      {activeTab === 'experiments' && <BenchmarkExperimentsTab benchmarkId={benchmarkId} />}
+      {activeTab === 'runs' && <ProjectRunsTab projectId={projectId} />}
+      {activeTab === 'experiments' && <ProjectExperimentsTab projectId={projectId} />}
       {activeTab === 'analytics' && (
-        <BenchmarkAnalyticsTab benchmarkId={benchmarkId} readOnly={isReadOnly} />
+        <ProjectAnalyticsTab projectId={projectId} readOnly={isReadOnly} />
       )}
-      {activeTab === 'targets' && <TargetsTab benchmarkId={benchmarkId} />}
+      {activeTab === 'targets' && <TargetsTab projectId={projectId} />}
 
       {!isReadOnly && (
         <RunEvalModal
           open={showRunEval}
           onClose={() => setShowRunEval(false)}
-          benchmarkId={benchmarkId}
+          projectId={projectId}
         />
       )}
     </div>
   );
 }
 
-function BenchmarkRunsTab({ benchmarkId }: { benchmarkId: string }) {
+function ProjectRunsTab({ projectId }: { projectId: string }) {
   const queryClient = useQueryClient();
-  const { data, isLoading, error } = useBenchmarkRunList(benchmarkId);
-  const { data: remoteStatus } = useRemoteStatus(benchmarkId);
+  const { data, isLoading, error } = useProjectRunList(projectId);
+  const { data: remoteStatus } = useRemoteStatus(projectId);
   const [sourceFilter, setSourceFilter] = useState<RunSourceFilter>('all');
   const [syncInFlight, setSyncInFlight] = useState(false);
 
@@ -122,13 +122,13 @@ function BenchmarkRunsTab({ benchmarkId }: { benchmarkId: string }) {
   async function handleSyncRemote() {
     setSyncInFlight(true);
     try {
-      await syncRemoteResultsApi(benchmarkId);
+      await syncRemoteResultsApi(projectId);
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['benchmarks', benchmarkId, 'runs'] }),
-        queryClient.invalidateQueries({ queryKey: ['benchmarks', benchmarkId, 'experiments'] }),
-        queryClient.invalidateQueries({ queryKey: ['benchmarks', benchmarkId, 'compare'] }),
-        queryClient.invalidateQueries({ queryKey: ['benchmarks', benchmarkId, 'targets'] }),
-        queryClient.invalidateQueries({ queryKey: ['remote-status', benchmarkId] }),
+        queryClient.invalidateQueries({ queryKey: ['projects', projectId, 'runs'] }),
+        queryClient.invalidateQueries({ queryKey: ['projects', projectId, 'experiments'] }),
+        queryClient.invalidateQueries({ queryKey: ['projects', projectId, 'compare'] }),
+        queryClient.invalidateQueries({ queryKey: ['projects', projectId, 'targets'] }),
+        queryClient.invalidateQueries({ queryKey: ['remote-status', projectId] }),
       ]);
     } finally {
       setSyncInFlight(false);
@@ -162,13 +162,13 @@ function BenchmarkRunsTab({ benchmarkId }: { benchmarkId: string }) {
         syncInFlight={syncInFlight}
         onSync={handleSyncRemote}
       />
-      <RunList runs={filteredRuns} benchmarkId={benchmarkId} />
+      <RunList runs={filteredRuns} projectId={projectId} />
     </div>
   );
 }
 
-function BenchmarkExperimentsTab({ benchmarkId }: { benchmarkId: string }) {
-  const { data, isLoading } = useQuery(benchmarkExperimentsOptions(benchmarkId));
+function ProjectExperimentsTab({ projectId }: { projectId: string }) {
+  const { data, isLoading } = useQuery(projectExperimentsOptions(projectId));
   const experiments = (data as ExperimentsResponse | undefined)?.experiments ?? [];
 
   if (isLoading) {
@@ -211,21 +211,21 @@ function BenchmarkExperimentsTab({ benchmarkId }: { benchmarkId: string }) {
   );
 }
 
-function BenchmarkAnalyticsTab({
-  benchmarkId,
+function ProjectAnalyticsTab({
+  projectId,
   readOnly,
 }: {
-  benchmarkId: string;
+  projectId: string;
   readOnly: boolean;
 }) {
-  const { data, isLoading, isError, error } = useQuery(benchmarkCompareOptions(benchmarkId));
+  const { data, isLoading, isError, error } = useQuery(projectCompareOptions(projectId));
   return (
     <AnalyticsTab
       data={data}
       isLoading={isLoading}
       isError={isError}
       error={error}
-      benchmarkId={benchmarkId}
+      projectId={projectId}
       readOnly={readOnly}
     />
   );

--- a/apps/studio/src/routes/projects/$projectId_/evals/$runId.$evalId.tsx
+++ b/apps/studio/src/routes/projects/$projectId_/evals/$runId.$evalId.tsx
@@ -1,5 +1,5 @@
 /**
- * Benchmark-scoped eval detail route.
+ * Project-scoped eval detail route.
  */
 
 import { createFileRoute } from '@tanstack/react-router';
@@ -7,15 +7,15 @@ import { useState } from 'react';
 
 import { EvalDetail } from '~/components/EvalDetail';
 import { RunEvalModal } from '~/components/RunEvalModal';
-import { isPassing, useBenchmarkRunDetail, useStudioConfig } from '~/lib/api';
+import { isPassing, useProjectRunDetail, useStudioConfig } from '~/lib/api';
 
-export const Route = createFileRoute('/benchmarks/$benchmarkId_/evals/$runId/$evalId')({
-  component: BenchmarkEvalDetailPage,
+export const Route = createFileRoute('/projects/$projectId_/evals/$runId/$evalId')({
+  component: ProjectEvalDetailPage,
 });
 
-function BenchmarkEvalDetailPage() {
-  const { benchmarkId, runId, evalId } = Route.useParams();
-  const { data, isLoading, error } = useBenchmarkRunDetail(benchmarkId, runId);
+function ProjectEvalDetailPage() {
+  const { projectId, runId, evalId } = Route.useParams();
+  const { data, isLoading, error } = useProjectRunDetail(projectId, runId);
   const { data: config } = useStudioConfig();
   const [showRunEval, setShowRunEval] = useState(false);
   const isReadOnly = config?.read_only === true;
@@ -82,12 +82,12 @@ function BenchmarkEvalDetailPage() {
           </button>
         )}
       </div>
-      <EvalDetail eval={result} runId={runId} benchmarkId={benchmarkId} />
+      <EvalDetail eval={result} runId={runId} projectId={projectId} />
       {!isReadOnly && (
         <RunEvalModal
           open={showRunEval}
           onClose={() => setShowRunEval(false)}
-          benchmarkId={benchmarkId}
+          projectId={projectId}
           prefill={{
             testIds: [evalId],
             target: result.target,

--- a/apps/studio/src/routes/projects/$projectId_/runs/$runId.tsx
+++ b/apps/studio/src/routes/projects/$projectId_/runs/$runId.tsx
@@ -1,5 +1,5 @@
 /**
- * Benchmark-scoped run detail route.
+ * Project-scoped run detail route.
  */
 
 import { createFileRoute } from '@tanstack/react-router';
@@ -8,15 +8,15 @@ import { useState } from 'react';
 import { ResumeRunActions } from '~/components/ResumeRunActions';
 import { RunDetail } from '~/components/RunDetail';
 import { RunEvalModal } from '~/components/RunEvalModal';
-import { useBenchmarkRunDetail, useStudioConfig } from '~/lib/api';
+import { useProjectRunDetail, useStudioConfig } from '~/lib/api';
 
-export const Route = createFileRoute('/benchmarks/$benchmarkId_/runs/$runId')({
-  component: BenchmarkRunDetailPage,
+export const Route = createFileRoute('/projects/$projectId_/runs/$runId')({
+  component: ProjectRunDetailPage,
 });
 
-function BenchmarkRunDetailPage() {
-  const { benchmarkId, runId } = Route.useParams();
-  const { data, isLoading, error } = useBenchmarkRunDetail(benchmarkId, runId);
+function ProjectRunDetailPage() {
+  const { projectId, runId } = Route.useParams();
+  const { data, isLoading, error } = useProjectRunDetail(projectId, runId);
   const { data: config } = useStudioConfig();
   const [showRunEval, setShowRunEval] = useState(false);
   const isReadOnly = config?.read_only === true;
@@ -75,7 +75,7 @@ function BenchmarkRunDetailPage() {
             runDir={data?.run_dir}
             suiteFilter={data?.suite_filter}
             target={target ?? undefined}
-            benchmarkId={benchmarkId}
+            projectId={projectId}
             isReadOnly={isReadOnly}
             plannedTestCount={data?.planned_test_count}
           />
@@ -90,12 +90,12 @@ function BenchmarkRunDetailPage() {
           )}
         </div>
       </div>
-      <RunDetail results={data?.results ?? []} runId={runId} benchmarkId={benchmarkId} />
+      <RunDetail results={data?.results ?? []} runId={runId} projectId={projectId} />
       {!isReadOnly && (
         <RunEvalModal
           open={showRunEval}
           onClose={() => setShowRunEval(false)}
-          benchmarkId={benchmarkId}
+          projectId={projectId}
           prefill={prefill}
         />
       )}


### PR DESCRIPTION
## Summary

PR 3 of 4 in the benchmark → project rename. **Stacks on #1243 (PR 2).** Updates the Studio web UI to match the new wire format.

### Renames
- **Routes** (TanStack file-routes): \`apps/studio/src/routes/benchmarks/$benchmarkId*\` → \`projects/$projectId*\` (3 files). \`routeTree.gen.ts\` regenerated via \`@tanstack/router-cli generate\`.
- **Components**: \`BenchmarkCard.tsx\` → \`ProjectCard.tsx\`. \`BenchmarksDashboard\` / \`SingleBenchmarkHome\` / \`BenchmarkHomePage\` / 3 tab components / 2 sidebar variants all renamed.
- **API hooks**: \`useBenchmarkList\`, \`useBenchmarkRunList\`, \`useBenchmarkRunDetail\`, \`useAllBenchmarkRuns\`, \`benchmarkApiBase\`, all \`benchmark*Options\` (15 hooks/factories), \`addBenchmarkApi\`, \`removeBenchmarkApi\` → \`*Project*\` equivalents.
- **Types**: \`BenchmarkSummary\` / \`BenchmarkListResponse\` / \`BenchmarkEntry\` → \`Project*\`. Envelope field \`benchmarks: ...\` → \`projects: ...\`. Wire fields \`benchmark_id\`, \`benchmark_name\`, \`multi_benchmark_dashboard\` → \`project_*\`.
- **URL strings**: \`/api/benchmarks/*\` → \`/api/projects/*\`. Cache query keys \`['benchmarks', ...]\` → \`['projects', ...]\`.
- **UI strings**: "Benchmarks"/"All Benchmarks"/"Add Benchmark" → "Projects"/"All Projects"/"Add Project". "Benchmark path" placeholder → "Project path".

### Out of scope
- \`benchmark.json\` per-run artifact comments — kept (Agent Skills compatibility).
- \`examples/*-benchmark\` directory references — kept (academic benchmark-suite semantics; PR 4 documents this distinction in AGENTS.md).

### Test plan

- [x] \`bun run typecheck\` — passes
- [x] \`bun run lint\` — clean (after \`biome --write\` import-order auto-fix)
- [x] \`bun run test\` — **2374 tests pass** (1768 core + 67 eval + 539 cli, 0 fail)
- [x] \`bun run build\` — all packages including Studio dist
- [x] Pre-push hooks green
- [x] **End-to-end UAT** with \`agent-browser\` against \`HOME=/tmp/uat-pr3-home\`:
  1. Legacy \`~/.agentv/benchmarks.yaml\` auto-migrated on Studio startup (PR 1 migration kicks in).
  2. \`GET /api/config\` returns \`{ project_name, multi_project_dashboard }\`.
  3. \`GET /api/projects\` returns \`{ projects: [...] }\` envelope.
  4. Home dashboard renders \`<h1>Projects</h1>\`, \`Add Project\` button, \`<ProjectCard>\` for the migrated entry.
  5. Click → navigates to \`/projects/demo\`; back link reads "← All Projects".

🤖 Generated with [Claude Code](https://claude.com/claude-code)