### PR TITLE
style(brand): present AgentV wordmark

### DIFF
--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>agentv</title>
+    <title>AgentV</title>
   </head>
   <body class="bg-gray-950 text-gray-100">
     <div id="root"></div>

--- a/apps/dashboard/src/components/BrandName.tsx
+++ b/apps/dashboard/src/components/BrandName.tsx
@@ -6,8 +6,14 @@ export function BrandName({ appName }: { appName: string }) {
   }
 
   return (
-    <span className="av-brand-name">
-      agent<span className="text-cyan-400">v</span>
+    <span className="av-brand-name" aria-label="AgentV">
+      <span className="text-cyan-400" aria-hidden="true">
+        A
+      </span>
+      <span aria-hidden="true">gent</span>
+      <span className="text-cyan-400" aria-hidden="true">
+        V
+      </span>
     </span>
   );
 }

--- a/apps/dashboard/src/routes/settings.tsx
+++ b/apps/dashboard/src/routes/settings.tsx
@@ -16,6 +16,8 @@ import {
   useStudioConfig,
 } from '~/lib/api';
 
+import { BrandName } from '~/components/BrandName';
+
 export const Route = createFileRoute('/settings')({
   component: SettingsPage,
 });
@@ -67,7 +69,9 @@ function SettingsPage() {
     <div className="mx-auto max-w-2xl space-y-6">
       <div>
         <h1 className="text-2xl font-semibold text-white">Settings</h1>
-        <p className="mt-1 text-sm text-gray-400">Configure {appName}</p>
+        <p className="mt-1 text-sm text-gray-400">
+          Configure <BrandName appName={appName} />
+        </p>
       </div>
 
       {/* Pass Threshold Card */}

--- a/apps/dashboard/src/styles/globals.css
+++ b/apps/dashboard/src/styles/globals.css
@@ -13,6 +13,7 @@ body {
 .av-brand-name {
   font-family: "JetBrains Mono", ui-monospace, "Cascadia Code", "Fira Code", monospace;
   letter-spacing: 0;
+  white-space: nowrap;
 }
 
 /* Scrollbar styling for dark theme */

--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -6,7 +6,14 @@ export default defineConfig({
   image: { service: { entrypoint: 'astro/assets/services/noop' } },
   integrations: [
     starlight({
-      title: 'agent v',
+      title: 'AgentV',
+      logo: {
+        src: './src/assets/logo.svg',
+        alt: 'AgentV mark',
+      },
+      components: {
+        SiteTitle: './src/components/StarlightSiteTitle.astro',
+      },
       disable404Route: true,
       head: [
         {

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
-  <rect width="32" height="32" rx="6" fill="#06b6d4"/>
-  <text x="16" y="23" text-anchor="middle" font-family="'IBM Plex Mono', 'JetBrains Mono', monospace" font-weight="bold" font-size="18" fill="#0a2a30">v</text>
+  <rect width="32" height="32" rx="6" fill="#0a2a30"/>
+  <text x="16" y="21" text-anchor="middle" font-family="'IBM Plex Mono', 'JetBrains Mono', monospace" font-weight="bold" font-size="12" fill="#06b6d4">AV</text>
 </svg>

--- a/apps/web/src/assets/logo.svg
+++ b/apps/web/src/assets/logo.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none">
-  <rect width="120" height="120" rx="24" fill="#06b6d4"/>
-  <text x="60" y="82" text-anchor="middle" font-family="'IBM Plex Mono', 'JetBrains Mono', monospace" font-weight="bold" font-size="64" fill="#0a2a30">v</text>
+  <rect width="120" height="120" rx="24" fill="#0a2a30"/>
+  <text x="60" y="76" text-anchor="middle" font-family="'IBM Plex Mono', 'JetBrains Mono', monospace" font-weight="bold" font-size="44" fill="#06b6d4">AV</text>
 </svg>

--- a/apps/web/src/components/BrandWordmark.astro
+++ b/apps/web/src/components/BrandWordmark.astro
@@ -1,0 +1,66 @@
+---
+interface Props {
+  class?: string;
+}
+
+const className = Astro.props.class;
+---
+
+<span class:list={['av-brand-wordmark', className]} aria-label="AgentV" translate="no">
+  <span class="av-brand-wordmark__letter" aria-hidden="true">A</span>
+  <span aria-hidden="true">gent</span>
+  <span class="av-brand-wordmark__letter" aria-hidden="true">V</span>
+</span>
+
+<style>
+  .av-brand-wordmark {
+    display: inline-flex;
+    align-items: baseline;
+    color: var(--av-brand-text-color, currentColor);
+    font-family: var(
+      --av-font-mono,
+      "JetBrains Mono",
+      "IBM Plex Mono",
+      ui-monospace,
+      "Cascadia Code",
+      "Fira Code",
+      monospace
+    );
+    font-weight: 700;
+    letter-spacing: 0;
+    text-transform: none;
+    white-space: nowrap;
+  }
+
+  .av-brand-wordmark__letter {
+    color: var(--av-brand-letter-color, #06b6d4);
+  }
+
+  .av-brand-wordmark--hero {
+    --av-brand-text-color: var(--av-text);
+    font-size: clamp(1.35rem, 3vw, 2.15rem);
+    line-height: 1;
+  }
+
+  .av-brand-wordmark--terminal {
+    --av-brand-text-color: var(--av-text-muted);
+    font-size: 0.6875rem;
+    font-weight: 600;
+  }
+
+  .av-brand-wordmark--inline {
+    display: inline-flex;
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  .av-brand-wordmark--docs {
+    font-size: var(--sl-text-h4);
+  }
+
+  .av-brand-wordmark--not-found {
+    --av-brand-text-color: hsl(0, 0%, 85%);
+    font-size: 1.35rem;
+    font-weight: 600;
+  }
+</style>

--- a/apps/web/src/components/Lander.astro
+++ b/apps/web/src/components/Lander.astro
@@ -1,4 +1,5 @@
 ---
+import BrandWordmark from './BrandWordmark.astro';
 ---
 
 <div class="av-root">
@@ -6,11 +7,11 @@
 <nav class="av-nav" id="av-nav">
   <div class="av-nav-inner">
     <a href="/" class="av-nav-logo">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none" width="28" height="28">
-        <rect width="120" height="120" rx="24" fill="#06b6d4"/>
-        <text x="60" y="82" text-anchor="middle" font-family="'IBM Plex Mono', 'JetBrains Mono', monospace" font-weight="bold" font-size="64" fill="#0a2a30">v</text>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none" width="28" height="28" aria-hidden="true">
+        <rect width="120" height="120" rx="24" fill="#0a2a30"/>
+        <text x="60" y="76" text-anchor="middle" font-family="'IBM Plex Mono', 'JetBrains Mono', monospace" font-weight="bold" font-size="44" fill="#06b6d4">AV</text>
       </svg>
-      <span class="av-wordmark">agent<span class="av-wordmark-v">v</span></span>
+      <BrandWordmark />
     </a>
     <div class="av-nav-links">
       <a href="/docs/">Docs</a>
@@ -45,6 +46,7 @@
     <div class="av-hero-bg"></div>
     <div class="av-hero-inner">
       <div class="av-hero-text">
+        <p class="av-hero-brand"><BrandWordmark class="av-brand-wordmark--hero" /></p>
         <span class="av-hero-label">&gt; AI agent evaluation framework</span>
         <h1>Evaluate agents with<br/><span class="av-gradient-text">terminal precision</span></h1>
         <p class="av-hero-sub">
@@ -73,7 +75,7 @@
             <span class="av-terminal-dot av-dot-red"></span>
             <span class="av-terminal-dot av-dot-yellow"></span>
             <span class="av-terminal-dot av-dot-green"></span>
-            <span class="av-terminal-title">agentv</span>
+            <span class="av-terminal-title"><BrandWordmark class="av-brand-wordmark--terminal" /></span>
           </div>
           <div class="av-terminal-body">
             <!-- Scene 1: agentv eval -->
@@ -227,7 +229,7 @@ tests:
             <tbody>
               <tr>
                 <td>Evaluate</td>
-                <td class="av-col-highlight"><strong>AgentV</strong></td>
+                <td class="av-col-highlight"><strong><BrandWordmark class="av-brand-wordmark--inline" /></strong></td>
                 <td>Pre-production</td>
                 <td>Score agents, detect regressions, gate CI/CD</td>
               </tr>
@@ -347,15 +349,6 @@ tests:
   font-weight: 700;
   font-size: 1.05rem;
   letter-spacing: -0.02em;
-}
-
-.av-wordmark {
-  text-transform: lowercase;
-}
-
-.av-wordmark-v {
-  margin-left: 0.12em;
-  color: #06b6d4;
 }
 
 .av-nav-links {
@@ -576,6 +569,10 @@ tests:
   color: var(--av-indigo);
   margin-bottom: 1.5rem;
   letter-spacing: 0.01em;
+}
+
+.av-hero-brand {
+  margin: 0 0 1rem;
 }
 
 .av-hero-text h1 {

--- a/apps/web/src/components/StarlightSiteTitle.astro
+++ b/apps/web/src/components/StarlightSiteTitle.astro
@@ -1,0 +1,60 @@
+---
+import config from 'virtual:starlight/user-config';
+import { logos } from 'virtual:starlight/user-images';
+
+import BrandWordmark from './BrandWordmark.astro';
+
+const { siteTitleHref } = Astro.locals.starlightRoute;
+---
+
+<a href={siteTitleHref} class="site-title sl-flex" aria-label="AgentV home">
+  {
+    config.logo && logos.dark && (
+      <>
+        <img
+          class:list={{ 'light:sl-hidden print:hidden': !('src' in config.logo) }}
+          alt={config.logo.alt}
+          src={logos.dark.src}
+          width={logos.dark.width}
+          height={logos.dark.height}
+        />
+        {!('src' in config.logo) && (
+          <img
+            class="dark:sl-hidden print:block"
+            alt={config.logo.alt}
+            src={logos.light?.src}
+            width={logos.light?.width}
+            height={logos.light?.height}
+          />
+        )}
+      </>
+    )
+  }
+  <span class:list={{ 'sr-only': config.logo?.replacesTitle }}>
+    <BrandWordmark class="av-brand-wordmark--docs" />
+  </span>
+</a>
+
+<style>
+  @layer starlight.core {
+    .site-title {
+      align-items: center;
+      gap: var(--sl-nav-gap);
+      color: var(--sl-color-text-accent);
+      text-decoration: none;
+      min-width: 0;
+    }
+
+    .site-title span {
+      overflow: hidden;
+    }
+
+    .site-title img {
+      height: calc(var(--sl-nav-height) - 2 * var(--sl-nav-pad-y));
+      width: auto;
+      max-width: 100%;
+      object-fit: contain;
+      object-position: 0 50%;
+    }
+  }
+</style>

--- a/apps/web/src/content/docs/docs/tools/dashboard.mdx
+++ b/apps/web/src/content/docs/docs/tools/dashboard.mdx
@@ -75,7 +75,7 @@ Legacy `studio.threshold`, `studio.pass_threshold`, and root-level `pass_thresho
 
 ## White label
 
-Dashboard shows `agentv` by default. Override the displayed name with `dashboard.app_name` in project-local `.agentv/config.yaml`:
+Dashboard shows AgentV by default. Override the displayed name with `dashboard.app_name` in project-local `.agentv/config.yaml`:
 
 ```yaml
 dashboard:

--- a/apps/web/src/pages/404.astro
+++ b/apps/web/src/pages/404.astro
@@ -1,4 +1,5 @@
 ---
+import BrandWordmark from '../components/BrandWordmark.astro';
 ---
 
 <!doctype html>
@@ -45,17 +46,6 @@
         justify-content: center;
         gap: 0.75rem;
         margin-bottom: 2.5rem;
-      }
-
-      .wordmark {
-        font-size: 1.35rem;
-        font-weight: 600;
-        letter-spacing: -0.02em;
-        color: hsl(0, 0%, 85%);
-      }
-
-      .wordmark-v {
-        color: #06b6d4;
       }
 
       .error-text {
@@ -107,11 +97,11 @@
   <body>
     <div class="card">
       <div class="logo">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none" width="32" height="32">
-          <rect width="120" height="120" rx="24" fill="#06b6d4"/>
-          <text x="60" y="82" text-anchor="middle" font-family="'IBM Plex Mono', 'JetBrains Mono', monospace" font-weight="bold" font-size="64" fill="#0a2a30">v</text>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none" width="32" height="32" aria-hidden="true">
+          <rect width="120" height="120" rx="24" fill="#0a2a30"/>
+          <text x="60" y="76" text-anchor="middle" font-family="'IBM Plex Mono', 'JetBrains Mono', monospace" font-weight="bold" font-size="44" fill="#06b6d4">AV</text>
         </svg>
-        <span class="wordmark">agent<span class="wordmark-v">v</span></span>
+        <BrandWordmark class="av-brand-wordmark--not-found" />
       </div>
       <p class="error-text">404 - Page Not Found</p>
       <nav class="nav-links">


### PR DESCRIPTION
## Summary
- Update Dashboard, docs, landing, and 404 visible brand presentation from lowercase `agentv`/`agent v` to capital-case `AgentV`.
- Add a reusable Astro `BrandWordmark` and Starlight `SiteTitle` override so docs and landing share the same cyan `A`/`V` treatment.
- Refresh logo/favicon presentation to an `AV` mark and keep lowercase `agentv` only for commands, package names, URLs, and `.agentv` paths.

## Visual Evidence
Private evidence repo: `agentv-assets-private`
Latest evidence commit: `d4854920de69cce133b2060519a1d1b52a1b1ed7`
Evidence directory: `dogfood/av-goc-4-branding/`

Before:
- `before-dashboard-branding.png`
- `before-docs-branding.png`
- `before-landing-branding.png`

After:
- `dashboard-branding.png`
- `docs-branding.png`
- `landing-branding.png`

## Verification
- `git fetch origin` and created fresh worktree from `origin/main` at `d9ba66b8b677b65900b0e145933ee43c716f820f`.
- `bun install --frozen-lockfile`
- `bunx biome check apps/dashboard/index.html apps/dashboard/src/components/BrandName.tsx apps/dashboard/src/routes/settings.tsx apps/dashboard/src/styles/globals.css apps/web/astro.config.mjs apps/web/public/favicon.svg apps/web/src/assets/logo.svg apps/web/src/components/BrandWordmark.astro apps/web/src/components/StarlightSiteTitle.astro apps/web/src/components/Lander.astro apps/web/src/pages/404.astro apps/web/src/content/docs/docs/tools/dashboard.mdx`
- `bun --filter @agentv/dashboard build`
- `bun --filter @agentv/web build`
- `bun --filter @agentv/dashboard test`
- `bun --filter @agentv/core build`
- `bun --filter agentv build`
- Pre-push hook passed: workspace typecheck and `biome check .`
- `agent-browser` screenshots captured for Dashboard, docs, and landing before/after.

## Blockers
No implementation blockers. Coordination note: requested Agent Mail contact approval for `FrostyBasin` could not be completed because this MCP session was not authenticated as that identity; implementation continued under `agentv--gap-branding`.