### PR TITLE
fix(docker): run compose service as host user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   agentv:
+    user: "${UID:-1000}:${GID:-1000}"
     build: .
     ports:
       - "${PORT:-3117}:${PORT:-3117}"


### PR DESCRIPTION
## Summary

Docker Compose now runs AgentV as the invoking host user by default, so bind-mounted result files are not written as root during local container runs.

## Verification

- `docker compose config`
- `bunx biome check apps/studio/vite.config.ts docker-compose.yml`
- pre-push hook on `git push`: `bun run build`, `bun run typecheck`, `bun run lint`, `bun run test`, `bun run validate:examples`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)