### PR TITLE
fix(codex): use stream_log for target logging

### DIFF
--- a/.agentv/targets.yaml
+++ b/.agentv/targets.yaml
@@ -118,7 +118,7 @@ targets:
     grader_target: grader
     cwd: ${{ CODEX_WORKSPACE_DIR }}
     log_dir: ${{ CODEX_LOG_DIR }}
-    log_format: json
+    stream_log: raw
 
   # ── LLM targets (direct model access) ─────────────────────────────
   - name: gh-models

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,18 @@ agent-orchestrator.yaml
 # Agent configuration and activity logs
 .agents/
 .claude/
+.codex/
+.factory/
+.vscode/mcp.json
 .opencode/
 .ao/
+
+# MCP Agent Mail local configs (contain bearer tokens)
+.mcp.json
+codex.mcp.json
+cline.mcp.json
+factory.mcp.json
+windsurf.mcp.json
 
 # Gas Town / Beads shared state
 .beads/.br_history/
@@ -39,3 +49,6 @@ state.json
 
 # bv (beads viewer) local config and caches
 .bv/
+
+# Claude Code local settings (contains secrets)
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,14 @@ AI agents are the primary users of AgentV—not humans reading docs. Design for 
 - Keep the bead updated with notes for user-visible decisions, verification evidence, blockers, and handoff state.
 - Before handoff or commit, run `br sync --flush-only`, then stage `.beads/` along with the code changes when the bead graph is part of the change.
 
+### MCP Agent Mail
+- Agent Mail is available as `mcp-agent-mail` at `http://127.0.0.1:8765/api/` when the local server is running.
+- Start the server with `am` in a new shell, or run `/home/entity/.local/share/mcp_agent_mail/scripts/run_server_with_token.sh`.
+- At session start, call `ensure_project` for `/home/entity/projects/EntityProcess/agentv`, then `register_agent` if this session does not already have an Agent Mail identity.
+- Before editing shared files, create advisory reservations with `file_reservation_paths` for the intended paths/globs.
+- Use threads for coordination: `send_message` with a stable `thread_id`, `fetch_inbox` to check mail, and `acknowledge_message` after acting on a message.
+- Do not commit project-local Agent Mail config files; they contain bearer tokens and are ignored by `.gitignore`.
+
 ### Worktree Setup
 - For any feature, bug fix, or non-trivial repo change, work from a dedicated git worktree based on the latest `origin/main`.
 - Before starting implementation, run `git fetch origin` and verify your worktree `HEAD` is based on the current `origin/main` commit.

