### PR TITLE
fix(config): complete layered home config migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ AGENTV_RESULTS_REPO=EntityProcess/agentv-evalresults \
 ```
 
 The script clones AgentV examples into `~/agentv-dashboard`, clones the results
-repo, writes the Dashboard project registry, builds the Docker image, and starts
-Dashboard at `http://localhost:3117`.
+repo, writes the Dashboard project registry under `$AGENTV_HOME/config.yaml`,
+builds the Docker image, and starts Dashboard at `http://localhost:3117`.
 
 ## License
 

--- a/apps/cli/src/commands/results/remote.ts
+++ b/apps/cli/src/commands/results/remote.ts
@@ -9,6 +9,7 @@ import {
   type ResultsRepoStatus,
   directPushResults,
   directorySizeBytes,
+  getProject,
   getProjectForPath,
   getResultsRepoStatus,
   listGitRuns,
@@ -135,9 +136,20 @@ async function loadNormalizedResultsConfig(
 ): Promise<Required<ResultsConfig> | undefined> {
   const repoRoot = (await findRepoRoot(cwd)) ?? cwd;
   const config = await loadConfig(path.join(cwd, '_'), repoRoot);
-  const resolvedProjectId =
-    projectId ?? getProjectForPath(repoRoot)?.id ?? getProjectForPath(cwd)?.id;
-  const resultsConfig = resolveResultsConfigForProject(config, resolvedProjectId);
+  const project =
+    projectId !== undefined
+      ? getProject(projectId)
+      : (getProjectForPath(repoRoot) ?? getProjectForPath(cwd));
+  const projectResults = project?.results
+    ? {
+        mode: project.results.mode,
+        repo: project.results.repo,
+        path: project.results.path,
+        auto_push: project.results.autoPush,
+        branch_prefix: project.results.branchPrefix,
+      }
+    : undefined;
+  const resultsConfig = projectResults ?? resolveResultsConfigForProject(config, project?.id);
   if (!resultsConfig) {
     return undefined;
   }

--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -1214,7 +1214,7 @@ export function createApp(
 
   // ── Benchmark resolution wrapper ──────────────────────────────────────
   // Resolves projectId → DataContext, returning 404 if not found. The
-  // registry is re-read on every request, so edits to projects.yaml (or
+  // registry is re-read on every request, so edits to config.yaml (or
   // POST /api/projects) take effect without restarting the server.
   function withProject(
     c: C,

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -839,7 +839,7 @@ describe('serve app', () => {
       }
     });
 
-    it('uses AGENTV_HOME results_by_project for project-scoped remote status', async () => {
+    it('uses registered project results for project-scoped remote status', async () => {
       const previousHome = process.env.AGENTV_HOME;
       const homeDir = path.join(tempDir, 'agentv-home-project-status');
       process.env.AGENTV_HOME = homeDir;
@@ -854,13 +854,7 @@ describe('serve app', () => {
         );
         writeFileSync(
           path.join(homeDir, 'config.yaml'),
-          `results_by_project:
-  agentv:
-    mode: github
-    repo: EntityProcess/agentv-examples-eval-results
-    path: /home/entity/projects/EntityProcess/agentv-examples-eval-results
-    auto_push: true
-results:
+          `results:
   mode: github
   repo: EntityProcess/fallback-results
 `,
@@ -871,6 +865,12 @@ results:
               id: 'agentv',
               name: 'AgentV',
               path: projectDir,
+              results: {
+                mode: 'github',
+                repo: 'EntityProcess/agentv-examples-eval-results',
+                path: '/home/entity/projects/EntityProcess/agentv-examples-eval-results',
+                autoPush: true,
+              },
               addedAt: '2026-01-01T00:00:00.000Z',
               lastOpenedAt: '2026-01-01T00:00:00.000Z',
             },

--- a/apps/web/src/content/docs/docs/evaluation/running-evals.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/running-evals.mdx
@@ -431,7 +431,7 @@ The `{timestamp}` placeholder is replaced with an ISO-like timestamp (e.g., `202
 
 ### AGENTV_HOME
 
-Override AgentV's lightweight home/config directory. This directory stores files such as `config.yaml`, `projects.yaml`, `version-check.json`, `last-config.json`, and managed helper binaries.
+Override AgentV's lightweight home/config directory. This directory stores files such as `config.yaml`, `version-check.json`, `last-config.json`, and managed helper binaries. Registered Dashboard projects live under `projects:` in this home `config.yaml`.
 
 ```bash
 # Linux/macOS

--- a/apps/web/src/content/docs/docs/tools/dashboard.mdx
+++ b/apps/web/src/content/docs/docs/tools/dashboard.mdx
@@ -175,9 +175,9 @@ agentv dashboard --add /path/to/my-evals
 agentv dashboard --add /path/to/other-evals
 ```
 
-Each path must contain a `.agentv/` directory. Registered projects are stored in `$AGENTV_HOME/projects.yaml`, or `~/.agentv/projects.yaml` when `AGENTV_HOME` is unset.
+Each path must contain a `.agentv/` directory. Registered projects are stored under `projects:` in `$AGENTV_HOME/config.yaml`, or `~/.agentv/config.yaml` when `AGENTV_HOME` is unset.
 
-To register a remote repo and keep it synced automatically, add a `source` block to the entry in `$AGENTV_HOME/projects.yaml`:
+To register a remote repo and keep it synced automatically, add a `source` block to the entry in `$AGENTV_HOME/config.yaml`:
 
 ```yaml
 projects:
@@ -193,11 +193,11 @@ On each Dashboard startup, AgentV clones the repo if the path is empty (`git clo
 
 ### Runtime behavior: no restart needed
 
-`projects.yaml` is the single source of truth. Dashboard re-reads it on every `/api/projects` request (which the UI polls every ~10 s), so any of these changes appear live without restarting `agentv serve`:
+`$AGENTV_HOME/config.yaml` is the single source of truth for registered projects. Dashboard re-reads it on every `/api/projects` request (which the UI polls every ~10 s), so any of these changes appear live without restarting `agentv serve`:
 
 - Adding via the UI's **Add Project** form or `POST /api/projects`.
 - Removing via the UI's **Remove** button or `DELETE /api/projects/:id`.
-- Editing `$AGENTV_HOME/projects.yaml` directly.
+- Editing the `projects:` block in `$AGENTV_HOME/config.yaml` directly.
 - Mounting the file via a Kubernetes ConfigMap — GitOps the ConfigMap and Dashboard reflects it within the next poll.
 
 This satisfies the 24/7-Dashboard use case: the server stays up; projects come and go through config edits or API calls.
@@ -238,40 +238,33 @@ Dashboard can display runs pushed to a remote git repository by other machines o
 
 ### Configuration
 
-Add a `results` block to `.agentv/config.yaml`:
+For a registered project, put result repo settings on that project's entry in `$AGENTV_HOME/config.yaml`:
 
 ```yaml
-results:
-  mode: github
-  repo: EntityProcess/agentv-evals     # GitHub repo (owner/repo or full URL)
-  path: ~/data/agentv-results          # Local clone path on this machine
-  auto_push: true                      # Push directly to base branch after every eval run
+projects:
+  - id: agentv
+    name: AgentV
+    path: /home/entity/projects/EntityProcess/agentv
+    results:
+      mode: github
+      repo: EntityProcess/agentv-examples-eval-results
+      path: /home/entity/projects/EntityProcess/agentv-examples-eval-results
+      auto_push: true
 ```
 
 `results.path` is the filesystem location of the local clone AgentV manages for the results repo. It is **not** a subdirectory inside the remote repo.
 
-For machine-local multi-project dashboards, put per-project results repos in `$AGENTV_HOME/config.yaml` (or `~/.agentv/config.yaml`) instead of editing each source repo:
+You can also set a top-level global fallback in the same file. This is used when the current project is not registered or its registry entry has no `results` block:
 
 ```yaml
-results_by_project:
-  agentv:
-    mode: github
-    repo: EntityProcess/agentv-examples-eval-results
-    path: /home/entity/projects/EntityProcess/agentv-examples-eval-results
-    auto_push: true
-  wtg-ai-prompts:
-    mode: github
-    repo: WiseTechGlobal/WTG.AI.Prompts.EvalResults
-    path: /home/entity/projects/WiseTechGlobal/WTG.AI.Prompts.EvalResults
-    auto_push: true
-  wisetechacademy-evals:
-    mode: github
-    repo: WiseTechGlobal/WiseTechAcademy.EvalResults
-    path: /home/entity/projects/WiseTechGlobal/WiseTechAcademy.EvalResults
-    auto_push: true
+results:
+  mode: github
+  repo: EntityProcess/default-eval-results
+  path: /home/entity/projects/EntityProcess/default-eval-results
+  auto_push: true
 ```
 
-The keys under `results_by_project` must match the project IDs in `$AGENTV_HOME/projects.yaml`. Project-local `.agentv/config.yaml` `results` blocks still take precedence. A top-level global `results` block remains the fallback for projects without a specific mapping.
+Project-local `.agentv/config.yaml` is for portable eval defaults such as `execution`, `eval_patterns`, and `dashboard`. Do not put `projects` in project-local config; AgentV warns and ignores it there. `results_by_project` is deprecated; use `projects[].results` in `$AGENTV_HOME/config.yaml`.
 
 With `auto_push: true`, every new `agentv eval` or `agentv pipeline bench` pushes results directly to the configured repo's base branch (e.g., `main`). Results appear immediately in Dashboard without requiring PR merges.
 

--- a/docs/plans/public-agentv-demo-projects.md
+++ b/docs/plans/public-agentv-demo-projects.md
@@ -104,7 +104,7 @@ Companion source repos must be independently cloneable. They may copy patterns f
 
 ```mermaid
 flowchart TB
-  setup[Public demo setup] --> registry[AgentV projects.yaml]
+  setup[Public demo setup] --> registry[AgentV home config.yaml projects]
   registry --> dash[AgentV Dashboard]
   setup --> dexter[dexter-evals project]
   setup --> swe[swe-evals project]
@@ -191,7 +191,7 @@ After this review is applied, create Beads from U1-U5 and broadcast one Agent Ma
 
 - **Goal:** Replace or supplement the private-only Dashboard demo configuration with a public project set that registers AgentV examples, `dexter-evals`, and `swe-evals`.
 - **Primary outputs:** updates in the deployment/setup repository, project-spec/result-spec configuration, plus any AgentV docs or examples needed to point users at the public setup.
-- **Patterns to follow:** current `agentv-deploy` project-spec handling, clone-or-update logic, `~/.agentv/projects.yaml` snake_case wire format, and `packages/core/src/projects.ts` source interpolation behavior.
+- **Patterns to follow:** current `agentv-deploy` project-spec handling, clone-or-update logic, `~/.agentv/config.yaml` `projects:` snake_case wire format, and `packages/core/src/projects.ts` source interpolation behavior.
 - **Test scenarios:**
   - Local setup creates or updates the three public project entries and leaves private WiseTech projects out of the public profile.
   - Local setup creates or updates public result-repo mappings for `dexter-evals` and `swe-evals`.
@@ -199,7 +199,7 @@ After this review is applied, create Beads from U1-U5 and broadcast one Agent Ma
   - Missing public companion repos fail with actionable messages or leave source metadata for later sync.
   - Project registry YAML uses `added_at`, `last_opened_at`, and optional `source` with snake_case keys.
   - Docker config, if added, validates without requiring private WiseTech secrets.
-- **Verification:** Run the setup script in `--no-serve` or equivalent mode, inspect generated `projects.yaml` and result config, start Dashboard from source, and confirm all public projects and remote-synced results appear. For Dashboard UI verification, rebuild `apps/dashboard/dist/` before browser UAT. Capture Dashboard UX gaps as follow-up Beads with screenshots or run-artifact references.
+- **Verification:** Run the setup script in `--no-serve` or equivalent mode, inspect generated home `config.yaml` project entries and result config, start Dashboard from source, and confirm all public projects and remote-synced results appear. For Dashboard UI verification, rebuild `apps/dashboard/dist/` before browser UAT. Capture Dashboard UX gaps as follow-up Beads with screenshots or run-artifact references.
 - **Covers:** R1, R2, R3, R4, R5, R19, R20, R21, R22, R23
 
 ---

--- a/packages/core/src/evaluation/loaders/config-loader.ts
+++ b/packages/core/src/evaluation/loaders/config-loader.ts
@@ -46,8 +46,6 @@ export type ResultsConfig = {
   readonly branch_prefix?: string;
 };
 
-export type ResultsByProjectConfig = Record<string, ResultsConfig>;
-
 export type HooksConfig = {
   /** Shell command to run once at agentv startup. stdout is parsed for env var exports. */
   readonly before_session?: string;
@@ -58,7 +56,6 @@ export type AgentVConfig = {
   readonly eval_patterns?: readonly string[];
   readonly execution?: ExecutionDefaults;
   readonly results?: ResultsConfig;
-  readonly results_by_project?: ResultsByProjectConfig;
   readonly hooks?: HooksConfig;
 };
 
@@ -68,10 +65,9 @@ export type AgentVConfig = {
  * Project-local `.agentv/config.yaml` files are searched from the eval file
  * directory up to the repo root. If no project-local config is found, AgentV
  * falls back to the home/global config at `${AGENTV_HOME:-~/.agentv}/config.yaml`.
- * The first valid project-local file wins for normal settings. Machine-local
- * `results_by_project` mappings from the global config are still attached when
- * the project-local file has no `results` block, so registered projects can use
- * per-machine results repos without editing source-controlled config.
+ * The first valid project-local file wins for normal settings. Registered
+ * project bindings such as result repos live in the home config `projects:`
+ * registry and are resolved by Dashboard/remote-results code separately.
  */
 export async function loadConfig(
   evalFilePath: string,
@@ -89,17 +85,7 @@ export async function loadConfig(
 
     const config = await readConfigFile(configPath);
     if (config) {
-      if (config.results) return config;
-
-      const globalConfig = (await fileExists(globalConfigPath))
-        ? await readConfigFile(globalConfigPath)
-        : null;
-      return {
-        ...config,
-        ...((config.results_by_project ?? globalConfig?.results_by_project)
-          ? { results_by_project: config.results_by_project ?? globalConfig?.results_by_project }
-          : {}),
-      };
+      return config;
     }
   }
 
@@ -140,10 +126,6 @@ async function readConfigFile(configPath: string): Promise<AgentVConfig | null> 
       configPath,
     );
     const results = parseResultsConfig((parsed as Record<string, unknown>).results, configPath);
-    const resultsByProject = parseResultsByProjectConfig(
-      (parsed as Record<string, unknown>).results_by_project,
-      configPath,
-    );
     const hooks = parseHooksConfig((parsed as Record<string, unknown>).hooks, configPath);
 
     return {
@@ -151,7 +133,6 @@ async function readConfigFile(configPath: string): Promise<AgentVConfig | null> 
       eval_patterns: evalPatterns as readonly string[] | undefined,
       execution: executionDefaults,
       results,
-      ...(resultsByProject && { results_by_project: resultsByProject }),
       ...(hooks && { hooks }),
     };
   } catch (error) {
@@ -664,44 +645,15 @@ export function parseResultsConfig(raw: unknown, configPath: string): ResultsCon
   };
 }
 
-export function parseResultsByProjectConfig(
-  raw: unknown,
-  configPath: string,
-): ResultsByProjectConfig | undefined {
-  if (raw === undefined || raw === null) {
-    return undefined;
-  }
-  if (typeof raw !== 'object' || Array.isArray(raw)) {
-    logWarning(`Invalid results_by_project in ${configPath}, expected object`);
-    return undefined;
-  }
-
-  const entries: ResultsByProjectConfig = {};
-  for (const [projectId, value] of Object.entries(raw as Record<string, unknown>)) {
-    if (!projectId.trim()) {
-      logWarning(`Invalid results_by_project key in ${configPath}, expected non-empty project id`);
-      continue;
-    }
-    const parsed = parseResultsConfig(value, `${configPath} results_by_project.${projectId}`);
-    if (parsed) {
-      entries[projectId] = parsed;
-    }
-  }
-
-  return Object.keys(entries).length > 0 ? entries : undefined;
-}
-
 export function resolveResultsConfigForProject(
   config: AgentVConfig | null | undefined,
-  projectId?: string,
+  _projectId?: string,
 ): ResultsConfig | undefined {
   if (!config) {
     return undefined;
   }
 
-  const projectResults =
-    projectId && projectId.trim().length > 0 ? config.results_by_project?.[projectId] : undefined;
-  return projectResults ?? config.results;
+  return config.results;
 }
 
 /**

--- a/packages/core/src/evaluation/validation/config-validator.ts
+++ b/packages/core/src/evaluation/validation/config-validator.ts
@@ -1,5 +1,7 @@
 import { readFile } from 'node:fs/promises';
+import path from 'node:path';
 
+import { getAgentvConfigDir } from '../../paths.js';
 import { interpolateEnv } from '../interpolation.js';
 import { parseYamlValue } from '../yaml-loader.js';
 import type { ValidationError, ValidationResult } from './types.js';
@@ -7,8 +9,12 @@ import type { ValidationError, ValidationResult } from './types.js';
 /**
  * Validate a config.yaml file for schema compliance and structural correctness.
  */
-export async function validateConfigFile(filePath: string): Promise<ValidationResult> {
+export async function validateConfigFile(
+  filePath: string,
+  options: { scope?: 'project' | 'global' } = {},
+): Promise<ValidationResult> {
   const errors: ValidationError[] = [];
+  const scope = options.scope ?? inferConfigScope(filePath);
 
   try {
     const content = await readFile(filePath, 'utf8');
@@ -67,80 +73,38 @@ export async function validateConfigFile(filePath: string): Promise<ValidationRe
       }
     }
 
-    const results = config.results;
-    if (results !== undefined) {
-      if (typeof results !== 'object' || results === null || Array.isArray(results)) {
+    validateResultsConfig(errors, filePath, config.results, 'results');
+
+    const projects = config.projects;
+    if (projects !== undefined) {
+      if (scope === 'project') {
+        errors.push({
+          severity: 'warning',
+          filePath,
+          location: 'projects',
+          message:
+            "Field 'projects' is only valid in $AGENTV_HOME/config.yaml. Ignoring project registry entries in project-local .agentv/config.yaml.",
+        });
+      } else if (!Array.isArray(projects)) {
         errors.push({
           severity: 'error',
           filePath,
-          location: 'results',
-          message: "Field 'results' must be an object",
+          location: 'projects',
+          message: "Field 'projects' must be an array",
         });
       } else {
-        const resultsRecord = results as Record<string, unknown>;
-        if (resultsRecord.mode !== 'github') {
-          errors.push({
-            severity: 'error',
-            filePath,
-            location: 'results.mode',
-            message: "Field 'results.mode' must be 'github'",
-          });
-        }
-        if (typeof resultsRecord.repo !== 'string' || resultsRecord.repo.trim().length === 0) {
-          errors.push({
-            severity: 'error',
-            filePath,
-            location: 'results.repo',
-            message: "Field 'results.repo' must be a non-empty string",
-          });
-        }
-        if (resultsRecord.path !== undefined) {
-          if (typeof resultsRecord.path !== 'string' || resultsRecord.path.trim().length === 0) {
-            errors.push({
-              severity: 'error',
-              filePath,
-              location: 'results.path',
-              message: "Field 'results.path' must be a non-empty string",
-            });
-          } else {
-            const p = resultsRecord.path.trim();
-            const isFilesystemPath =
-              p.startsWith('/') ||
-              p.startsWith('~/') ||
-              p.startsWith('~\\') ||
-              p === '~' ||
-              /^[A-Za-z]:[/\\]/.test(p);
-            if (!isFilesystemPath) {
-              errors.push({
-                severity: 'error',
-                filePath,
-                location: 'results.path',
-                message: `'results.path' must be an absolute or home-relative filesystem path (e.g., ~/data/agentv-results). Found: '${p}'. Remove 'path' to use the default.`,
-              });
-            }
-          }
-        }
-        if (resultsRecord.auto_push !== undefined && typeof resultsRecord.auto_push !== 'boolean') {
-          errors.push({
-            severity: 'error',
-            filePath,
-            location: 'results.auto_push',
-            message: "Field 'results.auto_push' must be a boolean",
-          });
-        }
-        if (
-          resultsRecord.branch_prefix !== undefined &&
-          (typeof resultsRecord.branch_prefix !== 'string' ||
-            resultsRecord.branch_prefix.trim().length === 0)
-        ) {
-          errors.push({
-            severity: 'error',
-            filePath,
-            location: 'results.branch_prefix',
-            message: "Field 'results.branch_prefix' must be a non-empty string",
-          });
-        }
+        validateProjects(errors, filePath, projects);
       }
+    }
+
+    if (config.results_by_project !== undefined) {
+      errors.push({
+        severity: 'warning',
+        filePath,
+        location: 'results_by_project',
+        message:
+          "Field 'results_by_project' is deprecated. Put per-project result repo settings under projects[].results in $AGENTV_HOME/config.yaml.",
+      });
     }
 
     const allowedFields = new Set([
@@ -149,6 +113,8 @@ export async function validateConfigFile(filePath: string): Promise<ValidationRe
       'required_version',
       'execution',
       'results',
+      'projects',
+      'results_by_project',
       'dashboard',
       'studio',
     ]);
@@ -176,4 +142,134 @@ export async function validateConfigFile(filePath: string): Promise<ValidationRe
     });
     return { valid: false, filePath, fileType: 'config', errors };
   }
+}
+
+function inferConfigScope(filePath: string): 'project' | 'global' {
+  const globalConfigPath = path.resolve(getAgentvConfigDir(), 'config.yaml');
+  if (path.resolve(filePath) === globalConfigPath) {
+    return 'global';
+  }
+  return filePath.split(/[\\/]/).includes('.agentv') ? 'project' : 'global';
+}
+
+function validateProjects(errors: ValidationError[], filePath: string, projects: unknown[]): void {
+  projects.forEach((project, index) => {
+    const location = `projects[${index}]`;
+    if (typeof project !== 'object' || project === null || Array.isArray(project)) {
+      errors.push({
+        severity: 'error',
+        filePath,
+        location,
+        message: `Field '${location}' must be an object`,
+      });
+      return;
+    }
+
+    const projectRecord = project as Record<string, unknown>;
+    validateRequiredString(errors, filePath, projectRecord.id, `${location}.id`);
+    validateRequiredString(errors, filePath, projectRecord.name, `${location}.name`);
+    validateRequiredString(errors, filePath, projectRecord.path, `${location}.path`);
+    validateResultsConfig(errors, filePath, projectRecord.results, `${location}.results`);
+  });
+}
+
+function validateRequiredString(
+  errors: ValidationError[],
+  filePath: string,
+  value: unknown,
+  location: string,
+): void {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    errors.push({
+      severity: 'error',
+      filePath,
+      location,
+      message: `Field '${location}' must be a non-empty string`,
+    });
+  }
+}
+
+function validateResultsConfig(
+  errors: ValidationError[],
+  filePath: string,
+  rawResults: unknown,
+  location: string,
+): void {
+  if (rawResults === undefined) {
+    return;
+  }
+
+  if (typeof rawResults !== 'object' || rawResults === null || Array.isArray(rawResults)) {
+    errors.push({
+      severity: 'error',
+      filePath,
+      location,
+      message: `Field '${location}' must be an object`,
+    });
+    return;
+  }
+
+  const resultsRecord = rawResults as Record<string, unknown>;
+  if (resultsRecord.mode !== 'github') {
+    errors.push({
+      severity: 'error',
+      filePath,
+      location: `${location}.mode`,
+      message: `Field '${location}.mode' must be 'github'`,
+    });
+  }
+  validateRequiredString(errors, filePath, resultsRecord.repo, `${location}.repo`);
+
+  if (resultsRecord.path !== undefined) {
+    if (typeof resultsRecord.path !== 'string' || resultsRecord.path.trim().length === 0) {
+      errors.push({
+        severity: 'error',
+        filePath,
+        location: `${location}.path`,
+        message: `Field '${location}.path' must be a non-empty string`,
+      });
+    } else {
+      const p = resultsRecord.path.trim();
+      if (!isFilesystemPath(p)) {
+        errors.push({
+          severity: 'error',
+          filePath,
+          location: `${location}.path`,
+          message: `'${location}.path' must be an absolute or home-relative filesystem path (e.g., ~/data/agentv-results). Found: '${p}'. Remove 'path' to use the default.`,
+        });
+      }
+    }
+  }
+
+  if (resultsRecord.auto_push !== undefined && typeof resultsRecord.auto_push !== 'boolean') {
+    errors.push({
+      severity: 'error',
+      filePath,
+      location: `${location}.auto_push`,
+      message: `Field '${location}.auto_push' must be a boolean`,
+    });
+  }
+
+  if (
+    resultsRecord.branch_prefix !== undefined &&
+    (typeof resultsRecord.branch_prefix !== 'string' ||
+      resultsRecord.branch_prefix.trim().length === 0)
+  ) {
+    errors.push({
+      severity: 'error',
+      filePath,
+      location: `${location}.branch_prefix`,
+      message: `Field '${location}.branch_prefix' must be a non-empty string`,
+    });
+  }
+}
+
+function isFilesystemPath(p: string): boolean {
+  return (
+    p.startsWith('/') ||
+    p.startsWith('~/') ||
+    p.startsWith('~\\') ||
+    p === '~' ||
+    /^[A-Za-z]:[/\\]/.test(p)
+  );
 }

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -9,8 +9,8 @@ function readEnvPath(name: string): string | undefined {
 
 /**
  * AgentV's lightweight home/config directory. Stores machine-local config files
- * such as config.yaml, projects.yaml, version-check.json, last-config.json, and
- * managed helper binaries. AGENTV_HOME relocates only this config/home surface.
+ * such as config.yaml, version-check.json, last-config.json, and managed helper
+ * binaries. AGENTV_HOME relocates only this config/home surface.
  */
 export function getAgentvConfigDir(): string {
   return readEnvPath('AGENTV_HOME') ?? path.join(os.homedir(), '.agentv');

--- a/packages/core/src/projects.ts
+++ b/packages/core/src/projects.ts
@@ -6,11 +6,11 @@
  * matching the "project" terminology used by Arize Phoenix, Langfuse,
  * Braintrust, W&B Weave, and LangSmith.
  *
- * The registry lives at `~/.agentv/projects.yaml` and is the single source
- * of truth for which projects Dashboard shows. Dashboard re-reads the file on every
- * `/api/projects` request, so edits (direct, via POST /api/projects, via
- * the CLI's --add/--remove, or via a Kubernetes ConfigMap mount) are reflected
- * without restarting `agentv serve`.
+ * The registry lives under `projects:` in `~/.agentv/config.yaml` and is the
+ * single source of truth for which projects Dashboard shows. Dashboard re-reads
+ * the file on every `/api/projects` request, so edits (direct, via
+ * POST /api/projects, via the CLI's --add/--remove, or via a Kubernetes
+ * ConfigMap mount) are reflected without restarting `agentv serve`.
  *
  * YAML format (all keys snake_case per AGENTS.md §"Wire Format Convention"):
  *   projects:
@@ -20,6 +20,11 @@
  *       source:
  *         url: ${{ PROJECT_REPO_URL }}
  *         ref: ${{ PROJECT_REPO_REF:-main }}
+ *       results:
+ *         mode: github
+ *         repo: example/my-app-results
+ *         path: /srv/agentv/results/my-app
+ *         auto_push: true
  *       added_at: "2026-03-20T10:00:00Z"
  *       last_opened_at: "2026-03-30T14:00:00Z"
  *
@@ -28,15 +33,11 @@
  *   subsequent runs — git pull --ff-only
  *
  * Concurrency: the registry assumes a single writer. All mutating calls
- * (add/remove/touchProject) do read-modify-write on projects.yaml
- * without a lock. Dashboard's HTTP handlers are serialized by Node's
+ * (add/remove/touchProject) do read-modify-write on config.yaml without a
+ * lock, preserving unrelated top-level config keys. Dashboard's HTTP handlers
+ * are serialized by Node's
  * single-threaded event loop, which satisfies the 24/7 deployment case.
  * Run only one `agentv` process against a given home at a time.
- *
- * Legacy registry filename: the registry used to be called `benchmarks.yaml`
- * with a top-level `benchmarks:` key. On first load, a one-time migration
- * detects the old file, rewrites the top-level key to `projects:`, and
- * atomically renames the file. See migrateLegacyBenchmarksFile() below.
  *
  * To extend:
  *   - CRUD: loadProjectRegistry() / saveProjectRegistry() + the
@@ -45,16 +46,7 @@
  *     registration; it does not run in the request path.
  */
 
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  renameSync,
-  statSync,
-  unlinkSync,
-  writeFileSync,
-} from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { stringify as stringifyYaml } from 'yaml';
@@ -64,6 +56,14 @@ import { parseYamlValue } from './evaluation/yaml-loader.js';
 import { getAgentvConfigDir } from './paths.js';
 
 // ── Types ───────────────────────────────────────────────────────────────
+
+export interface ProjectResultsConfig {
+  mode: 'github';
+  repo: string;
+  path?: string;
+  autoPush?: boolean;
+  branchPrefix?: string;
+}
 
 export interface ProjectSource {
   url: string;
@@ -77,6 +77,7 @@ export interface ProjectEntry {
   addedAt: string;
   lastOpenedAt: string;
   source?: ProjectSource;
+  results?: ProjectResultsConfig;
 }
 
 export interface ProjectRegistry {
@@ -86,89 +87,7 @@ export interface ProjectRegistry {
 // ── Registry path ───────────────────────────────────────────────────────
 
 export function getProjectsRegistryPath(): string {
-  return path.join(getAgentvConfigDir(), 'projects.yaml');
-}
-
-/** Legacy registry path, kept private — only the migration helper reads it. */
-function getLegacyBenchmarksRegistryPath(): string {
-  return path.join(getAgentvConfigDir(), 'benchmarks.yaml');
-}
-
-// ── Legacy file migration ───────────────────────────────────────────────
-// One-time, idempotent. Called at the top of loadProjectRegistry() so any
-// entry point (CLI, Dashboard server, tests) picks the new file up transparently.
-//
-// Rules:
-//   - projects.yaml exists, benchmarks.yaml missing → no-op (already migrated).
-//   - benchmarks.yaml exists, projects.yaml missing → migrate: read → rewrite
-//     top-level key benchmarks: → projects: → atomic rename temp → projects.yaml,
-//     then unlink benchmarks.yaml. Logs one line to stderr.
-//   - both exist → projects.yaml wins; benchmarks.yaml is left alone but a
-//     one-line warning goes to stderr so the operator can investigate.
-//   - neither exists → no-op (fresh install).
-//
-// The migration only rewrites the top-level key; entry shapes are unchanged.
-
-function migrateLegacyBenchmarksFile(): void {
-  const newPath = getProjectsRegistryPath();
-  const oldPath = getLegacyBenchmarksRegistryPath();
-  const newExists = existsSync(newPath);
-  const oldExists = existsSync(oldPath);
-
-  if (!oldExists) return;
-
-  if (newExists) {
-    console.warn(
-      `[agentv] Both ${oldPath} and ${newPath} exist. Using ${path.basename(newPath)}; ` +
-        `delete ${path.basename(oldPath)} when you've confirmed the new file is correct.`,
-    );
-    return;
-  }
-
-  let parsed: { benchmarks?: unknown } | null = null;
-  try {
-    const raw = readFileSync(oldPath, 'utf-8');
-    parsed = parseYamlValue(raw) as { benchmarks?: unknown } | null;
-  } catch (err) {
-    console.warn(
-      `[agentv] Failed to read legacy ${path.basename(oldPath)} for migration: ${(err as Error).message}. Leaving the file in place; you may need to migrate it manually.`,
-    );
-    return;
-  }
-
-  // Rewrite top-level key only; entries themselves stay snake_case on disk.
-  const entries =
-    parsed && typeof parsed === 'object' && Array.isArray(parsed.benchmarks)
-      ? (parsed.benchmarks as unknown[])
-      : [];
-  const newContent = stringifyYaml({ projects: entries });
-
-  // Atomic temp + rename so a crash mid-write never leaves a corrupted
-  // projects.yaml. Only after the rename succeeds do we unlink the old file.
-  const tempPath = `${newPath}.migrating`;
-  try {
-    mkdirSync(path.dirname(newPath), { recursive: true });
-    writeFileSync(tempPath, newContent, 'utf-8');
-    renameSync(tempPath, newPath);
-    unlinkSync(oldPath);
-  } catch (err) {
-    // Clean up the temp if rename failed.
-    try {
-      if (existsSync(tempPath)) unlinkSync(tempPath);
-    } catch {
-      /* best-effort */
-    }
-    console.warn(
-      `[agentv] Failed to migrate ${path.basename(oldPath)} → ${path.basename(newPath)}: ` +
-        `${(err as Error).message}. Legacy file left in place.`,
-    );
-    return;
-  }
-
-  console.log(
-    `[agentv] Migrated registry: ${path.basename(oldPath)} → ${path.basename(newPath)} ` +
-      `(${entries.length} entr${entries.length === 1 ? 'y' : 'ies'})`,
-  );
+  return path.join(getAgentvConfigDir(), 'config.yaml');
 }
 
 // ── Load / Save ─────────────────────────────────────────────────────────
@@ -181,6 +100,14 @@ interface ProjectSourceYaml {
   ref: string;
 }
 
+interface ProjectResultsYaml {
+  mode: 'github';
+  repo: string;
+  path?: string;
+  auto_push?: boolean;
+  branch_prefix?: string;
+}
+
 interface ProjectEntryYaml {
   id: string;
   name: string;
@@ -188,6 +115,7 @@ interface ProjectEntryYaml {
   added_at: string;
   last_opened_at: string;
   source?: ProjectSourceYaml;
+  results?: ProjectResultsYaml;
 }
 
 function fromYaml(raw: unknown): ProjectEntry | null {
@@ -209,6 +137,20 @@ function fromYaml(raw: unknown): ProjectEntry | null {
       entry.source = { url: s.url, ref: s.ref };
     }
   }
+  if (e.results && typeof e.results === 'object') {
+    const r = e.results as Partial<ProjectResultsYaml>;
+    if (r.mode === 'github' && typeof r.repo === 'string' && r.repo.trim().length > 0) {
+      entry.results = {
+        mode: 'github',
+        repo: r.repo.trim(),
+        ...(typeof r.path === 'string' && r.path.trim().length > 0 ? { path: r.path.trim() } : {}),
+        ...(typeof r.auto_push === 'boolean' ? { autoPush: r.auto_push } : {}),
+        ...(typeof r.branch_prefix === 'string' && r.branch_prefix.trim().length > 0
+          ? { branchPrefix: r.branch_prefix.trim() }
+          : {}),
+      };
+    }
+  }
   return entry;
 }
 
@@ -223,11 +165,21 @@ function toYaml(entry: ProjectEntry): ProjectEntryYaml {
   if (entry.source) {
     yaml.source = { url: entry.source.url, ref: entry.source.ref };
   }
+  if (entry.results) {
+    yaml.results = {
+      mode: entry.results.mode,
+      repo: entry.results.repo,
+      ...(entry.results.path !== undefined && { path: entry.results.path }),
+      ...(entry.results.autoPush !== undefined && { auto_push: entry.results.autoPush }),
+      ...(entry.results.branchPrefix !== undefined && {
+        branch_prefix: entry.results.branchPrefix,
+      }),
+    };
+  }
   return yaml;
 }
 
 export function loadProjectRegistry(): ProjectRegistry {
-  migrateLegacyBenchmarksFile();
   const registryPath = getProjectsRegistryPath();
   if (!existsSync(registryPath)) {
     return { projects: [] };
@@ -256,8 +208,20 @@ export function saveProjectRegistry(registry: ProjectRegistry): void {
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
-  const payload = { projects: registry.projects.map(toYaml) };
+  const payload = { ...readHomeConfig(registryPath), projects: registry.projects.map(toYaml) };
   writeFileSync(registryPath, stringifyYaml(payload), 'utf-8');
+}
+
+function readHomeConfig(configPath: string): Record<string, unknown> {
+  if (!existsSync(configPath)) return {};
+  try {
+    const parsed = parseYamlValue(readFileSync(configPath, 'utf-8')) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
 }
 
 // ── CRUD operations ─────────────────────────────────────────────────────

--- a/packages/core/test/evaluation/loaders/config-loader.test.ts
+++ b/packages/core/test/evaluation/loaders/config-loader.test.ts
@@ -14,7 +14,6 @@ import {
   extractTrialsConfig,
   loadConfig,
   parseExecutionDefaults,
-  parseResultsByProjectConfig,
   parseResultsConfig,
   resolveResultsConfigForProject,
 } from '../../../src/evaluation/loaders/config-loader.js';
@@ -94,8 +93,8 @@ describe('loadConfig', () => {
     }
   });
 
-  it('keeps global results_by_project available when project-local config has no results', async () => {
-    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'agentv-global-project-results-'));
+  it('does not merge global results into project-local config', async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'agentv-local-results-isolated-'));
     try {
       const projectDir = path.join(tempDir, 'project');
       const evalDir = path.join(projectDir, 'evals');
@@ -110,61 +109,16 @@ describe('loadConfig', () => {
       );
       writeFileSync(
         path.join(homeDir, 'config.yaml'),
-        `results_by_project:
-  agentv:
-    mode: github
-    repo: EntityProcess/agentv-examples-eval-results
-    path: /home/entity/projects/EntityProcess/agentv-examples-eval-results
-    auto_push: true
+        `results:
+  mode: github
+  repo: EntityProcess/global-results
 `,
       );
 
       await withOptionalEnv('AGENTV_HOME', homeDir, async () => {
         const config = await loadConfig(path.join(evalDir, 'suite.eval.yaml'), projectDir);
         expect(config?.execution).toEqual({ keep_workspaces: true });
-        expect(resolveResultsConfigForProject(config, 'agentv')).toEqual({
-          mode: 'github',
-          repo: 'EntityProcess/agentv-examples-eval-results',
-          path: '/home/entity/projects/EntityProcess/agentv-examples-eval-results',
-          auto_push: true,
-        });
-      });
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
-  });
-
-  it('keeps project-local results ahead of global results_by_project', async () => {
-    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'agentv-local-results-precedence-'));
-    try {
-      const projectDir = path.join(tempDir, 'project');
-      const evalDir = path.join(projectDir, 'evals');
-      const localConfigDir = path.join(projectDir, '.agentv');
-      const homeDir = path.join(tempDir, 'home');
-      mkdirSync(evalDir, { recursive: true });
-      mkdirSync(localConfigDir, { recursive: true });
-      mkdirSync(homeDir, { recursive: true });
-      writeFileSync(
-        path.join(localConfigDir, 'config.yaml'),
-        `results:
-  mode: github
-  repo: EntityProcess/local-results
-`,
-      );
-      writeFileSync(
-        path.join(homeDir, 'config.yaml'),
-        `results_by_project:
-  agentv:
-    mode: github
-    repo: EntityProcess/global-results
-`,
-      );
-
-      await withOptionalEnv('AGENTV_HOME', homeDir, async () => {
-        const config = await loadConfig(path.join(evalDir, 'suite.eval.yaml'), projectDir);
-        expect(resolveResultsConfigForProject(config, 'agentv')?.repo).toBe(
-          'EntityProcess/local-results',
-        );
+        expect(resolveResultsConfigForProject(config, 'agentv')).toBeUndefined();
       });
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
@@ -405,51 +359,11 @@ describe('parseResultsConfig', () => {
   });
 });
 
-describe('parseResultsByProjectConfig', () => {
-  it('parses per-project results mappings', () => {
-    const result = parseResultsByProjectConfig(
-      {
-        agentv: {
-          mode: 'github',
-          repo: 'EntityProcess/agentv-examples-eval-results',
-          path: '/home/entity/projects/EntityProcess/agentv-examples-eval-results',
-          auto_push: true,
-        },
-      },
-      '/tmp/config.yaml',
-    );
-
-    expect(result?.agentv).toEqual({
-      mode: 'github',
-      repo: 'EntityProcess/agentv-examples-eval-results',
-      path: '/home/entity/projects/EntityProcess/agentv-examples-eval-results',
-      auto_push: true,
-    });
-  });
-});
-
 describe('resolveResultsConfigForProject', () => {
-  it('uses project mapping before top-level results fallback', () => {
+  it('returns top-level results regardless of project id', () => {
     const result = resolveResultsConfigForProject(
       {
         results: { mode: 'github', repo: 'EntityProcess/fallback' },
-        results_by_project: {
-          agentv: { mode: 'github', repo: 'EntityProcess/project' },
-        },
-      },
-      'agentv',
-    );
-
-    expect(result?.repo).toBe('EntityProcess/project');
-  });
-
-  it('falls back to top-level results when no project mapping matches', () => {
-    const result = resolveResultsConfigForProject(
-      {
-        results: { mode: 'github', repo: 'EntityProcess/fallback' },
-        results_by_project: {
-          other: { mode: 'github', repo: 'EntityProcess/project' },
-        },
       },
       'agentv',
     );

--- a/packages/core/test/evaluation/validation/config-validator.test.ts
+++ b/packages/core/test/evaluation/validation/config-validator.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { afterAll, beforeAll, describe, expect, it, spyOn } from 'bun:test';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -77,6 +77,142 @@ describe('validateConfigFile', () => {
 
     expect(result.valid).toBe(true);
     expect(result.errors).toHaveLength(0);
+  });
+
+  it('accepts projects field in global config', async () => {
+    const filePath = path.join(tempDir, 'global-config.yaml');
+    await writeFile(
+      filePath,
+      `projects:
+  - id: agentv
+    name: AgentV
+    path: /srv/agentv
+    results:
+      mode: github
+      repo: EntityProcess/agentv-results
+      path: /srv/agentv-results
+      auto_push: true
+      branch_prefix: eval-results
+`,
+    );
+
+    const result = await validateConfigFile(filePath, { scope: 'global' });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('infers AGENTV_HOME config.yaml as global even when the home dir is named .agentv', async () => {
+    const fakeHome = path.join(tempDir, 'fake-user-home');
+    const homeConfigDir = path.join(fakeHome, '.agentv');
+    const filePath = path.join(homeConfigDir, 'config.yaml');
+    await mkdir(homeConfigDir, { recursive: true });
+    await writeFile(
+      filePath,
+      `projects:
+  - id: agentv
+    name: AgentV
+    path: /srv/agentv
+`,
+    );
+
+    const homedirSpy = spyOn(os, 'homedir').mockReturnValue(fakeHome);
+    try {
+      const result = await validateConfigFile(filePath);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    } finally {
+      homedirSpy.mockRestore();
+    }
+  });
+
+  it('warns when projects field appears in project-local config', async () => {
+    const projectDir = path.join(tempDir, 'project-with-projects-field');
+    const filePath = path.join(projectDir, '.agentv', 'config.yaml');
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(
+      filePath,
+      `projects:
+  - id: misplaced
+    name: Misplaced
+    path: /srv/misplaced
+`,
+    );
+
+    const result = await validateConfigFile(filePath);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        severity: 'warning',
+        location: 'projects',
+      }),
+    );
+  });
+
+  it('errors on invalid global project entries and nested results config', async () => {
+    const filePath = path.join(tempDir, 'global-config-invalid-projects.yaml');
+    await writeFile(
+      filePath,
+      `projects:
+  - id: ""
+    name: 42
+    path:
+    results:
+      mode: local
+      repo: ""
+      path: repo/subdir
+      auto_push: yes
+      branch_prefix: ""
+  - not-an-object
+`,
+    );
+
+    const result = await validateConfigFile(filePath, { scope: 'global' });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ severity: 'error', location: 'projects[0].id' }),
+        expect.objectContaining({ severity: 'error', location: 'projects[0].name' }),
+        expect.objectContaining({ severity: 'error', location: 'projects[0].path' }),
+        expect.objectContaining({ severity: 'error', location: 'projects[0].results.mode' }),
+        expect.objectContaining({ severity: 'error', location: 'projects[0].results.repo' }),
+        expect.objectContaining({ severity: 'error', location: 'projects[0].results.path' }),
+        expect.objectContaining({
+          severity: 'error',
+          location: 'projects[0].results.auto_push',
+        }),
+        expect.objectContaining({
+          severity: 'error',
+          location: 'projects[0].results.branch_prefix',
+        }),
+        expect.objectContaining({ severity: 'error', location: 'projects[1]' }),
+      ]),
+    );
+  });
+
+  it('warns on deprecated results_by_project', async () => {
+    const filePath = path.join(tempDir, 'deprecated-results-by-project.yaml');
+    await writeFile(
+      filePath,
+      `results_by_project:
+  agentv:
+    mode: github
+    repo: EntityProcess/agentv-results
+`,
+    );
+
+    const result = await validateConfigFile(filePath, { scope: 'global' });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        severity: 'warning',
+        location: 'results_by_project',
+      }),
+    );
   });
 
   it('accepts legacy studio field without warnings', async () => {

--- a/packages/core/test/projects.test.ts
+++ b/packages/core/test/projects.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -9,6 +9,7 @@ import {
   getProjectsRegistryPath,
   loadProjectRegistry,
   removeProject,
+  saveProjectRegistry,
   touchProject,
 } from '../src/projects.js';
 
@@ -100,6 +101,14 @@ describe('projects registry', () => {
     });
   });
 
+  it('stores project registry entries under AGENTV_HOME config.yaml', () => {
+    addProject(makeRepo('home-config'));
+
+    expect(path.basename(getProjectsRegistryPath())).toBe('config.yaml');
+    const yamlOnDisk = readFileSync(getProjectsRegistryPath(), 'utf-8');
+    expect(yamlOnDisk).toContain('projects:');
+  });
+
   it('round-trips source field through YAML', () => {
     const registryPath = getProjectsRegistryPath();
     mkdirSync(path.dirname(registryPath), { recursive: true });
@@ -122,6 +131,67 @@ describe('projects registry', () => {
     expect(registry.projects).toHaveLength(1);
     const entry = registry.projects[0];
     expect(entry.source).toEqual({ url: 'https://github.com/example/repo', ref: 'main' });
+  });
+
+  it('round-trips project results config through YAML', () => {
+    const registryPath = getProjectsRegistryPath();
+    mkdirSync(path.dirname(registryPath), { recursive: true });
+    writeFileSync(
+      registryPath,
+      `projects:
+  - id: results-project
+    name: Results Project
+    path: /srv/agentv/repo
+    results:
+      mode: github
+      repo: EntityProcess/results-project-runs
+      path: /srv/agentv/results/results-project
+      auto_push: true
+      branch_prefix: eval-results
+    added_at: "2026-01-01T00:00:00Z"
+    last_opened_at: "2026-01-01T00:00:00Z"
+`,
+      'utf-8',
+    );
+
+    const registry = loadProjectRegistry();
+    expect(registry.projects[0].results).toEqual({
+      mode: 'github',
+      repo: 'EntityProcess/results-project-runs',
+      path: '/srv/agentv/results/results-project',
+      autoPush: true,
+      branchPrefix: 'eval-results',
+    });
+
+    saveProjectRegistry(registry);
+    const yamlOnDisk = readFileSync(registryPath, 'utf-8');
+    expect(yamlOnDisk).toContain('auto_push: true');
+    expect(yamlOnDisk).toContain('branch_prefix: eval-results');
+    expect(yamlOnDisk).not.toContain('autoPush:');
+    expect(yamlOnDisk).not.toContain('branchPrefix:');
+  });
+
+  it('preserves unrelated global config keys when saving projects', () => {
+    const registryPath = getProjectsRegistryPath();
+    mkdirSync(path.dirname(registryPath), { recursive: true });
+    writeFileSync(
+      registryPath,
+      `results:
+  mode: github
+  repo: EntityProcess/default-results
+dashboard:
+  app_name: AgentV
+`,
+      'utf-8',
+    );
+
+    addProject(makeRepo('preserve-global-config'));
+
+    const yamlOnDisk = readFileSync(registryPath, 'utf-8');
+    expect(yamlOnDisk).toContain('results:');
+    expect(yamlOnDisk).toContain('repo: EntityProcess/default-results');
+    expect(yamlOnDisk).toContain('dashboard:');
+    expect(yamlOnDisk).toContain('projects:');
   });
 
   it('interpolates env vars in source url', () => {
@@ -153,125 +223,5 @@ describe('projects registry', () => {
 
     const reloaded = loadProjectRegistry().projects.find((p) => p.id === entry.id);
     expect(reloaded?.source).toBeUndefined();
-  });
-});
-
-// ── Legacy benchmarks.yaml → projects.yaml migration ─────────────────────
-// Migration runs on every loadProjectRegistry() call but only acts when the
-// state demands it. These tests cover the four state transitions: legacy
-// only, new only, both present, neither.
-
-describe('legacy benchmarks.yaml migration', () => {
-  let fakeHome: string;
-  // biome-ignore lint/suspicious/noExplicitAny: spy typing from bun:test is intentionally loose.
-  let homedirSpy: any;
-
-  beforeEach(() => {
-    fakeHome = mkdtempSync(path.join(os.tmpdir(), 'agentv-migration-'));
-    homedirSpy = spyOn(os, 'homedir').mockReturnValue(fakeHome);
-  });
-
-  afterEach(() => {
-    homedirSpy?.mockRestore?.();
-    rmSync(fakeHome, { recursive: true, force: true });
-  });
-
-  function legacyPath(): string {
-    return path.join(fakeHome, '.agentv', 'benchmarks.yaml');
-  }
-
-  function writeLegacy(content: string): void {
-    mkdirSync(path.dirname(legacyPath()), { recursive: true });
-    writeFileSync(legacyPath(), content, 'utf-8');
-  }
-
-  it('migrates legacy benchmarks.yaml to projects.yaml on first load', () => {
-    writeLegacy(`benchmarks:
-  - id: legacy-app
-    name: Legacy App
-    path: /srv/legacy
-    added_at: "2026-01-01T00:00:00Z"
-    last_opened_at: "2026-01-02T00:00:00Z"
-`);
-
-    const registry = loadProjectRegistry();
-
-    // The migration ran: legacy gone, new file present, content preserved.
-    expect(existsSync(legacyPath())).toBe(false);
-    expect(existsSync(getProjectsRegistryPath())).toBe(true);
-    expect(registry.projects).toHaveLength(1);
-    expect(registry.projects[0]).toMatchObject({
-      id: 'legacy-app',
-      name: 'Legacy App',
-      path: '/srv/legacy',
-      addedAt: '2026-01-01T00:00:00Z',
-      lastOpenedAt: '2026-01-02T00:00:00Z',
-    });
-
-    // On-disk YAML has the new top-level key.
-    const yamlOnDisk = readFileSync(getProjectsRegistryPath(), 'utf-8');
-    expect(yamlOnDisk).toContain('projects:');
-    expect(yamlOnDisk).not.toMatch(/^benchmarks:/m);
-  });
-
-  it('is idempotent — second load is a no-op once migrated', () => {
-    writeLegacy(`benchmarks:
-  - id: legacy-app
-    name: Legacy App
-    path: /srv/legacy
-    added_at: "2026-01-01T00:00:00Z"
-    last_opened_at: "2026-01-01T00:00:00Z"
-`);
-    loadProjectRegistry(); // migrate
-    const firstMtime = readFileSync(getProjectsRegistryPath(), 'utf-8');
-    loadProjectRegistry(); // should be no-op
-    const secondMtime = readFileSync(getProjectsRegistryPath(), 'utf-8');
-    expect(secondMtime).toBe(firstMtime);
-    expect(existsSync(legacyPath())).toBe(false);
-  });
-
-  it('prefers projects.yaml and warns when both files exist', () => {
-    // Both files present, with different content.
-    writeLegacy(`benchmarks:
-  - id: stale
-    name: Stale Legacy
-    path: /srv/stale
-    added_at: "2026-01-01T00:00:00Z"
-    last_opened_at: "2026-01-01T00:00:00Z"
-`);
-    mkdirSync(path.dirname(getProjectsRegistryPath()), { recursive: true });
-    writeFileSync(
-      getProjectsRegistryPath(),
-      `projects:
-  - id: fresh
-    name: Fresh
-    path: /srv/fresh
-    added_at: "2026-02-01T00:00:00Z"
-    last_opened_at: "2026-02-01T00:00:00Z"
-`,
-      'utf-8',
-    );
-
-    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      const registry = loadProjectRegistry();
-      // Loaded from projects.yaml, not the legacy file.
-      expect(registry.projects).toHaveLength(1);
-      expect(registry.projects[0].id).toBe('fresh');
-      // Legacy file is left in place for the operator to inspect/delete.
-      expect(existsSync(legacyPath())).toBe(true);
-      // Warning was emitted.
-      expect(warnSpy).toHaveBeenCalled();
-    } finally {
-      warnSpy.mockRestore?.();
-    }
-  });
-
-  it('is a no-op when neither file exists (fresh install)', () => {
-    const registry = loadProjectRegistry();
-    expect(registry.projects).toEqual([]);
-    expect(existsSync(legacyPath())).toBe(false);
-    // loadProjectRegistry doesn't pre-create the new file; saveProjectRegistry does.
-    expect(existsSync(getProjectsRegistryPath())).toBe(false);
   });
 });

--- a/scripts/setup-dashboard-deployment.sh
+++ b/scripts/setup-dashboard-deployment.sh
@@ -52,6 +52,7 @@ require_command() {
 
 require_command docker
 require_command git
+require_command bun
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 deploy_dir="${AGENTV_DEPLOY_DIR:-$HOME/agentv-dashboard}"
@@ -141,14 +142,40 @@ write_project_registry() {
   mkdir -p "$home_dir"
   local now
   now="$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")"
-  cat > "$home_dir/projects.yaml" <<EOF
-projects:
-  - id: agentv-examples
-    name: AgentV Examples
-    path: /data/projects/agentv-examples
-    added_at: "$now"
-    last_opened_at: "$now"
-EOF
+  if [[ -f "$home_dir/config.yaml" ]]; then
+    cp "$home_dir/config.yaml" "$home_dir/config.yaml.bak"
+  fi
+  bun --eval '
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { parse, stringify } from "yaml";
+
+const [configPath, now, resultsRepo] = process.argv.slice(1);
+const existing = existsSync(configPath) ? parse(readFileSync(configPath, "utf8")) : {};
+const config = existing && typeof existing === "object" && !Array.isArray(existing) ? existing : {};
+const projects = Array.isArray(config.projects) ? config.projects : [];
+const existingEntry = projects.find((project) => {
+  return project && typeof project === "object" && project.id === "agentv-examples";
+});
+const nextEntry = {
+  id: "agentv-examples",
+  name: "AgentV Examples",
+  path: "/data/projects/agentv-examples",
+  results: {
+    mode: "github",
+    repo: resultsRepo,
+    path: "/data/results/agentv-evalresults",
+    auto_push: false,
+    branch_prefix: "eval-results",
+  },
+  added_at:
+    existingEntry && typeof existingEntry.added_at === "string" ? existingEntry.added_at : now,
+  last_opened_at: now,
+};
+config.projects = [...projects.filter((project) => {
+  return !(project && typeof project === "object" && project.id === "agentv-examples");
+}), nextEntry];
+writeFileSync(configPath, stringify(config), "utf8");
+' "$home_dir/config.yaml" "$now" "$results_repo"
 }
 
 stage_examples_project() {


### PR DESCRIPTION
## Summary

Layered config is now consistently based on `$AGENTV_HOME/config.yaml`: Dashboard deployment seeds the new `projects:` registry shape, global validation no longer mistakes the real home config for a project-local config, and `projects[].results` is validated with the same result-repo rules as top-level `results`.

Project-scoped remote status now prefers registered project result settings over global fallback settings, so Dashboard deployments can keep per-project result repos in the home registry without `results_by_project`.

## Verification

- `bun test packages/core/test/evaluation/validation/config-validator.test.ts`
- `bun test packages/core/test/projects.test.ts apps/cli/test/commands/results/serve.test.ts`
- `bun run build`
- `bun run typecheck`
- `bun run lint`
- `bash -n scripts/setup-dashboard-deployment.sh`
- Scratch smoke: `agentv validate` accepts `$AGENTV_HOME/config.yaml` with `projects:` and no false project-local warning.
- Scratch smoke: `agentv validate <project>/.agentv/config.yaml` warns that `projects:` is only valid in `$AGENTV_HOME/config.yaml`.
- Scratch smoke: project-scoped `/api/projects/:id/remote/status` returns the registered `projects[].results` repo/path over the global fallback.
- Scratch deployment smoke: `scripts/setup-dashboard-deployment.sh --no-start` writes `home/config.yaml`, does not write `home/projects.yaml`, and preserves unrelated home config keys plus other project entries.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
