### PR TITLE
fix(dashboard): make run tables mobile scrollable

### DIFF
--- a/apps/dashboard/src/components/RunDetail.tsx
+++ b/apps/dashboard/src/components/RunDetail.tsx
@@ -5,6 +5,10 @@
  * Category Breakdown is shown as a clean table with coloured pass-rate pills.
  * The All Evals table shows ERR badge instead of 0% for execution errors.
  *
+ * Data tables keep cells on one line and scroll horizontally on narrow
+ * viewports. Add future columns by extending the table; the min-width keeps the
+ * mobile behavior stable instead of clipping the right side.
+ *
  * Also renders a collapsible "Run Log" section sourced from the run's
  * captured `console.log` file (served by `/api/runs/:id/log`). Hidden when no
  * log is available — e.g. for remote runs or local runs that completed before
@@ -136,8 +140,8 @@ export function RunDetail({ results, runId, projectId }: RunDetailProps) {
       {/* Category Breakdown */}
       <div>
         <h3 className="mb-3 text-sm font-medium text-gray-400">Category Breakdown</h3>
-        <div className="overflow-hidden rounded-lg border border-gray-800">
-          <table className="w-full text-left text-sm">
+        <div className="max-w-full overflow-x-auto rounded-lg border border-gray-800">
+          <table className="min-w-[620px] w-full whitespace-nowrap text-left text-sm">
             <thead className="border-b border-gray-800 bg-gray-900/50">
               <tr>
                 <th className="px-4 py-2.5 font-medium text-gray-400">Category</th>
@@ -150,11 +154,11 @@ export function RunDetail({ results, runId, projectId }: RunDetailProps) {
             <tbody className="divide-y divide-gray-800/50">
               {categories.map((cat) => {
                 const label = (
-                  <span className="flex min-w-0 flex-col">
+                  <span className="flex min-w-0 items-baseline gap-2">
                     <span className="truncate">{cat.displayName}</span>
                     {cat.mutedDisplayName ? (
                       <span
-                        className="mt-0.5 truncate text-xs font-normal text-gray-500"
+                        className="truncate text-xs font-normal text-gray-500"
                         title={cat.mutedDisplayName}
                       >
                         {cat.mutedDisplayName}
@@ -165,12 +169,12 @@ export function RunDetail({ results, runId, projectId }: RunDetailProps) {
 
                 return (
                   <tr key={cat.name} className="transition-colors hover:bg-gray-900/30">
-                    <td className="px-4 py-2.5 font-medium text-gray-200">
+                    <td className="w-[18rem] max-w-[18rem] px-4 py-2.5 font-medium text-gray-200">
                       {projectId ? (
                         <Link
                           to="/projects/$projectId/runs/$runId/category/$category"
                           params={{ projectId, runId, category: cat.name }}
-                          className="text-cyan-400 hover:text-cyan-300 hover:underline"
+                          className="flex min-w-0 text-cyan-400 hover:text-cyan-300 hover:underline"
                           title={cat.mutedDisplayName ?? cat.displayName}
                         >
                           {label}
@@ -179,7 +183,7 @@ export function RunDetail({ results, runId, projectId }: RunDetailProps) {
                         <Link
                           to="/runs/$runId/category/$category"
                           params={{ runId, category: cat.name }}
-                          className="text-cyan-400 hover:text-cyan-300 hover:underline"
+                          className="flex min-w-0 text-cyan-400 hover:text-cyan-300 hover:underline"
                           title={cat.mutedDisplayName ?? cat.displayName}
                         >
                           {label}
@@ -209,13 +213,13 @@ export function RunDetail({ results, runId, projectId }: RunDetailProps) {
       {/* All Evals */}
       <div>
         <h3 className="mb-3 text-sm font-medium text-gray-400">All Evals</h3>
-        <div className="overflow-hidden rounded-lg border border-gray-800">
-          <table className="w-full text-left text-sm">
+        <div className="max-w-full overflow-x-auto rounded-lg border border-gray-800">
+          <table className="min-w-[760px] w-full whitespace-nowrap text-left text-sm">
             <thead className="border-b border-gray-800 bg-gray-900/50">
               <tr>
                 <th className="w-8 px-4 py-3" />
-                <th className="px-4 py-3 font-medium text-gray-400">Test ID</th>
-                <th className="px-4 py-3 font-medium text-gray-400">Target</th>
+                <th className="w-[24rem] px-4 py-3 font-medium text-gray-400">Test ID</th>
+                <th className="w-[12rem] px-4 py-3 font-medium text-gray-400">Target</th>
                 <th className="w-48 px-4 py-3 font-medium text-gray-400">Score</th>
                 <th className="px-4 py-3 text-right font-medium text-gray-400">Duration</th>
                 <th className="px-4 py-3 text-right font-medium text-gray-400">Cost</th>
@@ -242,12 +246,13 @@ export function RunDetail({ results, runId, projectId }: RunDetailProps) {
                         </span>
                       )}
                     </td>
-                    <td className="px-4 py-3">
+                    <td className="w-[24rem] max-w-[24rem] px-4 py-3">
                       {projectId ? (
                         <Link
                           to="/projects/$projectId/evals/$runId/$evalId"
                           params={{ projectId, runId, evalId: result.testId }}
-                          className="font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
+                          className="block truncate font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
+                          title={result.testId}
                         >
                           {result.testId}
                         </Link>
@@ -255,13 +260,19 @@ export function RunDetail({ results, runId, projectId }: RunDetailProps) {
                         <Link
                           to="/evals/$runId/$evalId"
                           params={{ runId, evalId: result.testId }}
-                          className="font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
+                          className="block truncate font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
+                          title={result.testId}
                         >
                           {result.testId}
                         </Link>
                       )}
                     </td>
-                    <td className="px-4 py-3 text-gray-400">{result.target ?? '-'}</td>
+                    <td
+                      className="w-[12rem] max-w-[12rem] truncate px-4 py-3 text-gray-400"
+                      title={result.target ?? undefined}
+                    >
+                      {result.target ?? '-'}
+                    </td>
                     <td className="px-4 py-3">
                       {isError ? (
                         <span className="inline-flex rounded-full bg-red-900/50 px-2 py-0.5 text-xs font-medium text-red-400">

--- a/apps/dashboard/src/components/RunList.tsx
+++ b/apps/dashboard/src/components/RunList.tsx
@@ -5,6 +5,10 @@
  * source badge, date, test count, and coloured pass-rate pill.
  * Clicking a row navigates to the run detail view.
  *
+ * The table keeps cells on one line and scrolls horizontally on narrow
+ * viewports. Add future columns by extending the table; the min-width keeps the
+ * mobile behavior stable instead of squeezing or clipping right-side columns.
+ *
  * In-progress runs (status `starting` / `running`, surfaced by the backend
  * via the RunMeta `status` field while a Dashboard-launched run is still
  * tracked in-memory) render a pulsing cyan dot instead of the pass/fail
@@ -326,13 +330,13 @@ export function RunList({
           </div>
         </div>
       )}
-      <div className="overflow-hidden rounded-lg border border-gray-800">
-        <table className="w-full text-left text-sm">
+      <div className="max-w-full overflow-x-auto rounded-lg border border-gray-800">
+        <table className="min-w-[780px] w-full whitespace-nowrap text-left text-sm">
           <thead className="border-b border-gray-800 bg-gray-900/50">
             <tr>
               {enableCombine && <th className="w-10 px-4 py-3" />}
               <th className="w-8 px-4 py-3" />
-              <th className="px-4 py-3 font-medium text-gray-400">Run</th>
+              <th className="w-[22rem] px-4 py-3 font-medium text-gray-400">Run</th>
               <th className="px-4 py-3 font-medium text-gray-400">Source</th>
               <th className="px-4 py-3 text-right font-medium text-gray-400">Passed</th>
               <th className="px-4 py-3 text-right font-medium text-gray-400">Failed</th>
@@ -390,28 +394,30 @@ export function RunList({
                   </td>
 
                   {/* Run name */}
-                  <td className="px-4 py-3">
-                    {projectId ? (
-                      <Link
-                        to="/projects/$projectId/runs/$runId"
-                        params={{ projectId, runId: run.filename }}
-                        className="font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
-                      >
-                        {label}
-                      </Link>
-                    ) : (
-                      <Link
-                        to="/runs/$runId"
-                        params={{ runId: run.filename }}
-                        className="font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
-                      >
-                        {label}
-                      </Link>
-                    )}
-                    <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs">
+                  <td className="w-[22rem] max-w-[22rem] px-4 py-3">
+                    <div className="flex min-w-0 items-center gap-2">
+                      {projectId ? (
+                        <Link
+                          to="/projects/$projectId/runs/$runId"
+                          params={{ projectId, runId: run.filename }}
+                          className="block min-w-0 truncate font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
+                          title={label}
+                        >
+                          {label}
+                        </Link>
+                      ) : (
+                        <Link
+                          to="/runs/$runId"
+                          params={{ runId: run.filename }}
+                          className="block min-w-0 truncate font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
+                          title={label}
+                        >
+                          {label}
+                        </Link>
+                      )}
                       {metadataDirty ? (
                         <span
-                          className="rounded-md border border-yellow-900/60 bg-yellow-950/20 px-1.5 py-0.5 text-yellow-300"
+                          className="shrink-0 rounded-md border border-yellow-900/60 bg-yellow-950/20 px-1.5 py-0.5 text-xs text-yellow-300"
                           title="Use Sync Metadata to push this metadata to the results repo."
                         >
                           Pending sync

--- a/apps/dashboard/src/routes/projects/$projectId.tsx
+++ b/apps/dashboard/src/routes/projects/$projectId.tsx
@@ -71,8 +71,8 @@ function ProjectHomePage() {
       </div>
 
       {/* Tab navigation */}
-      <div className="border-b border-gray-800">
-        <div className="flex gap-1">
+      <div className="overflow-x-auto border-b border-gray-800">
+        <div className="flex min-w-max gap-1">
           {tabs.map((t) => (
             <button
               type="button"
@@ -84,7 +84,7 @@ function ProjectHomePage() {
                   search: { tab: t.id } as Record<string, string>,
                 })
               }
-              className={`px-4 py-2 text-sm font-medium transition-colors ${
+              className={`shrink-0 px-4 py-2 text-sm font-medium transition-colors ${
                 activeTab === t.id
                   ? 'border-b-2 border-cyan-400 text-cyan-400'
                   : 'text-gray-400 hover:text-gray-300'

--- a/apps/dashboard/src/routes/projects/$projectId_/runs/$runId.tsx
+++ b/apps/dashboard/src/routes/projects/$projectId_/runs/$runId.tsx
@@ -63,10 +63,15 @@ function ProjectRunDetailPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <div className="flex flex-wrap items-center gap-2">
-            <h1 className="text-2xl font-semibold text-white">{header.heading}</h1>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <h1
+              className="min-w-0 truncate text-xl font-semibold text-white sm:text-2xl"
+              title={header.heading}
+            >
+              {header.heading}
+            </h1>
             {header.sourceBadge ? (
               <span className="rounded-md border border-cyan-900/60 bg-cyan-950/20 px-2 py-0.5 text-xs font-medium text-cyan-300">
                 {header.sourceBadge}
@@ -84,7 +89,7 @@ function ProjectRunDetailPage() {
             </div>
           ) : null}
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3 sm:justify-end">
           {!isReadOnly && isActiveRun ? (
             <StopRunButton
               runId={runId}

--- a/apps/dashboard/src/routes/runs/$runId.tsx
+++ b/apps/dashboard/src/routes/runs/$runId.tsx
@@ -64,10 +64,15 @@ function RunDetailPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <div className="flex flex-wrap items-center gap-2">
-            <h1 className="text-2xl font-semibold text-white">{header.heading}</h1>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <h1
+              className="min-w-0 truncate text-xl font-semibold text-white sm:text-2xl"
+              title={header.heading}
+            >
+              {header.heading}
+            </h1>
             {header.sourceBadge ? (
               <span className="rounded-md border border-cyan-900/60 bg-cyan-950/20 px-2 py-0.5 text-xs font-medium text-cyan-300">
                 {header.sourceBadge}
@@ -85,7 +90,7 @@ function RunDetailPage() {
             </div>
           ) : null}
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3 sm:justify-end">
           {!isReadOnly && isActiveRun ? (
             <StopRunButton runId={runId} status={runStatus} isReadOnly={isReadOnly} />
           ) : (


### PR DESCRIPTION
## Summary
- Make Dashboard run-list and run-detail tables horizontally scrollable on narrow viewports.
- Keep table cells one-line with fixed minimum table widths and truncation for long run/test labels.
- Stack run-detail header actions on mobile and make the project tab strip scrollable so adjacent page chrome is not clipped.

## Red/Green UAT
Red, live `entity-vps:3227` at 390x844:
- Run list `http://entity-vps:3227/projects/wtg-ai-prompts?tab=runs`: table was ~692px wide inside a ~334px wrapper with `overflow-x: hidden`, so right-side columns were clipped.
- Run detail `http://entity-vps:3227/projects/financial-research-agent/runs/av-h60-live-codex-azure%3A%3A2026-06-05T14-11-27-119Z`: detail tables were ~463px/~452px inside ~342px wrappers with `overflow-x: hidden`.

Green, branch-local Dashboard after rebuilding `apps/dashboard/dist`:
- Run list at 390x844: table is ~960px wide inside a ~332px wrapper with `overflow-x: auto`; page `documentScrollWidth` remains 390.
- Run detail at 390x844: detail tables are 620px/760px inside ~340px wrappers with `overflow-x: auto`; page `documentScrollWidth` remains 390.
- Desktop screenshots at 1440x900 still show the normal dense table layout.

## Evidence
Private evidence repo commit: `8ecf9f7805b6e6fd4b33c06d5a5108e53b10515f`

Screenshots:
- `dogfood/av-goc-1-mobile/red/run-list-mobile.png`
- `dogfood/av-goc-1-mobile/red/run-detail-mobile.png`
- `dogfood/av-goc-1-mobile/green/run-list-mobile.png`
- `dogfood/av-goc-1-mobile/green/run-list-desktop.png`
- `dogfood/av-goc-1-mobile/green/run-detail-mobile.png`
- `dogfood/av-goc-1-mobile/green/run-detail-desktop.png`

## Verification
- `bun --filter @agentv/dashboard build`
- `bun --filter @agentv/core build && bun --filter agentv build`
- `bun --filter @agentv/dashboard test` (61 pass)
- `bunx biome check apps/dashboard/src/components/RunList.tsx apps/dashboard/src/components/RunDetail.tsx apps/dashboard/src/routes/projects/'$projectId'.tsx apps/dashboard/src/routes/projects/'$projectId_'/runs/'$runId'.tsx apps/dashboard/src/routes/runs/'$runId'.tsx`
- Pre-push hook: `bun --filter @agentv/core typecheck && bun --filter @agentv/phoenix-adapter typecheck && bun --filter agentv typecheck`, then `biome check .`
- `agent-browser` mobile and desktop screenshots for the two problem views
