### PR TITLE
fix(dashboard): clarify remote run actions

### DIFF
--- a/apps/dashboard/src/components/AnalyticsTab.tsx
+++ b/apps/dashboard/src/components/AnalyticsTab.tsx
@@ -717,6 +717,7 @@ function PerRunRow({
             <TagsEditor
               runId={run.run_id}
               currentTags={tags}
+              source={run.source}
               projectId={projectId}
               onClose={onEndEdit}
             />
@@ -762,11 +763,13 @@ function TagChips({ tags, dirty }: { tags: string[]; dirty: boolean }) {
 function TagsEditor({
   runId,
   currentTags,
+  source,
   projectId,
   onClose,
 }: {
   runId: string;
   currentTags: string[];
+  source: 'local' | 'remote';
   projectId?: string;
   onClose: () => void;
 }) {
@@ -838,6 +841,12 @@ function TagsEditor({
           Multi-valued. Enter or comma adds; Backspace removes the last chip.
         </span>
       </div>
+      {source === 'remote' ? (
+        <div className="rounded-md border border-yellow-900/60 bg-yellow-950/20 px-3 py-2 text-xs text-yellow-300">
+          Remote tag edits are saved as local metadata. Use Sync Metadata to push them to the
+          results repo.
+        </div>
+      ) : null}
       <div className="flex flex-wrap items-center gap-2 rounded-md border border-gray-700 bg-gray-950 px-2 py-1.5 focus-within:border-cyan-500 focus-within:ring-1 focus-within:ring-cyan-500">
         {tags.map((t) => (
           <span

--- a/apps/dashboard/src/components/RunList.tsx
+++ b/apps/dashboard/src/components/RunList.tsx
@@ -26,7 +26,13 @@ import {
   useStudioConfig,
 } from '~/lib/api';
 import { formatRunLabel } from '~/lib/run-label';
-import type { RunMeta } from '~/lib/types';
+import {
+  buildCombineSuccessMessage,
+  buildDeleteSuccessMessage,
+  formatSelectedRunCount,
+  runSelectionDisabledReason,
+} from '~/lib/run-list-actions';
+import type { CombineRunsResponse, RunMeta } from '~/lib/types';
 
 import { PassRatePill } from './PassRatePill';
 
@@ -38,6 +44,13 @@ interface RunListProps {
   isFetchingNextPage?: boolean;
   onLoadMore?: () => void;
   enableCombine?: boolean;
+}
+
+interface RunActionFeedback {
+  kind: 'success' | 'error';
+  message: string;
+  combinedRunId?: string;
+  sourceRunIds?: string[];
 }
 
 function formatDate(ts: string | undefined | null): { date: string; full: string } {
@@ -75,19 +88,13 @@ export function RunList({
   const sentinelRef = useRef<HTMLTableRowElement | null>(null);
   const requestingNextPageRef = useRef(false);
   const [selectedRunIds, setSelectedRunIds] = useState<string[]>([]);
-  const [combineError, setCombineError] = useState<string | null>(null);
+  const [actionFeedback, setActionFeedback] = useState<RunActionFeedback | null>(null);
   const [combineInFlight, setCombineInFlight] = useState(false);
   const [deleteInFlight, setDeleteInFlight] = useState(false);
   const selectableRunIds = useMemo(
     () =>
       runs
-        .filter(
-          (run) =>
-            enableCombine &&
-            run.source === 'local' &&
-            run.status !== 'starting' &&
-            run.status !== 'running',
-        )
+        .filter((run) => enableCombine && !runSelectionDisabledReason(run))
         .map((run) => run.filename),
     [enableCombine, runs],
   );
@@ -150,11 +157,13 @@ export function RunList({
 
   async function handleCombine() {
     if (selectedRunIds.length < 2 || combineInFlight) return;
-    setCombineError(null);
+    const sourceRunIds = [...selectedRunIds];
+    setActionFeedback(null);
     setCombineInFlight(true);
     try {
+      let result: CombineRunsResponse;
       try {
-        await combineRunsApi(selectedRunIds, 'error', projectId);
+        result = await combineRunsApi(sourceRunIds, 'error', projectId);
       } catch (err) {
         if (!(err instanceof CombineRunsApiError) || err.status !== 409) {
           throw err;
@@ -164,12 +173,18 @@ export function RunList({
           `${count} duplicate (test_id, target) pair${count === 1 ? '' : 's'} found. Replace duplicates with the latest timestamp?`,
         );
         if (!confirmed) return;
-        await combineRunsApi(selectedRunIds, 'latest', projectId);
+        result = await combineRunsApi(sourceRunIds, 'latest', projectId);
       }
       setSelectedRunIds([]);
+      setActionFeedback({
+        kind: 'success',
+        message: buildCombineSuccessMessage(sourceRunIds.length, result.display_name),
+        combinedRunId: result.run_id,
+        sourceRunIds,
+      });
       await invalidateRunQueries();
     } catch (err) {
-      setCombineError((err as Error).message);
+      setActionFeedback({ kind: 'error', message: (err as Error).message });
     } finally {
       setCombineInFlight(false);
     }
@@ -177,22 +192,36 @@ export function RunList({
 
   async function handleDelete() {
     if (selectedRunIds.length === 0 || deleteInFlight) return;
-    const count = selectedRunIds.length;
-    const confirmed = window.confirm(
-      `Delete ${count} local run${count === 1 ? '' : 's'}? This removes the run workspace and artifacts from disk.`,
-    );
+    await deleteRuns(selectedRunIds, 'selected');
+  }
+
+  async function handleDeleteCombinedSources() {
+    const sourceRunIds = actionFeedback?.sourceRunIds ?? [];
+    if (sourceRunIds.length === 0 || deleteInFlight) return;
+    await deleteRuns(sourceRunIds, 'combined-sources');
+  }
+
+  async function deleteRuns(runIds: readonly string[], reason: 'selected' | 'combined-sources') {
+    const count = runIds.length;
+    const noun = count === 1 ? 'run' : 'runs';
+    const prompt =
+      reason === 'combined-sources'
+        ? `Delete the ${count} source local ${noun} used for the combined run? The combined run will remain.`
+        : `Delete ${count} local ${noun}? This removes the run workspace and artifacts from disk.`;
+    const confirmed = window.confirm(prompt);
     if (!confirmed) return;
 
-    setCombineError(null);
+    setActionFeedback(null);
     setDeleteInFlight(true);
     try {
-      for (const runId of selectedRunIds) {
+      for (const runId of runIds) {
         await deleteRunApi(runId, projectId);
       }
       setSelectedRunIds([]);
+      setActionFeedback({ kind: 'success', message: buildDeleteSuccessMessage(count) });
       await invalidateRunQueries();
     } catch (err) {
-      setCombineError((err as Error).message);
+      setActionFeedback({ kind: 'error', message: (err as Error).message });
     } finally {
       setDeleteInFlight(false);
     }
@@ -225,29 +254,74 @@ export function RunList({
   return (
     <div className="space-y-3">
       {enableCombine && (
-        <div className="flex items-center justify-between gap-3 rounded-lg border border-gray-800 bg-gray-900/40 px-4 py-3">
-          <div className="min-w-0">
+        <div className="flex flex-col gap-3 rounded-lg border border-gray-800 bg-gray-900/40 px-4 py-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0 space-y-1">
             <p className="text-sm font-medium text-gray-200">
-              {selectedRunIds.length} local run{selectedRunIds.length === 1 ? '' : 's'} selected
+              {formatSelectedRunCount(selectedRunIds.length)}
             </p>
-            {combineError && <p className="mt-1 text-xs text-red-400">{combineError}</p>}
+            <p className="text-xs text-gray-500">
+              Select completed local runs to combine or delete. Remote runs stay read-only here.
+            </p>
+            {actionFeedback && (
+              <div
+                className={`mt-2 rounded-md border px-3 py-2 text-sm ${
+                  actionFeedback.kind === 'success'
+                    ? 'border-emerald-900/60 bg-emerald-950/20 text-emerald-300'
+                    : 'border-red-900/60 bg-red-950/20 text-red-300'
+                }`}
+                role={actionFeedback.kind === 'error' ? 'alert' : 'status'}
+              >
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                  <span>{actionFeedback.message}</span>
+                  {actionFeedback.combinedRunId ? (
+                    projectId ? (
+                      <Link
+                        to="/projects/$projectId/runs/$runId"
+                        params={{ projectId, runId: actionFeedback.combinedRunId }}
+                        className="font-medium text-cyan-300 hover:text-cyan-200 hover:underline"
+                      >
+                        Open combined run
+                      </Link>
+                    ) : (
+                      <Link
+                        to="/runs/$runId"
+                        params={{ runId: actionFeedback.combinedRunId }}
+                        className="font-medium text-cyan-300 hover:text-cyan-200 hover:underline"
+                      >
+                        Open combined run
+                      </Link>
+                    )
+                  ) : null}
+                  {actionFeedback.sourceRunIds && actionFeedback.sourceRunIds.length > 0 ? (
+                    <button
+                      type="button"
+                      onClick={() => void handleDeleteCombinedSources()}
+                      disabled={deleteInFlight || combineInFlight}
+                      className="font-medium text-red-300 hover:text-red-200 hover:underline disabled:cursor-not-allowed disabled:text-gray-500"
+                    >
+                      {deleteInFlight ? 'Deleting sources...' : 'Delete source runs'}
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+            )}
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex shrink-0 items-center gap-2">
             <button
               type="button"
               onClick={() => void handleDelete()}
               disabled={selectedRunIds.length === 0 || deleteInFlight || combineInFlight}
-              className="rounded-md border border-red-900/70 px-3 py-1.5 text-sm font-medium text-red-300 hover:border-red-700 hover:bg-red-950/40 disabled:cursor-not-allowed disabled:border-gray-800 disabled:text-gray-500"
+              className="whitespace-nowrap rounded-md border border-red-900/70 px-3 py-1.5 text-sm font-medium text-red-300 hover:border-red-700 hover:bg-red-950/40 disabled:cursor-not-allowed disabled:border-gray-800 disabled:text-gray-500"
             >
-              {deleteInFlight ? 'Deleting...' : 'Delete'}
+              {deleteInFlight ? 'Deleting...' : 'Delete selected'}
             </button>
             <button
               type="button"
               onClick={() => void handleCombine()}
               disabled={selectedRunIds.length < 2 || combineInFlight || deleteInFlight}
-              className="rounded-md bg-cyan-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-cyan-500 disabled:cursor-not-allowed disabled:bg-gray-700 disabled:text-gray-400"
+              className="whitespace-nowrap rounded-md bg-cyan-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-cyan-500 disabled:cursor-not-allowed disabled:bg-gray-700 disabled:text-gray-400"
             >
-              {combineInFlight ? 'Combining...' : 'Combine'}
+              {combineInFlight ? 'Combining...' : 'Combine selected'}
             </button>
           </div>
         </div>
@@ -275,7 +349,9 @@ export function RunList({
               const label = formatRunLabel(run);
               const passedCount = Math.round(run.pass_rate * run.test_count);
               const failedCount = run.test_count - passedCount;
-              const selectable = selectableRunIds.includes(run.filename);
+              const selectionDisabledReason = runSelectionDisabledReason(run);
+              const selectable =
+                !selectionDisabledReason && selectableRunIds.includes(run.filename);
               const metadataDirty = run.metadata_dirty === true;
               return (
                 <tr key={run.filename} className="transition-colors hover:bg-gray-900/30">
@@ -286,7 +362,12 @@ export function RunList({
                         checked={selectedSet.has(run.filename)}
                         disabled={!selectable}
                         onChange={() => toggleRun(run.filename)}
-                        aria-label={`Select ${label}`}
+                        title={selectionDisabledReason}
+                        aria-label={
+                          selectionDisabledReason
+                            ? `${label}: ${selectionDisabledReason}`
+                            : `Select ${label}`
+                        }
                         className="h-4 w-4 rounded border-gray-700 bg-gray-900 text-cyan-500 disabled:opacity-30"
                       />
                     </td>
@@ -329,8 +410,11 @@ export function RunList({
                     )}
                     <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs">
                       {metadataDirty ? (
-                        <span className="rounded-md border border-yellow-900/60 bg-yellow-950/20 px-1.5 py-0.5 text-yellow-300">
-                          Pending metadata
+                        <span
+                          className="rounded-md border border-yellow-900/60 bg-yellow-950/20 px-1.5 py-0.5 text-yellow-300"
+                          title="Use Sync Metadata to push this metadata to the results repo."
+                        >
+                          Pending sync
                         </span>
                       ) : null}
                     </div>

--- a/apps/dashboard/src/components/RunSourceToolbar.tsx
+++ b/apps/dashboard/src/components/RunSourceToolbar.tsx
@@ -87,7 +87,7 @@ export function RunSourceToolbar({
                 title={!syncView.canSync ? syncView.nextAction : undefined}
                 className="rounded-md border border-cyan-800 bg-cyan-950/40 px-3 py-1.5 text-sm font-medium text-cyan-300 transition-colors hover:bg-cyan-900/50 disabled:cursor-not-allowed disabled:opacity-60"
               >
-                {syncInFlight ? 'Syncing...' : 'Sync Project'}
+                {syncInFlight ? 'Syncing...' : syncView.actionLabel}
               </button>
             ) : null}
           </div>

--- a/apps/dashboard/src/lib/project-sync-status.test.ts
+++ b/apps/dashboard/src/lib/project-sync-status.test.ts
@@ -28,9 +28,26 @@ describe('getProjectSyncView', () => {
     expect(view).toMatchObject({
       state: 'dirty',
       label: 'Dirty',
+      actionLabel: 'Sync Metadata',
       canSync: true,
     });
     expect(view.nextAction).toContain('no reset');
+  });
+
+  it('uses a push-oriented action label when local results are ahead', () => {
+    expect(
+      getProjectSyncView({
+        configured: true,
+        available: true,
+        sync_status: 'ahead',
+        ahead: 1,
+        auto_push: true,
+      }),
+    ).toMatchObject({
+      state: 'ahead',
+      actionLabel: 'Push Results',
+      canSync: true,
+    });
   });
 
   it('treats diverged history as a conflict-safe blocked state', () => {

--- a/apps/dashboard/src/lib/project-sync-status.ts
+++ b/apps/dashboard/src/lib/project-sync-status.ts
@@ -15,6 +15,7 @@ export type ProjectSyncTone = 'neutral' | 'good' | 'info' | 'warn' | 'danger';
 export interface ProjectSyncView {
   state: ProjectSyncState;
   label: string;
+  actionLabel: string;
   tone: ProjectSyncTone;
   summary: string;
   nextAction?: string;
@@ -70,6 +71,7 @@ export function getProjectSyncView(
     return {
       state: 'syncing',
       label: 'Syncing',
+      actionLabel: 'Syncing...',
       tone: 'info',
       summary: 'Sync is in progress.',
       canSync: false,
@@ -80,6 +82,7 @@ export function getProjectSyncView(
     return {
       state: 'unconfigured',
       label: 'Not configured',
+      actionLabel: 'Sync Project',
       tone: 'neutral',
       summary: 'Remote results are not configured for this project.',
       canSync: false,
@@ -90,6 +93,7 @@ export function getProjectSyncView(
     return {
       state: 'unavailable',
       label: 'Unavailable',
+      actionLabel: 'Sync Project',
       tone: 'warn',
       summary: 'The remote results cache is not available locally.',
       nextAction: 'Sync Project can clone or refresh the configured results repo.',
@@ -102,6 +106,7 @@ export function getProjectSyncView(
     return {
       state: 'conflicted',
       label: state === 'diverged' ? 'Conflicted' : 'Conflicted',
+      actionLabel: 'Sync Project',
       tone: 'danger',
       summary:
         status.block_reason ??
@@ -117,6 +122,7 @@ export function getProjectSyncView(
     return {
       state: 'dirty',
       label: 'Dirty',
+      actionLabel: 'Sync Metadata',
       tone: 'warn',
       summary: status.block_reason ?? 'Local result metadata has pending edits.',
       nextAction:
@@ -131,6 +137,7 @@ export function getProjectSyncView(
     return {
       state: 'behind',
       label: 'Behind',
+      actionLabel: 'Sync Project',
       tone: 'info',
       summary: `Remote has ${status.behind ?? 0} commit${status.behind === 1 ? '' : 's'} to pull.`,
       nextAction: 'Sync Project will fast-forward when possible.',
@@ -142,6 +149,7 @@ export function getProjectSyncView(
     return {
       state: 'ahead',
       label: 'Ahead',
+      actionLabel: 'Push Results',
       tone: 'info',
       summary: `Local results are ${status.ahead ?? 0} commit${status.ahead === 1 ? '' : 's'} ahead.`,
       nextAction:
@@ -155,6 +163,7 @@ export function getProjectSyncView(
   return {
     state: 'clean',
     label: 'Clean',
+    actionLabel: 'Sync Project',
     tone: 'good',
     summary: 'Local and remote result metadata are in sync.',
     canSync: true,

--- a/apps/dashboard/src/lib/run-list-actions.test.ts
+++ b/apps/dashboard/src/lib/run-list-actions.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  buildCombineSuccessMessage,
+  buildDeleteSuccessMessage,
+  formatSelectedRunCount,
+  runSelectionDisabledReason,
+} from './run-list-actions';
+
+describe('runSelectionDisabledReason', () => {
+  it('explains why remote runs are not local workspace actions', () => {
+    expect(runSelectionDisabledReason({ source: 'remote' })).toContain('Remote runs');
+  });
+
+  it('explains why active runs cannot be selected', () => {
+    expect(runSelectionDisabledReason({ source: 'local', status: 'running' })).toContain(
+      'Running runs',
+    );
+  });
+
+  it('allows completed local runs', () => {
+    expect(runSelectionDisabledReason({ source: 'local', status: 'finished' })).toBeUndefined();
+  });
+});
+
+describe('run action copy', () => {
+  it('uses local-run wording for selection, combine, and delete feedback', () => {
+    expect(formatSelectedRunCount(2)).toBe('2 local runs selected');
+    expect(buildCombineSuccessMessage(2, 'combined/demo')).toBe(
+      'Combined 2 local runs into combined/demo.',
+    );
+    expect(buildDeleteSuccessMessage(1)).toBe('Deleted 1 local run.');
+  });
+});

--- a/apps/dashboard/src/lib/run-list-actions.ts
+++ b/apps/dashboard/src/lib/run-list-actions.ts
@@ -1,0 +1,25 @@
+import type { RunMeta } from './types';
+
+type SelectableRun = Pick<RunMeta, 'source' | 'status'>;
+
+export function runSelectionDisabledReason(run: SelectableRun): string | undefined {
+  if (run.source === 'remote') {
+    return 'Remote runs cannot be combined or deleted from the local workspace.';
+  }
+  if (run.status === 'starting' || run.status === 'running') {
+    return 'Running runs cannot be combined or deleted yet.';
+  }
+  return undefined;
+}
+
+export function formatSelectedRunCount(count: number): string {
+  return `${count} local run${count === 1 ? '' : 's'} selected`;
+}
+
+export function buildCombineSuccessMessage(sourceCount: number, displayName: string): string {
+  return `Combined ${sourceCount} local run${sourceCount === 1 ? '' : 's'} into ${displayName}.`;
+}
+
+export function buildDeleteSuccessMessage(count: number): string {
+  return `Deleted ${count} local run${count === 1 ? '' : 's'}.`;
+}


### PR DESCRIPTION
## Summary

This PR fixes UX gaps found while dogfooding the Dashboard flows for remote result sync, tags, combining runs, and deleting source runs.

The red-state pass showed three rough edges:

- The run action bar was error-only: after combining runs there was no success state, no link to the new combined run, and no guided way to delete the now-redundant source runs.
- The combine/delete controls did not explain that only completed local runs are actionable; remote runs are intentionally read-only in this table.
- Remote tag editing did not tell users that tag changes are stored as local metadata overlays and need to be pushed with project sync.

## Changes

- Adds a success/error action state to `RunList`.
- After combining local runs, shows:
  - a success message naming the combined run
  - an `Open combined run` link
  - a `Delete source runs` action that deletes only the source local runs after confirmation
- Renames table actions to `Combine selected` and `Delete selected`, keeps button labels stable, and explains that remote runs stay read-only.
- Adds disabled checkbox reasons for remote or still-running runs.
- Changes remote sync action labels based on state:
  - dirty metadata: `Sync Metadata`
  - local results ahead: `Push Results`
  - normal/clean states: `Sync Project`
- Adds remote tag editor guidance: remote tag edits are local metadata until synced.
- Adds focused tests for run action copy/selectability and sync action labels.

## Evidence

Private dogfood evidence was saved and pushed to `agentv-assets-private@0d6997d`:

- `dogfood/av-ch1-dashboard-ux/red-finance-runs.png`
- `dogfood/av-ch1-dashboard-ux/red-finance-analytics-tags.png`
- `dogfood/av-ch1-dashboard-ux/green-fixture-runs-selected.png`
- `dogfood/av-ch1-dashboard-ux/green-fixture-combined-feedback.png`
- `dogfood/av-ch1-dashboard-ux/green-fixture-source-runs-deleted.png`
- `dogfood/av-ch1-dashboard-ux/green-finance-remote-tag-editor.png`

The combine/delete browser test used a disposable local fixture at `/tmp/agentv-av-ch1-combine-project`, not real demo runs. The remote tag editor was opened without saving tag changes.

## Verification

- `bunx biome check apps/dashboard/src/components/AnalyticsTab.tsx apps/dashboard/src/components/RunList.tsx apps/dashboard/src/components/RunSourceToolbar.tsx apps/dashboard/src/lib/project-sync-status.ts apps/dashboard/src/lib/project-sync-status.test.ts apps/dashboard/src/lib/run-list-actions.ts apps/dashboard/src/lib/run-list-actions.test.ts`
- `bun --filter @agentv/dashboard test`
- `bun --filter @agentv/dashboard build`
- Browser UAT with `agent-browser` against `http://127.0.0.1:3238`
- Pre-push hook passed:
  - `bun --filter @agentv/core typecheck && bun --filter @agentv/phoenix-adapter typecheck && bun --filter agentv typecheck`
  - `biome check .`
