### PR TITLE
fix(core): allow templated use_target validation

### DIFF
--- a/packages/core/src/evaluation/validation/targets-validator.ts
+++ b/packages/core/src/evaluation/validation/targets-validator.ts
@@ -19,6 +19,10 @@ function isObject(value: unknown): value is JsonObject {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
 // Cross-provider settings derived from the schema source of truth in targets.ts.
 // Adding a field to COMMON_TARGET_SETTINGS automatically makes it valid here.
 const COMMON_SETTINGS = new Set<string>(COMMON_TARGET_SETTINGS);
@@ -320,9 +324,11 @@ export async function validateTargetsFile(filePath: string): Promise<ValidationR
   const absolutePath = path.resolve(filePath);
 
   let parsed: unknown;
+  let rawParsed: unknown;
   try {
     const content = await readFile(absolutePath, 'utf8');
-    parsed = interpolateEnv(parseYamlValue(content), process.env);
+    rawParsed = parseYamlValue(content);
+    parsed = interpolateEnv(rawParsed, process.env);
   } catch (error) {
     errors.push({
       severity: 'error',
@@ -484,6 +490,8 @@ export async function validateTargetsFile(filePath: string): Promise<ValidationR
 
   // Validate targets array
   const targets = parsed.targets;
+  const rawTargets =
+    isObject(rawParsed) && Array.isArray(rawParsed.targets) ? rawParsed.targets : [];
   if (!Array.isArray(targets)) {
     errors.push({
       severity: 'error',
@@ -542,8 +550,9 @@ export async function validateTargetsFile(filePath: string): Promise<ValidationR
 
     // Required field: provider
     const provider = target.provider;
-    const hasUseTarget =
-      typeof target.use_target === 'string' && target.use_target.trim().length > 0;
+    const rawTarget = rawTargets[i];
+    const rawUseTarget = isObject(rawTarget) ? rawTarget.use_target : undefined;
+    const hasUseTarget = isNonEmptyString(target.use_target) || isNonEmptyString(rawUseTarget);
     const providerValue = typeof provider === 'string' ? provider.trim().toLowerCase() : undefined;
     const isTemplated = typeof provider === 'string' && /^\$\{\{.+\}\}$/.test(provider.trim());
     if (!hasUseTarget && (typeof provider !== 'string' || provider.trim().length === 0)) {

--- a/packages/core/test/evaluation/validation/targets-validator.test.ts
+++ b/packages/core/test/evaluation/validation/targets-validator.test.ts
@@ -122,6 +122,51 @@ describe('validateTargetsFile', () => {
     expect(result.valid).toBe(true);
   });
 
+  it('accepts env-templated use_target values without resolving the env during validation', async () => {
+    const filePath = path.join(tempDir, 'templated-use-target.yaml');
+    await writeFile(
+      filePath,
+      `targets:
+  - name: default
+    use_target: \${{ AGENT_TARGET }}
+  - name: grader
+    use_target: \${{ GRADER_TARGET }}
+  - name: codex-agent
+    provider: codex
+    grader_target: grader
+`,
+    );
+
+    const originalAgentTarget = process.env.AGENT_TARGET;
+    const originalGraderTarget = process.env.GRADER_TARGET;
+    Reflect.deleteProperty(process.env, 'AGENT_TARGET');
+    Reflect.deleteProperty(process.env, 'GRADER_TARGET');
+
+    try {
+      const result = await validateTargetsFile(filePath);
+
+      expect(result.valid).toBe(true);
+      expect(
+        result.errors.some(
+          (error) =>
+            error.severity === 'error' &&
+            error.message.includes("Missing or invalid 'provider' field"),
+        ),
+      ).toBe(false);
+    } finally {
+      if (originalAgentTarget === undefined) {
+        Reflect.deleteProperty(process.env, 'AGENT_TARGET');
+      } else {
+        process.env.AGENT_TARGET = originalAgentTarget;
+      }
+      if (originalGraderTarget === undefined) {
+        Reflect.deleteProperty(process.env, 'GRADER_TARGET');
+      } else {
+        process.env.GRADER_TARGET = originalGraderTarget;
+      }
+    }
+  });
+
   it('rejects azure api_format with a migration error', async () => {
     const filePath = path.join(tempDir, 'azure-api-format.yaml');
     await writeFile(


### PR DESCRIPTION
Bead: av-njl

Summary:
- Accept env-templated `use_target` values during targets.yaml validation even when the referenced env vars are unset.
- Preserve provider validation for targets that do not supply a concrete or templated `use_target`.
- Add regression coverage for unresolved `AGENT_TARGET` and `GRADER_TARGET`.

Verification from worker handoff:
- `bun test packages/core/test/evaluation/validation/targets-validator.test.ts`
- `bun --filter @agentv/core typecheck`
- `bun --filter @agentv/core test`
- `bun run test`
- `bun run validate:examples`

Integration review: diff checked against current `origin/main`; no PR existed before this one.