### PR TITLE
[codex] Ignore Gas Town runtime files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,9 @@ agent-orchestrator.yaml
 .claude/
 .opencode/
 .ao/
+
+# Gas Town (added by gt)
+.beads/
+.runtime/
+.logs/
+state.json


### PR DESCRIPTION
## Summary

- Ignore local Gas Town and Beads runtime artifacts in AgentV checkouts.

## Validation
- git diff --check




