### PR TITLE
fix(targets): preserve azure deployment base urls

### DIFF
--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -1092,6 +1092,10 @@ function normalizeOpenAIBaseUrl(value: string | undefined): string {
     return DEFAULT_OPENAI_BASE_URL;
   }
 
+  if (/\.openai\.azure\.com\/openai\/deployments\/[^/]+$/i.test(trimmed)) {
+    return trimmed;
+  }
+
   return trimmed.endsWith('/v1') ? trimmed : `${trimmed}/v1`;
 }
 

--- a/packages/core/test/evaluation/providers/targets.test.ts
+++ b/packages/core/test/evaluation/providers/targets.test.ts
@@ -1016,6 +1016,32 @@ describe('resolveTargetDefinition', () => {
     ).toThrow(/baseUrl.*base_url/i);
   });
 
+  it('preserves Azure deployment-scoped OpenAI base URLs', () => {
+    const target = resolveTargetDefinition(
+      {
+        name: 'azure-chat',
+        provider: 'openai',
+        base_url: 'https://resource.openai.azure.com/openai/deployments/gpt-4o',
+        api_key: '${{ AZURE_OPENAI_API_KEY }}',
+        model: '${{ AZURE_DEPLOYMENT_NAME }}',
+        api_format: 'chat',
+      },
+      {
+        AZURE_OPENAI_API_KEY: 'test-key',
+        AZURE_DEPLOYMENT_NAME: 'gpt-4o',
+      },
+    );
+
+    expect(target.kind).toBe('openai');
+    if (target.kind !== 'openai') {
+      throw new Error('expected openai target');
+    }
+
+    expect(target.config.baseURL).toBe(
+      'https://resource.openai.azure.com/openai/deployments/gpt-4o',
+    );
+  });
+
   it('resolves agentv target with model and default temperature', () => {
     const target = resolveTargetDefinition(
       {


### PR DESCRIPTION
## Summary
- Preserves configured Azure deployment base URLs when preparing target provider settings.
- Adds regression coverage for Azure target URL handling.

## Verification
- Provider regression tests passed in the implementation session.
- Public demo live Codex + Azure artifact verification was recorded on bead av-h60.

Bead: av-h60