### PR TITLE
chore(studio): track project-mode unification

### DIFF
--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -133,7 +133,7 @@ export function resolveDashboardMode(
     return { projectDashboard: false };
   }
 
-  return { projectDashboard: projectCount > 1 };
+  return { projectDashboard: projectCount > 0 };
 }
 
 // ── Feedback persistence ─────────────────────────────────────────────────

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -111,9 +111,9 @@ describe('resolveDashboardMode', () => {
     });
   });
 
-  it('defaults to single-project mode when exactly one project is registered', () => {
+  it('uses the project dashboard flow when exactly one project is registered', () => {
     expect(resolveDashboardMode(1, {})).toEqual({
-      projectDashboard: false,
+      projectDashboard: true,
     });
   });
 

--- a/apps/cli/test/unit/studio-navigation.test.ts
+++ b/apps/cli/test/unit/studio-navigation.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  categoryPath,
+  evalPath,
+  experimentPath,
+  jobPath,
+  projectHomePath,
+  resolveIndexRoute,
+  runPath,
+  runsHomePath,
+  suitePath,
+} from '../../../studio/src/lib/navigation.ts';
+
+describe('studio navigation helpers', () => {
+  it('redirects the root entrypoint to the only registered project', () => {
+    expect(resolveIndexRoute(['demo-project'], undefined, 'analytics')).toEqual({
+      kind: 'redirect',
+      redirectPath: '/projects/demo-project?tab=analytics',
+    });
+  });
+
+  it('keeps explicit single-project mode on the legacy root home', () => {
+    expect(resolveIndexRoute(['demo-project'], false, 'runs')).toEqual({
+      kind: 'single-project-home',
+    });
+  });
+
+  it('keeps the dashboard for zero or many projects', () => {
+    expect(resolveIndexRoute([], true)).toEqual({ kind: 'dashboard' });
+    expect(resolveIndexRoute(['one', 'two'], true)).toEqual({ kind: 'dashboard' });
+  });
+
+  it('builds project-scoped drill-down paths', () => {
+    expect(projectHomePath('demo project', 'runs')).toBe('/projects/demo%20project?tab=runs');
+    expect(runPath('run::1', 'demo project')).toBe('/projects/demo%20project/runs/run%3A%3A1');
+    expect(evalPath('run::1', 'case/a', 'demo project')).toBe(
+      '/projects/demo%20project/evals/run%3A%3A1/case%2Fa',
+    );
+    expect(jobPath('job/1', 'demo project')).toBe('/projects/demo%20project/jobs/job%2F1');
+    expect(categoryPath('run::1', 'Safety > PII', 'demo project')).toBe(
+      '/projects/demo%20project/runs/run%3A%3A1/category/Safety%20%3E%20PII',
+    );
+    expect(suitePath('run::1', 'evals/smoke.eval.yaml', 'demo project')).toBe(
+      '/projects/demo%20project/runs/run%3A%3A1/suite/evals%2Fsmoke.eval.yaml',
+    );
+    expect(experimentPath('prod-baseline', 'demo project')).toBe(
+      '/projects/demo%20project/experiments/prod-baseline',
+    );
+  });
+
+  it('keeps unscoped paths for legacy single-project routes', () => {
+    expect(runPath('run::1')).toBe('/runs/run%3A%3A1');
+    expect(evalPath('run::1', 'case/a')).toBe('/evals/run%3A%3A1/case%2Fa');
+    expect(jobPath('job/1')).toBe('/jobs/job%2F1');
+    expect(categoryPath('run::1', 'Safety')).toBe('/runs/run%3A%3A1/category/Safety');
+    expect(suitePath('run::1', 'evals/smoke.eval.yaml')).toBe(
+      '/runs/run%3A%3A1/suite/evals%2Fsmoke.eval.yaml',
+    );
+    expect(runsHomePath()).toBe('/?tab=runs');
+  });
+});

--- a/apps/studio/src/components/Breadcrumbs.tsx
+++ b/apps/studio/src/components/Breadcrumbs.tsx
@@ -7,6 +7,16 @@
 
 import { Link, useMatches } from '@tanstack/react-router';
 
+import {
+  categoryPath,
+  evalPath,
+  experimentPath,
+  jobPath,
+  projectHomePath,
+  runPath,
+  suitePath,
+} from '~/lib/navigation';
+
 interface BreadcrumbSegment {
   label: string;
   to?: string;
@@ -35,7 +45,7 @@ function deriveSegments(matches: ReturnType<typeof useMatches>): BreadcrumbSegme
       if (!segments.some((s) => s.label === params.projectId)) {
         segments.push({
           label: params.projectId,
-          to: `/projects/${encodeURIComponent(params.projectId)}`,
+          to: projectHomePath(params.projectId),
         });
       }
       if (routeId === '/projects/$projectId') {
@@ -43,43 +53,104 @@ function deriveSegments(matches: ReturnType<typeof useMatches>): BreadcrumbSegme
       }
     }
 
-    if (routeId.includes('/runs/$runId/category/$category')) {
-      if (!segments.some((s) => s.label === params.runId)) {
+    if (routeId.includes('/projects/$projectId_/jobs/$runId')) {
+      if (!segments.some((s) => s.label === formatRunLabel(params.runId))) {
         segments.push({
           label: formatRunLabel(params.runId),
-          to: `/runs/${encodeURIComponent(params.runId)}`,
+          to: jobPath(params.runId, params.projectId),
+        });
+      }
+    } else if (routeId.includes('/projects/$projectId_/runs/$runId/category/$category')) {
+      if (!segments.some((s) => s.label === formatRunLabel(params.runId))) {
+        segments.push({
+          label: formatRunLabel(params.runId),
+          to: runPath(params.runId, params.projectId),
         });
       }
       segments.push({
         label: params.category ?? 'Category',
-        to: match.pathname,
+        to: categoryPath(params.runId, params.category ?? 'Category', params.projectId),
       });
-    } else if (routeId.includes('/runs/$runId/suite/$suite')) {
-      segments.push({
-        label: params.suite ?? 'Suite',
-        to: match.pathname,
-      });
-    } else if (routeId.includes('/runs/$runId')) {
-      segments.push({
-        label: formatRunLabel(params.runId),
-        to: match.pathname,
-      });
-    } else if (routeId.includes('/evals/$runId/$evalId')) {
-      // For eval pages, show the run as a parent segment too
-      if (!segments.some((s) => s.label === params.runId)) {
+    } else if (routeId.includes('/projects/$projectId_/runs/$runId/suite/$suite')) {
+      if (!segments.some((s) => s.label === formatRunLabel(params.runId))) {
         segments.push({
           label: formatRunLabel(params.runId),
-          to: `/runs/${encodeURIComponent(params.runId)}`,
+          to: runPath(params.runId, params.projectId),
+        });
+      }
+      segments.push({
+        label: params.suite ?? 'Suite',
+        to: suitePath(params.runId, params.suite ?? 'Suite', params.projectId),
+      });
+    } else if (routeId.includes('/projects/$projectId_/runs/$runId')) {
+      segments.push({
+        label: formatRunLabel(params.runId),
+        to: runPath(params.runId, params.projectId),
+      });
+    } else if (routeId.includes('/projects/$projectId_/evals/$runId/$evalId')) {
+      if (!segments.some((s) => s.label === formatRunLabel(params.runId))) {
+        segments.push({
+          label: formatRunLabel(params.runId),
+          to: runPath(params.runId, params.projectId),
         });
       }
       segments.push({
         label: params.evalId ?? 'Eval',
-        to: match.pathname,
+        to: evalPath(params.runId, params.evalId ?? 'Eval', params.projectId),
+      });
+    } else if (routeId.includes('/projects/$projectId_/experiments/$experimentName')) {
+      segments.push({
+        label: params.experimentName ?? 'Experiment',
+        to: experimentPath(params.experimentName ?? 'Experiment', params.projectId),
+      });
+    } else if (routeId.includes('/runs/$runId/category/$category')) {
+      if (!segments.some((s) => s.label === formatRunLabel(params.runId))) {
+        segments.push({
+          label: formatRunLabel(params.runId),
+          to: runPath(params.runId),
+        });
+      }
+      segments.push({
+        label: params.category ?? 'Category',
+        to: categoryPath(params.runId, params.category ?? 'Category'),
+      });
+    } else if (routeId.includes('/runs/$runId/suite/$suite')) {
+      if (!segments.some((s) => s.label === formatRunLabel(params.runId))) {
+        segments.push({
+          label: formatRunLabel(params.runId),
+          to: runPath(params.runId),
+        });
+      }
+      segments.push({
+        label: params.suite ?? 'Suite',
+        to: suitePath(params.runId, params.suite ?? 'Suite'),
+      });
+    } else if (routeId.includes('/jobs/$runId')) {
+      segments.push({
+        label: formatRunLabel(params.runId),
+        to: jobPath(params.runId),
+      });
+    } else if (routeId.includes('/runs/$runId')) {
+      segments.push({
+        label: formatRunLabel(params.runId),
+        to: runPath(params.runId),
+      });
+    } else if (routeId.includes('/evals/$runId/$evalId')) {
+      // For eval pages, show the run as a parent segment too
+      if (!segments.some((s) => s.label === formatRunLabel(params.runId))) {
+        segments.push({
+          label: formatRunLabel(params.runId),
+          to: runPath(params.runId),
+        });
+      }
+      segments.push({
+        label: params.evalId ?? 'Eval',
+        to: evalPath(params.runId, params.evalId ?? 'Eval'),
       });
     } else if (routeId.includes('/experiments/$experimentName')) {
       segments.push({
         label: params.experimentName ?? 'Experiment',
-        to: match.pathname,
+        to: experimentPath(params.experimentName ?? 'Experiment'),
       });
     } else if (routeId === '/index' || routeId === '/') {
       segments.push({ label: 'Home', to: '/' });

--- a/apps/studio/src/components/EvalDetail.tsx
+++ b/apps/studio/src/components/EvalDetail.tsx
@@ -48,7 +48,7 @@ function findFirstFile(nodes: FileNode[]): string | null {
 
 export function EvalDetail({ eval: result, runId, projectId }: EvalDetailProps) {
   const [activeTab, setActiveTab] = useState<Tab>('checks');
-  const { data: config } = useStudioConfig();
+  const { data: config } = useStudioConfig(projectId);
   const isReadOnly = config?.read_only === true;
 
   const tabs: { id: Tab; label: string }[] = [
@@ -83,7 +83,7 @@ export function EvalDetail({ eval: result, runId, projectId }: EvalDetailProps) 
       <div className="min-h-0 flex-1">
         {activeTab === 'checks' && (
           <div className="overflow-auto p-4">
-            <ChecksTab result={result} />
+            <ChecksTab result={result} projectId={projectId} />
           </div>
         )}
         {activeTab === 'files' && (
@@ -133,8 +133,8 @@ function AssertionCard({ assertion }: { assertion: AssertionEntry }) {
  * Checks tab: overall score → per-grader scores → assertions → failure reasons.
  * Assertions are grouped by evaluator when per-score assertion data is available.
  */
-function ChecksTab({ result }: { result: EvalResult }) {
-  const { data: config } = useStudioConfig();
+function ChecksTab({ result, projectId }: { result: EvalResult; projectId?: string }) {
+  const { data: config } = useStudioConfig(projectId);
   const passThreshold = config?.threshold ?? config?.pass_threshold ?? 0.8;
 
   const hasFailed =

--- a/apps/studio/src/components/ResumeRunActions.tsx
+++ b/apps/studio/src/components/ResumeRunActions.tsx
@@ -71,7 +71,14 @@ export function ResumeRunActions({
     try {
       const body = buildResumeRequestBody({ mode, runDir, suiteFilter, target });
       const response = await launchEvalRun(body, projectId);
-      navigate({ to: '/jobs/$runId', params: { runId: response.id } });
+      if (projectId) {
+        navigate({
+          to: '/projects/$projectId/jobs/$runId',
+          params: { projectId, runId: response.id },
+        });
+      } else {
+        navigate({ to: '/jobs/$runId', params: { runId: response.id } });
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to launch resume');
       setBusy(null);

--- a/apps/studio/src/components/RunDetail.tsx
+++ b/apps/studio/src/components/RunDetail.tsx
@@ -93,7 +93,7 @@ function buildCategoryGroups(results: EvalResult[], passThreshold: number): Cate
 }
 
 export function RunDetail({ results, runId, projectId }: RunDetailProps) {
-  const { data: config } = useStudioConfig();
+  const { data: config } = useStudioConfig(projectId);
   const passThreshold = config?.threshold ?? config?.pass_threshold ?? 0.8;
 
   const total = results.length;
@@ -143,7 +143,25 @@ export function RunDetail({ results, runId, projectId }: RunDetailProps) {
             <tbody className="divide-y divide-gray-800/50">
               {categories.map((cat) => (
                 <tr key={cat.name} className="transition-colors hover:bg-gray-900/30">
-                  <td className="px-4 py-2.5 font-medium text-gray-200">{cat.name}</td>
+                  <td className="px-4 py-2.5 font-medium text-gray-200">
+                    {projectId ? (
+                      <Link
+                        to="/projects/$projectId/runs/$runId/category/$category"
+                        params={{ projectId, runId, category: cat.name }}
+                        className="text-cyan-400 hover:text-cyan-300 hover:underline"
+                      >
+                        {cat.name}
+                      </Link>
+                    ) : (
+                      <Link
+                        to="/runs/$runId/category/$category"
+                        params={{ runId, category: cat.name }}
+                        className="text-cyan-400 hover:text-cyan-300 hover:underline"
+                      >
+                        {cat.name}
+                      </Link>
+                    )}
+                  </td>
                   <td className="px-4 py-2.5">
                     <PassRatePill rate={cat.total > 0 ? cat.passed / cat.total : 0} />
                   </td>

--- a/apps/studio/src/components/RunEvalModal.tsx
+++ b/apps/studio/src/components/RunEvalModal.tsx
@@ -23,6 +23,7 @@ import {
   useEvalTargets,
   useStudioConfig,
 } from '~/lib/api';
+import { runsHomePath } from '~/lib/navigation';
 import type { RunEvalRequest } from '~/lib/types';
 import {
   buildRunEvalRequest,
@@ -69,7 +70,7 @@ export function RunEvalModal({ open, onClose, projectId, prefill }: RunEvalModal
   // Data
   const { data: discoverData } = useEvalDiscover(projectId);
   const { data: targetsData } = useEvalTargets(projectId);
-  const { data: runStatus } = useEvalRunStatus(activeRunId);
+  const { data: runStatus } = useEvalRunStatus(activeRunId, projectId);
   const { data: studioConfig } = useStudioConfig(projectId);
 
   const evalFiles = useMemo(() => discoverData?.eval_files ?? [], [discoverData]);
@@ -170,7 +171,7 @@ export function RunEvalModal({ open, onClose, projectId, prefill }: RunEvalModal
   if (activeRunId && runStatus) {
     function handleRunInBackground() {
       onClose();
-      navigate({ to: '/', search: { tab: 'runs' } as Record<string, string> });
+      navigate({ to: runsHomePath(projectId) });
     }
     return (
       <ModalShell onClose={onClose} title="Eval Run">

--- a/apps/studio/src/components/RunList.tsx
+++ b/apps/studio/src/components/RunList.tsx
@@ -49,7 +49,7 @@ function formatDate(ts: string | undefined | null): { date: string; full: string
 }
 
 export function RunList({ runs, projectId, emptyMessage }: RunListProps) {
-  const { data: config } = useStudioConfig();
+  const { data: config } = useStudioConfig(projectId);
   const passThreshold = config?.threshold ?? DEFAULT_PASS_THRESHOLD;
 
   if (runs.length === 0) {

--- a/apps/studio/src/components/Sidebar.tsx
+++ b/apps/studio/src/components/Sidebar.tsx
@@ -19,6 +19,7 @@ import { Link, useLocation, useMatchRoute } from '@tanstack/react-router';
 
 import {
   isPassing,
+  projectCategorySuitesOptions,
   projectExperimentsOptions,
   useAllProjectRuns,
   useCategorySuites,
@@ -86,6 +87,18 @@ export function Sidebar() {
     to: '/projects/$projectId/experiments/$experimentName',
     fuzzy: true,
   });
+  const projectCategoryMatch = matchRoute({
+    to: '/projects/$projectId/runs/$runId/category/$category',
+    fuzzy: true,
+  });
+  const projectSuiteMatch = matchRoute({
+    to: '/projects/$projectId/runs/$runId/suite/$suite',
+    fuzzy: true,
+  });
+  const projectJobMatch = matchRoute({
+    to: '/projects/$projectId/jobs/$runId',
+    fuzzy: true,
+  });
   const projectMatch = matchRoute({
     to: '/projects/$projectId',
     fuzzy: true,
@@ -105,6 +118,37 @@ export function Sidebar() {
   if (projectRunMatch && typeof projectRunMatch === 'object' && 'projectId' in projectRunMatch) {
     const { projectId, runId } = projectRunMatch as { projectId: string; runId: string };
     return <ProjectRunDetailSidebar projectId={projectId} currentRunId={runId} />;
+  }
+
+  if (projectJobMatch && typeof projectJobMatch === 'object' && 'projectId' in projectJobMatch) {
+    const { projectId } = projectJobMatch as { projectId: string };
+    return <ProjectRunDetailSidebar projectId={projectId} />;
+  }
+
+  if (
+    projectCategoryMatch &&
+    typeof projectCategoryMatch === 'object' &&
+    'projectId' in projectCategoryMatch
+  ) {
+    const { projectId, runId, category } = projectCategoryMatch as {
+      projectId: string;
+      runId: string;
+      category: string;
+    };
+    return <ProjectCategorySidebar projectId={projectId} runId={runId} category={category} />;
+  }
+
+  if (
+    projectSuiteMatch &&
+    typeof projectSuiteMatch === 'object' &&
+    'projectId' in projectSuiteMatch
+  ) {
+    const { projectId, runId, suite } = projectSuiteMatch as {
+      projectId: string;
+      runId: string;
+      suite: string;
+    };
+    return <ProjectSuiteSidebar projectId={projectId} runId={runId} suite={suite} />;
   }
 
   if (
@@ -484,7 +528,7 @@ function ProjectEvalSidebar({
   currentEvalId: string;
 }) {
   const { data } = useProjectRunDetail(projectId, runId);
-  const { data: config } = useStudioConfig();
+  const { data: config } = useStudioConfig(projectId);
   const passThreshold = config?.threshold ?? config?.pass_threshold ?? 0.8;
 
   return (
@@ -531,6 +575,122 @@ function ProjectEvalSidebar({
             </Link>
           );
         })}
+      </nav>
+    </SidebarShell>
+  );
+}
+
+function ProjectSuiteSidebar({
+  projectId,
+  runId,
+  suite,
+}: {
+  projectId: string;
+  runId: string;
+  suite: string;
+}) {
+  const { data } = useProjectRunDetail(projectId, runId);
+  const { data: config } = useStudioConfig(projectId);
+  const passThreshold = config?.threshold ?? config?.pass_threshold ?? 0.8;
+  const suiteResults = (data?.results ?? []).filter((r) => (r.suite ?? 'Uncategorized') === suite);
+
+  return (
+    <SidebarShell>
+      <div className="flex items-center gap-2 border-b border-gray-800 px-4 py-4">
+        <Link to="/" className="text-lg font-semibold text-white hover:text-cyan-400">
+          AgentV Studio
+        </Link>
+      </div>
+
+      <div className="border-b border-gray-800 px-4 py-2">
+        <Link
+          to="/projects/$projectId/runs/$runId"
+          params={{ projectId, runId }}
+          className="text-xs text-gray-400 hover:text-cyan-400"
+        >
+          &larr; Back to run
+        </Link>
+        <p className="mt-1 truncate text-sm font-medium text-gray-300">{runId}</p>
+        <p className="truncate text-xs text-gray-500">{suite}</p>
+      </div>
+
+      <nav className="flex-1 overflow-y-auto px-2 py-3">
+        <div className="mb-2 px-2 text-xs font-medium uppercase tracking-wider text-gray-500">
+          Evaluations
+        </div>
+        {suiteResults.map((result) => {
+          const passed = isPassing(result.score, passThreshold);
+          return (
+            <Link
+              key={result.testId}
+              to="/projects/$projectId/evals/$runId/$evalId"
+              params={{ projectId, runId, evalId: result.testId }}
+              className="mb-0.5 flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-gray-400 transition-colors hover:bg-gray-800/50 hover:text-gray-200"
+            >
+              <span className={`text-xs ${passed ? 'text-emerald-400' : 'text-red-400'}`}>
+                {passed ? '\u2713' : '\u2717'}
+              </span>
+              <span className="truncate">{result.testId}</span>
+            </Link>
+          );
+        })}
+      </nav>
+    </SidebarShell>
+  );
+}
+
+function ProjectCategorySidebar({
+  projectId,
+  runId,
+  category,
+}: {
+  projectId: string;
+  runId: string;
+  category: string;
+}) {
+  const { data } = useQuery(projectCategorySuitesOptions(projectId, runId, category));
+  const suites = data?.suites ?? [];
+
+  return (
+    <SidebarShell>
+      <div className="flex items-center gap-2 border-b border-gray-800 px-4 py-4">
+        <Link to="/" className="text-lg font-semibold text-white hover:text-cyan-400">
+          AgentV Studio
+        </Link>
+      </div>
+
+      <div className="border-b border-gray-800 px-4 py-2">
+        <Link
+          to="/projects/$projectId/runs/$runId"
+          params={{ projectId, runId }}
+          className="text-xs text-gray-400 hover:text-cyan-400"
+        >
+          &larr; Back to run
+        </Link>
+        <p className="mt-1 truncate text-sm font-medium text-gray-300">{runId}</p>
+        <p className="truncate text-xs text-gray-500">{category}</p>
+      </div>
+
+      <nav className="flex-1 overflow-y-auto px-2 py-3">
+        <div className="mb-2 px-2 text-xs font-medium uppercase tracking-wider text-gray-500">
+          Suites
+        </div>
+
+        {suites.map((ds) => (
+          <Link
+            key={ds.name}
+            to="/projects/$projectId/runs/$runId/suite/$suite"
+            params={{ projectId, runId, suite: ds.name }}
+            className="mb-0.5 flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-gray-400 transition-colors hover:bg-gray-800/50 hover:text-gray-200"
+          >
+            <span
+              className={`text-xs ${ds.passed === ds.total ? 'text-emerald-400' : 'text-red-400'}`}
+            >
+              {ds.passed === ds.total ? '\u2713' : '\u2717'}
+            </span>
+            <span className="truncate">{ds.name}</span>
+          </Link>
+        ))}
       </nav>
     </SidebarShell>
   );

--- a/apps/studio/src/lib/api.ts
+++ b/apps/studio/src/lib/api.ts
@@ -582,10 +582,13 @@ export async function stopEvalRun(
   return res.json() as Promise<{ stopped: boolean; reason?: string; status?: string }>;
 }
 
-export function evalRunStatusOptions(runId: string | null) {
+export function evalRunStatusOptions(runId: string | null, projectId?: string) {
+  const url = projectId
+    ? `${projectApiBase(projectId)}/eval/status/${runId}`
+    : `/api/eval/status/${runId}`;
   return queryOptions({
-    queryKey: ['eval-status', runId],
-    queryFn: () => fetchJson<EvalRunStatus>(`/api/eval/status/${runId}`),
+    queryKey: ['eval-status', projectId ?? '', runId],
+    queryFn: () => fetchJson<EvalRunStatus>(url),
     enabled: !!runId,
     refetchInterval: (query) => {
       const status = query.state.data?.status;
@@ -595,8 +598,8 @@ export function evalRunStatusOptions(runId: string | null) {
   });
 }
 
-export function useEvalRunStatus(runId: string | null) {
-  return useQuery(evalRunStatusOptions(runId));
+export function useEvalRunStatus(runId: string | null, projectId?: string) {
+  return useQuery(evalRunStatusOptions(runId, projectId));
 }
 
 export function evalRunsOptions(projectId?: string) {

--- a/apps/studio/src/lib/navigation.ts
+++ b/apps/studio/src/lib/navigation.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure Studio route helpers.
+ *
+ * These keep project-aware path generation in one place so redirects,
+ * breadcrumbs, and regression tests all agree on the canonical URLs.
+ */
+
+export type StudioTabId = 'runs' | 'experiments' | 'analytics' | 'targets';
+
+export interface IndexRouteDecision {
+  kind: 'dashboard' | 'single-project-home' | 'redirect';
+  redirectPath?: string;
+}
+
+export function projectHomePath(projectId: string, tab?: StudioTabId): string {
+  const base = `/projects/${encodeURIComponent(projectId)}`;
+  return tab ? `${base}?tab=${encodeURIComponent(tab)}` : base;
+}
+
+export function runPath(runId: string, projectId?: string): string {
+  return projectId
+    ? `/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(runId)}`
+    : `/runs/${encodeURIComponent(runId)}`;
+}
+
+export function evalPath(runId: string, evalId: string, projectId?: string): string {
+  return projectId
+    ? `/projects/${encodeURIComponent(projectId)}/evals/${encodeURIComponent(runId)}/${encodeURIComponent(evalId)}`
+    : `/evals/${encodeURIComponent(runId)}/${encodeURIComponent(evalId)}`;
+}
+
+export function experimentPath(experimentName: string, projectId?: string): string {
+  return projectId
+    ? `/projects/${encodeURIComponent(projectId)}/experiments/${encodeURIComponent(experimentName)}`
+    : `/experiments/${encodeURIComponent(experimentName)}`;
+}
+
+export function jobPath(runId: string, projectId?: string): string {
+  return projectId
+    ? `/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(runId)}`
+    : `/jobs/${encodeURIComponent(runId)}`;
+}
+
+export function categoryPath(runId: string, category: string, projectId?: string): string {
+  return projectId
+    ? `/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(runId)}/category/${encodeURIComponent(category)}`
+    : `/runs/${encodeURIComponent(runId)}/category/${encodeURIComponent(category)}`;
+}
+
+export function suitePath(runId: string, suite: string, projectId?: string): string {
+  return projectId
+    ? `/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(runId)}/suite/${encodeURIComponent(suite)}`
+    : `/runs/${encodeURIComponent(runId)}/suite/${encodeURIComponent(suite)}`;
+}
+
+export function runsHomePath(projectId?: string): string {
+  return projectId ? projectHomePath(projectId, 'runs') : '/?tab=runs';
+}
+
+export function experimentsHomePath(projectId?: string): string {
+  return projectId ? projectHomePath(projectId, 'experiments') : '/?tab=experiments';
+}
+
+export function resolveIndexRoute(
+  projectIds: string[],
+  projectDashboard: boolean | undefined,
+  tab?: StudioTabId,
+): IndexRouteDecision {
+  if (projectDashboard === false) {
+    return { kind: 'single-project-home' };
+  }
+
+  if (projectIds.length === 1) {
+    return {
+      kind: 'redirect',
+      redirectPath: projectHomePath(projectIds[0], tab),
+    };
+  }
+
+  return { kind: 'dashboard' };
+}

--- a/apps/studio/src/routeTree.gen.ts
+++ b/apps/studio/src/routeTree.gen.ts
@@ -19,8 +19,11 @@ import { Route as EvalsRunIdEvalIdRouteImport } from './routes/evals/$runId.$eva
 import { Route as RunsRunIdSuiteSuiteRouteImport } from './routes/runs/$runId_.suite.$suite'
 import { Route as RunsRunIdCategoryCategoryRouteImport } from './routes/runs/$runId_.category.$category'
 import { Route as ProjectsProjectIdRunsRunIdRouteImport } from './routes/projects/$projectId_/runs/$runId'
+import { Route as ProjectsProjectIdJobsRunIdRouteImport } from './routes/projects/$projectId_/jobs/$runId'
 import { Route as ProjectsProjectIdExperimentsExperimentNameRouteImport } from './routes/projects/$projectId_/experiments/$experimentName'
 import { Route as ProjectsProjectIdEvalsRunIdEvalIdRouteImport } from './routes/projects/$projectId_/evals/$runId.$evalId'
+import { Route as ProjectsProjectIdRunsRunIdSuiteSuiteRouteImport } from './routes/projects/$projectId_/runs/$runId_.suite.$suite'
+import { Route as ProjectsProjectIdRunsRunIdCategoryCategoryRouteImport } from './routes/projects/$projectId_/runs/$runId_.category.$category'
 
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
@@ -75,6 +78,12 @@ const ProjectsProjectIdRunsRunIdRoute =
     path: '/projects/$projectId/runs/$runId',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ProjectsProjectIdJobsRunIdRoute =
+  ProjectsProjectIdJobsRunIdRouteImport.update({
+    id: '/projects/$projectId_/jobs/$runId',
+    path: '/projects/$projectId/jobs/$runId',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ProjectsProjectIdExperimentsExperimentNameRoute =
   ProjectsProjectIdExperimentsExperimentNameRouteImport.update({
     id: '/projects/$projectId_/experiments/$experimentName',
@@ -87,6 +96,18 @@ const ProjectsProjectIdEvalsRunIdEvalIdRoute =
     path: '/projects/$projectId/evals/$runId/$evalId',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ProjectsProjectIdRunsRunIdSuiteSuiteRoute =
+  ProjectsProjectIdRunsRunIdSuiteSuiteRouteImport.update({
+    id: '/projects/$projectId_/runs/$runId_/suite/$suite',
+    path: '/projects/$projectId/runs/$runId/suite/$suite',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ProjectsProjectIdRunsRunIdCategoryCategoryRoute =
+  ProjectsProjectIdRunsRunIdCategoryCategoryRouteImport.update({
+    id: '/projects/$projectId_/runs/$runId_/category/$category',
+    path: '/projects/$projectId/runs/$runId/category/$category',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -97,10 +118,13 @@ export interface FileRoutesByFullPath {
   '/runs/$runId': typeof RunsRunIdRoute
   '/evals/$runId/$evalId': typeof EvalsRunIdEvalIdRoute
   '/projects/$projectId/experiments/$experimentName': typeof ProjectsProjectIdExperimentsExperimentNameRoute
+  '/projects/$projectId/jobs/$runId': typeof ProjectsProjectIdJobsRunIdRoute
   '/projects/$projectId/runs/$runId': typeof ProjectsProjectIdRunsRunIdRoute
   '/runs/$runId/category/$category': typeof RunsRunIdCategoryCategoryRoute
   '/runs/$runId/suite/$suite': typeof RunsRunIdSuiteSuiteRoute
   '/projects/$projectId/evals/$runId/$evalId': typeof ProjectsProjectIdEvalsRunIdEvalIdRoute
+  '/projects/$projectId/runs/$runId/category/$category': typeof ProjectsProjectIdRunsRunIdCategoryCategoryRoute
+  '/projects/$projectId/runs/$runId/suite/$suite': typeof ProjectsProjectIdRunsRunIdSuiteSuiteRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -111,10 +135,13 @@ export interface FileRoutesByTo {
   '/runs/$runId': typeof RunsRunIdRoute
   '/evals/$runId/$evalId': typeof EvalsRunIdEvalIdRoute
   '/projects/$projectId/experiments/$experimentName': typeof ProjectsProjectIdExperimentsExperimentNameRoute
+  '/projects/$projectId/jobs/$runId': typeof ProjectsProjectIdJobsRunIdRoute
   '/projects/$projectId/runs/$runId': typeof ProjectsProjectIdRunsRunIdRoute
   '/runs/$runId/category/$category': typeof RunsRunIdCategoryCategoryRoute
   '/runs/$runId/suite/$suite': typeof RunsRunIdSuiteSuiteRoute
   '/projects/$projectId/evals/$runId/$evalId': typeof ProjectsProjectIdEvalsRunIdEvalIdRoute
+  '/projects/$projectId/runs/$runId/category/$category': typeof ProjectsProjectIdRunsRunIdCategoryCategoryRoute
+  '/projects/$projectId/runs/$runId/suite/$suite': typeof ProjectsProjectIdRunsRunIdSuiteSuiteRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -126,10 +153,13 @@ export interface FileRoutesById {
   '/runs/$runId': typeof RunsRunIdRoute
   '/evals/$runId/$evalId': typeof EvalsRunIdEvalIdRoute
   '/projects/$projectId_/experiments/$experimentName': typeof ProjectsProjectIdExperimentsExperimentNameRoute
+  '/projects/$projectId_/jobs/$runId': typeof ProjectsProjectIdJobsRunIdRoute
   '/projects/$projectId_/runs/$runId': typeof ProjectsProjectIdRunsRunIdRoute
   '/runs/$runId_/category/$category': typeof RunsRunIdCategoryCategoryRoute
   '/runs/$runId_/suite/$suite': typeof RunsRunIdSuiteSuiteRoute
   '/projects/$projectId_/evals/$runId/$evalId': typeof ProjectsProjectIdEvalsRunIdEvalIdRoute
+  '/projects/$projectId_/runs/$runId_/category/$category': typeof ProjectsProjectIdRunsRunIdCategoryCategoryRoute
+  '/projects/$projectId_/runs/$runId_/suite/$suite': typeof ProjectsProjectIdRunsRunIdSuiteSuiteRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -142,10 +172,13 @@ export interface FileRouteTypes {
     | '/runs/$runId'
     | '/evals/$runId/$evalId'
     | '/projects/$projectId/experiments/$experimentName'
+    | '/projects/$projectId/jobs/$runId'
     | '/projects/$projectId/runs/$runId'
     | '/runs/$runId/category/$category'
     | '/runs/$runId/suite/$suite'
     | '/projects/$projectId/evals/$runId/$evalId'
+    | '/projects/$projectId/runs/$runId/category/$category'
+    | '/projects/$projectId/runs/$runId/suite/$suite'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -156,10 +189,13 @@ export interface FileRouteTypes {
     | '/runs/$runId'
     | '/evals/$runId/$evalId'
     | '/projects/$projectId/experiments/$experimentName'
+    | '/projects/$projectId/jobs/$runId'
     | '/projects/$projectId/runs/$runId'
     | '/runs/$runId/category/$category'
     | '/runs/$runId/suite/$suite'
     | '/projects/$projectId/evals/$runId/$evalId'
+    | '/projects/$projectId/runs/$runId/category/$category'
+    | '/projects/$projectId/runs/$runId/suite/$suite'
   id:
     | '__root__'
     | '/'
@@ -170,10 +206,13 @@ export interface FileRouteTypes {
     | '/runs/$runId'
     | '/evals/$runId/$evalId'
     | '/projects/$projectId_/experiments/$experimentName'
+    | '/projects/$projectId_/jobs/$runId'
     | '/projects/$projectId_/runs/$runId'
     | '/runs/$runId_/category/$category'
     | '/runs/$runId_/suite/$suite'
     | '/projects/$projectId_/evals/$runId/$evalId'
+    | '/projects/$projectId_/runs/$runId_/category/$category'
+    | '/projects/$projectId_/runs/$runId_/suite/$suite'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -185,10 +224,13 @@ export interface RootRouteChildren {
   RunsRunIdRoute: typeof RunsRunIdRoute
   EvalsRunIdEvalIdRoute: typeof EvalsRunIdEvalIdRoute
   ProjectsProjectIdExperimentsExperimentNameRoute: typeof ProjectsProjectIdExperimentsExperimentNameRoute
+  ProjectsProjectIdJobsRunIdRoute: typeof ProjectsProjectIdJobsRunIdRoute
   ProjectsProjectIdRunsRunIdRoute: typeof ProjectsProjectIdRunsRunIdRoute
   RunsRunIdCategoryCategoryRoute: typeof RunsRunIdCategoryCategoryRoute
   RunsRunIdSuiteSuiteRoute: typeof RunsRunIdSuiteSuiteRoute
   ProjectsProjectIdEvalsRunIdEvalIdRoute: typeof ProjectsProjectIdEvalsRunIdEvalIdRoute
+  ProjectsProjectIdRunsRunIdCategoryCategoryRoute: typeof ProjectsProjectIdRunsRunIdCategoryCategoryRoute
+  ProjectsProjectIdRunsRunIdSuiteSuiteRoute: typeof ProjectsProjectIdRunsRunIdSuiteSuiteRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -263,6 +305,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsProjectIdRunsRunIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/projects/$projectId_/jobs/$runId': {
+      id: '/projects/$projectId_/jobs/$runId'
+      path: '/projects/$projectId/jobs/$runId'
+      fullPath: '/projects/$projectId/jobs/$runId'
+      preLoaderRoute: typeof ProjectsProjectIdJobsRunIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/projects/$projectId_/experiments/$experimentName': {
       id: '/projects/$projectId_/experiments/$experimentName'
       path: '/projects/$projectId/experiments/$experimentName'
@@ -275,6 +324,20 @@ declare module '@tanstack/react-router' {
       path: '/projects/$projectId/evals/$runId/$evalId'
       fullPath: '/projects/$projectId/evals/$runId/$evalId'
       preLoaderRoute: typeof ProjectsProjectIdEvalsRunIdEvalIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/projects/$projectId_/runs/$runId_/suite/$suite': {
+      id: '/projects/$projectId_/runs/$runId_/suite/$suite'
+      path: '/projects/$projectId/runs/$runId/suite/$suite'
+      fullPath: '/projects/$projectId/runs/$runId/suite/$suite'
+      preLoaderRoute: typeof ProjectsProjectIdRunsRunIdSuiteSuiteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/projects/$projectId_/runs/$runId_/category/$category': {
+      id: '/projects/$projectId_/runs/$runId_/category/$category'
+      path: '/projects/$projectId/runs/$runId/category/$category'
+      fullPath: '/projects/$projectId/runs/$runId/category/$category'
+      preLoaderRoute: typeof ProjectsProjectIdRunsRunIdCategoryCategoryRouteImport
       parentRoute: typeof rootRouteImport
     }
   }
@@ -290,11 +353,16 @@ const rootRouteChildren: RootRouteChildren = {
   EvalsRunIdEvalIdRoute: EvalsRunIdEvalIdRoute,
   ProjectsProjectIdExperimentsExperimentNameRoute:
     ProjectsProjectIdExperimentsExperimentNameRoute,
+  ProjectsProjectIdJobsRunIdRoute: ProjectsProjectIdJobsRunIdRoute,
   ProjectsProjectIdRunsRunIdRoute: ProjectsProjectIdRunsRunIdRoute,
   RunsRunIdCategoryCategoryRoute: RunsRunIdCategoryCategoryRoute,
   RunsRunIdSuiteSuiteRoute: RunsRunIdSuiteSuiteRoute,
   ProjectsProjectIdEvalsRunIdEvalIdRoute:
     ProjectsProjectIdEvalsRunIdEvalIdRoute,
+  ProjectsProjectIdRunsRunIdCategoryCategoryRoute:
+    ProjectsProjectIdRunsRunIdCategoryCategoryRoute,
+  ProjectsProjectIdRunsRunIdSuiteSuiteRoute:
+    ProjectsProjectIdRunsRunIdSuiteSuiteRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/studio/src/routes/index.tsx
+++ b/apps/studio/src/routes/index.tsx
@@ -1,13 +1,13 @@
 /**
- * Home route: shows the projects dashboard by default when multiple projects
- * are registered, or the existing tabbed landing page (Runs, Experiments,
- * Analytics, Targets) in single-project mode.
+ * Home route: thin entry layer that either redirects to the only registered
+ * project, shows the projects dashboard, or falls back to the legacy
+ * single-project home when Studio is explicitly running in single mode.
  *
  * Uses URL search param `?tab=` for tab persistence.
  */
 
 import { Link, createFileRoute, useNavigate, useRouterState } from '@tanstack/react-router';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
 import { AnalyticsTab } from '~/components/AnalyticsTab';
@@ -27,8 +27,8 @@ import {
   useRunList,
   useStudioConfig,
 } from '~/lib/api';
-
-type TabId = 'runs' | 'experiments' | 'analytics' | 'targets';
+import { type StudioTabId, resolveIndexRoute } from '~/lib/navigation';
+type TabId = StudioTabId;
 
 const tabs: { id: TabId; label: string }[] = [
   { id: 'runs', label: '🏃 Recent Runs' },
@@ -42,16 +42,34 @@ export const Route = createFileRoute('/')({
 });
 
 function HomePage() {
+  const navigate = useNavigate();
+  const routerState = useRouterState();
+  const searchParams = routerState.location.search as Record<string, string>;
+  const tab = searchParams.tab as TabId | undefined;
   const { data: projectData, isLoading: projectsLoading } = useProjectList();
   const { data: config, isLoading: configLoading } = useStudioConfig();
-  const hasProjects = (projectData?.projects.length ?? 0) > 0;
-  const projectDashboard = config?.project_dashboard;
+  const projects = projectData?.projects ?? [];
+  const decision = resolveIndexRoute(
+    projects.map((project) => project.id),
+    config?.project_dashboard,
+    tab,
+  );
+
+  useEffect(() => {
+    if (decision.kind === 'redirect' && decision.redirectPath) {
+      navigate({ to: decision.redirectPath, replace: true });
+    }
+  }, [decision, navigate]);
 
   if (projectsLoading || configLoading) {
     return <LoadingSkeleton />;
   }
 
-  if (projectDashboard === true || (projectDashboard === undefined && hasProjects)) {
+  if (decision.kind === 'redirect') {
+    return <LoadingSkeleton />;
+  }
+
+  if (decision.kind === 'dashboard') {
     return <ProjectsDashboard />;
   }
 
@@ -138,11 +156,20 @@ function ProjectsDashboard() {
         </div>
       )}
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {projects.map((project) => (
-          <ProjectCard key={project.id} project={project} />
-        ))}
-      </div>
+      {projects.length === 0 ? (
+        <div className="rounded-lg border border-gray-800 bg-gray-900/50 p-8 text-center">
+          <p className="text-lg text-gray-300">No projects registered yet.</p>
+          <p className="mt-2 text-sm text-gray-500">
+            Add a project path to start browsing runs, experiments, analytics, and targets.
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {projects.map((project) => (
+            <ProjectCard key={project.id} project={project} />
+          ))}
+        </div>
+      )}
 
       {!isReadOnly && <RunEvalModal open={showRunEval} onClose={() => setShowRunEval(false)} />}
     </div>

--- a/apps/studio/src/routes/projects/$projectId.tsx
+++ b/apps/studio/src/routes/projects/$projectId.tsx
@@ -43,7 +43,7 @@ function ProjectHomePage() {
   const tab = searchParams.tab as TabId | undefined;
   const navigate = useNavigate();
   const [showRunEval, setShowRunEval] = useState(false);
-  const { data: config } = useStudioConfig();
+  const { data: config } = useStudioConfig(projectId);
   const isReadOnly = config?.read_only === true;
 
   const activeTab: TabId = tabs.some((t) => t.id === tab) ? (tab as TabId) : 'experiments';
@@ -177,8 +177,8 @@ function ProjectRunsTab({ projectId }: { projectId: string }) {
                   </span>
                 </div>
                 <Link
-                  to="/jobs/$runId"
-                  params={{ runId: run.id }}
+                  to="/projects/$projectId/jobs/$runId"
+                  params={{ projectId, runId: run.id }}
                   className="flex-shrink-0 text-xs text-cyan-400 hover:text-cyan-300"
                 >
                   View Log →

--- a/apps/studio/src/routes/projects/$projectId_/evals/$runId.$evalId.tsx
+++ b/apps/studio/src/routes/projects/$projectId_/evals/$runId.$evalId.tsx
@@ -16,7 +16,7 @@ export const Route = createFileRoute('/projects/$projectId_/evals/$runId/$evalId
 function ProjectEvalDetailPage() {
   const { projectId, runId, evalId } = Route.useParams();
   const { data, isLoading, error } = useProjectRunDetail(projectId, runId);
-  const { data: config } = useStudioConfig();
+  const { data: config } = useStudioConfig(projectId);
   const [showRunEval, setShowRunEval] = useState(false);
   const isReadOnly = config?.read_only === true;
 

--- a/apps/studio/src/routes/projects/$projectId_/jobs/$runId.tsx
+++ b/apps/studio/src/routes/projects/$projectId_/jobs/$runId.tsx
@@ -1,0 +1,147 @@
+/**
+ * Project-scoped job detail route for Studio-launched eval runs.
+ */
+
+import { Link, createFileRoute } from '@tanstack/react-router';
+
+import { StopRunButton } from '~/components/StopRunButton';
+import { useEvalRunStatus, useStudioConfig } from '~/lib/api';
+
+export const Route = createFileRoute('/projects/$projectId_/jobs/$runId')({
+  component: ProjectJobDetailPage,
+});
+
+function ProjectJobDetailPage() {
+  const { projectId, runId } = Route.useParams();
+  const { data: status, isLoading, error } = useEvalRunStatus(runId, projectId);
+  const { data: config } = useStudioConfig(projectId);
+  const isReadOnly = config?.read_only === true;
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <BackLink projectId={projectId} />
+        <div className="h-8 w-48 animate-pulse rounded bg-gray-800" />
+        <div className="h-64 animate-pulse rounded-lg bg-gray-900" />
+      </div>
+    );
+  }
+
+  if (error || !status) {
+    return (
+      <div className="space-y-4">
+        <BackLink projectId={projectId} />
+        <div className="rounded-lg border border-red-900/50 bg-red-950/20 p-4 text-sm text-red-400">
+          {error ? `Failed to load run: ${error.message}` : 'Run not found.'}
+        </div>
+      </div>
+    );
+  }
+
+  const isTerminal = status.status === 'finished' || status.status === 'failed';
+
+  const statusColors: Record<string, string> = {
+    starting: 'text-yellow-400',
+    running: 'text-cyan-400',
+    finished: 'text-emerald-400',
+    failed: 'text-red-400',
+  };
+
+  const statusColor = statusColors[status.status] ?? 'text-gray-400';
+
+  return (
+    <div className="space-y-4">
+      <BackLink projectId={projectId} />
+
+      <div className="flex min-w-0 items-center justify-between gap-4">
+        <div className="min-w-0">
+          <h1 className="truncate font-mono text-base font-semibold text-white">{runId}</h1>
+          <p className="mt-0.5 text-xs text-gray-500">
+            Started {new Date(status.started_at).toLocaleString()}
+            {status.finished_at && (
+              <>
+                {' · '}Finished {new Date(status.finished_at).toLocaleString()}
+                {' · '}
+                {Math.round(
+                  (new Date(status.finished_at).getTime() - new Date(status.started_at).getTime()) /
+                    1000,
+                )}
+                s
+              </>
+            )}
+          </p>
+        </div>
+        <div className="flex flex-shrink-0 items-center gap-3">
+          <StopRunButton
+            runId={runId}
+            status={status.status}
+            isReadOnly={isReadOnly}
+            projectId={projectId}
+          />
+          <span className={`text-sm font-medium ${statusColor}`}>
+            {status.status.charAt(0).toUpperCase() + status.status.slice(1)}
+          </span>
+          {!isTerminal && (
+            <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-cyan-400 border-t-transparent" />
+          )}
+        </div>
+      </div>
+
+      <div className="rounded-md border border-gray-700 bg-gray-950 px-4 py-3">
+        <p className="mb-1 text-xs font-medium uppercase tracking-wider text-gray-500">Command</p>
+        <code className="break-all text-xs text-cyan-300">{status.command}</code>
+      </div>
+
+      {status.stdout ? (
+        <div>
+          <p className="mb-1 text-xs font-medium uppercase tracking-wider text-gray-500">Output</p>
+          <div className="max-h-[60vh] overflow-y-auto rounded-lg border border-gray-700 bg-gray-950 p-4">
+            <pre className="whitespace-pre-wrap font-mono text-xs text-gray-200">
+              {status.stdout}
+            </pre>
+          </div>
+        </div>
+      ) : (
+        !isTerminal && (
+          <div className="flex items-center gap-2 text-sm text-gray-500">
+            <span className="inline-block h-2.5 w-2.5 animate-spin rounded-full border-2 border-gray-500 border-t-transparent" />
+            Waiting for output…
+          </div>
+        )
+      )}
+
+      {status.stderr && (
+        <div>
+          <p className="mb-1 text-xs font-medium uppercase tracking-wider text-red-500">Stderr</p>
+          <div className="max-h-48 overflow-y-auto rounded-lg border border-red-900/40 bg-red-950/20 p-4">
+            <pre className="whitespace-pre-wrap font-mono text-xs text-red-300">
+              {status.stderr}
+            </pre>
+          </div>
+        </div>
+      )}
+
+      {isTerminal && (
+        <p className="text-xs text-gray-500">
+          Exit code:{' '}
+          <span className={status.exit_code === 0 ? 'text-emerald-400' : 'text-red-400'}>
+            {status.exit_code}
+          </span>
+        </p>
+      )}
+    </div>
+  );
+}
+
+function BackLink({ projectId }: { projectId: string }) {
+  return (
+    <Link
+      to="/projects/$projectId"
+      params={{ projectId }}
+      search={{ tab: 'runs' } as Record<string, string>}
+      className="text-xs text-gray-400 hover:text-cyan-400"
+    >
+      ← Back to Runs
+    </Link>
+  );
+}

--- a/apps/studio/src/routes/projects/$projectId_/runs/$runId.tsx
+++ b/apps/studio/src/routes/projects/$projectId_/runs/$runId.tsx
@@ -17,7 +17,7 @@ export const Route = createFileRoute('/projects/$projectId_/runs/$runId')({
 function ProjectRunDetailPage() {
   const { projectId, runId } = Route.useParams();
   const { data, isLoading, error } = useProjectRunDetail(projectId, runId);
-  const { data: config } = useStudioConfig();
+  const { data: config } = useStudioConfig(projectId);
   const [showRunEval, setShowRunEval] = useState(false);
   const isReadOnly = config?.read_only === true;
 

--- a/apps/studio/src/routes/projects/$projectId_/runs/$runId_.category.$category.tsx
+++ b/apps/studio/src/routes/projects/$projectId_/runs/$runId_.category.$category.tsx
@@ -1,0 +1,93 @@
+/**
+ * Project-scoped category drill-down route.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { Link, createFileRoute } from '@tanstack/react-router';
+
+import { ScoreBar } from '~/components/ScoreBar';
+import { StatsCards } from '~/components/StatsCards';
+import { projectCategorySuitesOptions } from '~/lib/api';
+
+export const Route = createFileRoute('/projects/$projectId_/runs/$runId_/category/$category')({
+  component: ProjectCategoryPage,
+});
+
+function ProjectCategoryPage() {
+  const { projectId, runId, category } = Route.useParams();
+  const { data, isLoading, error } = useQuery(
+    projectCategorySuitesOptions(projectId, runId, category),
+  );
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <div className="h-8 w-64 animate-pulse rounded bg-gray-800" />
+        <div className="grid grid-cols-5 gap-4">
+          {['s1', 's2', 's3', 's4', 's5'].map((id) => (
+            <div key={id} className="h-20 animate-pulse rounded-lg bg-gray-900" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-900/50 bg-red-950/20 p-6 text-red-400">
+        Failed to load category: {error.message}
+      </div>
+    );
+  }
+
+  const suites = data?.suites ?? [];
+  const total = suites.reduce((sum, suite) => sum + suite.total, 0);
+  const passed = suites.reduce((sum, suite) => sum + suite.passed, 0);
+  const failed = total - passed;
+  const passRate = total > 0 ? passed / total : 0;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-white">{category}</h1>
+        <p className="mt-1 text-sm text-gray-400">Category in run: {runId}</p>
+      </div>
+
+      <StatsCards total={total} passed={passed} failed={failed} passRate={passRate} />
+
+      {suites.length === 0 ? (
+        <div className="rounded-lg border border-gray-800 bg-gray-900 p-8 text-center">
+          <p className="text-lg text-gray-400">No suites in this category</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <h3 className="text-sm font-medium text-gray-400">Suites</h3>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {suites.map((suite) => (
+              <Link
+                key={suite.name}
+                to="/projects/$projectId/runs/$runId/suite/$suite"
+                params={{ projectId, runId, suite: suite.name }}
+                className="rounded-lg border border-gray-800 bg-gray-900 p-3 text-left transition-colors hover:border-gray-700"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="truncate text-sm font-medium text-gray-200">{suite.name}</span>
+                  <span className="ml-2 text-xs text-gray-500">
+                    {suite.passed}/{suite.total}
+                  </span>
+                </div>
+                <div className="mt-2">
+                  <ScoreBar score={suite.avg_score} />
+                </div>
+                <div className="mt-1 flex gap-3 text-xs">
+                  <span className="text-emerald-400">{suite.passed} passed</span>
+                  {suite.failed > 0 && <span className="text-red-400">{suite.failed} failed</span>}
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/studio/src/routes/projects/$projectId_/runs/$runId_.suite.$suite.tsx
+++ b/apps/studio/src/routes/projects/$projectId_/runs/$runId_.suite.$suite.tsx
@@ -1,0 +1,121 @@
+/**
+ * Project-scoped suite drill-down route.
+ */
+
+import { Link, createFileRoute } from '@tanstack/react-router';
+
+import { PassRatePill } from '~/components/PassRatePill';
+import { StatsCards } from '~/components/StatsCards';
+import { isPassing, useProjectRunDetail, useStudioConfig } from '~/lib/api';
+
+export const Route = createFileRoute('/projects/$projectId_/runs/$runId_/suite/$suite')({
+  component: ProjectSuitePage,
+});
+
+function ProjectSuitePage() {
+  const { projectId, runId, suite } = Route.useParams();
+  const { data, isLoading, error } = useProjectRunDetail(projectId, runId);
+  const { data: config } = useStudioConfig(projectId);
+  const passThreshold = config?.threshold ?? config?.pass_threshold ?? 0.8;
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <div className="h-8 w-64 animate-pulse rounded bg-gray-800" />
+        <div className="grid grid-cols-5 gap-4">
+          {['s1', 's2', 's3', 's4', 's5'].map((id) => (
+            <div key={id} className="h-20 animate-pulse rounded-lg bg-gray-900" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-900/50 bg-red-950/20 p-6 text-red-400">
+        Failed to load run: {error.message}
+      </div>
+    );
+  }
+
+  const results = (data?.results ?? []).filter(
+    (result) => (result.suite ?? 'Uncategorized') === suite,
+  );
+  const total = results.length;
+  const passed = results.filter((result) => isPassing(result.score, passThreshold)).length;
+  const failed = total - passed;
+  const passRate = total > 0 ? passed / total : 0;
+  const totalCost = results.reduce((sum, result) => sum + (result.costUsd ?? 0), 0);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-white">{suite}</h1>
+        <p className="mt-1 text-sm text-gray-400">Suite in run: {runId}</p>
+      </div>
+
+      <StatsCards
+        total={total}
+        passed={passed}
+        failed={failed}
+        passRate={passRate}
+        totalCost={totalCost > 0 ? totalCost : undefined}
+      />
+
+      {total === 0 ? (
+        <div className="rounded-lg border border-gray-800 bg-gray-900 p-8 text-center">
+          <p className="text-lg text-gray-400">No evaluations in this suite</p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-gray-800">
+          <table className="w-full text-left text-sm">
+            <thead className="border-b border-gray-800 bg-gray-900/50">
+              <tr>
+                <th className="px-4 py-3 font-medium text-gray-400">Test ID</th>
+                <th className="px-4 py-3 font-medium text-gray-400">Target</th>
+                <th className="w-48 px-4 py-3 font-medium text-gray-400">Score</th>
+                <th className="px-4 py-3 text-right font-medium text-gray-400">Duration</th>
+                <th className="px-4 py-3 text-right font-medium text-gray-400">Cost</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-800/50">
+              {results.map((result, idx) => (
+                <tr
+                  key={`${result.testId}-${idx}`}
+                  className="transition-colors hover:bg-gray-900/30"
+                >
+                  <td className="px-4 py-3">
+                    <Link
+                      to="/projects/$projectId/evals/$runId/$evalId"
+                      params={{ projectId, runId, evalId: result.testId }}
+                      className="font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
+                    >
+                      {result.testId}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-gray-400">{result.target ?? '-'}</td>
+                  <td className="px-4 py-3">
+                    {result.executionStatus === 'execution_error' ? (
+                      <span className="inline-flex rounded-full bg-red-900/50 px-2 py-0.5 text-xs font-medium text-red-400">
+                        ERR
+                      </span>
+                    ) : (
+                      <PassRatePill rate={result.score} />
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums text-gray-400">
+                    {result.durationMs != null ? `${(result.durationMs / 1000).toFixed(1)}s` : '-'}
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums text-gray-400">
+                    {result.costUsd != null ? `$${result.costUsd.toFixed(4)}` : '-'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Objective
Converge Studio onto a single project-scoped architecture so "single-project mode" becomes a UI presentation choice, not a separate routing/data path.

## Why
- PR #1251 fixed a bug caused by drift between unscoped single-project experiment detail pages and project-scoped multi-project pages.
- The current split makes routes, navigation, breadcrumbs, and data fetching easy to diverge.
- Phoenix-style behavior is the target: when one project exists, auto-focus it; when many exist, show project selection; underneath, use the same project-scoped pages.

## Proposed approach
1. Make project-scoped routes the canonical Studio routes for runs, experiments, analytics, targets, and drill-down pages.
2. Treat the current unscoped home as a thin redirect/selection layer:
   - 0 projects: onboarding/empty state
   - 1 project: automatically land on that project
   - many projects: show projects dashboard / picker
3. Move any remaining unscoped data loaders, links, sidebar logic, and breadcrumbs onto project-scoped equivalents.
4. Preserve current UX features; only remove duplicate mode-specific plumbing.
5. Add focused regression coverage for route/link generation so single-vs-multi drift cannot recur.

## Acceptance signals
- Opening Studio with one registered project still gives a streamlined experience, without exposing broken or missing features.
- Opening Studio with many projects uses the same run/experiment/detail pages after a project is selected.
- No page fetches unscoped run/experiment data after a project has been selected.
- Sidebar, breadcrumbs, and deep links remain project-aware across runs, experiments, evals, analytics, and targets.
- Existing URLs either continue to work or redirect cleanly to project-scoped URLs.

## Non-goals
- Redesigning Studio visuals
- Changing scoring or backend result semantics
- Reworking project registry behavior beyond what is needed to unify the UI flow

## Suggested implementation order
1. Inventory remaining unscoped routes/components used after project selection.
2. Introduce redirect behavior from single-project entrypoints to the selected project.
3. Remove duplicate unscoped detail pages once project-scoped equivalents fully cover them.
4. Add regression tests for project-aware navigation and route generation.

## Handoff notes
- Start from `origin/main` after PR #1251.
- Use PR #1251 as the concrete example of the drift this refactor should eliminate.
- Prefer deleting duplicated mode-specific code rather than layering more conditionals on top.
