### PR TITLE
feat(results): support global per-project results config

### DIFF
--- a/apps/cli/src/commands/results/remote.ts
+++ b/apps/cli/src/commands/results/remote.ts
@@ -9,11 +9,13 @@ import {
   type ResultsRepoStatus,
   directPushResults,
   directorySizeBytes,
+  getProjectForPath,
   getResultsRepoStatus,
   listGitRuns,
   loadConfig,
   materializeGitRun,
   normalizeResultsConfig,
+  resolveResultsConfigForProject,
   resolveResultsRepoRunsDir,
   syncResultsRepo,
 } from '@agentv/core';
@@ -129,13 +131,17 @@ async function maybeWarnLargeArtifact(runDir: string): Promise<void> {
 
 async function loadNormalizedResultsConfig(
   cwd: string,
+  projectId?: string,
 ): Promise<Required<ResultsConfig> | undefined> {
   const repoRoot = (await findRepoRoot(cwd)) ?? cwd;
   const config = await loadConfig(path.join(cwd, '_'), repoRoot);
-  if (!config?.results) {
+  const resolvedProjectId =
+    projectId ?? getProjectForPath(repoRoot)?.id ?? getProjectForPath(cwd)?.id;
+  const resultsConfig = resolveResultsConfigForProject(config, resolvedProjectId);
+  if (!resultsConfig) {
     return undefined;
   }
-  return normalizeResultsConfig(config.results);
+  return normalizeResultsConfig(resultsConfig);
 }
 
 export function encodeRemoteRunId(filename: string): string {
@@ -150,8 +156,11 @@ export function decodeRemoteRunId(filename: string): string {
   return filename.replace(REMOTE_RUN_PREFIX, '');
 }
 
-export async function getRemoteResultsStatus(cwd: string): Promise<RemoteResultsStatus> {
-  const config = await loadNormalizedResultsConfig(cwd);
+export async function getRemoteResultsStatus(
+  cwd: string,
+  projectId?: string,
+): Promise<RemoteResultsStatus> {
+  const config = await loadNormalizedResultsConfig(cwd, projectId);
   const status = getResultsRepoStatus(config);
   let runCount = 0;
   if (config && status.available) {
@@ -167,8 +176,11 @@ export async function getRemoteResultsStatus(cwd: string): Promise<RemoteResults
   };
 }
 
-export async function syncRemoteResults(cwd: string): Promise<RemoteResultsStatus> {
-  const config = await loadNormalizedResultsConfig(cwd);
+export async function syncRemoteResults(
+  cwd: string,
+  projectId?: string,
+): Promise<RemoteResultsStatus> {
+  const config = await loadNormalizedResultsConfig(cwd, projectId);
   if (!config) {
     return {
       ...getResultsRepoStatus(),
@@ -186,12 +198,13 @@ export async function syncRemoteResults(cwd: string): Promise<RemoteResultsStatu
     };
   }
 
-  return getRemoteResultsStatus(cwd);
+  return getRemoteResultsStatus(cwd, projectId);
 }
 
 export async function listMergedResultFiles(
   cwd: string,
   limit?: number,
+  projectId?: string,
 ): Promise<{ runs: SourcedResultFileMeta[]; remote_status: RemoteResultsStatus }> {
   const localRuns = listResultFiles(cwd).map(
     (meta) =>
@@ -202,8 +215,8 @@ export async function listMergedResultFiles(
       }) satisfies SourcedResultFileMeta,
   );
 
-  const remoteStatus = await getRemoteResultsStatus(cwd);
-  const config = await loadNormalizedResultsConfig(cwd);
+  const remoteStatus = await getRemoteResultsStatus(cwd, projectId);
+  const config = await loadNormalizedResultsConfig(cwd, projectId);
   if (!config || !remoteStatus.available) {
     return {
       runs: limit !== undefined && limit > 0 ? localRuns.slice(0, limit) : localRuns,
@@ -263,20 +276,22 @@ export async function listMergedResultFiles(
 export async function findRunById(
   cwd: string,
   runId: string,
+  projectId?: string,
 ): Promise<SourcedResultFileMeta | undefined> {
-  const { runs } = await listMergedResultFiles(cwd);
+  const { runs } = await listMergedResultFiles(cwd, undefined, projectId);
   return runs.find((run) => run.filename === runId);
 }
 
 export async function ensureRemoteRunAvailable(
   cwd: string,
   meta: Pick<SourcedResultFileMeta, 'source' | 'path'>,
+  projectId?: string,
 ): Promise<void> {
   if (meta.source !== 'remote' || existsSync(meta.path)) {
     return;
   }
 
-  const config = await loadNormalizedResultsConfig(cwd);
+  const config = await loadNormalizedResultsConfig(cwd, projectId);
   if (!config) {
     throw new Error('Remote results are not configured');
   }

--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -272,6 +272,7 @@ function stripHeavyFields(results: readonly EvaluationResult[]) {
 interface DataContext {
   searchDir: string;
   agentvDir: string;
+  projectId?: string;
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: Hono Context generic varies by route
@@ -289,31 +290,38 @@ function inferExperimentFromRunId(runId: string): string | undefined {
   return experiment;
 }
 
-async function ensureRunReadable(searchDir: string, meta: SourcedResultFileMeta): Promise<void> {
-  await ensureRemoteRunAvailable(searchDir, meta);
+async function ensureRunReadable(
+  searchDir: string,
+  meta: SourcedResultFileMeta,
+  projectId?: string,
+): Promise<void> {
+  await ensureRemoteRunAvailable(searchDir, meta, projectId);
 }
 
 async function loadManifestResultsForMeta(
   searchDir: string,
   meta: SourcedResultFileMeta,
+  projectId?: string,
 ): Promise<EvaluationResult[]> {
-  await ensureRunReadable(searchDir, meta);
+  await ensureRunReadable(searchDir, meta, projectId);
   return loadManifestResults(meta.path);
 }
 
 async function loadLightweightResultsForMeta(
   searchDir: string,
   meta: SourcedResultFileMeta,
+  projectId?: string,
 ): Promise<ReturnType<typeof loadLightweightResults>> {
-  await ensureRunReadable(searchDir, meta);
+  await ensureRunReadable(searchDir, meta, projectId);
   return loadLightweightResults(meta.path);
 }
 
 async function parseManifestForMeta(
   searchDir: string,
   meta: SourcedResultFileMeta,
+  projectId?: string,
 ): Promise<ReturnType<typeof parseResultManifest>> {
-  await ensureRunReadable(searchDir, meta);
+  await ensureRunReadable(searchDir, meta, projectId);
   return parseResultManifest(readFileSync(meta.path, 'utf8'));
 }
 
@@ -361,8 +369,8 @@ function paginateRuns<T extends { filename: string }>(
   };
 }
 
-async function handleRuns(c: C, { searchDir, agentvDir }: DataContext) {
-  const { runs: metas } = await listMergedResultFiles(searchDir);
+async function handleRuns(c: C, { searchDir, agentvDir, projectId }: DataContext) {
+  const { runs: metas } = await listMergedResultFiles(searchDir, undefined, projectId);
   const { threshold: passThreshold } = loadStudioConfig(agentvDir);
   const parsedLimit = parseRunPageLimit(c.req.query('limit'));
   if (parsedLimit === null) {
@@ -378,7 +386,7 @@ async function handleRuns(c: C, { searchDir, agentvDir }: DataContext) {
       let passRate = m.passRate;
       let avgScore = m.avgScore;
       try {
-        const records = await loadLightweightResultsForMeta(searchDir, m);
+        const records = await loadLightweightResultsForMeta(searchDir, m, projectId);
         if (records.length > 0) {
           target = records[0].target;
           experiment = records[0].experiment ?? experiment;
@@ -421,9 +429,9 @@ async function handleRuns(c: C, { searchDir, agentvDir }: DataContext) {
   });
 }
 
-async function handleRunLog(c: C, { searchDir }: DataContext) {
+async function handleRunLog(c: C, { searchDir, projectId }: DataContext) {
   const filename = c.req.param('filename') ?? '';
-  const meta = await findRunById(searchDir, filename);
+  const meta = await findRunById(searchDir, filename, projectId);
   if (!meta) return c.json({ error: 'Run not found' }, 404);
   if (meta.source === 'remote') {
     return c.json({ error: 'Run log is not available for remote runs' }, 404);
@@ -440,12 +448,12 @@ async function handleRunLog(c: C, { searchDir }: DataContext) {
   }
 }
 
-async function handleRunDetail(c: C, { searchDir }: DataContext) {
+async function handleRunDetail(c: C, { searchDir, projectId }: DataContext) {
   const filename = c.req.param('filename') ?? '';
-  const meta = await findRunById(searchDir, filename);
+  const meta = await findRunById(searchDir, filename, projectId);
   if (!meta) return c.json({ error: 'Run not found' }, 404);
   try {
-    const loaded = await loadManifestResultsForMeta(searchDir, meta);
+    const loaded = await loadManifestResultsForMeta(searchDir, meta, projectId);
     // Surface run_dir + suite_filter for local runs so the UI can launch a
     // Dashboard-side resume against this exact run. Remote runs live in the
     // results-repo cache and cannot be resumed in place, so omit both fields.
@@ -501,12 +509,12 @@ function deriveResumeMeta(
   return out;
 }
 
-async function handleRunSuites(c: C, { searchDir, agentvDir }: DataContext) {
+async function handleRunSuites(c: C, { searchDir, agentvDir, projectId }: DataContext) {
   const filename = c.req.param('filename') ?? '';
-  const meta = await findRunById(searchDir, filename);
+  const meta = await findRunById(searchDir, filename, projectId);
   if (!meta) return c.json({ error: 'Run not found' }, 404);
   try {
-    const loaded = await loadManifestResultsForMeta(searchDir, meta);
+    const loaded = await loadManifestResultsForMeta(searchDir, meta, projectId);
     const { threshold: pass_threshold } = loadStudioConfig(agentvDir);
     const suiteMap = new Map<string, { total: number; passed: number; scoreSum: number }>();
     for (const r of loaded) {
@@ -530,12 +538,12 @@ async function handleRunSuites(c: C, { searchDir, agentvDir }: DataContext) {
   }
 }
 
-async function handleRunCategories(c: C, { searchDir, agentvDir }: DataContext) {
+async function handleRunCategories(c: C, { searchDir, agentvDir, projectId }: DataContext) {
   const filename = c.req.param('filename') ?? '';
-  const meta = await findRunById(searchDir, filename);
+  const meta = await findRunById(searchDir, filename, projectId);
   if (!meta) return c.json({ error: 'Run not found' }, 404);
   try {
-    const loaded = await loadManifestResultsForMeta(searchDir, meta);
+    const loaded = await loadManifestResultsForMeta(searchDir, meta, projectId);
     const { threshold: pass_threshold } = loadStudioConfig(agentvDir);
     const categoryMap = new Map<
       string,
@@ -569,13 +577,13 @@ async function handleRunCategories(c: C, { searchDir, agentvDir }: DataContext) 
   }
 }
 
-async function handleCategorySuites(c: C, { searchDir, agentvDir }: DataContext) {
+async function handleCategorySuites(c: C, { searchDir, agentvDir, projectId }: DataContext) {
   const filename = c.req.param('filename') ?? '';
   const category = decodeURIComponent(c.req.param('category') ?? '');
-  const meta = await findRunById(searchDir, filename);
+  const meta = await findRunById(searchDir, filename, projectId);
   if (!meta) return c.json({ error: 'Run not found' }, 404);
   try {
-    const loaded = await loadManifestResultsForMeta(searchDir, meta);
+    const loaded = await loadManifestResultsForMeta(searchDir, meta, projectId);
     const { threshold: pass_threshold } = loadStudioConfig(agentvDir);
     const filtered = loaded.filter((r) => (r.category ?? DEFAULT_CATEGORY) === category);
     const suiteMap = new Map<string, { total: number; passed: number; scoreSum: number }>();
@@ -600,13 +608,13 @@ async function handleCategorySuites(c: C, { searchDir, agentvDir }: DataContext)
   }
 }
 
-async function handleEvalDetail(c: C, { searchDir }: DataContext) {
+async function handleEvalDetail(c: C, { searchDir, projectId }: DataContext) {
   const filename = c.req.param('filename') ?? '';
   const evalId = c.req.param('evalId');
-  const meta = await findRunById(searchDir, filename);
+  const meta = await findRunById(searchDir, filename, projectId);
   if (!meta) return c.json({ error: 'Run not found' }, 404);
   try {
-    const loaded = await loadManifestResultsForMeta(searchDir, meta);
+    const loaded = await loadManifestResultsForMeta(searchDir, meta, projectId);
     const result = loaded.find((r) => r.testId === evalId);
     if (!result) return c.json({ error: 'Eval not found' }, 404);
     return c.json({ eval: result });
@@ -615,13 +623,13 @@ async function handleEvalDetail(c: C, { searchDir }: DataContext) {
   }
 }
 
-async function handleEvalFiles(c: C, { searchDir }: DataContext) {
+async function handleEvalFiles(c: C, { searchDir, projectId }: DataContext) {
   const filename = c.req.param('filename') ?? '';
   const evalId = c.req.param('evalId');
-  const meta = await findRunById(searchDir, filename);
+  const meta = await findRunById(searchDir, filename, projectId);
   if (!meta) return c.json({ error: 'Run not found' }, 404);
   try {
-    const records = await parseManifestForMeta(searchDir, meta);
+    const records = await parseManifestForMeta(searchDir, meta, projectId);
     const record = records.find((r) => r.test_id === evalId);
     if (!record) return c.json({ error: 'Eval not found' }, 404);
 
@@ -652,9 +660,9 @@ async function handleEvalFiles(c: C, { searchDir }: DataContext) {
   }
 }
 
-async function handleEvalFileContent(c: C, { searchDir }: DataContext) {
+async function handleEvalFileContent(c: C, { searchDir, projectId }: DataContext) {
   const filename = c.req.param('filename') ?? '';
-  const meta = await findRunById(searchDir, filename);
+  const meta = await findRunById(searchDir, filename, projectId);
   if (!meta) return c.json({ error: 'Run not found' }, 404);
 
   // Extract the wildcard suffix without depending on decoded route params.
@@ -664,7 +672,7 @@ async function handleEvalFileContent(c: C, { searchDir }: DataContext) {
 
   if (!filePath) return c.json({ error: 'No file path specified' }, 400);
 
-  await ensureRunReadable(searchDir, meta);
+  await ensureRunReadable(searchDir, meta, projectId);
   const baseDir = path.dirname(meta.path);
   const absolutePath = path.resolve(baseDir, filePath);
 
@@ -689,8 +697,8 @@ async function handleEvalFileContent(c: C, { searchDir }: DataContext) {
   }
 }
 
-async function handleExperiments(c: C, { searchDir, agentvDir }: DataContext) {
-  const { runs: metas } = await listMergedResultFiles(searchDir);
+async function handleExperiments(c: C, { searchDir, agentvDir, projectId }: DataContext) {
+  const { runs: metas } = await listMergedResultFiles(searchDir, undefined, projectId);
   const { threshold: pass_threshold } = loadStudioConfig(agentvDir);
   const experimentMap = new Map<
     string,
@@ -705,7 +713,7 @@ async function handleExperiments(c: C, { searchDir, agentvDir }: DataContext) {
 
   for (const m of metas) {
     try {
-      const records = await loadLightweightResultsForMeta(searchDir, m);
+      const records = await loadLightweightResultsForMeta(searchDir, m, projectId);
       for (const r of records) {
         const experiment = r.experiment ?? 'default';
         const entry = experimentMap.get(experiment) ?? {
@@ -742,8 +750,8 @@ async function handleExperiments(c: C, { searchDir, agentvDir }: DataContext) {
   return c.json({ experiments });
 }
 
-async function handleCompare(c: C, { searchDir, agentvDir }: DataContext) {
-  const { runs: metas } = await listMergedResultFiles(searchDir);
+async function handleCompare(c: C, { searchDir, agentvDir, projectId }: DataContext) {
+  const { runs: metas } = await listMergedResultFiles(searchDir, undefined, projectId);
   const { threshold: pass_threshold } = loadStudioConfig(agentvDir);
 
   // Optional tag filter: `?tags=baseline,v2-prompt` keeps only runs that
@@ -812,7 +820,7 @@ async function handleCompare(c: C, { searchDir, agentvDir }: DataContext) {
         if (!runTags.some((t) => filterTags.has(t))) continue;
       }
 
-      const records = await loadLightweightResultsForMeta(searchDir, m);
+      const records = await loadLightweightResultsForMeta(searchDir, m, projectId);
       const runTestMap = new Map<
         string,
         { test_id: string; score: number; passed: boolean; execution_status?: string }
@@ -950,8 +958,8 @@ async function handleCompare(c: C, { searchDir, agentvDir }: DataContext) {
   });
 }
 
-async function handleTargets(c: C, { searchDir, agentvDir }: DataContext) {
-  const { runs: metas } = await listMergedResultFiles(searchDir);
+async function handleTargets(c: C, { searchDir, agentvDir, projectId }: DataContext) {
+  const { runs: metas } = await listMergedResultFiles(searchDir, undefined, projectId);
   const { threshold: pass_threshold } = loadStudioConfig(agentvDir);
   const targetMap = new Map<
     string,
@@ -965,7 +973,7 @@ async function handleTargets(c: C, { searchDir, agentvDir }: DataContext) {
 
   for (const m of metas) {
     try {
-      const records = await loadLightweightResultsForMeta(searchDir, m);
+      const records = await loadLightweightResultsForMeta(searchDir, m, projectId);
       for (const r of records) {
         const target = r.target ?? 'default';
         const entry = targetMap.get(target) ?? {
@@ -1018,9 +1026,9 @@ function handleFeedbackRead(c: C, { searchDir }: DataContext) {
   return c.json(readFeedback(existsSync(resultsDir) ? resultsDir : searchDir));
 }
 
-async function handleRunTagsPut(c: C, { searchDir }: DataContext) {
+async function handleRunTagsPut(c: C, { searchDir, projectId }: DataContext) {
   const filename = c.req.param('filename') ?? '';
-  const meta = await findRunById(searchDir, filename);
+  const meta = await findRunById(searchDir, filename, projectId);
   if (!meta) return c.json({ error: 'Run not found' }, 404);
   if (meta.source === 'remote') {
     return c.json({ error: 'Tags can only be set on local runs' }, 400);
@@ -1049,9 +1057,9 @@ async function handleRunTagsPut(c: C, { searchDir }: DataContext) {
   }
 }
 
-async function handleRunTagsDelete(c: C, { searchDir }: DataContext) {
+async function handleRunTagsDelete(c: C, { searchDir, projectId }: DataContext) {
   const filename = c.req.param('filename') ?? '';
-  const meta = await findRunById(searchDir, filename);
+  const meta = await findRunById(searchDir, filename, projectId);
   if (!meta) return c.json({ error: 'Run not found' }, 404);
   if (meta.source === 'remote') {
     return c.json({ error: 'Tags can only be removed on local runs' }, 400);
@@ -1084,7 +1092,7 @@ export function createApp(
 ): Hono {
   const searchDir = cwd ?? resultDir;
   const agentvDir = path.join(searchDir, '.agentv');
-  const defaultCtx: DataContext = { searchDir, agentvDir };
+  const defaultCtx: DataContext = { searchDir, agentvDir, projectId: options?.currentProjectId };
   const readOnly = options?.readOnly === true;
   const app = new Hono();
 
@@ -1103,6 +1111,7 @@ export function createApp(
     return handler(c, {
       searchDir: project.path,
       agentvDir: path.join(project.path, '.agentv'),
+      projectId: project.id,
     });
   }
 
@@ -1153,7 +1162,7 @@ export function createApp(
         let passRate = 0;
         let lastRun: string | null = null;
         try {
-          const { runs: metas } = await listMergedResultFiles(p.path);
+          const { runs: metas } = await listMergedResultFiles(p.path, undefined, p.id);
           runCount = metas.length;
           if (metas.length > 0) {
             const totalPassRate = metas.reduce((sum, m) => sum + m.passRate, 0);
@@ -1192,7 +1201,7 @@ export function createApp(
     const project = getProject(c.req.param('projectId') ?? '');
     if (!project) return c.json({ error: 'Project not found' }, 404);
     try {
-      const { runs: metas } = await listMergedResultFiles(project.path);
+      const { runs: metas } = await listMergedResultFiles(project.path, undefined, project.id);
       const runCount = metas.length;
       const passRate = runCount > 0 ? metas.reduce((s, m) => s + m.passRate, 0) / runCount : 0;
       const lastRun = metas.length > 0 ? metas[0].timestamp : null;
@@ -1230,12 +1239,12 @@ export function createApp(
 
     for (const p of registry.projects) {
       try {
-        const { runs: metas } = await listMergedResultFiles(p.path);
+        const { runs: metas } = await listMergedResultFiles(p.path, undefined, p.id);
         for (const m of metas) {
           let target: string | undefined;
           let experiment = inferExperimentFromRunId(m.raw_filename);
           try {
-            const records = await loadLightweightResultsForMeta(p.path, m);
+            const records = await loadLightweightResultsForMeta(p.path, m, p.id);
             if (records.length > 0) {
               target = records[0].target;
               experiment = records[0].experiment ?? experiment;
@@ -1286,8 +1295,12 @@ export function createApp(
       currentProjectId: options?.currentProjectId,
     }),
   );
-  app.get('/api/remote/status', async (c) => c.json(await getRemoteResultsStatus(searchDir)));
-  app.post('/api/remote/sync', async (c) => c.json(await syncRemoteResults(searchDir)));
+  app.get('/api/remote/status', async (c) =>
+    c.json(await getRemoteResultsStatus(searchDir, defaultCtx.projectId)),
+  );
+  app.post('/api/remote/sync', async (c) =>
+    c.json(await syncRemoteResults(searchDir, defaultCtx.projectId)),
+  );
   app.get('/api/runs', (c) => handleRuns(c, defaultCtx));
   app.put('/api/runs/:filename/tags', (c) => {
     if (readOnly) {
@@ -1372,12 +1385,12 @@ export function createApp(
 
   // Aggregated index (unscoped only)
   app.get('/api/index', async (c) => {
-    const { runs: metas } = await listMergedResultFiles(searchDir);
+    const { runs: metas } = await listMergedResultFiles(searchDir, undefined, defaultCtx.projectId);
     const entries = await Promise.all(
       metas.map(async (m) => {
         let totalCostUsd = 0;
         try {
-          const loaded = await loadManifestResultsForMeta(searchDir, m);
+          const loaded = await loadManifestResultsForMeta(searchDir, m, defaultCtx.projectId);
           totalCostUsd = loaded.reduce((sum, r) => sum + (r.costUsd ?? 0), 0);
         } catch {
           // ignore load errors for aggregate
@@ -1409,11 +1422,13 @@ export function createApp(
   );
   app.get('/api/projects/:projectId/remote/status', (c) =>
     withProject(c, async (ctx, dataCtx) =>
-      ctx.json(await getRemoteResultsStatus(dataCtx.searchDir)),
+      ctx.json(await getRemoteResultsStatus(dataCtx.searchDir, dataCtx.projectId)),
     ),
   );
   app.post('/api/projects/:projectId/remote/sync', (c) =>
-    withProject(c, async (ctx, dataCtx) => ctx.json(await syncRemoteResults(dataCtx.searchDir))),
+    withProject(c, async (ctx, dataCtx) =>
+      ctx.json(await syncRemoteResults(dataCtx.searchDir, dataCtx.projectId)),
+    ),
   );
   app.get('/api/projects/:projectId/runs', (c) => withProject(c, handleRuns));
   app.put('/api/projects/:projectId/runs/:filename/tags', (c) => {

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -5,7 +5,7 @@ import os from 'node:os';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { addProject } from '@agentv/core';
+import { addProject, saveProjectRegistry } from '@agentv/core';
 
 import {
   createApp,
@@ -830,6 +830,67 @@ describe('serve app', () => {
         expect(data.path).toBe(
           path.join(tempDir, 'agentv-home-status', 'results', 'EntityProcess-agentv-evals'),
         );
+      } finally {
+        if (previousHome === undefined) {
+          process.env.AGENTV_HOME = undefined;
+        } else {
+          process.env.AGENTV_HOME = previousHome;
+        }
+      }
+    });
+
+    it('uses AGENTV_HOME results_by_project for project-scoped remote status', async () => {
+      const previousHome = process.env.AGENTV_HOME;
+      const homeDir = path.join(tempDir, 'agentv-home-project-status');
+      process.env.AGENTV_HOME = homeDir;
+
+      try {
+        const projectDir = path.join(tempDir, 'source-project');
+        mkdirSync(path.join(projectDir, '.agentv'), { recursive: true });
+        mkdirSync(homeDir, { recursive: true });
+        writeFileSync(
+          path.join(projectDir, '.agentv', 'config.yaml'),
+          'execution:\n  verbose: true\n',
+        );
+        writeFileSync(
+          path.join(homeDir, 'config.yaml'),
+          `results_by_project:
+  agentv:
+    mode: github
+    repo: EntityProcess/agentv-examples-eval-results
+    path: /home/entity/projects/EntityProcess/agentv-examples-eval-results
+    auto_push: true
+results:
+  mode: github
+  repo: EntityProcess/fallback-results
+`,
+        );
+        saveProjectRegistry({
+          projects: [
+            {
+              id: 'agentv',
+              name: 'AgentV',
+              path: projectDir,
+              addedAt: '2026-01-01T00:00:00.000Z',
+              lastOpenedAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        });
+
+        const app = createApp([], tempDir, tempDir, undefined, { studioDir });
+        const res = await app.request('/api/projects/agentv/remote/status');
+
+        expect(res.status).toBe(200);
+        const data = (await res.json()) as {
+          configured: boolean;
+          repo: string;
+          path: string;
+          auto_push: boolean;
+        };
+        expect(data.configured).toBe(true);
+        expect(data.repo).toBe('EntityProcess/agentv-examples-eval-results');
+        expect(data.path).toBe('/home/entity/projects/EntityProcess/agentv-examples-eval-results');
+        expect(data.auto_push).toBe(true);
       } finally {
         if (previousHome === undefined) {
           process.env.AGENTV_HOME = undefined;

--- a/apps/web/src/content/docs/docs/tools/dashboard.mdx
+++ b/apps/web/src/content/docs/docs/tools/dashboard.mdx
@@ -175,9 +175,9 @@ agentv dashboard --add /path/to/my-evals
 agentv dashboard --add /path/to/other-evals
 ```
 
-Each path must contain a `.agentv/` directory. Registered projects are stored in `~/.agentv/projects.yaml`.
+Each path must contain a `.agentv/` directory. Registered projects are stored in `$AGENTV_HOME/projects.yaml`, or `~/.agentv/projects.yaml` when `AGENTV_HOME` is unset.
 
-To register a remote repo and keep it synced automatically, add a `source` block to the entry in `~/.agentv/projects.yaml`:
+To register a remote repo and keep it synced automatically, add a `source` block to the entry in `$AGENTV_HOME/projects.yaml`:
 
 ```yaml
 projects:
@@ -197,7 +197,7 @@ On each Dashboard startup, AgentV clones the repo if the path is empty (`git clo
 
 - Adding via the UI's **Add Project** form or `POST /api/projects`.
 - Removing via the UI's **Remove** button or `DELETE /api/projects/:id`.
-- Editing `~/.agentv/projects.yaml` directly.
+- Editing `$AGENTV_HOME/projects.yaml` directly.
 - Mounting the file via a Kubernetes ConfigMap — GitOps the ConfigMap and Dashboard reflects it within the next poll.
 
 This satisfies the 24/7-Dashboard use case: the server stays up; projects come and go through config edits or API calls.
@@ -209,6 +209,13 @@ Dashboard opens the Projects dashboard by default, even when no projects or one 
 ```bash
 agentv dashboard          # Projects dashboard
 agentv dashboard --single # legacy single-project route layout
+```
+
+Use a different `AGENTV_HOME` and port per process when you want multiple non-Docker dashboard instances with separate project registries and global config:
+
+```bash
+AGENTV_HOME=/tmp/agentv-home-a agentv dashboard --port 3117
+AGENTV_HOME=/tmp/agentv-home-b agentv dashboard --port 3118
 ```
 
 The landing page shows a card for each project with run count, pass rate, and last run time.
@@ -242,6 +249,29 @@ results:
 ```
 
 `results.path` is the filesystem location of the local clone AgentV manages for the results repo. It is **not** a subdirectory inside the remote repo.
+
+For machine-local multi-project dashboards, put per-project results repos in `$AGENTV_HOME/config.yaml` (or `~/.agentv/config.yaml`) instead of editing each source repo:
+
+```yaml
+results_by_project:
+  agentv:
+    mode: github
+    repo: EntityProcess/agentv-examples-eval-results
+    path: /home/entity/projects/EntityProcess/agentv-examples-eval-results
+    auto_push: true
+  wtg-ai-prompts:
+    mode: github
+    repo: WiseTechGlobal/WTG.AI.Prompts.EvalResults
+    path: /home/entity/projects/WiseTechGlobal/WTG.AI.Prompts.EvalResults
+    auto_push: true
+  wisetechacademy-evals:
+    mode: github
+    repo: WiseTechGlobal/WiseTechAcademy.EvalResults
+    path: /home/entity/projects/WiseTechGlobal/WiseTechAcademy.EvalResults
+    auto_push: true
+```
+
+The keys under `results_by_project` must match the project IDs in `$AGENTV_HOME/projects.yaml`. Project-local `.agentv/config.yaml` `results` blocks still take precedence. A top-level global `results` block remains the fallback for projects without a specific mapping.
 
 With `auto_push: true`, every new `agentv eval` or `agentv pipeline bench` pushes results directly to the configured repo's base branch (e.g., `main`). Results appear immediately in Dashboard without requiring PR merges.
 

--- a/packages/core/src/evaluation/loaders/config-loader.ts
+++ b/packages/core/src/evaluation/loaders/config-loader.ts
@@ -46,6 +46,8 @@ export type ResultsConfig = {
   readonly branch_prefix?: string;
 };
 
+export type ResultsByProjectConfig = Record<string, ResultsConfig>;
+
 export type HooksConfig = {
   /** Shell command to run once at agentv startup. stdout is parsed for env var exports. */
   readonly before_session?: string;
@@ -56,6 +58,7 @@ export type AgentVConfig = {
   readonly eval_patterns?: readonly string[];
   readonly execution?: ExecutionDefaults;
   readonly results?: ResultsConfig;
+  readonly results_by_project?: ResultsByProjectConfig;
   readonly hooks?: HooksConfig;
 };
 
@@ -65,13 +68,17 @@ export type AgentVConfig = {
  * Project-local `.agentv/config.yaml` files are searched from the eval file
  * directory up to the repo root. If no project-local config is found, AgentV
  * falls back to the home/global config at `${AGENTV_HOME:-~/.agentv}/config.yaml`.
- * The first valid file wins; there is intentionally no cross-file merge.
+ * The first valid project-local file wins for normal settings. Machine-local
+ * `results_by_project` mappings from the global config are still attached when
+ * the project-local file has no `results` block, so registered projects can use
+ * per-machine results repos without editing source-controlled config.
  */
 export async function loadConfig(
   evalFilePath: string,
   repoRoot: string,
 ): Promise<AgentVConfig | null> {
   const directories = buildDirectoryChain(evalFilePath, repoRoot);
+  const globalConfigPath = path.join(getAgentvConfigDir(), 'config.yaml');
 
   for (const directory of directories) {
     const configPath = path.join(directory, '.agentv', 'config.yaml');
@@ -81,10 +88,21 @@ export async function loadConfig(
     }
 
     const config = await readConfigFile(configPath);
-    if (config) return config;
+    if (config) {
+      if (config.results) return config;
+
+      const globalConfig = (await fileExists(globalConfigPath))
+        ? await readConfigFile(globalConfigPath)
+        : null;
+      return {
+        ...config,
+        ...((config.results_by_project ?? globalConfig?.results_by_project)
+          ? { results_by_project: config.results_by_project ?? globalConfig?.results_by_project }
+          : {}),
+      };
+    }
   }
 
-  const globalConfigPath = path.join(getAgentvConfigDir(), 'config.yaml');
   return (await fileExists(globalConfigPath)) ? readConfigFile(globalConfigPath) : null;
 }
 
@@ -122,6 +140,10 @@ async function readConfigFile(configPath: string): Promise<AgentVConfig | null> 
       configPath,
     );
     const results = parseResultsConfig((parsed as Record<string, unknown>).results, configPath);
+    const resultsByProject = parseResultsByProjectConfig(
+      (parsed as Record<string, unknown>).results_by_project,
+      configPath,
+    );
     const hooks = parseHooksConfig((parsed as Record<string, unknown>).hooks, configPath);
 
     return {
@@ -129,6 +151,7 @@ async function readConfigFile(configPath: string): Promise<AgentVConfig | null> 
       eval_patterns: evalPatterns as readonly string[] | undefined,
       execution: executionDefaults,
       results,
+      ...(resultsByProject && { results_by_project: resultsByProject }),
       ...(hooks && { hooks }),
     };
   } catch (error) {
@@ -639,6 +662,46 @@ export function parseResultsConfig(raw: unknown, configPath: string): ResultsCon
     ...(typeof obj.auto_push === 'boolean' && { auto_push: obj.auto_push }),
     ...(branchPrefix && { branch_prefix: branchPrefix }),
   };
+}
+
+export function parseResultsByProjectConfig(
+  raw: unknown,
+  configPath: string,
+): ResultsByProjectConfig | undefined {
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    logWarning(`Invalid results_by_project in ${configPath}, expected object`);
+    return undefined;
+  }
+
+  const entries: ResultsByProjectConfig = {};
+  for (const [projectId, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!projectId.trim()) {
+      logWarning(`Invalid results_by_project key in ${configPath}, expected non-empty project id`);
+      continue;
+    }
+    const parsed = parseResultsConfig(value, `${configPath} results_by_project.${projectId}`);
+    if (parsed) {
+      entries[projectId] = parsed;
+    }
+  }
+
+  return Object.keys(entries).length > 0 ? entries : undefined;
+}
+
+export function resolveResultsConfigForProject(
+  config: AgentVConfig | null | undefined,
+  projectId?: string,
+): ResultsConfig | undefined {
+  if (!config) {
+    return undefined;
+  }
+
+  const projectResults =
+    projectId && projectId.trim().length > 0 ? config.results_by_project?.[projectId] : undefined;
+  return projectResults ?? config.results;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export {
 } from './evaluation/loaders/agent-skills-parser.js';
 export {
   loadConfig,
+  resolveResultsConfigForProject,
   type AgentVConfig as AgentVYamlConfig,
   type ResultsConfig,
 } from './evaluation/loaders/config-loader.js';
@@ -100,6 +101,7 @@ export {
   addProject,
   removeProject,
   getProject,
+  getProjectForPath,
   touchProject,
   discoverProjects,
   deriveProjectId,

--- a/packages/core/src/projects.ts
+++ b/packages/core/src/projects.ts
@@ -338,6 +338,21 @@ export function getProject(projectId: string): ProjectEntry | undefined {
 }
 
 /**
+ * Look up the registered project containing a filesystem path.
+ * Exact path matches win; otherwise the deepest registered parent wins.
+ */
+export function getProjectForPath(fsPath: string): ProjectEntry | undefined {
+  const absPath = path.resolve(fsPath);
+  return loadProjectRegistry()
+    .projects.filter((p) => {
+      const projectPath = path.resolve(p.path);
+      const relative = path.relative(projectPath, absPath);
+      return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+    })
+    .sort((a, b) => path.resolve(b.path).length - path.resolve(a.path).length)[0];
+}
+
+/**
  * Update lastOpenedAt for a project.
  */
 export function touchProject(projectId: string): void {

--- a/packages/core/test/evaluation/loaders/config-loader.test.ts
+++ b/packages/core/test/evaluation/loaders/config-loader.test.ts
@@ -14,7 +14,9 @@ import {
   extractTrialsConfig,
   loadConfig,
   parseExecutionDefaults,
+  parseResultsByProjectConfig,
   parseResultsConfig,
+  resolveResultsConfigForProject,
 } from '../../../src/evaluation/loaders/config-loader.js';
 import type { JsonObject } from '../../../src/evaluation/types.js';
 
@@ -86,6 +88,83 @@ describe('loadConfig', () => {
         const config = await loadConfig(path.join(evalDir, 'suite.eval.yaml'), projectDir);
         expect(config?.eval_patterns).toEqual(['**/*.local.eval.yaml']);
         expect(config?.execution).toEqual({ keep_workspaces: true });
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps global results_by_project available when project-local config has no results', async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'agentv-global-project-results-'));
+    try {
+      const projectDir = path.join(tempDir, 'project');
+      const evalDir = path.join(projectDir, 'evals');
+      const localConfigDir = path.join(projectDir, '.agentv');
+      const homeDir = path.join(tempDir, 'home');
+      mkdirSync(evalDir, { recursive: true });
+      mkdirSync(localConfigDir, { recursive: true });
+      mkdirSync(homeDir, { recursive: true });
+      writeFileSync(
+        path.join(localConfigDir, 'config.yaml'),
+        'execution:\n  keep_workspaces: true\n',
+      );
+      writeFileSync(
+        path.join(homeDir, 'config.yaml'),
+        `results_by_project:
+  agentv:
+    mode: github
+    repo: EntityProcess/agentv-examples-eval-results
+    path: /home/entity/projects/EntityProcess/agentv-examples-eval-results
+    auto_push: true
+`,
+      );
+
+      await withOptionalEnv('AGENTV_HOME', homeDir, async () => {
+        const config = await loadConfig(path.join(evalDir, 'suite.eval.yaml'), projectDir);
+        expect(config?.execution).toEqual({ keep_workspaces: true });
+        expect(resolveResultsConfigForProject(config, 'agentv')).toEqual({
+          mode: 'github',
+          repo: 'EntityProcess/agentv-examples-eval-results',
+          path: '/home/entity/projects/EntityProcess/agentv-examples-eval-results',
+          auto_push: true,
+        });
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps project-local results ahead of global results_by_project', async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'agentv-local-results-precedence-'));
+    try {
+      const projectDir = path.join(tempDir, 'project');
+      const evalDir = path.join(projectDir, 'evals');
+      const localConfigDir = path.join(projectDir, '.agentv');
+      const homeDir = path.join(tempDir, 'home');
+      mkdirSync(evalDir, { recursive: true });
+      mkdirSync(localConfigDir, { recursive: true });
+      mkdirSync(homeDir, { recursive: true });
+      writeFileSync(
+        path.join(localConfigDir, 'config.yaml'),
+        `results:
+  mode: github
+  repo: EntityProcess/local-results
+`,
+      );
+      writeFileSync(
+        path.join(homeDir, 'config.yaml'),
+        `results_by_project:
+  agentv:
+    mode: github
+    repo: EntityProcess/global-results
+`,
+      );
+
+      await withOptionalEnv('AGENTV_HOME', homeDir, async () => {
+        const config = await loadConfig(path.join(evalDir, 'suite.eval.yaml'), projectDir);
+        expect(resolveResultsConfigForProject(config, 'agentv')?.repo).toBe(
+          'EntityProcess/local-results',
+        );
       });
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
@@ -323,6 +402,59 @@ describe('parseResultsConfig', () => {
     );
 
     expect(result).toBeUndefined();
+  });
+});
+
+describe('parseResultsByProjectConfig', () => {
+  it('parses per-project results mappings', () => {
+    const result = parseResultsByProjectConfig(
+      {
+        agentv: {
+          mode: 'github',
+          repo: 'EntityProcess/agentv-examples-eval-results',
+          path: '/home/entity/projects/EntityProcess/agentv-examples-eval-results',
+          auto_push: true,
+        },
+      },
+      '/tmp/config.yaml',
+    );
+
+    expect(result?.agentv).toEqual({
+      mode: 'github',
+      repo: 'EntityProcess/agentv-examples-eval-results',
+      path: '/home/entity/projects/EntityProcess/agentv-examples-eval-results',
+      auto_push: true,
+    });
+  });
+});
+
+describe('resolveResultsConfigForProject', () => {
+  it('uses project mapping before top-level results fallback', () => {
+    const result = resolveResultsConfigForProject(
+      {
+        results: { mode: 'github', repo: 'EntityProcess/fallback' },
+        results_by_project: {
+          agentv: { mode: 'github', repo: 'EntityProcess/project' },
+        },
+      },
+      'agentv',
+    );
+
+    expect(result?.repo).toBe('EntityProcess/project');
+  });
+
+  it('falls back to top-level results when no project mapping matches', () => {
+    const result = resolveResultsConfigForProject(
+      {
+        results: { mode: 'github', repo: 'EntityProcess/fallback' },
+        results_by_project: {
+          other: { mode: 'github', repo: 'EntityProcess/project' },
+        },
+      },
+      'agentv',
+    );
+
+    expect(result?.repo).toBe('EntityProcess/fallback');
   });
 });
 


### PR DESCRIPTION
## Summary

Registered Dashboard projects can now use machine-local results repos from `$AGENTV_HOME/config.yaml` without editing each source repo's `.agentv/config.yaml`. `results_by_project` maps project IDs to the existing `ResultsConfig` shape, while project-local `results` still wins and top-level global `results` remains the fallback.

Dashboard remote status, sync, run listing, and remote artifact materialization now carry the registered project id through the shared results helpers. Local eval auto-push also resolves the registered project containing the cwd, so evals launched from a registered source repo use the matching global results mapping.

## Evidence

Red on `origin/main`, same registered project plus global `results_by_project` only:

```json
{"configured":false,"available":false,"repo":"","local_dir":"","run_count":0}
```

Green on this branch:

```json
{"configured":true,"available":true,"repo":"EntityProcess/agentv-examples-eval-results","path":"/home/entity/projects/EntityProcess/agentv-examples-eval-results","auto_push":true,"branch_prefix":"eval-results","local_dir":"/home/entity/projects/EntityProcess/agentv-examples-eval-results","run_count":3}
```

## Verification

- `bun test packages/core/test/evaluation/loaders/config-loader.test.ts`
- `bun test ./test/commands/results/serve.test.ts` from `apps/cli`
- `bun run typecheck`
- `bun run lint`
- `bun run build`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
