### PR TITLE
docs(dashboard): document project results sync workflow

### DIFF
--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -172,6 +172,30 @@ function writeDirtyRemoteRunArtifact(
   return `${experiment}::${timestamp}`;
 }
 
+function writeRemoteTagMetadataOverlay(
+  repoDir: string,
+  experiment: string,
+  timestamp: string,
+  tags: readonly string[],
+): string {
+  const metadataPath = path.join(
+    repoDir,
+    '.agentv',
+    'results',
+    'metadata',
+    'runs',
+    experiment,
+    timestamp,
+    'tags.json',
+  );
+  mkdirSync(path.dirname(metadataPath), { recursive: true });
+  writeFileSync(
+    metadataPath,
+    `${JSON.stringify({ tags, updated_at: '2026-06-06T12:00:00.000Z' }, null, 2)}\n`,
+  );
+  return metadataPath;
+}
+
 // ── resolveSourceFile ────────────────────────────────────────────────────
 
 describe('resolveSourceFile', () => {
@@ -1077,21 +1101,101 @@ describe('serve app', () => {
   });
 
   describe('POST /api/projects/:projectId/remote/sync', () => {
-    it('returns project-scoped sync action fields after pushing safe local result metadata', async () => {
+    it('fast-forwards a clean behind results repo through project sync', async () => {
       const previousHome = process.env.AGENTV_HOME;
-      const homeDir = path.join(tempDir, 'agentv-home-project-sync');
+      const homeDir = path.join(tempDir, 'agentv-home-project-sync-pull');
       process.env.AGENTV_HOME = homeDir;
 
       try {
-        const { remoteDir, cloneDir } = initializeRemoteRepo(tempDir);
-        const projectDir = path.join(tempDir, 'source-project-sync');
+        const { remoteDir, cloneDir, seedDir } = initializeRemoteRepo(tempDir);
+        const projectDir = path.join(tempDir, 'source-project-sync-pull');
         mkdirSync(path.join(projectDir, '.agentv'), { recursive: true });
         mkdirSync(homeDir, { recursive: true });
         saveProjectRegistry({
           projects: [
             {
-              id: 'project-sync',
-              name: 'Project Sync',
+              id: 'project-sync-pull',
+              name: 'Project Sync Pull',
+              path: projectDir,
+              results: {
+                mode: 'github',
+                repo: `file://${remoteDir}`,
+                path: cloneDir,
+                autoPush: false,
+              },
+              addedAt: '2026-01-01T00:00:00.000Z',
+              lastOpenedAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        });
+        const runId = writeDirtyRemoteRunArtifact(
+          seedDir,
+          'project-sync-pull',
+          '2026-03-26T11-00-00-000Z',
+          RESULT_A,
+        );
+        git('git add .agentv && git commit --quiet -m "remote result"', seedDir);
+        git('git push --quiet origin main', seedDir);
+
+        const app = createApp([], tempDir, tempDir, undefined, { studioDir });
+        const res = await app.request('/api/projects/project-sync-pull/remote/sync', {
+          method: 'POST',
+        });
+
+        expect(res.status).toBe(200);
+        const data = (await res.json()) as {
+          sync_status: string;
+          commit_created?: boolean;
+          push_performed?: boolean;
+          pull_performed?: boolean;
+          blocked?: boolean;
+          run_count: number;
+        };
+        expect(data).toMatchObject({
+          sync_status: 'clean',
+          commit_created: false,
+          push_performed: false,
+          pull_performed: true,
+          blocked: false,
+          run_count: 1,
+        });
+        expect(
+          existsSync(
+            path.join(
+              cloneDir,
+              '.agentv',
+              'results',
+              'runs',
+              'project-sync-pull',
+              runId.replace('project-sync-pull::', ''),
+              'index.jsonl',
+            ),
+          ),
+        ).toBe(true);
+      } finally {
+        if (previousHome === undefined) {
+          process.env.AGENTV_HOME = undefined;
+        } else {
+          process.env.AGENTV_HOME = previousHome;
+        }
+      }
+    }, 15000);
+
+    it('commits and pushes dirty remote tag metadata through project sync', async () => {
+      const previousHome = process.env.AGENTV_HOME;
+      const homeDir = path.join(tempDir, 'agentv-home-project-sync-push');
+      process.env.AGENTV_HOME = homeDir;
+
+      try {
+        const { remoteDir, cloneDir } = initializeRemoteRepo(tempDir);
+        const projectDir = path.join(tempDir, 'source-project-sync-push');
+        mkdirSync(path.join(projectDir, '.agentv'), { recursive: true });
+        mkdirSync(homeDir, { recursive: true });
+        saveProjectRegistry({
+          projects: [
+            {
+              id: 'project-sync-push',
+              name: 'Project Sync Push',
               path: projectDir,
               results: {
                 mode: 'github',
@@ -1104,15 +1208,15 @@ describe('serve app', () => {
             },
           ],
         });
-        const runId = writeDirtyRemoteRunArtifact(
-          cloneDir,
-          'project-sync',
-          '2026-03-26T12-00-00-000Z',
-          RESULT_A,
-        );
+        const runTimestamp = '2026-03-26T12-00-00-000Z';
+        writeRemoteRunArtifact(cloneDir, 'project-sync-push', runTimestamp, RESULT_A);
+        writeRemoteTagMetadataOverlay(cloneDir, 'project-sync-push', runTimestamp, [
+          'pending-review',
+          'shared',
+        ]);
 
         const app = createApp([], tempDir, tempDir, undefined, { studioDir });
-        const res = await app.request('/api/projects/project-sync/remote/sync', {
+        const res = await app.request('/api/projects/project-sync-push/remote/sync', {
           method: 'POST',
         });
 
@@ -1134,7 +1238,7 @@ describe('serve app', () => {
           run_count: 1,
         });
         expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, tempDir)).toContain(
-          `.agentv/results/runs/project-sync/${runId.replace('project-sync::', '')}/benchmark.json`,
+          `.agentv/results/metadata/runs/project-sync-push/${runTimestamp}/tags.json`,
         );
       } finally {
         if (previousHome === undefined) {
@@ -1144,6 +1248,95 @@ describe('serve app', () => {
         }
       }
     }, 15000);
+
+    it('returns a blocked conflict state without resetting the results repo', async () => {
+      const previousHome = process.env.AGENTV_HOME;
+      const homeDir = path.join(tempDir, 'agentv-home-project-sync-conflict');
+      process.env.AGENTV_HOME = homeDir;
+
+      try {
+        const { remoteDir, cloneDir, seedDir } = initializeRemoteRepo(tempDir);
+        const projectDir = path.join(tempDir, 'source-project-sync-conflict');
+        mkdirSync(path.join(projectDir, '.agentv'), { recursive: true });
+        mkdirSync(homeDir, { recursive: true });
+        saveProjectRegistry({
+          projects: [
+            {
+              id: 'project-sync-conflict',
+              name: 'Project Sync Conflict',
+              path: projectDir,
+              results: {
+                mode: 'github',
+                repo: `file://${remoteDir}`,
+                path: cloneDir,
+                autoPush: true,
+              },
+              addedAt: '2026-01-01T00:00:00.000Z',
+              lastOpenedAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        });
+
+        const runTimestamp = '2026-03-26T13-00-00-000Z';
+        const relativeMetadataPath = path.posix.join(
+          '.agentv',
+          'results',
+          'metadata',
+          'runs',
+          'project-sync-conflict',
+          runTimestamp,
+          'tags.json',
+        );
+        writeRemoteTagMetadataOverlay(seedDir, 'project-sync-conflict', runTimestamp, ['base']);
+        git('git add .agentv && git commit --quiet -m "seed tag metadata"', seedDir);
+        git('git push --quiet origin main', seedDir);
+        git('git pull --ff-only --quiet', cloneDir);
+
+        writeRemoteTagMetadataOverlay(cloneDir, 'project-sync-conflict', runTimestamp, ['local']);
+        git('git add .agentv && git commit --quiet -m "local tag metadata"', cloneDir);
+        writeRemoteTagMetadataOverlay(seedDir, 'project-sync-conflict', runTimestamp, ['remote']);
+        git('git add .agentv && git commit --quiet -m "remote tag metadata"', seedDir);
+        git('git push --quiet origin main', seedDir);
+        git('git fetch --quiet origin --prune', cloneDir);
+        git('git merge origin/main || true', cloneDir);
+
+        const app = createApp([], tempDir, tempDir, undefined, { studioDir });
+        const res = await app.request('/api/projects/project-sync-conflict/remote/sync', {
+          method: 'POST',
+        });
+
+        expect(res.status).toBe(200);
+        const data = (await res.json()) as {
+          sync_status: string;
+          blocked?: boolean;
+          block_reason?: string;
+          pull_performed?: boolean;
+          push_performed?: boolean;
+          commit_created?: boolean;
+          conflicted_paths?: string[];
+          git_status?: string;
+        };
+        expect(data).toMatchObject({
+          sync_status: 'conflicted',
+          blocked: true,
+          pull_performed: false,
+          push_performed: false,
+          commit_created: false,
+        });
+        expect(data.block_reason).toContain('unresolved git conflicts');
+        expect(data.conflicted_paths).toContain(relativeMetadataPath);
+        expect(data.git_status).toContain('UU');
+        expect(readFileSync(path.join(cloneDir, relativeMetadataPath), 'utf8')).toContain(
+          '<<<<<<< HEAD',
+        );
+      } finally {
+        if (previousHome === undefined) {
+          process.env.AGENTV_HOME = undefined;
+        } else {
+          process.env.AGENTV_HOME = previousHome;
+        }
+      }
+    }, 20000);
   });
 
   // ── GET /api/runs/:filename ─────────────────────────────────────────

--- a/apps/web/src/content/docs/docs/tools/dashboard.mdx
+++ b/apps/web/src/content/docs/docs/tools/dashboard.mdx
@@ -144,7 +144,9 @@ Select 2+ rows with the checkboxes and click the sticky **Compare N** action to 
 
 ### Retroactive tags
 
-Click any row's **Tags** cell to tag a run after the fact. Each run can carry multiple free-form tags (max 20, up to 60 characters each); tags are stored in a `tags.json` sidecar next to `index.jsonl` in the run workspace, so they're mutable, non-destructive, and won't touch your eval YAML or run manifest. The chip editor supports Enter/comma to commit a new tag, Backspace to remove the last chip, and **Clear all** to remove every tag (deletes the sidecar). Remote runs are read-only.
+Click any row's **Tags** cell to tag a run after the fact. Each run can carry multiple free-form tags (max 20, up to 60 characters each); local tags are stored in a `tags.json` sidecar next to `index.jsonl` in the run workspace, so they're mutable, non-destructive, and won't touch your eval YAML or run manifest. The chip editor supports Enter/comma to commit a new tag, Backspace to remove the last chip, and **Clear all** to remove every tag (deletes the sidecar).
+
+Remote run payloads stay immutable, but their tags are editable. Dashboard writes remote tag changes as metadata overlays under `.agentv/results/metadata/runs/.../tags.json` in the configured results repo clone. Until those overlays are synced, the run and project show a dirty state; **Sync Project** commits and pushes them when it is safe to do so.
 
 Use tags to annotate ad-hoc variants, experiment cross-cuts, or status flags you didn't plan for up front — `baseline`, `v2-prompt`, `slow`, `after-retry-fix`, `regression`, etc. Unlike `experiment` — which groups runs and is baked into the JSONL at eval-run time — tags are mutable, multi-valued, and never touch the original run data.
 
@@ -244,11 +246,11 @@ IDs are derived from the directory name (e.g., `/home/user/repos/my-evals` becom
 
 ## Remote Results
 
-Dashboard can display runs pushed to a remote git repository by other machines or CI — alongside your local runs. Each run in the list carries a source badge: **local** (green) or **remote** (amber).
+Dashboard can display runs pushed to a remote git repository by other machines or CI alongside your local runs. Each run in the list carries a source badge: **local** (green) or **remote** (amber).
 
 ### Configuration
 
-For a registered project, put result repo settings on that project's entry in `$AGENTV_HOME/config.yaml`:
+For a registered project, put results repo settings on that project's entry in `$AGENTV_HOME/config.yaml`:
 
 ```yaml
 projects:
@@ -276,7 +278,12 @@ results:
 
 Project-local `.agentv/config.yaml` is for portable eval defaults such as `execution`, `eval_patterns`, and `dashboard`. Do not put `projects` in project-local config; AgentV warns and ignores it there. `results_by_project` is deprecated; use `projects[].results` in `$AGENTV_HOME/config.yaml`.
 
-With `auto_push: true`, every new `agentv eval` or `agentv pipeline bench` pushes results directly to the configured repo's base branch (e.g., `main`). Results appear immediately in Dashboard without requiring PR merges.
+The `source` block and the `results` block sync different repositories:
+
+- `projects[].source` is the eval source project. Dashboard startup clones or fast-forwards the project checkout so eval YAML, scripts, and project-local `.agentv/config.yaml` stay current.
+- `projects[].results` is the git-backed results store. **Sync Project** fetches, fast-forwards, and, when configured, pushes run artifacts and mutable metadata in that results repo clone.
+
+With `auto_push: true`, new `agentv eval` and `agentv pipeline bench` runs can push their run artifacts directly to the configured results repo. That run-level publish path is a convenience. The normal team workflow is project-level **Sync Project**, because it handles pulled remote runs, locally edited metadata, dirty state, and blocked conflict feedback in one project-scoped action.
 
 Each run writes to a unique timestamped directory, so concurrent pushes from multiple machines are safe — non-fast-forward conflicts are resolved automatically via rebase retry.
 
@@ -294,7 +301,9 @@ Uses `gh` CLI and `git` credentials already configured on the machine. If authen
 
 ### Syncing in Dashboard
 
-Once configured, Dashboard fetches remote runs on load. In the default multi-project flow, open a project card first, then use **Sync Remote Results** in that project's toolbar to pull the latest. The toolbar also shows when results were last synced and the configured repo.
+Once configured, Dashboard reads local runs and the configured results repo clone for that project. The status endpoint does not fetch from the remote on every page load; use **Sync Project** when you want to exchange changes with the results repo remote.
+
+In the default multi-project flow, open a project card first, then use **Sync Project** in that project's toolbar. The toolbar shows the project display name, sync state, last synced time, configured repo, and remote run count. Statuses include clean, unavailable, behind, ahead, dirty, diverged, conflicted, and syncing.
 
 Use the **All Sources / Local Only / Remote Only** filter to narrow the run list by origin.
 
@@ -305,3 +314,12 @@ Runs pushed from another machine or CI do not appear until you sync. Existing lo
 <Image src={studioRemoteResultsAfterSync} alt="AgentV Dashboard project view in multi-project mode after syncing, showing the newly fetched GitHub remote run alongside existing local and remote runs in the sidebar" />
 
 After sync, newly fetched remote runs appear in the list with a **remote** source badge, and Dashboard can open their details without checking out the remote branch locally.
+
+**Sync Project** fetches the results repo and only changes the clone when Git says it is safe:
+
+- A clean clone that is behind the remote is fast-forwarded.
+- Safe uncommitted changes under `.agentv/results/**`, such as remote tag metadata overlays, are committed and pushed when `auto_push: true`.
+- A local results repo that is ahead is pushed when `auto_push: true` and the committed paths are all under `.agentv/results/**`.
+- Dirty non-results files, dirty metadata plus remote changes, diverged history, unresolved conflicts, missing upstream branches, non-results commits ahead, and rejected pushes are blocked instead of reset.
+
+When sync is blocked, Dashboard keeps the local clone intact and shows the `block_reason`, `dirty_paths` or `conflicted_paths`, `git_status`, and a compact `git_diff_summary` so you can resolve the results repo manually before syncing again.


### PR DESCRIPTION
Bead: av-hbv.4

Summary:
- Document project-level results repo sync, local dirty metadata overlays, push behavior, and conflict handling.
- Distinguish source project sync from configured results repo sync.
- Add local-git Dashboard API coverage for pull, dirty metadata push, and blocked conflict state.

Verification from worker handoff:
- `bun test apps/cli/test/commands/results/serve.test.ts`
- `bunx biome check apps/cli/test/commands/results/serve.test.ts apps/web/src/content/docs/docs/tools/dashboard.mdx`
- `bun --filter agentv typecheck`
- `bun --filter @agentv/web build`
- `bun --filter agentv test`
- `git diff --check`

Integration note: branch was local-only during inventory and has now been pushed for review.