### PR TITLE
feat(dashboard): add project results sync UX

### DIFF
--- a/apps/cli/src/commands/results/remote-metadata.ts
+++ b/apps/cli/src/commands/results/remote-metadata.ts
@@ -1,0 +1,254 @@
+/**
+ * Mutable metadata overlays for remote result runs.
+ *
+ * Remote run artifacts under `.agentv/results/runs/**` are treated as immutable
+ * fetched payloads. Editable fields, starting with tags, live in a small
+ * sidecar tree under `.agentv/results/metadata/runs/**` inside the configured
+ * results repo checkout. That keeps local edits pushable by normal Git sync
+ * without rewriting the fetched run directory.
+ *
+ * To add another mutable field: create a sibling helper that maps the remote
+ * run manifest to the same metadata run directory, keep the on-disk keys
+ * snake_case, and compare the working tree file against the upstream Git ref
+ * so Dashboard can show pending local edits.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { RUN_TAGS_FILENAME, normalizeTags } from './run-tags.js';
+
+const RESULTS_RUNS_DIR = path.join('.agentv', 'results', 'runs');
+const REMOTE_METADATA_RUNS_DIR = path.join('.agentv', 'results', 'metadata', 'runs');
+
+interface TagsFile {
+  readonly tags: string[];
+  readonly updatedAt?: string;
+}
+
+interface RemoteRunMetadataPaths {
+  readonly runRelativePath: string;
+  readonly artifactTagsPath: string;
+  readonly artifactTagsGitPath: string;
+  readonly overlayTagsPath: string;
+  readonly overlayTagsGitPath: string;
+}
+
+interface RemoteRunTagsContext {
+  readonly paths: RemoteRunMetadataPaths;
+  readonly artifactTags: TagsFile | undefined;
+  readonly baseOverlayTags: TagsFile | undefined;
+  readonly localOverlayTags: TagsFile | undefined;
+}
+
+export interface RemoteRunTagState {
+  readonly tags: string[];
+  readonly remoteTags: string[];
+  readonly pendingTags?: string[];
+  readonly dirty: boolean;
+  readonly updatedAt?: string;
+  readonly metadataPath: string;
+}
+
+function cleanGitEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && !(key.startsWith('GIT_') && key !== 'GIT_SSH_COMMAND')) {
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
+function runGit(repoDir: string, args: readonly string[]): string {
+  return execFileSync('git', [...args], {
+    cwd: repoDir,
+    encoding: 'utf8',
+    env: cleanGitEnv(),
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function tryRunGit(repoDir: string, args: readonly string[]): string | undefined {
+  try {
+    return runGit(repoDir, args);
+  } catch {
+    return undefined;
+  }
+}
+
+function toGitPath(filePath: string): string {
+  return filePath.split(path.sep).join('/');
+}
+
+function readTagsFile(filePath: string): TagsFile | undefined {
+  if (!existsSync(filePath)) return undefined;
+  try {
+    return parseTagsFile(readFileSync(filePath, 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+function readTagsFromGit(
+  repoDir: string,
+  ref: string | undefined,
+  gitPath: string,
+): TagsFile | undefined {
+  if (!ref) return undefined;
+  const content = tryRunGit(repoDir, ['show', `${ref}:${gitPath}`]);
+  if (content === undefined) return undefined;
+  try {
+    return parseTagsFile(content);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseTagsFile(content: string): TagsFile | undefined {
+  const parsed = JSON.parse(content) as unknown;
+  if (!parsed || typeof parsed !== 'object') return undefined;
+  const record = parsed as Record<string, unknown>;
+  if (!Array.isArray(record.tags)) return undefined;
+  const tags = record.tags.filter((tag): tag is string => typeof tag === 'string');
+  return {
+    tags,
+    updatedAt: typeof record.updated_at === 'string' ? record.updated_at : undefined,
+  };
+}
+
+function equalTags(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((tag, index) => tag === b[index]);
+}
+
+function resolveComparisonRef(repoDir: string): string | undefined {
+  const upstream = tryRunGit(repoDir, [
+    'rev-parse',
+    '--abbrev-ref',
+    '--symbolic-full-name',
+    '@{upstream}',
+  ]);
+  if (upstream) return upstream;
+  return tryRunGit(repoDir, ['rev-parse', '--verify', 'HEAD']) ? 'HEAD' : undefined;
+}
+
+function resolveRemoteRunMetadataPaths(
+  repoDir: string,
+  manifestPath: string,
+): RemoteRunMetadataPaths {
+  const runsRoot = path.resolve(repoDir, RESULTS_RUNS_DIR);
+  const manifestDir = path.resolve(path.dirname(manifestPath));
+  const runRelativePath = path.relative(runsRoot, manifestDir);
+  if (
+    runRelativePath.length === 0 ||
+    runRelativePath.startsWith('..') ||
+    path.isAbsolute(runRelativePath)
+  ) {
+    throw new Error(
+      `Remote run manifest is outside the results repo runs directory: ${manifestPath}`,
+    );
+  }
+
+  const overlayTagsPath = path.join(
+    repoDir,
+    REMOTE_METADATA_RUNS_DIR,
+    runRelativePath,
+    RUN_TAGS_FILENAME,
+  );
+  const artifactTagsPath = path.join(runsRoot, runRelativePath, RUN_TAGS_FILENAME);
+
+  return {
+    runRelativePath,
+    artifactTagsPath,
+    artifactTagsGitPath: toGitPath(path.relative(repoDir, artifactTagsPath)),
+    overlayTagsPath,
+    overlayTagsGitPath: toGitPath(path.relative(repoDir, overlayTagsPath)),
+  };
+}
+
+function readRemoteRunTagsContext(repoDir: string, manifestPath: string): RemoteRunTagsContext {
+  const paths = resolveRemoteRunMetadataPaths(repoDir, manifestPath);
+  const comparisonRef = resolveComparisonRef(repoDir);
+  const artifactTags =
+    readTagsFile(paths.artifactTagsPath) ??
+    readTagsFromGit(repoDir, comparisonRef, paths.artifactTagsGitPath);
+  const baseOverlayTags = readTagsFromGit(repoDir, comparisonRef, paths.overlayTagsGitPath);
+  const localOverlayTags = readTagsFile(paths.overlayTagsPath);
+
+  return {
+    paths,
+    artifactTags,
+    baseOverlayTags,
+    localOverlayTags,
+  };
+}
+
+function toRemoteRunTagState(context: RemoteRunTagsContext): RemoteRunTagState {
+  const remoteTags = context.baseOverlayTags?.tags ?? context.artifactTags?.tags ?? [];
+  const effectiveTags = context.localOverlayTags?.tags ?? remoteTags;
+  const dirty = !equalTags(effectiveTags, remoteTags);
+
+  return {
+    tags: effectiveTags,
+    remoteTags,
+    ...(dirty && { pendingTags: effectiveTags }),
+    dirty,
+    updatedAt:
+      context.localOverlayTags?.updatedAt ??
+      context.baseOverlayTags?.updatedAt ??
+      context.artifactTags?.updatedAt,
+    metadataPath: context.paths.overlayTagsPath,
+  };
+}
+
+export function assertWritableResultsRepo(repoDir: string): void {
+  if (!existsSync(repoDir)) {
+    throw new Error('Writable results repo is not configured for remote metadata');
+  }
+  const insideWorkTree = tryRunGit(repoDir, ['rev-parse', '--is-inside-work-tree']);
+  if (insideWorkTree !== 'true') {
+    throw new Error(`Configured results repo is not a writable git checkout: ${repoDir}`);
+  }
+}
+
+export function isResultsRepoWorktreeDirty(repoDir: string): boolean {
+  if (!existsSync(repoDir)) return false;
+  const status = tryRunGit(repoDir, ['status', '--porcelain']);
+  return status !== undefined && status.trim().length > 0;
+}
+
+export function readRemoteRunTags(repoDir: string, manifestPath: string): RemoteRunTagState {
+  const context = readRemoteRunTagsContext(repoDir, manifestPath);
+  return toRemoteRunTagState(context);
+}
+
+export function writeRemoteRunTags(
+  repoDir: string,
+  manifestPath: string,
+  tags: readonly string[],
+): RemoteRunTagState {
+  assertWritableResultsRepo(repoDir);
+
+  const cleaned = normalizeTags(tags);
+  const context = readRemoteRunTagsContext(repoDir, manifestPath);
+  const remoteTags = context.baseOverlayTags?.tags ?? context.artifactTags?.tags ?? [];
+
+  if (equalTags(cleaned, remoteTags) && context.baseOverlayTags === undefined) {
+    rmSync(context.paths.overlayTagsPath, { force: true });
+    return readRemoteRunTags(repoDir, manifestPath);
+  }
+
+  const entry = {
+    tags: cleaned,
+    updated_at: new Date().toISOString(),
+  };
+  mkdirSync(path.dirname(context.paths.overlayTagsPath), { recursive: true });
+  writeFileSync(context.paths.overlayTagsPath, `${JSON.stringify(entry, null, 2)}\n`, 'utf8');
+  return readRemoteRunTags(repoDir, manifestPath);
+}
+
+export function deleteRemoteRunTags(repoDir: string, manifestPath: string): RemoteRunTagState {
+  return writeRemoteRunTags(repoDir, manifestPath, []);
+}

--- a/apps/cli/src/commands/results/remote.ts
+++ b/apps/cli/src/commands/results/remote.ts
@@ -27,6 +27,13 @@ import {
   listResultFiles,
   listResultFilesFromRunsDir,
 } from '../inspect/utils.js';
+import {
+  type RemoteRunTagState,
+  assertWritableResultsRepo,
+  deleteRemoteRunTags,
+  readRemoteRunTags,
+  writeRemoteRunTags,
+} from './remote-metadata.js';
 
 // ── In-memory TTL cache for listGitRuns ────────────────────────────
 // Avoids repeated expensive git ls-tree + git cat-file --batch operations
@@ -340,6 +347,55 @@ export async function ensureRemoteRunAvailable(
     path.posix.dirname(relativeManifestPath),
   );
   await materializeGitRun(config.path, relativeRunPath);
+}
+
+export async function readRemoteRunTagState(
+  cwd: string,
+  meta: Pick<SourcedResultFileMeta, 'source' | 'path'>,
+  projectId?: string,
+): Promise<RemoteRunTagState | undefined> {
+  if (meta.source !== 'remote') return undefined;
+  const config = await loadNormalizedResultsConfig(cwd, projectId);
+  if (!config) return undefined;
+
+  try {
+    return readRemoteRunTags(config.path, meta.path);
+  } catch {
+    return undefined;
+  }
+}
+
+export async function setRemoteRunTags(
+  cwd: string,
+  meta: Pick<SourcedResultFileMeta, 'source' | 'path'>,
+  tags: readonly string[],
+  projectId?: string,
+): Promise<RemoteRunTagState> {
+  if (meta.source !== 'remote') {
+    throw new Error('Remote metadata can only be set on remote runs');
+  }
+  const config = await loadNormalizedResultsConfig(cwd, projectId);
+  if (!config) {
+    throw new Error('Writable results repo is not configured for remote metadata');
+  }
+  assertWritableResultsRepo(config.path);
+  return writeRemoteRunTags(config.path, meta.path, tags);
+}
+
+export async function clearRemoteRunTags(
+  cwd: string,
+  meta: Pick<SourcedResultFileMeta, 'source' | 'path'>,
+  projectId?: string,
+): Promise<RemoteRunTagState> {
+  if (meta.source !== 'remote') {
+    throw new Error('Remote metadata can only be removed from remote runs');
+  }
+  const config = await loadNormalizedResultsConfig(cwd, projectId);
+  if (!config) {
+    throw new Error('Writable results repo is not configured for remote metadata');
+  }
+  assertWritableResultsRepo(config.path);
+  return deleteRemoteRunTags(config.path, meta.path);
 }
 
 export async function maybeAutoExportRunArtifacts(payload: RemoteExportPayload): Promise<void> {

--- a/apps/cli/src/commands/results/remote.ts
+++ b/apps/cli/src/commands/results/remote.ts
@@ -11,14 +11,14 @@ import {
   directorySizeBytes,
   getProject,
   getProjectForPath,
-  getResultsRepoStatus,
+  getResultsRepoSyncStatus,
   listGitRuns,
   loadConfig,
   materializeGitRun,
   normalizeResultsConfig,
   resolveResultsConfigForProject,
   resolveResultsRepoRunsDir,
-  syncResultsRepo,
+  syncResultsRepoForProject,
 } from '@agentv/core';
 
 import { findRepoRoot } from '../eval/shared.js';
@@ -52,6 +52,10 @@ function cachedListGitRuns(repoDir: string) {
       }
     });
   return promise;
+}
+
+function invalidateGitRunsCache(repoDir: string): void {
+  gitRunsCache.delete(repoDir);
 }
 
 export type RunSource = 'local' | 'remote';
@@ -173,7 +177,18 @@ export async function getRemoteResultsStatus(
   projectId?: string,
 ): Promise<RemoteResultsStatus> {
   const config = await loadNormalizedResultsConfig(cwd, projectId);
-  const status = getResultsRepoStatus(config);
+  const status = await getResultsRepoSyncStatus(config);
+  const runCount = await getRemoteRunCount(config, status);
+  return {
+    ...status,
+    run_count: runCount,
+  };
+}
+
+async function getRemoteRunCount(
+  config: Required<ResultsConfig> | undefined,
+  status: ResultsRepoStatus,
+): Promise<number> {
   let runCount = 0;
   if (config && status.available) {
     try {
@@ -182,10 +197,7 @@ export async function getRemoteResultsStatus(
       runCount = listResultFilesFromRunsDir(resolveResultsRepoRunsDir(config)).length;
     }
   }
-  return {
-    ...status,
-    run_count: runCount,
-  };
+  return runCount;
 }
 
 export async function syncRemoteResults(
@@ -195,22 +207,28 @@ export async function syncRemoteResults(
   const config = await loadNormalizedResultsConfig(cwd, projectId);
   if (!config) {
     return {
-      ...getResultsRepoStatus(),
+      ...(await getResultsRepoSyncStatus()),
       run_count: 0,
     };
   }
 
   try {
-    await syncResultsRepo(config);
-  } catch (error) {
+    const status = await syncResultsRepoForProject(config);
+    invalidateGitRunsCache(config.path);
     return {
-      ...getResultsRepoStatus(config),
+      ...status,
+      run_count: await getRemoteRunCount(config, status),
+    };
+  } catch (error) {
+    const status = await getResultsRepoSyncStatus(config);
+    return {
+      ...status,
       run_count: 0,
       last_error: getStatusMessage(error),
+      blocked: true,
+      block_reason: getStatusMessage(error),
     };
   }
-
-  return getRemoteResultsStatus(cwd, projectId);
 }
 
 export async function listMergedResultFiles(

--- a/apps/cli/src/commands/results/run-tags.ts
+++ b/apps/cli/src/commands/results/run-tags.ts
@@ -101,7 +101,7 @@ export function deleteRunTags(manifestPath: string): void {
  * Trim, validate, and deduplicate an incoming tag array. Throws on any
  * invalid entry so the caller can surface a user-friendly error.
  */
