### PR TITLE
fix(dashboard): support white-label app branding

### DIFF
--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -1002,8 +1002,10 @@ function handleConfig(
   { agentvDir, searchDir }: DataContext,
   options?: { readOnly?: boolean; projectDashboard?: boolean; currentProjectId?: string },
 ) {
+  const config = loadStudioConfig(agentvDir);
   return c.json({
-    ...loadStudioConfig(agentvDir),
+    threshold: config.threshold,
+    app_name: config.appName,
     read_only: options?.readOnly === true,
     project_name: path.basename(searchDir),
     project_dashboard: options?.projectDashboard === true,

--- a/apps/cli/src/commands/results/studio-config.ts
+++ b/apps/cli/src/commands/results/studio-config.ts
@@ -10,7 +10,7 @@
  * config.yaml format:
  *   required_version: ">=4.2.0"
  *   dashboard:
- *     app_name: agent v # displayed in the Dashboard shell
+ *     app_name: agentv # displayed in the Dashboard shell
  *     threshold: 0.8   # score >= this value is considered "pass"
  *
  * Backward compat: reads `studio.threshold`, `studio.pass_threshold`, and
@@ -33,7 +33,7 @@ export interface StudioConfig {
 
 const DEFAULTS: StudioConfig = {
   threshold: DEFAULT_THRESHOLD,
-  appName: 'agent v',
+  appName: 'agentv',
 };
 
 /**

--- a/apps/cli/src/commands/results/studio-config.ts
+++ b/apps/cli/src/commands/results/studio-config.ts
@@ -1,37 +1,39 @@
 /**
  * Dashboard configuration loader.
  *
- * Reads dashboard-specific settings from the `dashboard:` section of
- * `.agentv/config.yaml`, falling back to the legacy `studio:` section for
- * compatibility. Preserves all other fields (required_version,
- * eval_patterns, execution, etc.) when saving.
- *
- * Location: `.agentv/config.yaml`
+ * Reads dashboard-specific settings from the `dashboard:` section of config.yaml.
+ * Project-local `.agentv/config.yaml` takes precedence over the global
+ * `${AGENTV_HOME:-~/.agentv}/config.yaml`, with legacy `studio:` and root-level
+ * threshold keys still accepted for compatibility. Saving writes only to the
+ * project-local file and preserves unrelated fields.
  *
  * config.yaml format:
  *   required_version: ">=4.2.0"
  *   dashboard:
+ *     app_name: agent v # displayed in the Dashboard shell
  *     threshold: 0.8   # score >= this value is considered "pass"
  *
  * Backward compat: reads `studio.threshold`, `studio.pass_threshold`, and
  * root-level `pass_threshold` as fallbacks. On save, always writes `threshold`
  * under `dashboard:`.
  *
- * If no config.yaml exists, defaults are used.
+ * If no config.yaml exists in either location, defaults are used.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
-import { DEFAULT_THRESHOLD, parseYamlValue } from '@agentv/core';
+import { DEFAULT_THRESHOLD, getAgentvConfigDir, parseYamlValue } from '@agentv/core';
 import { stringify as stringifyYaml } from 'yaml';
 
 export interface StudioConfig {
   threshold: number;
+  appName: string;
 }
 
 const DEFAULTS: StudioConfig = {
   threshold: DEFAULT_THRESHOLD,
+  appName: 'agent v',
 };
 
 /**
@@ -43,31 +45,40 @@ const DEFAULTS: StudioConfig = {
  * Clamps `threshold` to [0, 1].
  */
 export function loadStudioConfig(agentvDir: string): StudioConfig {
-  const configPath = path.join(agentvDir, 'config.yaml');
+  const localConfigPath = path.join(agentvDir, 'config.yaml');
+  const globalConfigPath = path.join(getAgentvConfigDir(), 'config.yaml');
+  const localConfig = loadParsedConfig(localConfigPath);
+  const globalConfig =
+    path.resolve(globalConfigPath) === path.resolve(localConfigPath)
+      ? undefined
+      : loadParsedConfig(globalConfigPath);
 
-  if (!existsSync(configPath)) {
-    return { ...DEFAULTS };
-  }
-
-  const raw = readFileSync(configPath, 'utf-8');
-  const parsed = parseYamlValue(raw);
-
-  if (!parsed || typeof parsed !== 'object') {
-    return { ...DEFAULTS };
-  }
-
-  // Prefer dashboard config, then legacy studio config, then root-level pass_threshold.
-  const config = parsed as Record<string, unknown>;
   const threshold = [
-    readThreshold(config.dashboard),
-    readThreshold(config.studio),
-    typeof config.pass_threshold === 'number' ? config.pass_threshold : undefined,
+    readThreshold(localConfig?.dashboard),
+    readThreshold(localConfig?.studio),
+    typeof localConfig?.pass_threshold === 'number' ? localConfig.pass_threshold : undefined,
+    readThreshold(globalConfig?.dashboard),
+    readThreshold(globalConfig?.studio),
+    typeof globalConfig?.pass_threshold === 'number' ? globalConfig.pass_threshold : undefined,
     DEFAULTS.threshold,
   ].find((value) => value !== undefined) as number;
 
   return {
     threshold: Math.min(1, Math.max(0, threshold)),
+    appName:
+      readAppName(localConfig?.dashboard) ??
+      readAppName(globalConfig?.dashboard) ??
+      DEFAULTS.appName,
   };
+}
+
+function loadParsedConfig(configPath: string): Record<string, unknown> | undefined {
+  if (!existsSync(configPath)) return undefined;
+
+  const raw = readFileSync(configPath, 'utf-8');
+  const parsed = parseYamlValue(raw);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+  return parsed as Record<string, unknown>;
 }
 
 function readThreshold(section: unknown): number | undefined {
@@ -76,6 +87,14 @@ function readThreshold(section: unknown): number | undefined {
   if (typeof values.threshold === 'number') return values.threshold;
   if (typeof values.pass_threshold === 'number') return values.pass_threshold;
   return undefined;
+}
+
+function readAppName(section: unknown): string | undefined {
+  if (!section || typeof section !== 'object' || Array.isArray(section)) return undefined;
+  const value = (section as Record<string, unknown>).app_name;
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 /**
@@ -123,7 +142,12 @@ export function saveStudioConfig(agentvDir: string, config: StudioConfig): void 
   const { studio: _legacyStudio, ...withoutStudio } = existing;
   existing = {
     ...withoutStudio,
-    dashboard: { ...studioRest, ...dashboardRest, ...config },
+    dashboard: {
+      ...studioRest,
+      ...dashboardRest,
+      threshold: config.threshold,
+      app_name: config.appName,
+    },
   };
 
   const yamlStr = stringifyYaml(existing);

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -212,7 +212,7 @@ describe('resolveDashboardMode', () => {
 
 const MOCK_STUDIO_HTML = `<!doctype html>
 <html lang="en" class="dark">
-<head><title>AgentV Dashboard</title></head>
+<head><title>agent v</title></head>
 <body class="bg-gray-950 text-gray-100"><div id="root"></div></body>
 </html>`;
 
@@ -262,7 +262,7 @@ describe('serve app', () => {
       const res = await app.request('/');
       expect(res.status).toBe(200);
       const html = await res.text();
-      expect(html).toContain('AgentV Dashboard');
+      expect(html).toContain('agent v');
       expect(html).toContain('<div id="root">');
     });
   });
@@ -455,7 +455,7 @@ describe('serve app', () => {
       const res = await app.request('/');
       expect(res.status).toBe(200);
       const html = await res.text();
-      expect(html).toContain('AgentV Dashboard');
+      expect(html).toContain('agent v');
     });
 
     it('serves feedback API with empty results', async () => {
@@ -1069,7 +1069,7 @@ describe('serve app', () => {
       const res = await app.request('/runs/some-run');
       expect(res.status).toBe(200);
       const html = await res.text();
-      expect(html).toContain('AgentV Dashboard');
+      expect(html).toContain('agent v');
     });
 
     it('returns 404 JSON for unknown API routes', async () => {

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -212,7 +212,7 @@ describe('resolveDashboardMode', () => {
 
 const MOCK_STUDIO_HTML = `<!doctype html>
 <html lang="en" class="dark">
-<head><title>agent v</title></head>
+<head><title>agentv</title></head>
 <body class="bg-gray-950 text-gray-100"><div id="root"></div></body>
 </html>`;
 
@@ -262,7 +262,7 @@ describe('serve app', () => {
       const res = await app.request('/');
       expect(res.status).toBe(200);
       const html = await res.text();
-      expect(html).toContain('agent v');
+      expect(html).toContain('agentv');
       expect(html).toContain('<div id="root">');
     });
   });
@@ -455,7 +455,7 @@ describe('serve app', () => {
       const res = await app.request('/');
       expect(res.status).toBe(200);
       const html = await res.text();
-      expect(html).toContain('agent v');
+      expect(html).toContain('agentv');
     });
 
     it('serves feedback API with empty results', async () => {
@@ -1069,7 +1069,7 @@ describe('serve app', () => {
       const res = await app.request('/runs/some-run');
       expect(res.status).toBe(200);
       const html = await res.text();
-      expect(html).toContain('agent v');
+      expect(html).toContain('agentv');
     });
 
     it('returns 404 JSON for unknown API routes', async () => {

--- a/apps/cli/test/commands/results/studio-config.test.ts
+++ b/apps/cli/test/commands/results/studio-config.test.ts
@@ -30,7 +30,7 @@ describe('loadStudioConfig', () => {
   it('returns defaults when no config.yaml exists', () => {
     const config = loadStudioConfig(tempDir);
     expect(config.threshold).toBe(DEFAULT_THRESHOLD);
-    expect(config.appName).toBe('agent v');
+    expect(config.appName).toBe('agentv');
   });
 
   it.each([
@@ -69,7 +69,7 @@ describe('loadStudioConfig', () => {
 
   it('ignores blank dashboard.app_name', () => {
     writeFileSync(path.join(tempDir, 'config.yaml'), 'dashboard:\n  app_name: "  "\n');
-    expect(loadStudioConfig(tempDir).appName).toBe('agent v');
+    expect(loadStudioConfig(tempDir).appName).toBe('agentv');
   });
 
   it('falls back to global config.yaml for dashboard settings', () => {
@@ -183,7 +183,7 @@ describe('saveStudioConfig', () => {
       path.join(tempDir, 'config.yaml'),
       'required_version: ">=4.2.0"\npass_threshold: 0.8\ndashboard:\n  pass_threshold: 0.6\nstudio:\n  theme: dark\n  pass_threshold: 0.5\n',
     );
-    saveStudioConfig(tempDir, { threshold: 0.7, appName: 'agent v' });
+    saveStudioConfig(tempDir, { threshold: 0.7, appName: 'agentv' });
 
     const raw = readFileSync(path.join(tempDir, 'config.yaml'), 'utf-8');
     const parsed = parseYaml(raw) as Record<string, unknown>;
@@ -194,12 +194,12 @@ describe('saveStudioConfig', () => {
     expect(dashboard.theme).toBe('dark');
     expect(dashboard.pass_threshold).toBeUndefined();
     expect(dashboard.threshold).toBe(0.7);
-    expect(dashboard.app_name).toBe('agent v');
+    expect(dashboard.app_name).toBe('agentv');
     expect(dashboard.appName).toBeUndefined();
   });
 
   it('creates config.yaml when it does not exist', () => {
-    saveStudioConfig(tempDir, { threshold: 0.6, appName: 'agent v' });
+    saveStudioConfig(tempDir, { threshold: 0.6, appName: 'agentv' });
 
     const raw = readFileSync(path.join(tempDir, 'config.yaml'), 'utf-8');
     const parsed = parseYaml(raw) as Record<string, unknown>;
@@ -208,7 +208,7 @@ describe('saveStudioConfig', () => {
 
   it('creates directory if it does not exist', () => {
     const nestedDir = path.join(tempDir, 'nested', '.agentv');
-    saveStudioConfig(nestedDir, { threshold: 0.5, appName: 'agent v' });
+    saveStudioConfig(nestedDir, { threshold: 0.5, appName: 'agentv' });
 
     const raw = readFileSync(path.join(nestedDir, 'config.yaml'), 'utf-8');
     const parsed = parseYaml(raw) as Record<string, unknown>;

--- a/apps/cli/test/commands/results/studio-config.test.ts
+++ b/apps/cli/test/commands/results/studio-config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -10,18 +10,27 @@ import { loadStudioConfig, saveStudioConfig } from '../../../src/commands/result
 
 describe('loadStudioConfig', () => {
   let tempDir: string;
+  let previousAgentvHome: string | undefined;
 
   beforeEach(() => {
     tempDir = mkdtempSync(path.join(tmpdir(), 'studio-config-'));
+    previousAgentvHome = process.env.AGENTV_HOME;
+    process.env.AGENTV_HOME = path.join(tempDir, 'home');
   });
 
   afterEach(() => {
+    if (previousAgentvHome === undefined) {
+      process.env.AGENTV_HOME = undefined;
+    } else {
+      process.env.AGENTV_HOME = previousAgentvHome;
+    }
     rmSync(tempDir, { recursive: true, force: true });
   });
 
   it('returns defaults when no config.yaml exists', () => {
     const config = loadStudioConfig(tempDir);
     expect(config.threshold).toBe(DEFAULT_THRESHOLD);
+    expect(config.appName).toBe('agent v');
   });
 
   it.each([
@@ -50,6 +59,48 @@ describe('loadStudioConfig', () => {
       'dashboard:\n  threshold: 0.9\nstudio:\n  threshold: 0.5\n',
     );
     const config = loadStudioConfig(tempDir);
+    expect(config.threshold).toBe(0.9);
+  });
+
+  it('reads dashboard.app_name for white labelling', () => {
+    writeFileSync(path.join(tempDir, 'config.yaml'), 'dashboard:\n  app_name: ai evals\n');
+    expect(loadStudioConfig(tempDir).appName).toBe('ai evals');
+  });
+
+  it('ignores blank dashboard.app_name', () => {
+    writeFileSync(path.join(tempDir, 'config.yaml'), 'dashboard:\n  app_name: "  "\n');
+    expect(loadStudioConfig(tempDir).appName).toBe('agent v');
+  });
+
+  it('falls back to global config.yaml for dashboard settings', () => {
+    const homeDir = process.env.AGENTV_HOME;
+    if (!homeDir) throw new Error('AGENTV_HOME test setup failed');
+    mkdirSync(homeDir, { recursive: true });
+    writeFileSync(
+      path.join(homeDir, 'config.yaml'),
+      'dashboard:\n  app_name: ai evals\n  threshold: 0.6\n',
+    );
+
+    const config = loadStudioConfig(tempDir);
+    expect(config.appName).toBe('ai evals');
+    expect(config.threshold).toBe(0.6);
+  });
+
+  it('prefers local config.yaml over global config.yaml', () => {
+    const homeDir = process.env.AGENTV_HOME;
+    if (!homeDir) throw new Error('AGENTV_HOME test setup failed');
+    mkdirSync(homeDir, { recursive: true });
+    writeFileSync(
+      path.join(homeDir, 'config.yaml'),
+      'dashboard:\n  app_name: ai evals\n  threshold: 0.6\n',
+    );
+    writeFileSync(
+      path.join(tempDir, 'config.yaml'),
+      'dashboard:\n  app_name: local evals\n  threshold: 0.9\n',
+    );
+
+    const config = loadStudioConfig(tempDir);
+    expect(config.appName).toBe('local evals');
     expect(config.threshold).toBe(0.9);
   });
 
@@ -94,12 +145,20 @@ describe('loadStudioConfig', () => {
 
 describe('saveStudioConfig', () => {
   let tempDir: string;
+  let previousAgentvHome: string | undefined;
 
   beforeEach(() => {
     tempDir = mkdtempSync(path.join(tmpdir(), 'studio-config-'));
+    previousAgentvHome = process.env.AGENTV_HOME;
+    process.env.AGENTV_HOME = path.join(tempDir, 'home');
   });
 
   afterEach(() => {
+    if (previousAgentvHome === undefined) {
+      process.env.AGENTV_HOME = undefined;
+    } else {
+      process.env.AGENTV_HOME = previousAgentvHome;
+    }
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -108,13 +167,15 @@ describe('saveStudioConfig', () => {
       path.join(tempDir, 'config.yaml'),
       'required_version: ">=4.2.0"\neval_patterns:\n  - "**/*.eval.yaml"\n',
     );
-    saveStudioConfig(tempDir, { threshold: 0.9 });
+    saveStudioConfig(tempDir, { threshold: 0.9, appName: 'ai evals' });
 
     const raw = readFileSync(path.join(tempDir, 'config.yaml'), 'utf-8');
     const parsed = parseYaml(raw) as Record<string, unknown>;
     expect(parsed.required_version).toBe('>=4.2.0');
     expect(parsed.eval_patterns).toEqual(['**/*.eval.yaml']);
     expect((parsed.dashboard as Record<string, unknown>).threshold).toBe(0.9);
+    expect((parsed.dashboard as Record<string, unknown>).app_name).toBe('ai evals');
+    expect((parsed.dashboard as Record<string, unknown>).appName).toBeUndefined();
   });
 
   it('writes canonical dashboard.threshold and removes legacy threshold fields on save', () => {
@@ -122,7 +183,7 @@ describe('saveStudioConfig', () => {
       path.join(tempDir, 'config.yaml'),
       'required_version: ">=4.2.0"\npass_threshold: 0.8\ndashboard:\n  pass_threshold: 0.6\nstudio:\n  theme: dark\n  pass_threshold: 0.5\n',
     );
-    saveStudioConfig(tempDir, { threshold: 0.7 });
+    saveStudioConfig(tempDir, { threshold: 0.7, appName: 'agent v' });
 
     const raw = readFileSync(path.join(tempDir, 'config.yaml'), 'utf-8');
     const parsed = parseYaml(raw) as Record<string, unknown>;
@@ -133,10 +194,12 @@ describe('saveStudioConfig', () => {
     expect(dashboard.theme).toBe('dark');
     expect(dashboard.pass_threshold).toBeUndefined();
     expect(dashboard.threshold).toBe(0.7);
+    expect(dashboard.app_name).toBe('agent v');
+    expect(dashboard.appName).toBeUndefined();
   });
 
   it('creates config.yaml when it does not exist', () => {
-    saveStudioConfig(tempDir, { threshold: 0.6 });
+    saveStudioConfig(tempDir, { threshold: 0.6, appName: 'agent v' });
 
     const raw = readFileSync(path.join(tempDir, 'config.yaml'), 'utf-8');
     const parsed = parseYaml(raw) as Record<string, unknown>;
@@ -145,7 +208,7 @@ describe('saveStudioConfig', () => {
 
   it('creates directory if it does not exist', () => {
     const nestedDir = path.join(tempDir, 'nested', '.agentv');
-    saveStudioConfig(nestedDir, { threshold: 0.5 });
+    saveStudioConfig(nestedDir, { threshold: 0.5, appName: 'agent v' });
 
     const raw = readFileSync(path.join(nestedDir, 'config.yaml'), 'utf-8');
     const parsed = parseYaml(raw) as Record<string, unknown>;

--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AgentV Dashboard</title>
+    <title>agent v</title>
   </head>
   <body class="bg-gray-950 text-gray-100">
     <div id="root"></div>

--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>agent v</title>
+    <title>agentv</title>
   </head>
   <body class="bg-gray-950 text-gray-100">
     <div id="root"></div>

--- a/apps/dashboard/src/components/BrandName.tsx
+++ b/apps/dashboard/src/components/BrandName.tsx
@@ -7,7 +7,7 @@ export function BrandName({ appName }: { appName: string }) {
 
   return (
     <span className="av-brand-name">
-      agent <span className="text-cyan-400">v</span>
+      agent<span className="text-cyan-400">v</span>
     </span>
   );
 }

--- a/apps/dashboard/src/components/BrandName.tsx
+++ b/apps/dashboard/src/components/BrandName.tsx
@@ -1,0 +1,13 @@
+import { DEFAULT_APP_NAME } from '~/lib/api';
+
+export function BrandName({ appName }: { appName: string }) {
+  if (appName !== DEFAULT_APP_NAME) {
+    return <span className="av-brand-name">{appName}</span>;
+  }
+
+  return (
+    <span className="av-brand-name">
+      agent <span className="text-cyan-400">v</span>
+    </span>
+  );
+}

--- a/apps/dashboard/src/components/Layout.tsx
+++ b/apps/dashboard/src/components/Layout.tsx
@@ -11,8 +11,10 @@
 
 import { Outlet } from '@tanstack/react-router';
 
+import { DEFAULT_APP_NAME, useStudioConfig } from '~/lib/api';
 import { SidebarProvider, useSidebarContext } from '~/lib/sidebar-context';
 
+import { BrandName } from './BrandName';
 import { Breadcrumbs } from './Breadcrumbs';
 import { Sidebar } from './Sidebar';
 
@@ -26,6 +28,8 @@ export function Layout() {
 
 function LayoutInner() {
   const { toggle } = useSidebarContext();
+  const { data: config } = useStudioConfig();
+  const appName = config?.app_name ?? DEFAULT_APP_NAME;
 
   return (
     <div className="flex h-screen overflow-hidden">
@@ -59,7 +63,9 @@ function LayoutInner() {
               <line x1="3" y1="18" x2="21" y2="18" />
             </svg>
           </button>
-          <span className="text-sm font-semibold text-white">AgentV Dashboard</span>
+          <span className="text-sm font-semibold text-white">
+            <BrandName appName={appName} />
+          </span>
         </header>
 
         <Breadcrumbs />

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -18,6 +18,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Link, useLocation, useMatchRoute } from '@tanstack/react-router';
 
 import {
+  DEFAULT_APP_NAME,
   isPassing,
   projectCategorySuitesOptions,
   projectExperimentsOptions,
@@ -34,6 +35,8 @@ import {
 } from '~/lib/api';
 import { formatRunLabel, timeAgo } from '~/lib/run-label';
 import { useSidebarContext } from '~/lib/sidebar-context';
+
+import { BrandName } from './BrandName';
 
 /** Responsive <aside> wrapper. Handles mobile overlay and desktop static placement. */
 function SidebarShell({ children }: { children: ReactNode }) {
@@ -68,6 +71,19 @@ function SidebarShell({ children }: { children: ReactNode }) {
         {children}
       </aside>
     </>
+  );
+}
+
+function BrandHeader({ projectId }: { projectId?: string }) {
+  const { data: config } = useStudioConfig(projectId);
+  const appName = config?.app_name ?? DEFAULT_APP_NAME;
+
+  return (
+    <div className="flex items-center gap-2 border-b border-gray-800 px-4 py-4">
+      <Link to="/" className="truncate text-lg font-semibold text-white hover:text-cyan-400">
+        <BrandName appName={appName} />
+      </Link>
+    </div>
   );
 }
 
@@ -225,6 +241,7 @@ function RunSidebar() {
   const { data: localData } = useRunList();
   const { data: aggregatedData } = useAllProjectRuns();
   const data = useAggregated ? aggregatedData : localData;
+  const { data: config } = useStudioConfig();
 
   const { data: evalRunsData } = useEvalRuns();
   const activeRunCount = (evalRunsData?.runs ?? []).filter(
@@ -234,8 +251,8 @@ function RunSidebar() {
   return (
     <SidebarShell>
       <div className="flex items-center gap-2 border-b border-gray-800 px-4 py-4">
-        <Link to="/" className="text-lg font-semibold text-white hover:text-cyan-400">
-          AgentV Dashboard
+        <Link to="/" className="truncate text-lg font-semibold text-white hover:text-cyan-400">
+          <BrandName appName={config?.app_name ?? DEFAULT_APP_NAME} />
         </Link>
         {activeRunCount > 0 && (
           <span className="flex items-center gap-1 rounded-full bg-cyan-900/40 px-2 py-0.5 text-xs text-cyan-400">
@@ -312,11 +329,7 @@ function EvalSidebar({ runId, currentEvalId }: { runId: string; currentEvalId: s
 
   return (
     <SidebarShell>
-      <div className="flex items-center gap-2 border-b border-gray-800 px-4 py-4">
-        <Link to="/" className="text-lg font-semibold text-white hover:text-cyan-400">
-          AgentV Dashboard
-        </Link>
-      </div>
+      <BrandHeader />
 
       {/* Back to run link */}
       <div className="border-b border-gray-800 px-4 py-2">
@@ -370,11 +383,7 @@ function SuiteSidebar({ runId, suite }: { runId: string; suite: string }) {
 
   return (
     <SidebarShell>
-      <div className="flex items-center gap-2 border-b border-gray-800 px-4 py-4">
-        <Link to="/" className="text-lg font-semibold text-white hover:text-cyan-400">
-          AgentV Dashboard
-        </Link>
-      </div>
+      <BrandHeader />
 
       {/* Back to run link */}
       <div className="border-b border-gray-800 px-4 py-2">
@@ -422,11 +431,7 @@ function CategorySidebar({ runId, category }: { runId: string; category: string 
 
   return (
     <SidebarShell>
-      <div className="flex items-center gap-2 border-b border-gray-800 px-4 py-4">
-        <Link to="/" className="text-lg font-semibold text-white hover:text-cyan-400">
-          AgentV Dashboard
-        </Link>
-      </div>
+      <BrandHeader />
 
       <div className="border-b border-gray-800 px-4 py-2">
         <Link
@@ -478,11 +483,7 @@ function ProjectRunDetailSidebar({
 
   return (
     <SidebarShell>
-      <div className="flex items-center gap-2 border-b border-gray-800 px-4 py-4">
-        <Link to="/" className="text-lg font-semibold text-white hover:text-cyan-400">
-          AgentV Dashboard
-        </Link>
-      </div>
+      <BrandHeader projectId={projectId} />
 
       <div className="border-b border-gray-800 px-4 py-2">
         <Link to="/" className="text-xs text-gray-400 hover:text-cyan-400">
@@ -533,11 +534,7 @@ function ProjectEvalSidebar({
 
   return (
     <SidebarShell>
-      <div className="flex items-center gap-2 border-b border-gray-800 px-4 py-4">
-        <Link to="/" className="text-lg font-semibold text-white hover:text-cyan-400">
-          AgentV Dashboard
-        </Link>
-      </div>
+      <BrandHeader projectId={projectId} />
 
       <div className="border-b border-gray-800 px-4 py-2">
         <Link
@@ -596,11 +593,7 @@ function ProjectSuiteSidebar({
 
   return (
     <SidebarShell>
-      <div className="flex items-center gap-2 border-b border-gray-800 px-4 py-4">
-        <Link to="/" className="text-lg font-semibold text-white hover:text-cyan-400">
-          AgentV Dashboard
-        </Link>
-      </div>
+      <BrandHeader projectId={projectId} />
 
       <div className="border-b border-gray-800 px-4 py-2">
         <Link
@@ -653,11 +646,7 @@ function ProjectCategorySidebar({
 
   return (
     <SidebarShell>
-      <div className="flex items-center gap-2 border-b border-gray-800 px-4 py-4">
-        <Link to="/" className="text-lg font-semibold text-white hover:text-cyan-400">
-          AgentV Dashboard
-        </Link>
-      </div>
+      <BrandHeader projectId={projectId} />
 
       <div className="border-b border-gray-800 px-4 py-2">
         <Link
@@ -708,11 +697,7 @@ function ProjectExperimentSidebar({
 
   return (
     <SidebarShell>
-      <div className="flex items-center gap-2 border-b border-gray-800 px-4 py-4">
-        <Link to="/" className="text-lg font-semibold text-white hover:text-cyan-400">
-          AgentV Dashboard
-        </Link>
-      </div>
+      <BrandHeader projectId={projectId} />
 
       <div className="border-b border-gray-800 px-4 py-2">
         <Link
@@ -760,11 +745,7 @@ function ExperimentSidebar({ currentExperiment }: { currentExperiment: string })
 
   return (
     <SidebarShell>
-      <div className="flex items-center gap-2 border-b border-gray-800 px-4 py-4">
-        <Link to="/" className="text-lg font-semibold text-white hover:text-cyan-400">
-          AgentV Dashboard
-        </Link>
-      </div>
+      <BrandHeader />
 
       {/* Back to experiments tab */}
       <div className="border-b border-gray-800 px-4 py-2">

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -305,6 +305,7 @@ export function useRemoteStatus(projectId?: string) {
 
 /** Default pass threshold matching @agentv/core DEFAULT_THRESHOLD */
 export const DEFAULT_PASS_THRESHOLD = 0.8;
+export const DEFAULT_APP_NAME = 'agent v';
 
 export function isPassing(score: number, passThreshold: number = DEFAULT_PASS_THRESHOLD): boolean {
   return score >= passThreshold;

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -305,7 +305,7 @@ export function useRemoteStatus(projectId?: string) {
 
 /** Default pass threshold matching @agentv/core DEFAULT_THRESHOLD */
 export const DEFAULT_PASS_THRESHOLD = 0.8;
-export const DEFAULT_APP_NAME = 'agent v';
+export const DEFAULT_APP_NAME = 'agentv';
 
 export function isPassing(score: number, passThreshold: number = DEFAULT_PASS_THRESHOLD): boolean {
   return score >= passThreshold;

--- a/apps/dashboard/src/lib/types.ts
+++ b/apps/dashboard/src/lib/types.ts
@@ -249,6 +249,7 @@ export interface CategoriesResponse {
 
 export interface StudioConfigResponse {
   threshold: number;
+  app_name: string;
   /** @deprecated Use threshold */
   pass_threshold?: number;
   read_only?: boolean;

--- a/apps/dashboard/src/routes/settings.tsx
+++ b/apps/dashboard/src/routes/settings.tsx
@@ -9,7 +9,12 @@ import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { useState } from 'react';
 
-import { DEFAULT_PASS_THRESHOLD, saveStudioConfig, useStudioConfig } from '~/lib/api';
+import {
+  DEFAULT_APP_NAME,
+  DEFAULT_PASS_THRESHOLD,
+  saveStudioConfig,
+  useStudioConfig,
+} from '~/lib/api';
 
 export const Route = createFileRoute('/settings')({
   component: SettingsPage,
@@ -25,6 +30,7 @@ function SettingsPage() {
   const currentThreshold = config?.threshold ?? DEFAULT_PASS_THRESHOLD;
   const displayThreshold = threshold || String(currentThreshold);
   const isReadOnly = config?.read_only === true;
+  const appName = config?.app_name ?? DEFAULT_APP_NAME;
 
   const handleSave = async () => {
     const value = Number.parseFloat(threshold || String(currentThreshold));
@@ -61,7 +67,7 @@ function SettingsPage() {
     <div className="mx-auto max-w-2xl space-y-6">
       <div>
         <h1 className="text-2xl font-semibold text-white">Settings</h1>
-        <p className="mt-1 text-sm text-gray-400">Configure AgentV Dashboard</p>
+        <p className="mt-1 text-sm text-gray-400">Configure {appName}</p>
       </div>
 
       {/* Pass Threshold Card */}

--- a/apps/dashboard/src/styles/globals.css
+++ b/apps/dashboard/src/styles/globals.css
@@ -10,6 +10,11 @@ body {
     "Helvetica Neue", Arial, sans-serif;
 }
 
+.av-brand-name {
+  font-family: "JetBrains Mono", ui-monospace, "Cascadia Code", "Fira Code", monospace;
+  letter-spacing: 0;
+}
+
 /* Scrollbar styling for dark theme */
 ::-webkit-scrollbar {
   @apply w-2;

--- a/apps/web/src/content/docs/docs/tools/dashboard.mdx
+++ b/apps/web/src/content/docs/docs/tools/dashboard.mdx
@@ -75,7 +75,7 @@ Legacy `studio.threshold`, `studio.pass_threshold`, and root-level `pass_thresho
 
 ## White label
 
-Dashboard shows `agent v` by default. Override the displayed name with `dashboard.app_name` in project-local `.agentv/config.yaml`:
+Dashboard shows `agentv` by default. Override the displayed name with `dashboard.app_name` in project-local `.agentv/config.yaml`:
 
 ```yaml
 dashboard:

--- a/apps/web/src/content/docs/docs/tools/dashboard.mdx
+++ b/apps/web/src/content/docs/docs/tools/dashboard.mdx
@@ -73,6 +73,17 @@ dashboard:
 
 Legacy `studio.threshold`, `studio.pass_threshold`, and root-level `pass_threshold` values are still read for existing projects. When Dashboard saves settings, it writes the canonical `dashboard.threshold` field and preserves unrelated config.
 
+## White label
+
+Dashboard shows `agent v` by default. Override the displayed name with `dashboard.app_name` in project-local `.agentv/config.yaml`:
+
+```yaml
+dashboard:
+  app_name: ai evals
+```
+
+You can also set the same field globally in `$AGENTV_HOME/config.yaml` or `~/.agentv/config.yaml`. Project-local config takes precedence over the global value.
+
 ## Run Detail
 
 Click any run to see a breakdown by suite, per-test scores, target, duration, and cost. The source label (`local` or `remote`) tells you where the run came from.


### PR DESCRIPTION
## Summary

Dashboard now defaults its visible app brand to `agent v` instead of the old Studio label, with the default `v` rendered in cyan using the landing page's terminal-style monospace treatment.

Projects can white-label the Dashboard by setting `dashboard.app_name` in `.agentv/config.yaml`, and teams can set a global fallback in `$AGENTV_HOME/config.yaml` or `~/.agentv/config.yaml`. Project-local config wins over the global value, and the Dashboard API exposes the value as `app_name` to keep the JSON wire format snake_case.

## Verification

- `bun test apps/cli/test/commands/results/studio-config.test.ts apps/cli/test/commands/results/serve.test.ts`
- `bunx biome check apps/cli/src/commands/results/studio-config.ts apps/cli/src/commands/results/serve.ts apps/cli/test/commands/results/studio-config.test.ts apps/cli/test/commands/results/serve.test.ts apps/dashboard/src/components/BrandName.tsx apps/dashboard/src/components/Layout.tsx apps/dashboard/src/components/Sidebar.tsx apps/dashboard/src/lib/api.ts apps/dashboard/src/lib/types.ts apps/dashboard/src/routes/settings.tsx apps/dashboard/src/styles/globals.css apps/web/src/content/docs/docs/tools/dashboard.mdx`
- `cd apps/dashboard && bun run build`
- Pre-push hook passed: build, typecheck, lint, test, validate eval YAML files
- Manual UAT: `AGENTV_HOME/config.yaml` with `dashboard.app_name: ai evals` returned `app_name: "ai evals"` from `/api/config` and rendered `ai evals` in the sidebar
- Manual UAT: empty global config returned `app_name: "agent v"` from `/api/config` and rendered `agent v` with the `v` in cyan

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