--- a/packages/core/src/evaluation/providers/codex-cli.ts
+++ b/packages/core/src/evaluation/providers/codex-cli.ts
@@ -204,7 +204,7 @@ export class CodexCliProvider implements Provider {
 
   private resolveLogDirectory(): string | undefined {
     const disabled = isCodexLogStreamingDisabled();
-    if (disabled) {
+    if (disabled || this.config.streamLog === false) {
       return undefined;
     }
     if (this.config.logDir) {
@@ -236,7 +236,7 @@ export class CodexCliProvider implements Provider {
         targetName: this.targetName,
         evalCaseId: request.evalCaseId,
         attempt: request.attempt,
-        format: this.config.logFormat ?? 'summary',
+        format: this.config.streamLog === 'raw' ? 'json' : 'summary',
       });
       recordCodexLogEntry({
         filePath,

--- a/packages/core/src/evaluation/providers/codex.ts
+++ b/packages/core/src/evaluation/providers/codex.ts
@@ -284,7 +284,7 @@ export class CodexProvider implements Provider {
 
   private resolveLogDirectory(): string | undefined {
     const disabled = isCodexLogStreamingDisabled();
-    if (disabled) {
+    if (disabled || this.config.streamLog === false) {
       return undefined;
     }
     if (this.config.logDir) {
@@ -316,7 +316,7 @@ export class CodexProvider implements Provider {
         targetName: this.targetName,
         evalCaseId: request.evalCaseId,
         attempt: request.attempt,
-        format: this.config.logFormat ?? 'summary',
+        format: this.config.streamLog === 'raw' ? 'json' : 'summary',
       });
       recordCodexLogEntry({
         filePath,

--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -430,7 +430,6 @@ export interface CodexResolvedConfig {
   readonly cwd?: string;
   readonly timeoutMs?: number;
   readonly logDir?: string;
-  readonly logFormat?: 'summary' | 'json';
   /** New stream_log field. false=no stream log (default), 'raw'=per-event, 'summary'=consolidated. */
   readonly streamLog?: false | 'raw' | 'summary';
   readonly systemPrompt?: string;
@@ -1272,14 +1271,14 @@ function resolveCodexConfig(
   const cwdSource = target.cwd;
   const timeoutSource = target.timeout_seconds;
   const logDirSource = target.log_dir ?? target.log_directory;
-  const logFormatSource =
-    target.log_format ?? target.log_output_format ?? env.AGENTV_CODEX_LOG_FORMAT;
   const systemPromptSource = target.system_prompt;
 
-  const streamLogResult = resolveStreamLog(target, env.AGENTV_CODEX_LOG_FORMAT);
-  if (streamLogResult.deprecationWarning) {
-    process.stderr.write(`[agentv] ⚠ ${streamLogResult.deprecationWarning}\n`);
+  if (target.log_format !== undefined || target.log_output_format !== undefined) {
+    throw new Error(
+      `${target.name}: log_format is no longer supported for codex targets. Use stream_log instead.`,
+    );
   }
+  const streamLogResult = resolveStreamLog({ name: target.name, stream_log: target.stream_log });
 
   const model = resolveOptionalString(modelSource, env, `${target.name} codex model`, {
     allowLiteral: true,
@@ -1315,7 +1314,6 @@ function resolveCodexConfig(
     allowLiteral: true,
     optionalEnv: true,
   });
-  const logFormat = normalizeCodexLogFormat(logFormatSource);
 
   const systemPrompt =
     typeof systemPromptSource === 'string' && systemPromptSource.trim().length > 0
@@ -1330,7 +1328,6 @@ function resolveCodexConfig(
     cwd,
     timeoutMs,
     logDir,
-    logFormat,
     streamLog: streamLogResult.streamLog,
     systemPrompt,
   };
@@ -1351,20 +1348,6 @@ function normalizeCodexModelReasoningEffort(
   throw new Error(
     `codex model_reasoning_effort must be one of: ${[...CODEX_MODEL_REASONING_EFFORT_VALUES].join(', ')}`,
   );
-}
-
-function normalizeCodexLogFormat(value: unknown): 'summary' | 'json' | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  if (typeof value !== 'string') {
-    throw new Error("codex log format must be 'summary' or 'json'");
-  }
-  const normalized = value.trim().toLowerCase();
-  if (normalized === 'json' || normalized === 'summary') {
-    return normalized;
-  }
-  throw new Error("codex log format must be 'summary' or 'json'");
 }
 
 /**

--- a/packages/core/src/evaluation/validation/targets-validator.ts
+++ b/packages/core/src/evaluation/validation/targets-validator.ts
@@ -106,8 +106,7 @@ const CODEX_SETTINGS = new Set([
   'timeout_seconds',
   'log_dir',
   'log_directory',
-  'log_format',
-  'log_output_format',
+  'stream_log',
   'system_prompt',
 ]);
 
@@ -257,6 +256,26 @@ function validateUnknownSettings(
           "AgentV always uses Azure's Responses API (`/openai/v1/responses`). " +
           "If your deployment only exposes /chat/completions, use 'provider: openai' " +
           "with a deployment-scoped 'base_url' instead.",
+      ],
+    ]),
+    codex: new Map([
+      [
+        'log_format',
+        "The 'log_format' field is no longer supported on Codex targets. Use 'stream_log: raw' for per-event logs or 'stream_log: summary' for consolidated logs.",
+      ],
+      [
+        'log_output_format',
+        "The 'log_output_format' field is no longer supported on Codex targets. Use 'stream_log: raw' for per-event logs or 'stream_log: summary' for consolidated logs.",
+      ],
+    ]),
+    'codex-cli': new Map([
+      [
+        'log_format',
+        "The 'log_format' field is no longer supported on Codex targets. Use 'stream_log: raw' for per-event logs or 'stream_log: summary' for consolidated logs.",
+      ],
+      [
+        'log_output_format',
+        "The 'log_output_format' field is no longer supported on Codex targets. Use 'stream_log: raw' for per-event logs or 'stream_log: summary' for consolidated logs.",
       ],
     ]),
   };

--- a/packages/core/test/evaluation/providers/codex.test.ts
+++ b/packages/core/test/evaluation/providers/codex.test.ts
@@ -202,7 +202,7 @@ describe('CodexCliProvider', () => {
     }
   });
 
-  it('supports JSON log format for detailed inspection', async () => {
+  it('supports raw stream logs for detailed inspection', async () => {
     const runner = mock(async (options: { readonly onStdoutChunk?: (chunk: string) => void }) => {
       const event = JSON.stringify({
         type: 'item.completed',
@@ -221,7 +221,7 @@ describe('CodexCliProvider', () => {
       {
         executable: process.execPath,
         logDir: fixturesRoot,
-        logFormat: 'json',
+        streamLog: 'raw',
       },
       runner,
     );


### PR DESCRIPTION
## Summary

Codex targets now use the canonical `stream_log` setting for event logging. The old Codex `log_format` and `log_output_format` fields are rejected instead of being accepted through the deprecated compatibility path, and the Codex providers derive their logger format from `streamLog` directly.

Agent Mail setup guidance is now documented in `AGENTS.md`, and local Agent Mail token/config files are ignored.

## Verification

- `bun --filter @agentv/core test -- codex.test.ts`
- `bun run build`
- `AGENT_TARGET=codex LLM_TARGET=azure GRADER_TARGET=azure bun apps/cli/src/cli.ts validate .agentv/targets.yaml`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
