### PR TITLE
fix(studio): rename console log to run log

### DIFF
--- a/apps/cli/src/commands/results/eval-runner.ts
+++ b/apps/cli/src/commands/results/eval-runner.ts
@@ -285,7 +285,7 @@ function isCommandAvailable(cmd: string): boolean {
  * directory cannot be created or the file cannot be opened — callers fall back
  * to the in-memory buffer in that case.
  *
- * The log file is the source of truth shown by the RunDetail "Console Log"
+ * The log file is the source of truth shown by the RunDetail "Run Log"
  * section after the run completes. The in-memory `stdout`/`stderr` buffers on
  * `StudioRun` remain capped for live status polling.
  *

--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -325,17 +325,17 @@ async function handleRunLog(c: C, { searchDir }: DataContext) {
   const meta = await findRunById(searchDir, filename);
   if (!meta) return c.json({ error: 'Run not found' }, 404);
   if (meta.source === 'remote') {
-    return c.json({ error: 'Console log is not available for remote runs' }, 404);
+    return c.json({ error: 'Run log is not available for remote runs' }, 404);
   }
   const logPath = path.join(path.dirname(meta.path), 'console.log');
   if (!existsSync(logPath)) {
-    return c.json({ error: 'Console log not found for this run' }, 404);
+    return c.json({ error: 'Run log not found for this run' }, 404);
   }
   try {
     const content = readFileSync(logPath, 'utf8');
     return c.text(content);
   } catch {
-    return c.json({ error: 'Failed to read console log' }, 500);
+    return c.json({ error: 'Failed to read run log' }, 500);
   }
 }
 

--- a/apps/studio/src/components/RunDetail.tsx
+++ b/apps/studio/src/components/RunDetail.tsx
@@ -5,7 +5,7 @@
  * Category Breakdown is shown as a clean table with coloured pass-rate pills.
  * The All Evals table shows ERR badge instead of 0% for execution errors.
  *
- * Also renders a collapsible "Console Log" section sourced from the run's
+ * Also renders a collapsible "Run Log" section sourced from the run's
  * captured `console.log` file (served by `/api/runs/:id/log`). Hidden when no
  * log is available — e.g. for remote runs or local runs that completed before
  * the console-log capture feature shipped.
@@ -284,7 +284,7 @@ function ConsoleLogSection({ runId, projectId }: { runId: string; projectId?: st
       >
         <span className="flex items-center gap-2">
           <span aria-hidden="true">{open ? '▾' : '▸'}</span>
-          Console Log
+          Run Log
         </span>
         <span className="text-xs text-gray-500">
           {isLoading ? 'Loading…' : error ? 'Failed to load' : log ? `${log.length} chars` : ''}
@@ -294,7 +294,7 @@ function ConsoleLogSection({ runId, projectId }: { runId: string; projectId?: st
         <div className="mt-2 overflow-hidden rounded-lg border border-gray-800 bg-black">
           {error ? (
             <div className="p-4 text-sm text-red-400">
-              Failed to load console log: {(error as Error).message}
+              Failed to load run log: {(error as Error).message}
             </div>
           ) : (
             <pre className="max-h-[480px] overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-gray-200">

--- a/apps/studio/src/lib/api.ts
+++ b/apps/studio/src/lib/api.ts
@@ -44,7 +44,7 @@ async function fetchJson<T>(url: string): Promise<T> {
 
 /**
  * Fetch a text/plain endpoint. Treats 404 as `null` so callers can model
- * "log not yet captured" without throwing — used by the RunDetail console log
+ * "log not yet captured" without throwing — used by the RunDetail run log
  * viewer for runs that finished before this feature shipped (no console.log
  * on disk) and for remote runs.
  */


### PR DESCRIPTION
## Summary
- rename the AgentV Studio run detail section from Console Log to Run Log
- align related backend and frontend copy with the new label

## Testing
- bun test apps/cli/test/commands/results/serve.test.ts
- cd apps/studio && bun run build