-function normalizeTags(tags: readonly string[]): string[] {
+export function normalizeTags(tags: readonly string[]): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
   for (const raw of tags) {

--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -73,10 +73,13 @@ import {
 } from './manifest.js';
 import {
   type SourcedResultFileMeta,
+  clearRemoteRunTags,
   ensureRemoteRunAvailable,
   findRunById,
   getRemoteResultsStatus,
   listMergedResultFiles,
+  readRemoteRunTagState,
+  setRemoteRunTags,
   syncRemoteResults,
 } from './remote.js';
 import { deleteRunTags, readRunTags, writeRunTags } from './run-tags.js';
@@ -282,6 +285,13 @@ interface DataContext {
   projectId?: string;
 }
 
+interface RunTagFields {
+  readonly tags?: string[];
+  readonly remote_tags?: string[];
+  readonly pending_tags?: string[];
+  readonly metadata_dirty?: boolean;
+}
+
 // biome-ignore lint/suspicious/noExplicitAny: Hono Context generic varies by route
 type C = Context<any, any, any>;
 
@@ -295,6 +305,61 @@ function inferExperimentFromRunId(runId: string): string | undefined {
     return undefined;
   }
   return experiment;
+}
+
+async function readRunTagFields(
+  searchDir: string,
+  meta: SourcedResultFileMeta,
+  projectId?: string,
+): Promise<RunTagFields> {
+  if (meta.source === 'local') {
+    const tagsEntry = readRunTags(meta.path);
+    return tagsEntry ? { tags: tagsEntry.tags } : {};
+  }
+
+  const state = await readRemoteRunTagState(searchDir, meta, projectId);
+  if (!state) {
+    return {
+      tags: [],
+      remote_tags: [],
+      metadata_dirty: false,
+    };
+  }
+
+  return {
+    tags: state.tags,
+    remote_tags: state.remoteTags,
+    metadata_dirty: state.dirty,
+    ...(state.dirty && { pending_tags: state.pendingTags ?? state.tags }),
+  };
+}
+
+function remoteTagMutationResponse(state: {
+  readonly tags: string[];
+  readonly remoteTags: string[];
+  readonly pendingTags?: string[];
+  readonly dirty: boolean;
+  readonly updatedAt?: string;
+}) {
+  return {
+    tags: state.tags,
+    remote_tags: state.remoteTags,
+    metadata_dirty: state.dirty,
+    ...(state.dirty && { pending_tags: state.pendingTags ?? state.tags }),
+    updated_at: state.updatedAt ?? new Date().toISOString(),
+  };
+}
+
+function remoteMetadataErrorStatus(error: unknown): 400 | 409 {
+  const message = error instanceof Error ? error.message : String(error);
+  if (
+    message.includes('not configured') ||
+    message.includes('not a writable git checkout') ||
+    message.includes('outside the results repo runs directory')
+  ) {
+    return 409;
+  }
+  return 400;
 }
 
 async function ensureRunReadable(
@@ -411,7 +476,7 @@ async function handleRuns(c: C, { searchDir, agentvDir, projectId }: DataContext
       // or running so the RunList can render a spinner instead of the
       // pass/fail dot derived from a 0% pass rate.
       const liveStatus = getActiveRunStatus(m.path);
-      const tagsEntry = readRunTags(m.path);
+      const tagFields = await readRunTagFields(searchDir, m, projectId);
       return {
         filename: m.filename,
         display_name: m.displayName,
@@ -424,7 +489,7 @@ async function handleRuns(c: C, { searchDir, agentvDir, projectId }: DataContext
         source: m.source,
         ...(target && { target }),
         ...(experiment && { experiment }),
-        ...(tagsEntry && { tags: tagsEntry.tags }),
+        ...tagFields,
         ...(liveStatus && { status: liveStatus }),
       };
     }),
@@ -466,10 +531,12 @@ async function handleRunDetail(c: C, { searchDir, projectId }: DataContext) {
     // results-repo cache and cannot be resumed in place, so omit both fields.
     const resumeMeta = meta.source === 'local' ? deriveResumeMeta(searchDir, meta.path) : {};
     const liveStatus = meta.source === 'local' ? getActiveRunStatus(meta.path) : undefined;
+    const tagFields = await readRunTagFields(searchDir, meta, projectId);
     return c.json({
       results: stripHeavyFields(loaded),
       source: meta.source,
       source_label: meta.displayName,
+      ...tagFields,
       ...(liveStatus && { status: liveStatus }),
       ...resumeMeta,
     });
@@ -800,6 +867,9 @@ async function handleCompare(c: C, { searchDir, agentvDir, projectId }: DataCont
     experiment: string;
     target: string;
     tags?: string[];
+    remote_tags?: string[];
+    pending_tags?: string[];
+    metadata_dirty?: boolean;
     source: 'local' | 'remote';
     eval_count: number;
     passed_count: number;
@@ -821,9 +891,9 @@ async function handleCompare(c: C, { searchDir, agentvDir, projectId }: DataCont
     try {
       // Read tags before any heavy work so the `?tags=` filter can skip
       // non-matching runs without loading their JSONL records.
-      const tagsEntry = readRunTags(m.path);
+      const tagFields = await readRunTagFields(searchDir, m, projectId);
       if (filterTags.size > 0) {
-        const runTags = tagsEntry?.tags ?? [];
+        const runTags = tagFields.tags ?? [];
         if (!runTags.some((t) => filterTags.has(t))) continue;
       }
 
@@ -889,7 +959,7 @@ async function handleCompare(c: C, { searchDir, agentvDir, projectId }: DataCont
         started_at: runStartedAt,
         experiment: runExperiment,
         target: runTarget,
-        ...(tagsEntry && { tags: tagsEntry.tags }),
+        ...tagFields,
         source: m.source,
         eval_count: runEvalCount,
         passed_count: runPassedCount,
@@ -1037,9 +1107,6 @@ async function handleRunTagsPut(c: C, { searchDir, projectId }: DataContext) {
   const filename = c.req.param('filename') ?? '';
   const meta = await findRunById(searchDir, filename, projectId);
   if (!meta) return c.json({ error: 'Run not found' }, 404);
-  if (meta.source === 'remote') {
-    return c.json({ error: 'Tags can only be set on local runs' }, 400);
-  }
   let body: unknown;
   try {
     body = await c.req.json();
@@ -1054,13 +1121,18 @@ async function handleRunTagsPut(c: C, { searchDir, projectId }: DataContext) {
     return c.json({ error: 'Missing tags array' }, 400);
   }
   try {
+    if (meta.source === 'remote') {
+      const state = await setRemoteRunTags(searchDir, meta, tags as string[], projectId);
+      return c.json(remoteTagMutationResponse(state));
+    }
+
     const entry = writeRunTags(meta.path, tags as string[]);
     return c.json({
       tags: entry?.tags ?? [],
       updated_at: entry?.updated_at ?? new Date().toISOString(),
     });
   } catch (err) {
-    return c.json({ error: (err as Error).message }, 400);
+    return c.json({ error: (err as Error).message }, remoteMetadataErrorStatus(err));
   }
 }
 
@@ -1068,14 +1140,19 @@ async function handleRunTagsDelete(c: C, { searchDir, projectId }: DataContext) 
   const filename = c.req.param('filename') ?? '';
   const meta = await findRunById(searchDir, filename, projectId);
   if (!meta) return c.json({ error: 'Run not found' }, 404);
-  if (meta.source === 'remote') {
-    return c.json({ error: 'Tags can only be removed on local runs' }, 400);
-  }
   try {
+    if (meta.source === 'remote') {
+      const state = await clearRemoteRunTags(searchDir, meta, projectId);
+      return c.json({
+        ok: true,
+        ...remoteTagMutationResponse(state),
+      });
+    }
+
     deleteRunTags(meta.path);
     return c.json({ ok: true });
   } catch (err) {
-    return c.json({ error: (err as Error).message }, 500);
+    return c.json({ error: (err as Error).message }, remoteMetadataErrorStatus(err));
   }
 }
 
@@ -1368,6 +1445,10 @@ export function createApp(
       size_bytes: number;
       target?: string;
       experiment?: string;
+      tags?: string[];
+      remote_tags?: string[];
+      pending_tags?: string[];
+      metadata_dirty?: boolean;
       source: 'local' | 'remote';
       project_id: string;
       project_name: string;
@@ -1388,6 +1469,7 @@ export function createApp(
           } catch {
             // ignore enrichment errors
           }
+          const tagFields = await readRunTagFields(p.path, m, p.id);
           allRuns.push({
             filename: m.filename,
             display_name: m.displayName,
@@ -1400,6 +1482,7 @@ export function createApp(
             source: m.source,
             ...(target && { target }),
             ...(experiment && { experiment }),
+            ...tagFields,
             project_id: p.id,
             project_name: p.name,
           });

--- a/apps/cli/test/commands/results/remote-metadata.test.ts
+++ b/apps/cli/test/commands/results/remote-metadata.test.ts
@@ -1,0 +1,125 @@
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import {
+  deleteRemoteRunTags,
+  isResultsRepoWorktreeDirty,
+  readRemoteRunTags,
+  writeRemoteRunTags,
+} from '../../../src/commands/results/remote-metadata.js';
+
+const RUN_TIMESTAMP = '2026-06-06T10-00-00-000Z';
+
+function cleanGitEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && !(key.startsWith('GIT_') && key !== 'GIT_SSH_COMMAND')) {
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
+function git(cmd: string, cwd: string): string {
+  return execSync(cmd, {
+    cwd,
+    encoding: 'utf8',
+    env: cleanGitEnv(),
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function seedRepo(repoDir: string): string {
+  git('git init --quiet', repoDir);
+  git('git config user.email "test@example.com"', repoDir);
+  git('git config user.name "Test User"', repoDir);
+
+  const runDir = path.join(repoDir, '.agentv', 'results', 'runs', 'default', RUN_TIMESTAMP);
+  mkdirSync(runDir, { recursive: true });
+  writeFileSync(path.join(runDir, 'index.jsonl'), '{"test_id":"alpha","score":1}\n');
+  writeFileSync(
+    path.join(runDir, 'tags.json'),
+    `${JSON.stringify({ tags: ['remote-baseline'], updated_at: '2026-06-06T09:00:00.000Z' }, null, 2)}\n`,
+  );
+  git('git add .agentv', repoDir);
+  git('git commit --quiet -m "seed remote run"', repoDir);
+  return path.join(runDir, 'index.jsonl');
+}
+
+describe('remote metadata tags', () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = mkdtempSync(path.join(os.tmpdir(), 'agentv-remote-metadata-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it('writes tag edits as a metadata overlay without mutating the run artifact', () => {
+    const manifestPath = seedRepo(repoDir);
+    const artifactTagsPath = path.join(path.dirname(manifestPath), 'tags.json');
+    const originalArtifactTags = readFileSync(artifactTagsPath, 'utf8');
+
+    const state = writeRemoteRunTags(repoDir, manifestPath, ['pending', 'remote-baseline']);
+
+    expect(state.tags).toEqual(['pending', 'remote-baseline']);
+    expect(state.remoteTags).toEqual(['remote-baseline']);
+    expect(state.pendingTags).toEqual(['pending', 'remote-baseline']);
+    expect(state.dirty).toBe(true);
+    expect(state.metadataPath).toContain(
+      path.join('.agentv', 'results', 'metadata', 'runs', 'default', RUN_TIMESTAMP, 'tags.json'),
+    );
+    expect(readFileSync(artifactTagsPath, 'utf8')).toBe(originalArtifactTags);
+    expect(existsSync(state.metadataPath)).toBe(true);
+    expect(isResultsRepoWorktreeDirty(repoDir)).toBe(true);
+
+    const reloaded = readRemoteRunTags(repoDir, manifestPath);
+    expect(reloaded.tags).toEqual(['pending', 'remote-baseline']);
+    expect(reloaded.pendingTags).toEqual(['pending', 'remote-baseline']);
+    expect(reloaded.dirty).toBe(true);
+  });
+
+  it('uses committed metadata overlays as the clean remote baseline', () => {
+    const manifestPath = seedRepo(repoDir);
+    const state = writeRemoteRunTags(repoDir, manifestPath, ['accepted']);
+    git('git add .agentv/results/metadata', repoDir);
+    git('git commit --quiet -m "update tags"', repoDir);
+
+    const reloaded = readRemoteRunTags(repoDir, manifestPath);
+
+    expect(state.dirty).toBe(true);
+    expect(reloaded.tags).toEqual(['accepted']);
+    expect(reloaded.remoteTags).toEqual(['accepted']);
+    expect(reloaded.pendingTags).toBeUndefined();
+    expect(reloaded.dirty).toBe(false);
+  });
+
+  it('persists clearing remote tags as an empty pending overlay', () => {
+    const manifestPath = seedRepo(repoDir);
+
+    const state = deleteRemoteRunTags(repoDir, manifestPath);
+
+    expect(state.tags).toEqual([]);
+    expect(state.remoteTags).toEqual(['remote-baseline']);
+    expect(state.pendingTags).toEqual([]);
+    expect(state.dirty).toBe(true);
+    expect(readFileSync(state.metadataPath, 'utf8')).toContain('"tags": []');
+  });
+
+  it('rejects writes when the configured results path is not a git checkout', () => {
+    const runDir = path.join(repoDir, '.agentv', 'results', 'runs', 'default', RUN_TIMESTAMP);
+    mkdirSync(runDir, { recursive: true });
+    const manifestPath = path.join(runDir, 'index.jsonl');
+    writeFileSync(manifestPath, '{"test_id":"alpha","score":1}\n');
+
+    expect(() => writeRemoteRunTags(repoDir, manifestPath, ['blocked'])).toThrow(
+      'not a writable git checkout',
+    );
+  });
+});

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -136,6 +136,42 @@ function writeRemoteRunArtifact(
   return `${experiment}::${timestamp}`;
 }
 
+function writeDirtyRemoteRunArtifact(
+  cloneDir: string,
+  experiment: string,
+  timestamp: string,
+  resultRecord: object,
+): string {
+  const isoTimestamp = timestamp.replace(
+    /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/,
+    '$1T$2:$3:$4.$5Z',
+  );
+  const runDir = path.join(cloneDir, '.agentv', 'results', 'runs', experiment, timestamp);
+  mkdirSync(runDir, { recursive: true });
+  writeFileSync(path.join(runDir, 'index.jsonl'), toJsonl(resultRecord));
+  writeFileSync(
+    path.join(runDir, 'benchmark.json'),
+    JSON.stringify(
+      {
+        metadata: {
+          timestamp: isoTimestamp,
+          experiment,
+          targets: ['gpt-4o'],
+          tests_run: ['test-greeting'],
+        },
+        run_summary: {
+          'gpt-4o': {
+            pass_rate: { mean: 1 },
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  return `${experiment}::${timestamp}`;
+}
+
 // ── resolveSourceFile ────────────────────────────────────────────────────
 
 describe('resolveSourceFile', () => {
@@ -899,6 +935,76 @@ describe('serve app', () => {
         }
       }
     });
+  });
+
+  describe('POST /api/projects/:projectId/remote/sync', () => {
+    it('returns project-scoped sync action fields after pushing safe local result metadata', async () => {
+      const previousHome = process.env.AGENTV_HOME;
+      const homeDir = path.join(tempDir, 'agentv-home-project-sync');
+      process.env.AGENTV_HOME = homeDir;
+
+      try {
+        const { remoteDir, cloneDir } = initializeRemoteRepo(tempDir);
+        const projectDir = path.join(tempDir, 'source-project-sync');
+        mkdirSync(path.join(projectDir, '.agentv'), { recursive: true });
+        mkdirSync(homeDir, { recursive: true });
+        saveProjectRegistry({
+          projects: [
+            {
+              id: 'project-sync',
+              name: 'Project Sync',
+              path: projectDir,
+              results: {
+                mode: 'github',
+                repo: `file://${remoteDir}`,
+                path: cloneDir,
+                autoPush: true,
+              },
+              addedAt: '2026-01-01T00:00:00.000Z',
+              lastOpenedAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        });
+        const runId = writeDirtyRemoteRunArtifact(
+          cloneDir,
+          'project-sync',
+          '2026-03-26T12-00-00-000Z',
+          RESULT_A,
+        );
+
+        const app = createApp([], tempDir, tempDir, undefined, { studioDir });
+        const res = await app.request('/api/projects/project-sync/remote/sync', {
+          method: 'POST',
+        });
+
+        expect(res.status).toBe(200);
+        const data = (await res.json()) as {
+          sync_status: string;
+          commit_created?: boolean;
+          push_performed?: boolean;
+          pull_performed?: boolean;
+          blocked?: boolean;
+          run_count: number;
+        };
+        expect(data).toMatchObject({
+          sync_status: 'clean',
+          commit_created: true,
+          push_performed: true,
+          pull_performed: false,
+          blocked: false,
+          run_count: 1,
+        });
+        expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, tempDir)).toContain(
+          `.agentv/results/runs/project-sync/${runId.replace('project-sync::', '')}/benchmark.json`,
+        );
+      } finally {
+        if (previousHome === undefined) {
+          process.env.AGENTV_HOME = undefined;
+        } else {
+          process.env.AGENTV_HOME = previousHome;
+        }
+      }
+    }, 15000);
   });
 
   // ── GET /api/runs/:filename ─────────────────────────────────────────

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -796,6 +796,145 @@ describe('serve app', () => {
       expect(detailRes.status).toBe(200);
       expect(existsSync(runManifestPath)).toBe(true);
     }, 15000);
+
+    it('edits remote run tags through metadata overlay and reloads effective tags', async () => {
+      const { remoteDir, cloneDir } = initializeRemoteRepo(tempDir);
+      const runId = writeRemoteRunArtifact(
+        cloneDir,
+        'green-uat',
+        '2026-03-26T12-00-00-000Z',
+        RESULT_A,
+      );
+
+      mkdirSync(path.join(tempDir, '.agentv'), { recursive: true });
+      writeFileSync(
+        path.join(tempDir, '.agentv', 'config.yaml'),
+        `results:
+  mode: github
+  repo: file://${remoteDir}
+  path: ${cloneDir}
+`,
+      );
+
+      const filename = `remote::${runId}`;
+      const app = createApp([], tempDir, tempDir, undefined, { studioDir });
+      const putRes = await app.request(`/api/runs/${encodeURIComponent(filename)}/tags`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tags: ['pending-review', 'shared'] }),
+      });
+
+      expect(putRes.status).toBe(200);
+      const putData = (await putRes.json()) as {
+        tags: string[];
+        remote_tags: string[];
+        pending_tags: string[];
+        metadata_dirty: boolean;
+      };
+      expect(putData).toMatchObject({
+        tags: ['pending-review', 'shared'],
+        remote_tags: [],
+        pending_tags: ['pending-review', 'shared'],
+        metadata_dirty: true,
+      });
+
+      const artifactTagsPath = path.join(
+        cloneDir,
+        '.agentv',
+        'results',
+        'runs',
+        'green-uat',
+        '2026-03-26T12-00-00-000Z',
+        'tags.json',
+      );
+      const overlayTagsPath = path.join(
+        cloneDir,
+        '.agentv',
+        'results',
+        'metadata',
+        'runs',
+        'green-uat',
+        '2026-03-26T12-00-00-000Z',
+        'tags.json',
+      );
+      expect(existsSync(artifactTagsPath)).toBe(false);
+      expect(existsSync(overlayTagsPath)).toBe(true);
+
+      const listRes = await app.request('/api/runs');
+      expect(listRes.status).toBe(200);
+      const listData = (await listRes.json()) as {
+        runs: Array<{
+          filename: string;
+          tags: string[];
+          pending_tags: string[];
+          metadata_dirty: boolean;
+        }>;
+      };
+      expect(listData.runs[0]).toMatchObject({
+        filename,
+        tags: ['pending-review', 'shared'],
+        pending_tags: ['pending-review', 'shared'],
+        metadata_dirty: true,
+      });
+
+      const detailRes = await app.request(`/api/runs/${encodeURIComponent(filename)}`);
+      expect(detailRes.status).toBe(200);
+      const detailData = (await detailRes.json()) as {
+        tags: string[];
+        pending_tags: string[];
+        metadata_dirty: boolean;
+      };
+      expect(detailData).toMatchObject({
+        tags: ['pending-review', 'shared'],
+        pending_tags: ['pending-review', 'shared'],
+        metadata_dirty: true,
+      });
+
+      const reloadedApp = createApp([], tempDir, tempDir, undefined, { studioDir });
+      const reloadedRes = await reloadedApp.request('/api/runs');
+      expect(reloadedRes.status).toBe(200);
+      const reloadedData = (await reloadedRes.json()) as {
+        runs: Array<{ tags: string[]; pending_tags: string[]; metadata_dirty: boolean }>;
+      };
+      expect(reloadedData.runs[0]).toMatchObject({
+        tags: ['pending-review', 'shared'],
+        pending_tags: ['pending-review', 'shared'],
+        metadata_dirty: true,
+      });
+    }, 15000);
+
+    it('rejects remote tag edits when the configured results path is not writable', async () => {
+      const plainResultsDir = path.join(tempDir, 'plain-results');
+      const timestamp = '2026-03-26T13-00-00-000Z';
+      const runDir = path.join(plainResultsDir, '.agentv', 'results', 'runs', 'default', timestamp);
+      mkdirSync(runDir, { recursive: true });
+      writeFileSync(path.join(runDir, 'index.jsonl'), toJsonl(RESULT_A));
+
+      mkdirSync(path.join(tempDir, '.agentv'), { recursive: true });
+      writeFileSync(
+        path.join(tempDir, '.agentv', 'config.yaml'),
+        `results:
+  mode: github
+  repo: file://${path.join(tempDir, 'missing.git')}
+  path: ${plainResultsDir}
+`,
+      );
+
+      const app = createApp([], tempDir, tempDir, undefined, { studioDir });
+      const res = await app.request(
+        `/api/runs/${encodeURIComponent(`remote::${timestamp}`)}/tags`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tags: ['blocked'] }),
+        },
+      );
+
+      expect(res.status).toBe(409);
+      const data = (await res.json()) as { error: string };
+      expect(data.error).toContain('not a writable git checkout');
+      expect(existsSync(path.join(runDir, 'tags.json'))).toBe(false);
+    });
   });
 
   describe('GET /api/projects/all-runs', () => {

--- a/apps/dashboard/src/components/AnalyticsTab.tsx
+++ b/apps/dashboard/src/components/AnalyticsTab.tsx
@@ -628,11 +628,18 @@ function PerRunRow({
   readOnly: boolean;
 }) {
   const avgPct = Math.round(run.avg_score * 100);
-  const canEdit = !readOnly && run.source !== 'remote';
+  const canEdit = !readOnly;
   const tagsBtnRef = useRef<HTMLButtonElement>(null);
   const tags = run.tags ?? [];
+  const metadataDirty = run.metadata_dirty === true;
   const runLabel = tags[0] ?? run.run_id;
   const subLabel = runSubLabel(run.run_id);
+  const tagsButtonClass =
+    tags.length > 0
+      ? 'inline-flex flex-wrap items-center gap-1 rounded-md px-1 py-0.5 transition-colors hover:bg-gray-800/60'
+      : metadataDirty
+        ? 'rounded-md border border-yellow-900/60 bg-yellow-950/20 px-2 py-0.5 text-xs text-yellow-300 transition-colors hover:border-yellow-700'
+        : 'rounded-md border border-dashed border-gray-700 px-2 py-0.5 text-xs text-gray-500 transition-colors hover:border-cyan-800 hover:text-cyan-400';
 
   // Restore focus to the tags trigger button once the inline editor closes,
   // so keyboard users don't lose their place in the table.
@@ -675,39 +682,23 @@ function PerRunRow({
                 e.stopPropagation();
                 onStartEdit();
               }}
-              className={
-                tags.length > 0
-                  ? 'inline-flex flex-wrap items-center gap-1 rounded-md px-1 py-0.5 transition-colors hover:bg-gray-800/60'
-                  : 'rounded-md border border-dashed border-gray-700 px-2 py-0.5 text-xs text-gray-500 transition-colors hover:border-cyan-800 hover:text-cyan-400'
-              }
+              className={tagsButtonClass}
               aria-label={tags.length > 0 ? 'Edit tags' : 'Add tags'}
             >
               {tags.length > 0 ? (
-                tags.map((t) => (
-                  <span
-                    key={t}
-                    className="rounded-md border border-cyan-900/60 bg-cyan-950/30 px-2 py-0.5 text-xs font-medium text-cyan-300"
-                  >
-                    {t}
-                  </span>
-                ))
+                <TagChips tags={tags} dirty={metadataDirty} />
+              ) : metadataDirty ? (
+                <>Pending clear</>
               ) : (
                 <>+ tags</>
               )}
             </button>
           ) : tags.length > 0 ? (
-            <div className="inline-flex flex-wrap items-center gap-1">
-              {tags.map((t) => (
-                <span
-                  key={t}
-                  className="rounded-md border border-cyan-900/60 bg-cyan-950/30 px-2 py-0.5 text-xs font-medium text-cyan-300"
-                >
-                  {t}
-                </span>
-              ))}
-            </div>
+            <TagChips tags={tags} dirty={metadataDirty} />
           ) : (
-            <span className="text-gray-600">—</span>
+            <span className={metadataDirty ? 'text-yellow-400' : 'text-gray-600'}>
+              {metadataDirty ? 'Pending clear' : '—'}
+            </span>
           )}
         </td>
         <td className="px-4 py-3 align-middle text-gray-300">{run.experiment}</td>
@@ -733,6 +724,26 @@ function PerRunRow({
         </tr>
       )}
     </>
+  );
+}
+
+function TagChips({ tags, dirty }: { tags: string[]; dirty: boolean }) {
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1">
+      {tags.map((t) => (
+        <span
+          key={t}
+          className="rounded-md border border-cyan-900/60 bg-cyan-950/30 px-2 py-0.5 text-xs font-medium text-cyan-300"
+        >
+          {t}
+        </span>
+      ))}
+      {dirty ? (
+        <span className="rounded-md border border-yellow-900/60 bg-yellow-950/20 px-2 py-0.5 text-xs font-medium text-yellow-300">
+          Pending sync
+        </span>
+      ) : null}
+    </span>
   );
 }
 
@@ -774,6 +785,7 @@ function TagsEditor({
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['compare'] });
       qc.invalidateQueries({ queryKey: ['runs'] });
+      qc.invalidateQueries({ queryKey: ['remote-status', projectId ?? ''] });
       if (projectId) {
         qc.invalidateQueries({ queryKey: ['projects', projectId, 'compare'] });
         qc.invalidateQueries({ queryKey: ['projects', projectId, 'runs'] });
@@ -788,6 +800,7 @@ function TagsEditor({
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['compare'] });
       qc.invalidateQueries({ queryKey: ['runs'] });
+      qc.invalidateQueries({ queryKey: ['remote-status', projectId ?? ''] });
       if (projectId) {
         qc.invalidateQueries({ queryKey: ['projects', projectId, 'compare'] });
         qc.invalidateQueries({ queryKey: ['projects', projectId, 'runs'] });

--- a/apps/dashboard/src/components/Breadcrumbs.tsx
+++ b/apps/dashboard/src/components/Breadcrumbs.tsx
@@ -7,6 +7,7 @@
 
 import { Link, useMatches } from '@tanstack/react-router';
 
+import { useProjectList } from '~/lib/api';
 import {
   categoryPath,
   evalPath,
@@ -30,7 +31,10 @@ function formatRunLabel(runId: string | undefined): string {
   return timestamp || runId;
 }
 
-function deriveSegments(matches: ReturnType<typeof useMatches>): BreadcrumbSegment[] {
+function deriveSegments(
+  matches: ReturnType<typeof useMatches>,
+  projectNames: ReadonlyMap<string, string> = new Map(),
+): BreadcrumbSegment[] {
   const segments: BreadcrumbSegment[] = [];
 
   // Skip the root match (index 0)
@@ -42,10 +46,12 @@ function deriveSegments(matches: ReturnType<typeof useMatches>): BreadcrumbSegme
     if (routeId === '/' || routeId === '/_layout') continue;
 
     if (routeId.includes('/projects/$projectId') && params.projectId) {
-      if (!segments.some((s) => s.label === params.projectId)) {
+      const label = projectNames.get(params.projectId) ?? params.projectId;
+      const to = projectHomePath(params.projectId);
+      if (!segments.some((s) => s.to === to)) {
         segments.push({
-          label: params.projectId,
-          to: projectHomePath(params.projectId),
+          label,
+          to,
         });
       }
       if (routeId === '/projects/$projectId') {
@@ -162,7 +168,11 @@ function deriveSegments(matches: ReturnType<typeof useMatches>): BreadcrumbSegme
 
 export function Breadcrumbs() {
   const matches = useMatches();
-  const segments = deriveSegments(matches);
+  const { data: projectData } = useProjectList();
+  const projectNames = new Map(
+    (projectData?.projects ?? []).map((project) => [project.id, project.name]),
+  );
+  const segments = deriveSegments(matches, projectNames);
 
   if (segments.length === 0) return null;
 

--- a/apps/dashboard/src/components/RunList.tsx
+++ b/apps/dashboard/src/components/RunList.tsx
@@ -275,6 +275,7 @@ export function RunList({
               const passedCount = Math.round(run.pass_rate * run.test_count);
               const failedCount = run.test_count - passedCount;
               const selectable = selectableRunIds.includes(run.filename);
+              const metadataDirty = run.metadata_dirty === true;
               return (
                 <tr key={run.filename} className="transition-colors hover:bg-gray-900/30">
                   {enableCombine && (
@@ -325,6 +326,22 @@ export function RunList({
                         {label}
                       </Link>
                     )}
+                    <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs">
+                      <span
+                        className={`rounded-md border px-1.5 py-0.5 ${
+                          run.source === 'remote'
+                            ? 'border-cyan-900/60 bg-cyan-950/20 text-cyan-300'
+                            : 'border-gray-800 bg-gray-900/70 text-gray-500'
+                        }`}
+                      >
+                        {run.source === 'remote' ? 'Remote' : 'Local'}
+                      </span>
+                      {metadataDirty ? (
+                        <span className="rounded-md border border-yellow-900/60 bg-yellow-950/20 px-1.5 py-0.5 text-yellow-300">
+                          Pending metadata
+                        </span>
+                      ) : null}
+                    </div>
                   </td>
 
                   {/* Passed / Failed / Total */}

--- a/apps/dashboard/src/components/RunSourceToolbar.tsx
+++ b/apps/dashboard/src/components/RunSourceToolbar.tsx
@@ -1,3 +1,8 @@
+import {
+  formatLastSynced,
+  formatRemoteRunCount,
+  getProjectSyncView,
+} from '~/lib/project-sync-status';
 import type { RemoteStatusResponse } from '~/lib/types';
 
 export type RunSourceFilter = 'all' | 'local' | 'remote';
@@ -8,19 +13,8 @@ interface RunSourceToolbarProps {
   remoteStatus?: RemoteStatusResponse;
   syncInFlight?: boolean;
   onSync?: () => void;
-}
-
-function formatLastSynced(timestamp?: string): string {
-  if (!timestamp) {
-    return 'Never synced';
-  }
-
-  const parsed = new Date(timestamp);
-  if (Number.isNaN(parsed.getTime())) {
-    return 'Never synced';
-  }
-
-  return `Last synced ${parsed.toLocaleString()}`;
+  projectName?: string;
+  syncFeedback?: { kind: 'success' | 'warning' | 'error'; message: string } | null;
 }
 
 export function RunSourceToolbar({
@@ -29,9 +23,27 @@ export function RunSourceToolbar({
   remoteStatus,
   syncInFlight,
   onSync,
+  projectName,
+  syncFeedback,
 }: RunSourceToolbarProps) {
   const remoteConfigured = remoteStatus?.configured === true;
-  const remoteUnavailable = remoteConfigured && remoteStatus?.available !== true;
+  const syncView = getProjectSyncView(remoteStatus, syncInFlight);
+  const syncDisabled = syncInFlight === true || !syncView.canSync;
+  const statusToneClass = {
+    neutral: 'border-gray-700 bg-gray-800/70 text-gray-300',
+    good: 'border-emerald-800/70 bg-emerald-950/30 text-emerald-300',
+    info: 'border-cyan-800/70 bg-cyan-950/30 text-cyan-300',
+    warn: 'border-yellow-800/70 bg-yellow-950/30 text-yellow-300',
+    danger: 'border-red-800/70 bg-red-950/30 text-red-300',
+  }[syncView.tone];
+  const feedbackClass =
+    syncFeedback?.kind === 'success'
+      ? 'border-emerald-900/60 bg-emerald-950/20 text-emerald-300'
+      : syncFeedback?.kind === 'warning'
+        ? 'border-yellow-900/60 bg-yellow-950/20 text-yellow-300'
+        : 'border-red-900/60 bg-red-950/20 text-red-300';
+  const dirtyPathCount = remoteStatus?.dirty_paths?.length ?? 0;
+  const conflictedPathCount = remoteStatus?.conflicted_paths?.length ?? 0;
 
   return (
     <div className="flex flex-col gap-3 rounded-lg border border-gray-800 bg-gray-900/40 p-4">
@@ -59,24 +71,55 @@ export function RunSourceToolbar({
           })}
         </div>
 
-        {remoteConfigured && onSync ? (
-          <button
-            type="button"
-            onClick={onSync}
-            disabled={syncInFlight}
-            className="rounded-md border border-cyan-800 bg-cyan-950/40 px-3 py-1.5 text-sm font-medium text-cyan-300 transition-colors hover:bg-cyan-900/50 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {syncInFlight ? 'Syncing…' : 'Sync Remote Results'}
-          </button>
+        {remoteConfigured ? (
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${statusToneClass}`}
+            >
+              {syncView.label}
+            </span>
+            {onSync ? (
+              <button
+                type="button"
+                onClick={onSync}
+                disabled={syncDisabled}
+                title={!syncView.canSync ? syncView.nextAction : undefined}
+                className="rounded-md border border-cyan-800 bg-cyan-950/40 px-3 py-1.5 text-sm font-medium text-cyan-300 transition-colors hover:bg-cyan-900/50 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {syncInFlight ? 'Syncing...' : 'Sync Project'}
+              </button>
+            ) : null}
+          </div>
         ) : null}
       </div>
 
       {remoteConfigured ? (
-        <div className="flex flex-wrap items-center gap-3 text-sm text-gray-400">
-          <span>{formatLastSynced(remoteStatus?.last_synced_at)}</span>
-          {remoteStatus?.repo ? <span>Repo: {remoteStatus.repo}</span> : null}
-          {remoteUnavailable ? (
-            <span className="text-yellow-400">Remote cache unavailable</span>
+        <div className="space-y-2 text-sm">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-gray-400">
+            {projectName ? <span>Project: {projectName}</span> : null}
+            <span>{formatRemoteRunCount(remoteStatus?.run_count)}</span>
+            <span>{formatLastSynced(remoteStatus?.last_synced_at)}</span>
+            {remoteStatus?.repo ? <span>Repo: {remoteStatus.repo}</span> : null}
+          </div>
+          <p className={syncView.tone === 'danger' ? 'text-red-300' : 'text-gray-400'}>
+            {syncView.summary}
+          </p>
+          {syncView.nextAction ? (
+            <p className="text-xs text-gray-500">{syncView.nextAction}</p>
+          ) : null}
+          {dirtyPathCount > 0 || conflictedPathCount > 0 ? (
+            <div className="flex flex-wrap gap-2 text-xs">
+              {dirtyPathCount > 0 ? (
+                <span className="rounded-md border border-yellow-900/60 bg-yellow-950/20 px-2 py-0.5 text-yellow-300">
+                  {dirtyPathCount} dirty path{dirtyPathCount === 1 ? '' : 's'}
+                </span>
+              ) : null}
+              {conflictedPathCount > 0 ? (
+                <span className="rounded-md border border-red-900/60 bg-red-950/20 px-2 py-0.5 text-red-300">
+                  {conflictedPathCount} conflicted path{conflictedPathCount === 1 ? '' : 's'}
+                </span>
+              ) : null}
+            </div>
           ) : null}
         </div>
       ) : filter === 'all' ? (
@@ -88,10 +131,22 @@ export function RunSourceToolbar({
         </p>
       ) : null}
 
+      {syncFeedback ? (
+        <div className={`rounded-md border px-3 py-2 text-sm ${feedbackClass}`}>
+          {syncFeedback.message}
+        </div>
+      ) : null}
+
       {remoteStatus?.last_error ? (
         <div className="rounded-md border border-yellow-900/50 bg-yellow-950/20 px-3 py-2 text-sm text-yellow-300">
           {remoteStatus.last_error}
         </div>
+      ) : null}
+
+      {remoteStatus?.git_diff_summary && syncView.state !== 'clean' ? (
+        <pre className="max-h-32 overflow-auto whitespace-pre-wrap rounded-md border border-gray-800 bg-gray-950/60 px-3 py-2 text-xs text-gray-500">
+          {remoteStatus.git_diff_summary}
+        </pre>
       ) : null}
     </div>
   );

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -87,6 +87,11 @@ function BrandHeader({ projectId }: { projectId?: string }) {
   );
 }
 
+function useProjectDisplayName(projectId: string): string {
+  const { data } = useProjectList();
+  return data?.projects.find((project) => project.id === projectId)?.name ?? projectId;
+}
+
 export function Sidebar() {
   const matchRoute = useMatchRoute();
 
@@ -480,6 +485,7 @@ function ProjectRunDetailSidebar({
   currentRunId?: string;
 }) {
   const { data } = useProjectRunList(projectId);
+  const projectName = useProjectDisplayName(projectId);
 
   return (
     <SidebarShell>
@@ -489,7 +495,10 @@ function ProjectRunDetailSidebar({
         <Link to="/" className="text-xs text-gray-400 hover:text-cyan-400">
           &larr; All Projects
         </Link>
-        <p className="mt-1 truncate text-sm font-medium text-gray-300">{projectId}</p>
+        <p className="mt-1 truncate text-sm font-medium text-gray-300">{projectName}</p>
+        {projectName !== projectId ? (
+          <p className="truncate text-xs text-gray-600">{projectId}</p>
+        ) : null}
       </div>
 
       <nav className="flex-1 overflow-y-auto px-2 py-3">
@@ -531,6 +540,7 @@ function ProjectEvalSidebar({
   const { data } = useProjectRunDetail(projectId, runId);
   const { data: config } = useStudioConfig(projectId);
   const passThreshold = config?.threshold ?? config?.pass_threshold ?? 0.8;
+  const projectName = useProjectDisplayName(projectId);
 
   return (
     <SidebarShell>
@@ -544,6 +554,7 @@ function ProjectEvalSidebar({
         >
           &larr; Back to run
         </Link>
+        <p className="mt-1 truncate text-xs text-gray-500">{projectName}</p>
         <p className="mt-1 truncate text-sm font-medium text-gray-300">{runId}</p>
       </div>
 
@@ -590,6 +601,7 @@ function ProjectSuiteSidebar({
   const { data: config } = useStudioConfig(projectId);
   const passThreshold = config?.threshold ?? config?.pass_threshold ?? 0.8;
   const suiteResults = (data?.results ?? []).filter((r) => (r.suite ?? 'Uncategorized') === suite);
+  const projectName = useProjectDisplayName(projectId);
 
   return (
     <SidebarShell>
@@ -603,6 +615,7 @@ function ProjectSuiteSidebar({
         >
           &larr; Back to run
         </Link>
+        <p className="mt-1 truncate text-xs text-gray-500">{projectName}</p>
         <p className="mt-1 truncate text-sm font-medium text-gray-300">{runId}</p>
         <p className="truncate text-xs text-gray-500">{suite}</p>
       </div>
@@ -643,6 +656,7 @@ function ProjectCategorySidebar({
 }) {
   const { data } = useQuery(projectCategorySuitesOptions(projectId, runId, category));
   const suites = data?.suites ?? [];
+  const projectName = useProjectDisplayName(projectId);
 
   return (
     <SidebarShell>
@@ -656,6 +670,7 @@ function ProjectCategorySidebar({
         >
           &larr; Back to run
         </Link>
+        <p className="mt-1 truncate text-xs text-gray-500">{projectName}</p>
         <p className="mt-1 truncate text-sm font-medium text-gray-300">{runId}</p>
         <p className="truncate text-xs text-gray-500">{category}</p>
       </div>
@@ -694,6 +709,7 @@ function ProjectExperimentSidebar({
 }) {
   const { data } = useQuery(projectExperimentsOptions(projectId));
   const experiments = data?.experiments ?? [];
+  const projectName = useProjectDisplayName(projectId);
 
   return (
     <SidebarShell>
@@ -708,7 +724,10 @@ function ProjectExperimentSidebar({
         >
           &larr; All experiments
         </Link>
-        <p className="mt-1 truncate text-sm font-medium text-gray-300">{projectId}</p>
+        <p className="mt-1 truncate text-sm font-medium text-gray-300">{projectName}</p>
+        {projectName !== projectId ? (
+          <p className="truncate text-xs text-gray-600">{projectId}</p>
+        ) : null}
       </div>
 
       <nav className="flex-1 overflow-y-auto px-2 py-3">

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -528,7 +528,10 @@ export async function syncRemoteResultsApi(projectId?: string): Promise<RemoteSt
     method: 'POST',
   });
   if (!res.ok) {
-    throw new Error(`Failed to sync remote results: ${res.status}`);
+    const err = await res.json().catch(() => ({ error: res.statusText }));
+    throw new Error(
+      (err as { error?: string }).error ?? `Failed to sync remote results: ${res.status}`,
+    );
   }
   return res.json() as Promise<RemoteStatusResponse>;
 }

--- a/apps/dashboard/src/lib/project-sync-status.test.ts
+++ b/apps/dashboard/src/lib/project-sync-status.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  buildProjectSyncFeedback,
+  formatRemoteRunCount,
+  getProjectSyncView,
+} from './project-sync-status';
+
+describe('getProjectSyncView', () => {
+  it('keeps unconfigured remote results out of the sync action', () => {
+    expect(getProjectSyncView({ configured: false, available: false })).toMatchObject({
+      state: 'unconfigured',
+      canSync: false,
+    });
+  });
+
+  it('surfaces dirty metadata as syncable without reset language', () => {
+    const view = getProjectSyncView({
+      configured: true,
+      available: true,
+      sync_status: 'dirty',
+      dirty_paths: ['.agentv/results/metadata/runs/demo/tags.json'],
+      auto_push: false,
+    });
+
+    expect(view).toMatchObject({
+      state: 'dirty',
+      label: 'Dirty',
+      canSync: true,
+    });
+    expect(view.nextAction).toContain('no reset');
+  });
+
+  it('treats diverged history as a conflict-safe blocked state', () => {
+    expect(
+      getProjectSyncView({
+        configured: true,
+        available: true,
+        sync_status: 'diverged',
+        block_reason: 'Results repo local and remote histories have diverged',
+      }),
+    ).toMatchObject({
+      state: 'conflicted',
+      tone: 'danger',
+      canSync: false,
+    });
+  });
+});
+
+describe('buildProjectSyncFeedback', () => {
+  it('summarizes successful sync actions', () => {
+    expect(
+      buildProjectSyncFeedback({
+        configured: true,
+        available: true,
+        sync_status: 'clean',
+        commit_created: true,
+        pull_performed: true,
+        push_performed: true,
+      }),
+    ).toEqual({
+      kind: 'success',
+      message:
+        'Sync complete: committed pending metadata, pulled remote results, pushed local results.',
+    });
+  });
+
+  it('keeps blocked sync feedback explicit', () => {
+    expect(
+      buildProjectSyncFeedback({
+        configured: true,
+        available: true,
+        sync_status: 'conflicted',
+        blocked: true,
+        block_reason: 'Results repo has unresolved git conflicts',
+      }),
+    ).toEqual({
+      kind: 'warning',
+      message: 'Results repo has unresolved git conflicts',
+    });
+  });
+});
+
+describe('formatRemoteRunCount', () => {
+  it('pluralizes known remote run counts', () => {
+    expect(formatRemoteRunCount(1)).toBe('1 remote run');
+    expect(formatRemoteRunCount(2)).toBe('2 remote runs');
+  });
+});

--- a/apps/dashboard/src/lib/project-sync-status.ts
+++ b/apps/dashboard/src/lib/project-sync-status.ts
@@ -1,0 +1,167 @@
+import type { RemoteStatusResponse } from './types';
+
+export type ProjectSyncState =
+  | 'unconfigured'
+  | 'clean'
+  | 'unavailable'
+  | 'behind'
+  | 'ahead'
+  | 'dirty'
+  | 'conflicted'
+  | 'syncing';
+
+export type ProjectSyncTone = 'neutral' | 'good' | 'info' | 'warn' | 'danger';
+
+export interface ProjectSyncView {
+  state: ProjectSyncState;
+  label: string;
+  tone: ProjectSyncTone;
+  summary: string;
+  nextAction?: string;
+  canSync: boolean;
+}
+
+export function formatLastSynced(timestamp?: string): string {
+  if (!timestamp) {
+    return 'Never synced';
+  }
+
+  const parsed = new Date(timestamp);
+  if (Number.isNaN(parsed.getTime())) {
+    return 'Never synced';
+  }
+
+  return `Last synced ${parsed.toLocaleString()}`;
+}
+
+export function formatRemoteRunCount(count?: number): string {
+  if (typeof count !== 'number' || !Number.isFinite(count)) {
+    return 'Remote runs unknown';
+  }
+  return `${count} remote run${count === 1 ? '' : 's'}`;
+}
+
+export function getProjectSyncView(
+  status: RemoteStatusResponse | undefined,
+  syncInFlight = false,
+): ProjectSyncView {
+  if (syncInFlight || status?.sync_status === 'syncing') {
+    return {
+      state: 'syncing',
+      label: 'Syncing',
+      tone: 'info',
+      summary: 'Sync is in progress.',
+      canSync: false,
+    };
+  }
+
+  if (status?.configured !== true) {
+    return {
+      state: 'unconfigured',
+      label: 'Not configured',
+      tone: 'neutral',
+      summary: 'Remote results are not configured for this project.',
+      canSync: false,
+    };
+  }
+
+  if (status.available !== true || status.sync_status === 'unavailable') {
+    return {
+      state: 'unavailable',
+      label: 'Unavailable',
+      tone: 'warn',
+      summary: 'The remote results cache is not available locally.',
+      nextAction: 'Sync Project can clone or refresh the configured results repo.',
+      canSync: true,
+    };
+  }
+
+  const state = status.sync_status ?? 'clean';
+  if (state === 'conflicted' || state === 'diverged') {
+    return {
+      state: 'conflicted',
+      label: state === 'diverged' ? 'Conflicted' : 'Conflicted',
+      tone: 'danger',
+      summary:
+        status.block_reason ??
+        (state === 'diverged'
+          ? 'Local and remote results histories have diverged.'
+          : 'The results repo has unresolved conflicts.'),
+      nextAction: 'Resolve the results repo conflicts manually, then sync the project again.',
+      canSync: false,
+    };
+  }
+
+  if (state === 'dirty') {
+    return {
+      state: 'dirty',
+      label: 'Dirty',
+      tone: 'warn',
+      summary: status.block_reason ?? 'Local result metadata has pending edits.',
+      nextAction:
+        status.auto_push === true
+          ? 'Sync Project will commit safe result metadata changes before syncing.'
+          : 'Review or commit the pending result metadata; no reset will be performed.',
+      canSync: true,
+    };
+  }
+
+  if (state === 'behind') {
+    return {
+      state: 'behind',
+      label: 'Behind',
+      tone: 'info',
+      summary: `Remote has ${status.behind ?? 0} commit${status.behind === 1 ? '' : 's'} to pull.`,
+      nextAction: 'Sync Project will fast-forward when possible.',
+      canSync: true,
+    };
+  }
+
+  if (state === 'ahead') {
+    return {
+      state: 'ahead',
+      label: 'Ahead',
+      tone: 'info',
+      summary: `Local results are ${status.ahead ?? 0} commit${status.ahead === 1 ? '' : 's'} ahead.`,
+      nextAction:
+        status.auto_push === true
+          ? 'Sync Project will push safe result changes.'
+          : 'Enable auto_push or push the results repo manually.',
+      canSync: true,
+    };
+  }
+
+  return {
+    state: 'clean',
+    label: 'Clean',
+    tone: 'good',
+    summary: 'Local and remote result metadata are in sync.',
+    canSync: true,
+  };
+}
+
+export function buildProjectSyncFeedback(status: RemoteStatusResponse): {
+  kind: 'success' | 'warning';
+  message: string;
+} {
+  if (status.blocked || status.sync_status === 'conflicted' || status.sync_status === 'diverged') {
+    return {
+      kind: 'warning',
+      message: status.block_reason ?? 'Sync stopped before changing the results repo.',
+    };
+  }
+
+  const actions = [
+    status.commit_created ? 'committed pending metadata' : undefined,
+    status.pull_performed ? 'pulled remote results' : undefined,
+    status.push_performed ? 'pushed local results' : undefined,
+  ].filter((action): action is string => action !== undefined);
+
+  return {
+    kind: 'success',
+    message:
+      actions.length > 0
+        ? `Sync complete: ${actions.join(', ')}.`
+        : 'Sync complete; project results are up to date.',
+  };
+}

--- a/apps/dashboard/src/lib/types.ts
+++ b/apps/dashboard/src/lib/types.ts
@@ -21,6 +21,12 @@ export interface RunMeta {
   project_name?: string;
   /** Optional user-assigned tags from the run's sidecar tags.json. */
   tags?: string[];
+  /** Tags currently present in the remote results repo before local metadata overlays. */
+  remote_tags?: string[];
+  /** Locally edited tags waiting to sync back to the remote results repo. */
+  pending_tags?: string[];
+  /** True when local editable metadata differs from the fetched remote metadata. */
+  metadata_dirty?: boolean;
   /**
    * Live execution status. Only present for Dashboard-launched runs that are
    * still being tracked in-memory — used to render a spinner in RunList
@@ -184,6 +190,9 @@ export interface CompareRunEntry {
   experiment: string;
   target: string;
   tags?: string[];
+  remote_tags?: string[];
+  pending_tags?: string[];
+  metadata_dirty?: boolean;
   source: 'local' | 'remote';
   eval_count: number;
   passed_count: number;
@@ -202,6 +211,9 @@ export interface CompareResponse {
 
 export interface RunTagsResponse {
   tags: string[];
+  remote_tags?: string[];
+  pending_tags?: string[];
+  metadata_dirty?: boolean;
   updated_at: string;
 }
 
@@ -289,6 +301,28 @@ export interface RemoteStatusResponse {
   run_count?: number;
   last_synced_at?: string;
   last_error?: string;
+  sync_status?:
+    | 'clean'
+    | 'unavailable'
+    | 'behind'
+    | 'ahead'
+    | 'diverged'
+    | 'dirty'
+    | 'conflicted'
+    | 'syncing';
+  branch?: string;
+  upstream?: string;
+  ahead?: number;
+  behind?: number;
+  dirty_paths?: string[];
+  conflicted_paths?: string[];
+  git_status?: string;
+  git_diff_summary?: string;
+  blocked?: boolean;
+  block_reason?: string;
+  pull_performed?: boolean;
+  push_performed?: boolean;
+  commit_created?: boolean;
 }
 
 // ── Project types ──────────────────────────────────────────────────────

--- a/apps/dashboard/src/routes/index.tsx
+++ b/apps/dashboard/src/routes/index.tsx
@@ -33,6 +33,7 @@ import {
   resolveIndexRoute,
   resolveInitialProjectRedirect,
 } from '~/lib/navigation';
+import { buildProjectSyncFeedback } from '~/lib/project-sync-status';
 import { dedupeSyncedRuns } from '~/lib/run-dedupe';
 import type { RunMeta } from '~/lib/types';
 type TabId = StudioTabId;
@@ -230,6 +231,10 @@ function SingleProjectHome() {
   const [showRunEval, setShowRunEval] = useState(false);
   const [sourceFilter, setSourceFilter] = useState<RunSourceFilter>('all');
   const [syncInFlight, setSyncInFlight] = useState(false);
+  const [syncFeedback, setSyncFeedback] = useState<{
+    kind: 'success' | 'warning' | 'error';
+    message: string;
+  } | null>(null);
   const isReadOnly = config?.read_only === true;
 
   const activeTab: TabId = tabs.some((t) => t.id === tab) ? (tab as TabId) : 'runs';
@@ -240,8 +245,10 @@ function SingleProjectHome() {
 
   async function handleSyncRemote() {
     setSyncInFlight(true);
+    setSyncFeedback(null);
     try {
-      await syncRemoteResultsApi();
+      const result = await syncRemoteResultsApi();
+      setSyncFeedback(buildProjectSyncFeedback(result));
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['runs'] }),
         queryClient.invalidateQueries({ queryKey: ['experiments'] }),
@@ -249,6 +256,12 @@ function SingleProjectHome() {
         queryClient.invalidateQueries({ queryKey: ['targets'] }),
         queryClient.invalidateQueries({ queryKey: ['remote-status', ''] }),
       ]);
+    } catch (err) {
+      setSyncFeedback({
+        kind: 'error',
+        message: (err as Error).message,
+      });
+      await queryClient.invalidateQueries({ queryKey: ['remote-status', ''] });
     } finally {
       setSyncInFlight(false);
     }
@@ -304,7 +317,9 @@ function SingleProjectHome() {
           onSourceFilterChange={setSourceFilter}
           remoteStatus={remoteStatus}
           syncInFlight={syncInFlight}
+          syncFeedback={syncFeedback}
           onSyncRemote={handleSyncRemote}
+          projectName={config?.project_name}
           hasNextPage={hasNextPage}
           isFetchingNextPage={isFetchingNextPage}
           onLoadMore={() => void fetchNextPage()}
@@ -341,7 +356,9 @@ function RunsTabContent({
   onSourceFilterChange,
   remoteStatus,
   syncInFlight,
+  syncFeedback,
   onSyncRemote,
+  projectName,
   hasNextPage,
   isFetchingNextPage,
   onLoadMore,
@@ -354,7 +371,9 @@ function RunsTabContent({
   onSourceFilterChange: (filter: RunSourceFilter) => void;
   remoteStatus: ReturnType<typeof useRemoteStatus>['data'];
   syncInFlight: boolean;
+  syncFeedback: { kind: 'success' | 'warning' | 'error'; message: string } | null;
   onSyncRemote: () => void;
+  projectName?: string;
   hasNextPage: boolean | undefined;
   isFetchingNextPage: boolean;
   onLoadMore: () => void;
@@ -381,6 +400,8 @@ function RunsTabContent({
         remoteStatus={remoteStatus}
         syncInFlight={syncInFlight}
         onSync={onSyncRemote}
+        projectName={projectName}
+        syncFeedback={syncFeedback}
       />
       <RunList
         runs={runs}

--- a/apps/dashboard/src/routes/projects/$projectId.tsx
+++ b/apps/dashboard/src/routes/projects/$projectId.tsx
@@ -19,9 +19,11 @@ import {
   syncRemoteResultsApi,
   useEvalRuns,
   useInfiniteProjectRunList,
+  useProjectList,
   useRemoteStatus,
   useStudioConfig,
 } from '~/lib/api';
+import { buildProjectSyncFeedback } from '~/lib/project-sync-status';
 import { dedupeSyncedRuns } from '~/lib/run-dedupe';
 
 type TabId = 'runs' | 'experiments' | 'analytics' | 'targets';
@@ -45,14 +47,24 @@ function ProjectHomePage() {
   const navigate = useNavigate();
   const [showRunEval, setShowRunEval] = useState(false);
   const { data: config } = useStudioConfig(projectId);
+  const { data: projectData } = useProjectList();
   const isReadOnly = config?.read_only === true;
+  const projectName =
+    projectData?.projects.find((project) => project.id === projectId)?.name ??
+    config?.project_name ??
+    projectId;
 
   const activeTab: TabId = tabs.some((t) => t.id === tab) ? (tab as TabId) : 'runs';
 
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold text-white">{projectId}</h1>
+        <div>
+          <h1 className="text-2xl font-semibold text-white">{projectName}</h1>
+          {projectName !== projectId ? (
+            <p className="mt-0.5 text-sm text-gray-500">{projectId}</p>
+          ) : null}
+        </div>
         {!isReadOnly && (
           <button
             type="button"
@@ -90,7 +102,9 @@ function ProjectHomePage() {
         </div>
       </div>
 
-      {activeTab === 'runs' && <ProjectRunsTab projectId={projectId} readOnly={isReadOnly} />}
+      {activeTab === 'runs' && (
+        <ProjectRunsTab projectId={projectId} projectName={projectName} readOnly={isReadOnly} />
+      )}
       {activeTab === 'experiments' && <ExperimentsTab projectId={projectId} />}
       {activeTab === 'analytics' && (
         <ProjectAnalyticsTab projectId={projectId} readOnly={isReadOnly} />
@@ -108,7 +122,15 @@ function ProjectHomePage() {
   );
 }
 
-function ProjectRunsTab({ projectId, readOnly }: { projectId: string; readOnly: boolean }) {
+function ProjectRunsTab({
+  projectId,
+  projectName,
+  readOnly,
+}: {
+  projectId: string;
+  projectName: string;
+  readOnly: boolean;
+}) {
   const queryClient = useQueryClient();
   const { data, isLoading, error, hasNextPage, fetchNextPage, isFetchingNextPage } =
     useInfiniteProjectRunList(projectId);
@@ -116,6 +138,10 @@ function ProjectRunsTab({ projectId, readOnly }: { projectId: string; readOnly: 
   const { data: remoteStatus } = useRemoteStatus(projectId);
   const [sourceFilter, setSourceFilter] = useState<RunSourceFilter>('all');
   const [syncInFlight, setSyncInFlight] = useState(false);
+  const [syncFeedback, setSyncFeedback] = useState<{
+    kind: 'success' | 'warning' | 'error';
+    message: string;
+  } | null>(null);
   const activeRuns = (activeRunsData?.runs ?? []).filter(
     (run) => run.status === 'starting' || run.status === 'running',
   );
@@ -127,8 +153,11 @@ function ProjectRunsTab({ projectId, readOnly }: { projectId: string; readOnly: 
 
   async function handleSyncRemote() {
     setSyncInFlight(true);
+    setSyncFeedback(null);
     try {
-      await syncRemoteResultsApi(projectId);
+      const result = await syncRemoteResultsApi(projectId);
+      const feedback = buildProjectSyncFeedback(result);
+      setSyncFeedback(feedback);
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['projects', projectId, 'runs'] }),
         queryClient.invalidateQueries({ queryKey: ['projects', projectId, 'experiments'] }),
@@ -136,6 +165,12 @@ function ProjectRunsTab({ projectId, readOnly }: { projectId: string; readOnly: 
         queryClient.invalidateQueries({ queryKey: ['projects', projectId, 'targets'] }),
         queryClient.invalidateQueries({ queryKey: ['remote-status', projectId] }),
       ]);
+    } catch (err) {
+      setSyncFeedback({
+        kind: 'error',
+        message: (err as Error).message,
+      });
+      await queryClient.invalidateQueries({ queryKey: ['remote-status', projectId] });
     } finally {
       setSyncInFlight(false);
     }
@@ -196,6 +231,8 @@ function ProjectRunsTab({ projectId, readOnly }: { projectId: string; readOnly: 
         remoteStatus={remoteStatus}
         syncInFlight={syncInFlight}
         onSync={handleSyncRemote}
+        projectName={projectName}
+        syncFeedback={syncFeedback}
       />
       <RunList
         runs={filteredRuns}

--- a/packages/core/src/evaluation/results-repo.ts
+++ b/packages/core/src/evaluation/results-repo.ts
@@ -26,6 +26,16 @@ export interface ResultsRepoLocalPaths {
   readonly statusFile: string;
 }
 
+export type ResultsRepoSyncStatus =
+  | 'clean'
+  | 'unavailable'
+  | 'behind'
+  | 'ahead'
+  | 'diverged'
+  | 'dirty'
+  | 'conflicted'
+  | 'syncing';
+
 export interface ResultsRepoStatus {
   readonly configured: boolean;
   readonly available: boolean;
@@ -36,6 +46,20 @@ export interface ResultsRepoStatus {
   readonly local_dir?: string;
   readonly last_synced_at?: string;
   readonly last_error?: string;
+  readonly sync_status?: ResultsRepoSyncStatus;
+  readonly branch?: string;
+  readonly upstream?: string;
+  readonly ahead?: number;
+  readonly behind?: number;
+  readonly dirty_paths?: readonly string[];
+  readonly conflicted_paths?: readonly string[];
+  readonly git_status?: string;
+  readonly git_diff_summary?: string;
+  readonly blocked?: boolean;
+  readonly block_reason?: string;
+  readonly pull_performed?: boolean;
+  readonly push_performed?: boolean;
+  readonly commit_created?: boolean;
 }
 
 export interface CheckedOutResultsRepoBranch {
@@ -52,6 +76,20 @@ type PersistedStatus = {
   readonly last_synced_at?: string;
   readonly last_error?: string;
 };
+
+type ResultsRepoGitInspection = {
+  readonly syncStatus: ResultsRepoSyncStatus;
+  readonly branch?: string;
+  readonly upstream?: string;
+  readonly ahead?: number;
+  readonly behind?: number;
+  readonly dirtyPaths: readonly string[];
+  readonly conflictedPaths: readonly string[];
+  readonly gitStatus?: string;
+  readonly gitDiffSummary?: string;
+};
+
+const activeResultsRepoSyncs = new Set<string>();
 
 function sanitizeRepoSlug(repo: string): string {
   return repo.trim().replace(/[^A-Za-z0-9._-]+/g, '-');
@@ -200,6 +238,15 @@ async function fetchResultsRepo(repoDir: string): Promise<void> {
   await runGit(['fetch', 'origin', '--prune'], { cwd: repoDir });
 }
 
+async function isGitRepository(repoDir: string): Promise<boolean> {
+  try {
+    const { stdout } = await runGit(['rev-parse', '--is-inside-work-tree'], { cwd: repoDir });
+    return stdout.trim() === 'true';
+  } catch {
+    return false;
+  }
+}
+
 function updateStatusFile(config: ResultsConfig, patch: PersistedStatus): void {
   const cachePaths = getResultsRepoLocalPaths(config.repo);
   const current = readPersistedStatus(cachePaths.statusFile);
@@ -249,6 +296,7 @@ export function getResultsRepoStatus(config?: ResultsConfig): ResultsRepoStatus 
       available: false,
       repo: '',
       local_dir: '',
+      sync_status: 'unavailable',
     };
   }
 
@@ -266,7 +314,297 @@ export function getResultsRepoStatus(config?: ResultsConfig): ResultsRepoStatus 
     local_dir: normalized.path,
     last_synced_at: persisted.last_synced_at,
     last_error: persisted.last_error,
+    sync_status: existsSync(normalized.path) ? 'clean' : 'unavailable',
   };
+}
+
+function parseGitPorcelainPaths(status: string): {
+  dirtyPaths: string[];
+  conflictedPaths: string[];
+} {
+  const dirtyPaths = new Set<string>();
+  const conflictedPaths = new Set<string>();
+  const conflictCodes = new Set(['DD', 'AU', 'UD', 'UA', 'DU', 'AA', 'UU']);
+
+  for (const line of status.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    const code = line.slice(0, 2);
+    const rawPath = line.slice(3).trim();
+    const paths = rawPath.includes(' -> ') ? rawPath.split(' -> ') : [rawPath];
+
+    for (const p of paths.map((entry) => entry.trim()).filter(Boolean)) {
+      dirtyPaths.add(p);
+      if (conflictCodes.has(code)) {
+        conflictedPaths.add(p);
+      }
+    }
+  }
+
+  return {
+    dirtyPaths: [...dirtyPaths].sort(),
+    conflictedPaths: [...conflictedPaths].sort(),
+  };
+}
+
+async function getCurrentBranch(repoDir: string): Promise<string | undefined> {
+  const { stdout } = await runGit(['branch', '--show-current'], { cwd: repoDir, check: false });
+  const branch = stdout.trim();
+  if (branch) {
+    return branch;
+  }
+
+  const { stdout: sha } = await runGit(['rev-parse', '--short', 'HEAD'], {
+    cwd: repoDir,
+    check: false,
+  });
+  return sha.trim() ? `HEAD@${sha.trim()}` : undefined;
+}
+
+async function resolveComparisonRef(repoDir: string): Promise<string | undefined> {
+  const { stdout: upstream } = await runGit(
+    ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'],
+    { cwd: repoDir, check: false },
+  );
+  const upstreamRef = upstream.trim();
+  if (upstreamRef && !upstreamRef.includes('fatal:')) {
+    return upstreamRef;
+  }
+
+  const baseBranch = await resolveDefaultBranch(repoDir);
+  const fallback = `origin/${baseBranch}`;
+  const { stdout: fallbackSha } = await runGit(['rev-parse', '--verify', fallback], {
+    cwd: repoDir,
+    check: false,
+  });
+  return fallbackSha.trim() ? fallback : undefined;
+}
+
+async function getAheadBehind(
+  repoDir: string,
+  upstream: string | undefined,
+): Promise<{ ahead?: number; behind?: number }> {
+  if (!upstream) {
+    return {};
+  }
+
+  const { stdout } = await runGit(['rev-list', '--left-right', '--count', `HEAD...${upstream}`], {
+    cwd: repoDir,
+    check: false,
+  });
+  const [aheadText, behindText] = stdout.trim().split(/\s+/);
+  const ahead = Number.parseInt(aheadText ?? '', 10);
+  const behind = Number.parseInt(behindText ?? '', 10);
+
+  return {
+    ...(Number.isFinite(ahead) && { ahead }),
+    ...(Number.isFinite(behind) && { behind }),
+  };
+}
+
+async function hasInProgressGitConflict(repoDir: string): Promise<boolean> {
+  const markers = ['MERGE_HEAD', 'CHERRY_PICK_HEAD', 'REVERT_HEAD', 'REBASE_HEAD'];
+  for (const marker of markers) {
+    const { stdout } = await runGit(['rev-parse', '--git-path', marker], {
+      cwd: repoDir,
+      check: false,
+    });
+    const markerPath = stdout.trim();
+    const resolvedMarkerPath = path.isAbsolute(markerPath)
+      ? markerPath
+      : path.join(repoDir, markerPath);
+    if (markerPath && existsSync(resolvedMarkerPath)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function buildGitDiffSummary(
+  repoDir: string,
+  upstream: string | undefined,
+): Promise<string | undefined> {
+  const summaries: string[] = [];
+  for (const args of [
+    ['diff', '--stat'],
+    ['diff', '--cached', '--stat'],
+    ...(upstream ? ([['diff', '--stat', `${upstream}..HEAD`]] as string[][]) : []),
+  ]) {
+    const { stdout } = await runGit(args, { cwd: repoDir, check: false });
+    const summary = stdout.trim();
+    if (summary) {
+      summaries.push(summary);
+    }
+  }
+
+  return summaries.length > 0 ? summaries.join('\n') : undefined;
+}
+
+async function inspectResultsRepoGit(repoDir: string): Promise<ResultsRepoGitInspection> {
+  const branch = await getCurrentBranch(repoDir);
+  const upstream = await resolveComparisonRef(repoDir);
+  const { stdout: porcelain } = await runGit(
+    ['status', '--porcelain=v1', '--untracked-files=all'],
+    {
+      cwd: repoDir,
+      check: false,
+    },
+  );
+  const { stdout: shortStatus } = await runGit(['status', '--short', '--branch'], {
+    cwd: repoDir,
+    check: false,
+  });
+  const { dirtyPaths, conflictedPaths } = parseGitPorcelainPaths(porcelain);
+  const { ahead = 0, behind = 0 } = await getAheadBehind(repoDir, upstream);
+  const inProgressConflict = await hasInProgressGitConflict(repoDir);
+
+  let syncStatus: ResultsRepoSyncStatus = 'clean';
+  if (conflictedPaths.length > 0 || inProgressConflict) {
+    syncStatus = 'conflicted';
+  } else if (dirtyPaths.length > 0) {
+    syncStatus = 'dirty';
+  } else if (ahead > 0 && behind > 0) {
+    syncStatus = 'diverged';
+  } else if (behind > 0) {
+    syncStatus = 'behind';
+  } else if (ahead > 0) {
+    syncStatus = 'ahead';
+  }
+
+  return {
+    syncStatus,
+    branch,
+    upstream,
+    ahead,
+    behind,
+    dirtyPaths,
+    conflictedPaths,
+    gitStatus: shortStatus.trim() || undefined,
+    gitDiffSummary: await buildGitDiffSummary(repoDir, upstream),
+  };
+}
+
+function withGitInspection(
+  status: ResultsRepoStatus,
+  inspection: ResultsRepoGitInspection,
+): ResultsRepoStatus {
+  return {
+    ...status,
+    sync_status: inspection.syncStatus,
+    branch: inspection.branch,
+    upstream: inspection.upstream,
+    ahead: inspection.ahead,
+    behind: inspection.behind,
+    dirty_paths: inspection.dirtyPaths,
+    conflicted_paths: inspection.conflictedPaths,
+    git_status: inspection.gitStatus,
+    git_diff_summary: inspection.gitDiffSummary,
+  };
+}
+
+function withBlockedStatus(
+  status: ResultsRepoStatus,
+  blockReason: string,
+  flags?: {
+    readonly pullPerformed?: boolean;
+    readonly pushPerformed?: boolean;
+    readonly commitCreated?: boolean;
+  },
+): ResultsRepoStatus {
+  return {
+    ...status,
+    blocked: true,
+    block_reason: blockReason,
+    ...(flags?.pullPerformed !== undefined && { pull_performed: flags.pullPerformed }),
+    ...(flags?.pushPerformed !== undefined && { push_performed: flags.pushPerformed }),
+    ...(flags?.commitCreated !== undefined && { commit_created: flags.commitCreated }),
+  };
+}
+
+function withActionFlags(
+  status: ResultsRepoStatus,
+  flags: {
+    readonly pullPerformed: boolean;
+    readonly pushPerformed: boolean;
+    readonly commitCreated: boolean;
+  },
+): ResultsRepoStatus {
+  return {
+    ...status,
+    blocked: false,
+    pull_performed: flags.pullPerformed,
+    push_performed: flags.pushPerformed,
+    commit_created: flags.commitCreated,
+  };
+}
+
+function areSafeResultsRepoPaths(paths: readonly string[]): boolean {
+  return (
+    paths.length > 0 &&
+    paths.every(
+      (p) => p === RESULTS_REPO_RESULTS_DIR || p.startsWith(`${RESULTS_REPO_RESULTS_DIR}/`),
+    )
+  );
+}
+
+async function getAheadPaths(
+  repoDir: string,
+  upstream: string | undefined,
+): Promise<readonly string[]> {
+  if (!upstream) {
+    return [];
+  }
+  const { stdout } = await runGit(['diff', '--name-only', `${upstream}..HEAD`], {
+    cwd: repoDir,
+    check: false,
+  });
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .sort();
+}
+
+function getPushTargetBranch(upstream: string | undefined, baseBranch: string): string {
+  return upstream?.startsWith('origin/') ? upstream.slice('origin/'.length) : baseBranch;
+}
+
+async function statusFromInspection(
+  normalized: Required<ResultsConfig>,
+  repoDir: string,
+): Promise<ResultsRepoStatus> {
+  return withGitInspection(getResultsRepoStatus(normalized), await inspectResultsRepoGit(repoDir));
+}
+
+export async function getResultsRepoSyncStatus(config?: ResultsConfig): Promise<ResultsRepoStatus> {
+  const baseStatus = getResultsRepoStatus(config);
+  if (!config) {
+    return baseStatus;
+  }
+
+  const normalized = normalizeResultsConfig(config);
+  if (activeResultsRepoSyncs.has(normalized.path)) {
+    return {
+      ...baseStatus,
+      sync_status: 'syncing',
+    };
+  }
+
+  if (!existsSync(normalized.path) || !(await isGitRepository(normalized.path))) {
+    return {
+      ...baseStatus,
+      sync_status: 'unavailable',
+    };
+  }
+
+  try {
+    return withGitInspection(baseStatus, await inspectResultsRepoGit(normalized.path));
+  } catch (error) {
+    return {
+      ...baseStatus,
+      sync_status: 'unavailable',
+      last_error: getStatusMessage(error),
+    };
+  }
 }
 
 export async function syncResultsRepo(config: ResultsConfig): Promise<ResultsRepoStatus> {
@@ -287,6 +625,199 @@ export async function syncResultsRepo(config: ResultsConfig): Promise<ResultsRep
   }
 
   return getResultsRepoStatus(normalized);
+}
+
+function getStatusMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function syncResultsRepoForProject(config: ResultsConfig): Promise<ResultsRepoStatus> {
+  const normalized = normalizeResultsConfig(config);
+  const syncKey = normalized.path;
+  if (activeResultsRepoSyncs.has(syncKey)) {
+    return {
+      ...(await getResultsRepoSyncStatus(normalized)),
+      sync_status: 'syncing',
+      blocked: true,
+      block_reason: 'Results repo sync is already in progress',
+    };
+  }
+
+  activeResultsRepoSyncs.add(syncKey);
+  let pullPerformed = false;
+  let pushPerformed = false;
+  let commitCreated = false;
+
+  try {
+    const repoDir = await ensureResultsRepoClone(normalized);
+    await fetchResultsRepo(repoDir);
+    let inspection = await inspectResultsRepoGit(repoDir);
+
+    if (inspection.syncStatus === 'conflicted') {
+      const status = withGitInspection(getResultsRepoStatus(normalized), inspection);
+      updateStatusFile(normalized, {
+        last_error: 'Results repo has unresolved git conflicts',
+      });
+      return withBlockedStatus(status, 'Results repo has unresolved git conflicts', {
+        pullPerformed,
+        pushPerformed,
+        commitCreated,
+      });
+    }
+
+    if (inspection.syncStatus === 'dirty') {
+      if (!normalized.auto_push) {
+        const status = withGitInspection(getResultsRepoStatus(normalized), inspection);
+        updateStatusFile(normalized, {
+          last_error: 'Results repo has uncommitted changes and auto_push is disabled',
+        });
+        return withBlockedStatus(
+          status,
+          'Results repo has uncommitted changes and auto_push is disabled',
+          {
+            pullPerformed,
+            pushPerformed,
+            commitCreated,
+          },
+        );
+      }
+
+      if (!areSafeResultsRepoPaths(inspection.dirtyPaths)) {
+        const status = withGitInspection(getResultsRepoStatus(normalized), inspection);
+        updateStatusFile(normalized, {
+          last_error: 'Results repo has non-results working tree changes',
+        });
+        return withBlockedStatus(status, 'Results repo has non-results working tree changes', {
+          pullPerformed,
+          pushPerformed,
+          commitCreated,
+        });
+      }
+
+      if ((inspection.behind ?? 0) > 0) {
+        const status = withGitInspection(getResultsRepoStatus(normalized), inspection);
+        const reason = 'Results repo has uncommitted result changes and remote changes';
+        updateStatusFile(normalized, { last_error: reason });
+        return withBlockedStatus(status, reason, {
+          pullPerformed,
+          pushPerformed,
+          commitCreated,
+        });
+      }
+
+      await runGit(['add', '--all', '--', RESULTS_REPO_RESULTS_DIR], { cwd: repoDir });
+      await runGit(['commit', '-m', 'chore(results): sync local result metadata'], {
+        cwd: repoDir,
+      });
+      commitCreated = true;
+      inspection = await inspectResultsRepoGit(repoDir);
+    }
+
+    if (inspection.syncStatus === 'diverged') {
+      const status = withGitInspection(getResultsRepoStatus(normalized), inspection);
+      updateStatusFile(normalized, {
+        last_error: 'Results repo local and remote histories have diverged',
+      });
+      return withBlockedStatus(status, 'Results repo local and remote histories have diverged', {
+        pullPerformed,
+        pushPerformed,
+        commitCreated,
+      });
+    }
+
+    if ((inspection.behind ?? 0) > 0 && (inspection.ahead ?? 0) === 0) {
+      if (!inspection.upstream) {
+        const status = withGitInspection(getResultsRepoStatus(normalized), inspection);
+        updateStatusFile(normalized, {
+          last_error: 'Results repo has no upstream branch to pull from',
+        });
+        return withBlockedStatus(status, 'Results repo has no upstream branch to pull from', {
+          pullPerformed,
+          pushPerformed,
+          commitCreated,
+        });
+      }
+
+      try {
+        await runGit(['merge', '--ff-only', inspection.upstream], { cwd: repoDir });
+        pullPerformed = true;
+        inspection = await inspectResultsRepoGit(repoDir);
+      } catch (error) {
+        inspection = await inspectResultsRepoGit(repoDir);
+        const status = withGitInspection(getResultsRepoStatus(normalized), inspection);
+        const reason = `Results repo could not be fast-forwarded: ${getStatusMessage(error)}`;
+        updateStatusFile(normalized, { last_error: reason });
+        return withBlockedStatus(status, reason, {
+          pullPerformed,
+          pushPerformed,
+          commitCreated,
+        });
+      }
+    }
+
+    if ((inspection.ahead ?? 0) > 0) {
+      if (!normalized.auto_push) {
+        const status = withGitInspection(getResultsRepoStatus(normalized), inspection);
+        return withActionFlags(status, {
+          pullPerformed,
+          pushPerformed,
+          commitCreated,
+        });
+      }
+
+      const aheadPaths = await getAheadPaths(repoDir, inspection.upstream);
+      if (!inspection.upstream || !areSafeResultsRepoPaths(aheadPaths)) {
+        const status = withGitInspection(getResultsRepoStatus(normalized), inspection);
+        const reason = !inspection.upstream
+          ? 'Results repo has no upstream branch to push to'
+          : 'Results repo has non-results committed changes';
+        updateStatusFile(normalized, { last_error: reason });
+        return withBlockedStatus(status, reason, {
+          pullPerformed,
+          pushPerformed,
+          commitCreated,
+        });
+      }
+
+      const baseBranch = await resolveDefaultBranch(repoDir);
+      const targetBranch = getPushTargetBranch(inspection.upstream, baseBranch);
+      try {
+        await runGit(['push', 'origin', `HEAD:${targetBranch}`], { cwd: repoDir });
+        pushPerformed = true;
+        await fetchResultsRepo(repoDir);
+        inspection = await inspectResultsRepoGit(repoDir);
+      } catch (error) {
+        await fetchResultsRepo(repoDir).catch(() => undefined);
+        inspection = await inspectResultsRepoGit(repoDir);
+        const status = withGitInspection(getResultsRepoStatus(normalized), inspection);
+        const reason = `Results repo push was rejected: ${getStatusMessage(error)}`;
+        updateStatusFile(normalized, { last_error: reason });
+        return withBlockedStatus(status, reason, {
+          pullPerformed,
+          pushPerformed,
+          commitCreated,
+        });
+      }
+    }
+
+    updateStatusFile(normalized, {
+      last_synced_at: new Date().toISOString(),
+      last_error: undefined,
+    });
+
+    return withActionFlags(await statusFromInspection(normalized, repoDir), {
+      pullPerformed,
+      pushPerformed,
+      commitCreated,
+    });
+  } catch (error) {
+    updateStatusFile(normalized, {
+      last_error: withFriendlyGitHubAuthError(error).message,
+    });
+    throw withFriendlyGitHubAuthError(error);
+  } finally {
+    activeResultsRepoSyncs.delete(syncKey);
+  }
 }
 
 export async function checkoutResultsRepoBranch(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,8 +62,10 @@ export { toSnakeCaseDeep, toCamelCaseDeep } from './evaluation/case-conversion.j
 export {
   ensureResultsRepoClone,
   syncResultsRepo,
+  syncResultsRepoForProject,
   getResultsRepoLocalPaths,
   getResultsRepoStatus,
+  getResultsRepoSyncStatus,
   normalizeResultsConfig,
   resolveResultsRepoRunsDir,
   resolveResultsRepoUrl,
@@ -81,6 +83,7 @@ export {
   type GitListedRun,
   type PreparedResultsRepoBranch,
   type ResultsRepoLocalPaths,
+  type ResultsRepoSyncStatus,
   type ResultsRepoStatus,
 } from './evaluation/results-repo.js';
 export {

--- a/packages/core/test/evaluation/results-repo.test.ts
+++ b/packages/core/test/evaluation/results-repo.test.ts
@@ -9,9 +9,11 @@ import type { ResultsConfig } from '../../src/evaluation/loaders/config-loader.j
 import {
   directPushResults,
   ensureResultsRepoClone,
+  getResultsRepoSyncStatus,
   listGitRuns,
   materializeGitRun,
   syncResultsRepo,
+  syncResultsRepoForProject,
 } from '../../src/evaluation/results-repo.js';
 
 function cleanGitEnv(): Record<string, string> {
@@ -371,5 +373,149 @@ describe('results repo write path', () => {
 
     expect(git('git branch --show-current', cloneDir)).toBe('scratch');
     expect(git('git rev-parse origin/main', cloneDir)).toBe(remoteMain);
+  }, 20000);
+
+  it('reports behind, ahead, and diverged states from git refs', async () => {
+    const { remoteDir, seedDir } = initializeRemoteRepo(rootDir);
+    const cloneDir = path.join(rootDir, 'results-clone');
+    const config = createResultsConfig(remoteDir, cloneDir);
+
+    await ensureResultsRepoClone(config);
+    git('git config user.email "test@example.com"', cloneDir);
+    git('git config user.name "Test User"', cloneDir);
+
+    await expect(getResultsRepoSyncStatus(config)).resolves.toMatchObject({
+      sync_status: 'clean',
+      ahead: 0,
+      behind: 0,
+    });
+
+    const localRunDir = path.join(
+      cloneDir,
+      '.agentv',
+      'results',
+      'runs',
+      'local-only',
+      '2026-05-23T10-00-00-000Z',
+    );
+    writeRunArtifacts(localRunDir, 'local-only', '2026-05-23T10:00:00.000Z');
+    git('git add .agentv && git commit --quiet -m "local result"', cloneDir);
+
+    await expect(getResultsRepoSyncStatus(config)).resolves.toMatchObject({
+      sync_status: 'ahead',
+      ahead: 1,
+      behind: 0,
+    });
+
+    writeFileSync(path.join(seedDir, 'REMOTE.md'), 'remote update\n');
+    git('git add REMOTE.md && git commit --quiet -m "remote update"', seedDir);
+    git('git push --quiet origin main', seedDir);
+    git('git fetch --quiet origin --prune', cloneDir);
+
+    await expect(getResultsRepoSyncStatus(config)).resolves.toMatchObject({
+      sync_status: 'diverged',
+      ahead: 1,
+      behind: 1,
+    });
+  }, 20000);
+
+  it('fast-forwards a clean behind clone during project sync', async () => {
+    const { remoteDir, seedDir } = initializeRemoteRepo(rootDir);
+    const cloneDir = path.join(rootDir, 'results-clone');
+    const config = { ...createResultsConfig(remoteDir, cloneDir), auto_push: false };
+
+    await ensureResultsRepoClone(config);
+    writeFileSync(path.join(seedDir, 'REMOTE.md'), 'remote update\n');
+    git('git add REMOTE.md && git commit --quiet -m "remote update"', seedDir);
+    git('git push --quiet origin main', seedDir);
+
+    const status = await syncResultsRepoForProject(config);
+
+    expect(status).toMatchObject({
+      sync_status: 'clean',
+      pull_performed: true,
+      push_performed: false,
+      commit_created: false,
+      blocked: false,
+    });
+    expect(readFileSync(path.join(cloneDir, 'REMOTE.md'), 'utf8')).toBe('remote update\n');
+  }, 20000);
+
+  it('commits and pushes safe dirty result metadata when auto_push is enabled', async () => {
+    const { remoteDir } = initializeRemoteRepo(rootDir);
+    const cloneDir = path.join(rootDir, 'results-clone');
+    const config = createResultsConfig(remoteDir, cloneDir);
+
+    await ensureResultsRepoClone(config);
+    git('git config user.email "test@example.com"', cloneDir);
+    git('git config user.name "Test User"', cloneDir);
+
+    const runTimestamp = '2026-05-24T10-00-00-000Z';
+    const runDir = path.join(cloneDir, '.agentv', 'results', 'runs', 'metadata', runTimestamp);
+    writeRunArtifacts(runDir, 'metadata', '2026-05-24T10:00:00.000Z');
+
+    const status = await syncResultsRepoForProject(config);
+
+    expect(status).toMatchObject({
+      sync_status: 'clean',
+      commit_created: true,
+      push_performed: true,
+      blocked: false,
+    });
+    expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir)).toContain(
+      `.agentv/results/runs/metadata/${runTimestamp}/benchmark.json`,
+    );
+  }, 20000);
+
+  it('blocks dirty non-results changes with git summaries instead of resetting', async () => {
+    const { remoteDir } = initializeRemoteRepo(rootDir);
+    const cloneDir = path.join(rootDir, 'results-clone');
+    const config = createResultsConfig(remoteDir, cloneDir);
+
+    await ensureResultsRepoClone(config);
+    writeFileSync(path.join(cloneDir, 'NOTES.md'), 'do not auto-push me\n');
+
+    const status = await syncResultsRepoForProject(config);
+
+    expect(status.sync_status).toBe('dirty');
+    expect(status.blocked).toBe(true);
+    expect(status.block_reason).toContain('non-results');
+    expect(status.dirty_paths).toEqual(['NOTES.md']);
+    expect(status.git_status).toContain('NOTES.md');
+    expect(readFileSync(path.join(cloneDir, 'NOTES.md'), 'utf8')).toBe('do not auto-push me\n');
+  }, 20000);
+
+  it('blocks diverged committed histories with diff summary', async () => {
+    const { remoteDir, seedDir } = initializeRemoteRepo(rootDir);
+    const cloneDir = path.join(rootDir, 'results-clone');
+    const config = createResultsConfig(remoteDir, cloneDir);
+
+    await ensureResultsRepoClone(config);
+    git('git config user.email "test@example.com"', cloneDir);
+    git('git config user.name "Test User"', cloneDir);
+
+    const runDir = path.join(
+      cloneDir,
+      '.agentv',
+      'results',
+      'runs',
+      'local-only',
+      '2026-05-25T10-00-00-000Z',
+    );
+    writeRunArtifacts(runDir, 'local-only', '2026-05-25T10:00:00.000Z');
+    git('git add .agentv && git commit --quiet -m "local result"', cloneDir);
+
+    writeFileSync(path.join(seedDir, 'REMOTE.md'), 'remote update\n');
+    git('git add REMOTE.md && git commit --quiet -m "remote update"', seedDir);
+    git('git push --quiet origin main', seedDir);
+
+    const status = await syncResultsRepoForProject(config);
+
+    expect(status.sync_status).toBe('diverged');
+    expect(status.blocked).toBe(true);
+    expect(status.block_reason).toContain('diverged');
+    expect(status.git_status).toContain('[ahead 1, behind 1]');
+    expect(status.git_diff_summary).toContain('local-only');
+    expect(status.git_diff_summary).toContain('benchmark.json');
   }, 20000);
 });


### PR DESCRIPTION
## Summary
- Adds project-level results sync status/action UI for configured Dashboard projects.
- Surfaces clean/unavailable/behind/ahead/dirty/conflicted/syncing states with repo, remote run count, last synced, dirty/conflict path counts, diff summary, and safe next actions.
- Shows pending metadata badges for dirty remote run tags and enables remote tag edits through the existing tag mutation API.
- Uses project display names in project-scoped Dashboard chrome.

## Verification
- bun test apps/dashboard/src/lib/project-sync-status.test.ts
- bunx biome check apps/dashboard/src/lib/types.ts apps/dashboard/src/lib/project-sync-status.ts apps/dashboard/src/lib/project-sync-status.test.ts apps/dashboard/src/components/RunSourceToolbar.tsx apps/dashboard/src/components/RunList.tsx apps/dashboard/src/components/AnalyticsTab.tsx apps/dashboard/src/components/Breadcrumbs.tsx apps/dashboard/src/components/Sidebar.tsx apps/dashboard/src/routes/index.tsx apps/dashboard/src/routes/projects/$projectId.tsx apps/dashboard/src/lib/api.ts
- bun --filter @agentv/dashboard build
- bun --filter @agentv/core build (preflight for CLI source UAT)
- pre-push hook: typecheck + biome check . passed on successful push

## UAT Evidence
- Live project page: /tmp/agentv-av-hbv-3/project-runs-live.png
- Mock dirty metadata state: /tmp/agentv-av-hbv-3/project-runs-dirty-mock.png
- Mock blocked sync feedback: /tmp/agentv-av-hbv-3/project-sync-blocked-feedback-mock.png