### PR TITLE
chore(beads): track shared bead state

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,0 +1,40 @@
+# SQLite databases
+*.db
+*.db?*
+*.db-journal
+*.db-wal
+*.db-shm
+
+# Local history and recovery
+.br_history/
+.br_recovery/
+
+# Local version tracking
+.local_version
+
+# Runtime files
+*.lock
+*.tmp
+*.sock
+daemon.lock
+daemon.log
+daemon.pid
+last-touched
+redirect
+sync-state.json
+
+# Sync state and merge artifacts
+.sync.lock
+beads.base.jsonl
+beads.base.meta.json
+beads.left.jsonl
+beads.left.meta.json
+beads.right.jsonl
+beads.right.meta.json
+sync_base.jsonl
+
+# bv lock file
+.bv.lock
+
+# NOTE: Do not add negation patterns here.
+# JSONL files and config files are tracked by git by default because no pattern above ignores them.

--- a/.beads/README.md
+++ b/.beads/README.md
@@ -1,0 +1,18 @@
+# Beads
+
+AgentV uses Beads for repo-local task tracking.
+
+Use `br` for all Beads operations in this repository:
+
+```bash
+br ready --json
+br list --json
+br show <issue-id> --json
+br update <issue-id> --claim --json
+br close <issue-id> --reason "Completed" --json
+br sync --flush-only
+```
+
+The durable task graph is tracked as JSONL in `.beads/issues.jsonl`. Local SQLite
+databases, locks, history, and merge scratch files are ignored and should not be
+committed.

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,0 +1,2 @@
+# Beads Project Configuration
+issue_prefix: agentv

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,0 +1,4 @@
+{
+  "database": "beads.db",
+  "jsonl_export": "issues.jsonl"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,12 @@ agent-orchestrator.yaml
 .opencode/
 .ao/
 
-# Gas Town (added by gt)
-.beads/
+# Gas Town / Beads shared state
+.beads/.br_history/
+.beads/.bv.lock
 .runtime/
 .logs/
 state.json
+
+# bv (beads viewer) local config and caches
+.bv/

--- a/biome.json
+++ b/biome.json
@@ -40,6 +40,7 @@
       "**/.agentv/**",
       ".claude/**",
       ".opencode/**",
+      ".beads/**",
       ".entire/**",
       ".worktrees/**",
       "**/.astro/**",


### PR DESCRIPTION
## Summary
- track the repo-local Beads JSONL/config files instead of ignoring all of .beads
- use br-oriented Beads metadata and docs, with local SQLite/runtime files ignored
- keep Biome from scanning Beads runtime files

## Verification
- br list --json
- br sync --status --json
- bun run lint
- pre-push hook passed on push: build, typecheck, lint, test, validate eval YAML files