### PR TITLE
fix(results): separate execution errors from quality failures

### DIFF
--- a/apps/cli/src/commands/eval/artifact-writer.ts
+++ b/apps/cli/src/commands/eval/artifact-writer.ts
@@ -220,6 +220,10 @@ function computePassRate(result: EvaluationResult): number {
   return (result.score ?? 0) >= DEFAULT_THRESHOLD ? 1.0 : 0.0;
 }
 
+function isExecutionError(result: EvaluationResult): boolean {
+  return result.executionStatus === 'execution_error';
+}
+
 // ---------------------------------------------------------------------------
 // Tool-call counting from trace data
 // ---------------------------------------------------------------------------
@@ -410,8 +414,9 @@ export function buildBenchmarkArtifact(
 
   for (const target of targets) {
     const targetResults = results.filter((r) => r.target === target);
+    const qualityResults = targetResults.filter((r) => !isExecutionError(r));
 
-    const passRates = targetResults.map(computePassRate);
+    const passRates = qualityResults.map(computePassRate);
     const timings = targetResults
       .filter((r) => r.durationMs != null)
       .map((r) => (r.durationMs as number) / 1000);
@@ -446,6 +451,9 @@ export function buildBenchmarkArtifact(
   // Per-grader summary across all results
   const evaluatorScores = new Map<string, number[]>();
   for (const result of results) {
+    if (isExecutionError(result)) {
+      continue;
+    }
     if (result.scores) {
       for (const score of result.scores) {
         const key = `${score.name}:${score.type}`;
@@ -470,7 +478,7 @@ export function buildBenchmarkArtifact(
   ).length;
   if (errorCount > 0) {
     notes.push(
-      `${errorCount} test(s) had execution errors and are included in pass_rate as failures`,
+      `${errorCount} test(s) had execution errors and are excluded from quality pass_rate`,
     );
   }
   if (results.length === 0) {
@@ -529,7 +537,7 @@ export function buildAggregateGradingArtifact(
 ): AggregateGradingArtifact {
   const assertions: AggregateGradingArtifact['assertions'][number][] = [];
 
-  for (const result of results) {
+  for (const result of results.filter((r) => !isExecutionError(r))) {
     if (!result.assertions) continue;
     const testId = result.testId ?? 'unknown';
     for (const a of result.assertions) {

--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -414,6 +414,61 @@ function hasUsableTimestamp(timestamp: string | undefined): boolean {
   return !!timestamp && timestamp !== 'unknown' && !Number.isNaN(new Date(timestamp).getTime());
 }
 
+interface QualitySummaryInput {
+  readonly score: number;
+  readonly executionStatus?: string;
+}
+
+interface QualitySummaryStats {
+  readonly totalCount: number;
+  readonly qualityCount: number;
+  readonly passedCount: number;
+  readonly qualityFailureCount: number;
+  readonly executionErrorCount: number;
+  readonly scoreSum: number;
+  readonly passRate: number;
+  readonly avgScore: number;
+}
+
+function isExecutionErrorResult(result: QualitySummaryInput): boolean {
+  return result.executionStatus === 'execution_error';
+}
+
+function summarizeQualityResults(
+  results: readonly QualitySummaryInput[],
+  passThreshold: number,
+): QualitySummaryStats {
+  let qualityCount = 0;
+  let passedCount = 0;
+  let executionErrorCount = 0;
+  let scoreSum = 0;
+
+  for (const result of results) {
+    if (isExecutionErrorResult(result)) {
+      executionErrorCount++;
+      continue;
+    }
+
+    qualityCount++;
+    scoreSum += result.score;
+    if (result.score >= passThreshold) {
+      passedCount++;
+    }
+  }
+
+  const qualityFailureCount = qualityCount - passedCount;
+  return {
+    totalCount: results.length,
+    qualityCount,
+    passedCount,
+    qualityFailureCount,
+    executionErrorCount,
+    scoreSum,
+    passRate: qualityCount > 0 ? passedCount / qualityCount : 0,
+    avgScore: qualityCount > 0 ? scoreSum / qualityCount : 0,
+  };
+}
+
 function paginateRuns<T extends { filename: string }>(
   runs: T[],
   cursor: string | undefined,
@@ -463,18 +518,21 @@ async function handleRuns(c: C, { searchDir, agentvDir, projectId }: DataContext
       let testCount = m.testCount;
       let passRate = m.passRate;
       let avgScore = m.avgScore;
+      let executionErrorCount = 0;
       try {
         const records = await loadLightweightResultsForMeta(searchDir, m, projectId);
         if (records.length > 0) {
+          const qualitySummary = summarizeQualityResults(records, passThreshold);
           target = records[0].target;
           experiment = records[0].experiment ?? experiment;
           timestamp =
             hasUsableTimestamp(timestamp) || !records[0].timestamp
               ? timestamp
               : records[0].timestamp;
-          testCount = records.length;
-          passRate = records.filter((r) => r.score >= passThreshold).length / records.length;
-          avgScore = records.reduce((sum, r) => sum + r.score, 0) / records.length;
+          testCount = qualitySummary.totalCount;
+          passRate = qualitySummary.passRate;
+          avgScore = qualitySummary.avgScore;
+          executionErrorCount = qualitySummary.executionErrorCount;
         } else {
           // Run is in-progress with 0 results written yet — fall back to the
           // in-memory target stored when the Dashboard launched this run.
@@ -496,6 +554,7 @@ async function handleRuns(c: C, { searchDir, agentvDir, projectId }: DataContext
         test_count: testCount,
         pass_rate: passRate,
         avg_score: avgScore,
+        execution_error_count: executionErrorCount,
         size_bytes: m.sizeBytes,
         source: m.source,
         ...(target && { target }),
@@ -601,22 +660,24 @@ async function handleRunSuites(c: C, { searchDir, agentvDir, projectId }: DataCo
   try {
     const loaded = await loadManifestResultsForMeta(searchDir, meta, projectId);
     const { threshold: pass_threshold } = loadStudioConfig(agentvDir);
-    const suiteMap = new Map<string, { total: number; passed: number; scoreSum: number }>();
+    const suiteMap = new Map<string, EvaluationResult[]>();
     for (const r of loaded) {
       const ds = r.suite ?? r.target ?? 'default';
-      const entry = suiteMap.get(ds) ?? { total: 0, passed: 0, scoreSum: 0 };
-      entry.total++;
-      if (r.score >= pass_threshold) entry.passed++;
-      entry.scoreSum += r.score;
+      const entry = suiteMap.get(ds) ?? [];
+      entry.push(r);
       suiteMap.set(ds, entry);
     }
-    const suites = [...suiteMap.entries()].map(([name, entry]) => ({
-      name,
-      total: entry.total,
-      passed: entry.passed,
-      failed: entry.total - entry.passed,
-      avg_score: entry.total > 0 ? entry.scoreSum / entry.total : 0,
-    }));
+    const suites = [...suiteMap.entries()].map(([name, entry]) => {
+      const qualitySummary = summarizeQualityResults(entry, pass_threshold);
+      return {
+        name,
+        total: qualitySummary.totalCount,
+        passed: qualitySummary.passedCount,
+        failed: qualitySummary.qualityFailureCount,
+        avg_score: qualitySummary.avgScore,
+        execution_error_count: qualitySummary.executionErrorCount,
+      };
+    });
     return c.json({ suites });
   } catch {
     return c.json({ error: 'Failed to load suites' }, 500);
@@ -630,32 +691,29 @@ async function handleRunCategories(c: C, { searchDir, agentvDir, projectId }: Da
   try {
     const loaded = await loadManifestResultsForMeta(searchDir, meta, projectId);
     const { threshold: pass_threshold } = loadStudioConfig(agentvDir);
-    const categoryMap = new Map<
-      string,
-      { total: number; passed: number; scoreSum: number; suites: Set<string> }
-    >();
+    const categoryMap = new Map<string, { results: EvaluationResult[]; suites: Set<string> }>();
     for (const r of loaded) {
       const cat = r.category ?? DEFAULT_CATEGORY;
       const entry = categoryMap.get(cat) ?? {
-        total: 0,
-        passed: 0,
-        scoreSum: 0,
+        results: [],
         suites: new Set<string>(),
       };
-      entry.total++;
-      if (r.score >= pass_threshold) entry.passed++;
-      entry.scoreSum += r.score;
+      entry.results.push(r);
       entry.suites.add(r.suite ?? r.target ?? 'default');
       categoryMap.set(cat, entry);
     }
-    const categories = [...categoryMap.entries()].map(([name, entry]) => ({
-      name,
-      total: entry.total,
-      passed: entry.passed,
-      failed: entry.total - entry.passed,
-      avg_score: entry.total > 0 ? entry.scoreSum / entry.total : 0,
-      suite_count: entry.suites.size,
-    }));
+    const categories = [...categoryMap.entries()].map(([name, entry]) => {
+      const qualitySummary = summarizeQualityResults(entry.results, pass_threshold);
+      return {
+        name,
+        total: qualitySummary.totalCount,
+        passed: qualitySummary.passedCount,
+        failed: qualitySummary.qualityFailureCount,
+        avg_score: qualitySummary.avgScore,
+        execution_error_count: qualitySummary.executionErrorCount,
+        suite_count: entry.suites.size,
+      };
+    });
     return c.json({ categories });
   } catch {
     return c.json({ error: 'Failed to load categories' }, 500);
@@ -671,22 +729,24 @@ async function handleCategorySuites(c: C, { searchDir, agentvDir, projectId }: D
     const loaded = await loadManifestResultsForMeta(searchDir, meta, projectId);
     const { threshold: pass_threshold } = loadStudioConfig(agentvDir);
     const filtered = loaded.filter((r) => (r.category ?? DEFAULT_CATEGORY) === category);
-    const suiteMap = new Map<string, { total: number; passed: number; scoreSum: number }>();
+    const suiteMap = new Map<string, EvaluationResult[]>();
     for (const r of filtered) {
       const ds = r.suite ?? r.target ?? 'default';
-      const entry = suiteMap.get(ds) ?? { total: 0, passed: 0, scoreSum: 0 };
-      entry.total++;
-      if (r.score >= pass_threshold) entry.passed++;
-      entry.scoreSum += r.score;
+      const entry = suiteMap.get(ds) ?? [];
+      entry.push(r);
       suiteMap.set(ds, entry);
     }
-    const suites = [...suiteMap.entries()].map(([name, entry]) => ({
-      name,
-      total: entry.total,
-      passed: entry.passed,
-      failed: entry.total - entry.passed,
-      avg_score: entry.total > 0 ? entry.scoreSum / entry.total : 0,
-    }));
+    const suites = [...suiteMap.entries()].map(([name, entry]) => {
+      const qualitySummary = summarizeQualityResults(entry, pass_threshold);
+      return {
+        name,
+        total: qualitySummary.totalCount,
+        passed: qualitySummary.passedCount,
+        failed: qualitySummary.qualityFailureCount,
+        avg_score: qualitySummary.avgScore,
+        execution_error_count: qualitySummary.executionErrorCount,
+      };
+    });
     return c.json({ suites });
   } catch {
     return c.json({ error: 'Failed to load suites' }, 500);
@@ -791,7 +851,9 @@ async function handleExperiments(c: C, { searchDir, agentvDir, projectId }: Data
       targets: Set<string>;
       runFilenames: Set<string>;
       evalCount: number;
+      qualityCount: number;
       passedCount: number;
+      executionErrorCount: number;
       lastTimestamp: string;
     }
   >();
@@ -805,13 +867,20 @@ async function handleExperiments(c: C, { searchDir, agentvDir, projectId }: Data
           targets: new Set<string>(),
           runFilenames: new Set<string>(),
           evalCount: 0,
+          qualityCount: 0,
           passedCount: 0,
+          executionErrorCount: 0,
           lastTimestamp: '',
         };
         entry.runFilenames.add(m.filename);
         if (r.target) entry.targets.add(r.target);
         entry.evalCount++;
-        if (r.score >= pass_threshold) entry.passedCount++;
+        if (isExecutionErrorResult(r)) {
+          entry.executionErrorCount++;
+        } else {
+          entry.qualityCount++;
+          if (r.score >= pass_threshold) entry.passedCount++;
+        }
         if (r.timestamp && r.timestamp > entry.lastTimestamp) {
           entry.lastTimestamp = r.timestamp;
         }
@@ -827,8 +896,10 @@ async function handleExperiments(c: C, { searchDir, agentvDir, projectId }: Data
     run_count: entry.runFilenames.size,
     target_count: entry.targets.size,
     eval_count: entry.evalCount,
+    quality_count: entry.qualityCount,
     passed_count: entry.passedCount,
-    pass_rate: entry.evalCount > 0 ? entry.passedCount / entry.evalCount : 0,
+    execution_error_count: entry.executionErrorCount,
+    pass_rate: entry.qualityCount > 0 ? entry.passedCount / entry.qualityCount : 0,
     last_run: entry.lastTimestamp || null,
   }));
 
@@ -859,7 +930,9 @@ async function handleCompare(c: C, { searchDir, agentvDir, projectId }: DataCont
       experiment: string;
       target: string;
       evalCount: number;
+      qualityCount: number;
       passedCount: number;
+      executionErrorCount: number;
       scoreSum: number;
       tests: Array<{
         test_id: string;
@@ -883,7 +956,9 @@ async function handleCompare(c: C, { searchDir, agentvDir, projectId }: DataCont
     metadata_dirty?: boolean;
     source: 'local' | 'remote';
     eval_count: number;
+    quality_count: number;
     passed_count: number;
+    execution_error_count: number;
     pass_rate: number;
     avg_score: number;
     tests: Array<{
@@ -914,7 +989,9 @@ async function handleCompare(c: C, { searchDir, agentvDir, projectId }: DataCont
         { test_id: string; score: number; passed: boolean; execution_status?: string }
       >();
       let runEvalCount = 0;
+      let runQualityCount = 0;
       let runPassedCount = 0;
+      let runExecutionErrorCount = 0;
       let runScoreSum = 0;
       let runExperiment = 'default';
       let runTarget = 'default';
@@ -934,14 +1011,22 @@ async function handleCompare(c: C, { searchDir, agentvDir, projectId }: DataCont
           experiment,
           target,
           evalCount: 0,
+          qualityCount: 0,
           passedCount: 0,
+          executionErrorCount: 0,
           scoreSum: 0,
           tests: [],
         };
-        const passed = r.score >= pass_threshold;
+        const isExecutionError = isExecutionErrorResult(r);
+        const passed = !isExecutionError && r.score >= pass_threshold;
         entry.evalCount++;
-        if (passed) entry.passedCount++;
-        entry.scoreSum += r.score;
+        if (isExecutionError) {
+          entry.executionErrorCount++;
+        } else {
+          entry.qualityCount++;
+          if (passed) entry.passedCount++;
+          entry.scoreSum += r.score;
+        }
         entry.tests.push({
           test_id: r.testId,
           score: r.score,
@@ -958,8 +1043,13 @@ async function handleCompare(c: C, { searchDir, agentvDir, projectId }: DataCont
           execution_status: r.executionStatus,
         });
         runEvalCount++;
-        if (passed) runPassedCount++;
-        runScoreSum += r.score;
+        if (isExecutionError) {
+          runExecutionErrorCount++;
+        } else {
+          runQualityCount++;
+          if (passed) runPassedCount++;
+          runScoreSum += r.score;
+        }
       }
 
       if (runEvalCount === 0) continue;
@@ -973,9 +1063,11 @@ async function handleCompare(c: C, { searchDir, agentvDir, projectId }: DataCont
         ...tagFields,
         source: m.source,
         eval_count: runEvalCount,
+        quality_count: runQualityCount,
         passed_count: runPassedCount,
-        pass_rate: runPassedCount / runEvalCount,
-        avg_score: runScoreSum / runEvalCount,
+        execution_error_count: runExecutionErrorCount,
+        pass_rate: runQualityCount > 0 ? runPassedCount / runQualityCount : 0,
+        avg_score: runQualityCount > 0 ? runScoreSum / runQualityCount : 0,
         tests: runTests,
       });
     } catch {
@@ -994,8 +1086,8 @@ async function handleCompare(c: C, { searchDir, agentvDir, projectId }: DataCont
   const baselineScores = new Map<string, number>();
   if (baselineTarget) {
     for (const entry of cellMap.values()) {
-      if (entry.target === baselineTarget && entry.evalCount > 0) {
-        baselineScores.set(entry.experiment, entry.scoreSum / entry.evalCount);
+      if (entry.target === baselineTarget && entry.qualityCount > 0) {
+        baselineScores.set(entry.experiment, entry.scoreSum / entry.qualityCount);
       }
     }
   }
@@ -1011,13 +1103,15 @@ async function handleCompare(c: C, { searchDir, agentvDir, projectId }: DataCont
     // Cap to most recent entries to prevent unbounded payloads
     const cappedTests = dedupedTests.slice(-MAX_TESTS_PER_CELL);
 
-    const avgScore = entry.evalCount > 0 ? entry.scoreSum / entry.evalCount : 0;
+    const avgScore = entry.qualityCount > 0 ? entry.scoreSum / entry.qualityCount : 0;
     const cell: Record<string, unknown> = {
       experiment: entry.experiment,
       target: entry.target,
       eval_count: entry.evalCount,
+      quality_count: entry.qualityCount,
       passed_count: entry.passedCount,
-      pass_rate: entry.evalCount > 0 ? entry.passedCount / entry.evalCount : 0,
+      execution_error_count: entry.executionErrorCount,
+      pass_rate: entry.qualityCount > 0 ? entry.passedCount / entry.qualityCount : 0,
       avg_score: avgScore,
       tests: cappedTests,
     };
@@ -1055,7 +1149,9 @@ async function handleTargets(c: C, { searchDir, agentvDir, projectId }: DataCont
       experiments: Set<string>;
       runFilenames: Set<string>;
       evalCount: number;
+      qualityCount: number;
       passedCount: number;
+      executionErrorCount: number;
     }
   >();
 
@@ -1068,12 +1164,19 @@ async function handleTargets(c: C, { searchDir, agentvDir, projectId }: DataCont
           experiments: new Set<string>(),
           runFilenames: new Set<string>(),
           evalCount: 0,
+          qualityCount: 0,
           passedCount: 0,
+          executionErrorCount: 0,
         };
         entry.runFilenames.add(m.filename);
         if (r.experiment) entry.experiments.add(r.experiment);
         entry.evalCount++;
-        if (r.score >= pass_threshold) entry.passedCount++;
+        if (isExecutionErrorResult(r)) {
+          entry.executionErrorCount++;
+        } else {
+          entry.qualityCount++;
+          if (r.score >= pass_threshold) entry.passedCount++;
+        }
         targetMap.set(target, entry);
       }
     } catch {
@@ -1086,8 +1189,10 @@ async function handleTargets(c: C, { searchDir, agentvDir, projectId }: DataCont
     run_count: entry.runFilenames.size,
     experiment_count: entry.experiments.size,
     eval_count: entry.evalCount,
+    quality_count: entry.qualityCount,
     passed_count: entry.passedCount,
-    pass_rate: entry.evalCount > 0 ? entry.passedCount / entry.evalCount : 0,
+    execution_error_count: entry.executionErrorCount,
+    pass_rate: entry.qualityCount > 0 ? entry.passedCount / entry.qualityCount : 0,
   }));
 
   return c.json({ targets });
@@ -1379,29 +1484,56 @@ export function createApp(
     };
   }
 
+  async function summarizeProjectRunMetas(project: { id: string; path: string }) {
+    const { runs: metas } = await listMergedResultFiles(project.path, undefined, project.id);
+    const threshold = loadStudioConfig(path.join(project.path, '.agentv')).threshold;
+    let passRateSum = 0;
+    let executionErrorCount = 0;
+
+    for (const meta of metas) {
+      try {
+        const records = await loadLightweightResultsForMeta(project.path, meta, project.id);
+        if (records.length > 0) {
+          const qualitySummary = summarizeQualityResults(records, threshold);
+          passRateSum += qualitySummary.passRate;
+          executionErrorCount += qualitySummary.executionErrorCount;
+          continue;
+        }
+      } catch {
+        // Fall back to metadata below when materialized rows are unavailable.
+      }
+      passRateSum += meta.passRate;
+    }
+
+    return {
+      runCount: metas.length,
+      passRate: metas.length > 0 ? passRateSum / metas.length : 0,
+      executionErrorCount,
+      lastRun: metas.length > 0 ? metas[0].timestamp : null,
+    };
+  }
+
   app.get('/api/projects', async (c) => {
     const registry = loadProjectRegistry();
     const projects = await Promise.all(
       registry.projects.map(async (p) => {
-        let runCount = 0;
-        let passRate = 0;
-        let lastRun: string | null = null;
+        let summary = {
+          runCount: 0,
+          passRate: 0,
+          executionErrorCount: 0,
+          lastRun: null as string | null,
+        };
         try {
-          const { runs: metas } = await listMergedResultFiles(p.path, undefined, p.id);
-          runCount = metas.length;
-          if (metas.length > 0) {
-            const totalPassRate = metas.reduce((sum, m) => sum + m.passRate, 0);
-            passRate = totalPassRate / metas.length;
-            lastRun = metas[0].timestamp;
-          }
+          summary = await summarizeProjectRunMetas(p);
         } catch {
           // Project path may be missing or inaccessible
         }
         return {
           ...projectEntryToWire(p),
-          run_count: runCount,
-          pass_rate: passRate,
-          last_run: lastRun,
+          run_count: summary.runCount,
+          pass_rate: summary.passRate,
+          execution_error_count: summary.executionErrorCount,
+          last_run: summary.lastRun,
         };
       }),
     );
@@ -1426,17 +1558,15 @@ export function createApp(
     const project = getProject(c.req.param('projectId') ?? '');
     if (!project) return c.json({ error: 'Project not found' }, 404);
     try {
-      const { runs: metas } = await listMergedResultFiles(project.path, undefined, project.id);
-      const runCount = metas.length;
-      const passRate = runCount > 0 ? metas.reduce((s, m) => s + m.passRate, 0) / runCount : 0;
-      const lastRun = metas.length > 0 ? metas[0].timestamp : null;
+      const summary = await summarizeProjectRunMetas(project);
       return c.json({
         id: project.id,
         name: project.name,
         path: project.path,
-        run_count: runCount,
-        pass_rate: passRate,
-        last_run: lastRun,
+        run_count: summary.runCount,
+        pass_rate: summary.passRate,
+        execution_error_count: summary.executionErrorCount,
+        last_run: summary.lastRun,
       });
     } catch {
       return c.json({ error: 'Failed to read project' }, 500);
@@ -1454,6 +1584,7 @@ export function createApp(
       test_count: number;
       pass_rate: number;
       avg_score: number;
+      execution_error_count: number;
       size_bytes: number;
       target?: string;
       experiment?: string;
@@ -1472,11 +1603,21 @@ export function createApp(
         for (const m of metas) {
           let target: string | undefined;
           let experiment = inferExperimentFromRunId(m.raw_filename);
+          let passRate = m.passRate;
+          let avgScore = m.avgScore;
+          let executionErrorCount = 0;
           try {
             const records = await loadLightweightResultsForMeta(p.path, m, p.id);
             if (records.length > 0) {
+              const qualitySummary = summarizeQualityResults(
+                records,
+                loadStudioConfig(path.join(p.path, '.agentv')).threshold,
+              );
               target = records[0].target;
               experiment = records[0].experiment ?? experiment;
+              passRate = qualitySummary.passRate;
+              avgScore = qualitySummary.avgScore;
+              executionErrorCount = qualitySummary.executionErrorCount;
             }
           } catch {
             // ignore enrichment errors
@@ -1488,8 +1629,9 @@ export function createApp(
             path: m.path,
             timestamp: m.timestamp,
             test_count: m.testCount,
-            pass_rate: m.passRate,
-            avg_score: m.avgScore,
+            pass_rate: passRate,
+            avg_score: avgScore,
+            execution_error_count: executionErrorCount,
             size_bytes: m.sizeBytes,
             source: m.source,
             ...(target && { target }),
@@ -1632,18 +1774,33 @@ export function createApp(
     const entries = await Promise.all(
       metas.map(async (m) => {
         let totalCostUsd = 0;
+        let passRate = m.passRate;
+        let avgScore = m.avgScore;
+        let testCount = m.testCount;
+        let executionErrorCount = 0;
         try {
           const loaded = await loadManifestResultsForMeta(searchDir, m, defaultCtx.projectId);
           totalCostUsd = loaded.reduce((sum, r) => sum + (r.costUsd ?? 0), 0);
+          if (loaded.length > 0) {
+            const qualitySummary = summarizeQualityResults(
+              loaded,
+              loadStudioConfig(agentvDir).threshold,
+            );
+            testCount = qualitySummary.totalCount;
+            passRate = qualitySummary.passRate;
+            avgScore = qualitySummary.avgScore;
+            executionErrorCount = qualitySummary.executionErrorCount;
+          }
         } catch {
           // ignore load errors for aggregate
         }
         return {
           run_filename: m.filename,
           display_name: m.displayName,
-          test_count: m.testCount,
-          pass_rate: m.passRate,
-          avg_score: m.avgScore,
+          test_count: testCount,
+          pass_rate: passRate,
+          avg_score: avgScore,
+          execution_error_count: executionErrorCount,
           total_cost_usd: totalCostUsd,
           timestamp: m.timestamp,
         };

--- a/apps/cli/test/commands/eval/artifact-writer.test.ts
+++ b/apps/cli/test/commands/eval/artifact-writer.test.ts
@@ -288,7 +288,30 @@ describe('buildBenchmarkArtifact', () => {
     const results = [makeResult({ executionStatus: 'execution_error', score: 0 })];
 
     const benchmark = buildBenchmarkArtifact(results);
-    expect(benchmark.notes.some((n) => n.includes('execution errors'))).toBe(true);
+    expect(benchmark.notes).toContain(
+      '1 test(s) had execution errors and are excluded from quality pass_rate',
+    );
+  });
+
+  it('excludes execution errors from quality pass_rate and per-grader summary', () => {
+    const results = [
+      makeResult({
+        testId: 'quality-pass',
+        score: 1,
+        scores: [makeEvaluatorResult({ name: 'quality', type: 'llm-grader', score: 1 })],
+      }),
+      makeResult({
+        testId: 'provider-timeout',
+        score: 0,
+        executionStatus: 'execution_error',
+        scores: [makeEvaluatorResult({ name: 'quality', type: 'llm-grader', score: 0 })],
+      }),
+    ];
+
+    const benchmark = buildBenchmarkArtifact(results);
+
+    expect(benchmark.run_summary['test-target'].pass_rate.mean).toBe(1);
+    expect(benchmark.per_grader_summary?.['quality:llm-grader'].mean).toBe(1);
   });
 
   it('handles empty results', () => {
@@ -396,6 +419,37 @@ describe('buildAggregateGradingArtifact', () => {
     expect(aggregate.summary.total).toBe(1);
     expect(aggregate.summary.passed).toBe(1);
     expect(aggregate.summary.failed).toBe(0);
+  });
+
+  it('excludes execution-error assertions from aggregate quality summary', () => {
+    const results = [
+      makeResult({
+        testId: 'quality-pass',
+        assertions: [{ text: 'quality criterion', passed: true }],
+      }),
+      makeResult({
+        testId: 'provider-timeout',
+        executionStatus: 'execution_error',
+        assertions: [{ text: 'execution error placeholder', passed: false }],
+      }),
+    ];
+
+    const aggregate = buildAggregateGradingArtifact(results);
+
+    expect(aggregate.assertions).toEqual([
+      {
+        test_id: 'quality-pass',
+        text: 'quality criterion',
+        passed: true,
+        evidence: '',
+      },
+    ]);
+    expect(aggregate.summary).toEqual({
+      passed: 1,
+      failed: 0,
+      total: 1,
+      pass_rate: 1,
+    });
   });
 
   it('handles empty results array', () => {

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -55,6 +55,22 @@ const RESULT_B = {
   cost_usd: 0.003,
 };
 
+const RESULT_EXECUTION_ERROR = {
+  timestamp: '2026-03-18T10:00:07.000Z',
+  test_id: 'test-provider-timeout',
+  suite: 'demo',
+  category: 'runtime',
+  score: 0,
+  assertions: [{ text: 'Execution failed before grading', passed: false }],
+  target: 'gpt-4o',
+  execution_status: 'execution_error',
+  failure_stage: 'target',
+  failure_reason_code: 'provider_timeout',
+  execution_error: {
+    message: 'Provider timed out',
+  },
+};
+
 function toJsonl(...records: object[]): string {
   return `${records.map((r) => JSON.stringify(r)).join('\n')}\n`;
 }
@@ -679,6 +695,84 @@ describe('serve app', () => {
       const data = (await res.json()) as { runs: Array<{ pass_rate: number }> };
       expect(data.runs).toHaveLength(1);
       expect(data.runs[0].pass_rate).toBe(0);
+    });
+
+    it('reports execution errors separately from quality failures in run summaries', async () => {
+      const runsDir = path.join(tempDir, '.agentv', 'results', 'runs');
+      mkdirSync(runsDir, { recursive: true });
+      const filename = '2026-03-25T10-00-00-000Z';
+      const runDir = path.join(runsDir, filename);
+      mkdirSync(runDir, { recursive: true });
+      const qualityPass = { ...RESULT_A, category: 'runtime' };
+      const qualityFail = { ...RESULT_B, category: 'runtime' };
+      writeFileSync(
+        path.join(runDir, 'index.jsonl'),
+        toJsonl(qualityPass, qualityFail, RESULT_EXECUTION_ERROR),
+      );
+
+      const app = createApp([], tempDir, tempDir, undefined, { studioDir });
+
+      const runRes = await app.request('/api/runs');
+      expect(runRes.status).toBe(200);
+      const runData = (await runRes.json()) as {
+        runs: Array<{
+          test_count: number;
+          pass_rate: number;
+          avg_score: number;
+          execution_error_count?: number;
+        }>;
+      };
+      expect(runData.runs).toHaveLength(1);
+      expect(runData.runs[0].test_count).toBe(3);
+      expect(runData.runs[0].execution_error_count).toBe(1);
+      expect(runData.runs[0].pass_rate).toBe(0.5);
+      expect(runData.runs[0].avg_score).toBe(0.75);
+
+      const suitesRes = await app.request(`/api/runs/${filename}/suites`);
+      expect(suitesRes.status).toBe(200);
+      const suitesData = (await suitesRes.json()) as {
+        suites: Array<{
+          name: string;
+          total: number;
+          passed: number;
+          failed: number;
+          execution_error_count?: number;
+        }>;
+      };
+      expect(suitesData.suites).toEqual([
+        {
+          name: 'demo',
+          total: 3,
+          passed: 1,
+          failed: 1,
+          avg_score: 0.75,
+          execution_error_count: 1,
+        },
+      ]);
+
+      const categoriesRes = await app.request(`/api/runs/${filename}/categories`);
+      expect(categoriesRes.status).toBe(200);
+      const categoriesData = (await categoriesRes.json()) as {
+        categories: Array<{
+          name: string;
+          total: number;
+          passed: number;
+          failed: number;
+          execution_error_count?: number;
+          suite_count: number;
+        }>;
+      };
+      expect(categoriesData.categories).toEqual([
+        {
+          name: 'runtime',
+          total: 3,
+          passed: 1,
+          failed: 1,
+          avg_score: 0.75,
+          execution_error_count: 1,
+          suite_count: 1,
+        },
+      ]);
     });
 
     it('infers the experiment name from the run id when live results have not written it yet', async () => {

--- a/apps/dashboard/src/components/AnalyticsTab.tsx
+++ b/apps/dashboard/src/components/AnalyticsTab.tsx
@@ -27,6 +27,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { deleteRunTagsApi, saveRunTagsApi } from '~/lib/api';
+import { aggregateQualityCount, executionErrorCount } from '~/lib/result-summary';
 import type { CompareCell, CompareResponse, CompareRunEntry, CompareTestResult } from '~/lib/types';
 
 import { AnalyticsCharts } from './AnalyticsCharts';
@@ -74,9 +75,9 @@ export function AnalyticsTab({
   // When a filter is active, re-aggregate cells/runs client-side from the
   // filtered subset of runs. This avoids a network round-trip on every chip
   // click and keeps the backend responsible only for the initial fetch.
-  // Safe because the server already exposes per-run totals (`eval_count`,
-  // `passed_count`, `avg_score`); we just sum them per (experiment, target)
-  // bucket, weighting averages by run eval_count.
+  // Safe because the server already exposes per-run totals; we sum them per
+  // (experiment, target) bucket, weighting averages by quality_count so
+  // execution errors do not depress quality scores.
   const filteredData = useMemo<CompareResponse | undefined>(() => {
     if (!data) return data;
     if (filterTags.length === 0) return data;
@@ -89,7 +90,9 @@ export function AnalyticsTab({
       experiment: string;
       target: string;
       eval_count: number;
+      quality_count: number;
       passed_count: number;
+      execution_error_count: number;
       score_sum: number;
       tests: CompareTestResult[];
     };
@@ -105,13 +108,18 @@ export function AnalyticsTab({
         experiment: run.experiment,
         target: run.target,
         eval_count: 0,
+        quality_count: 0,
         passed_count: 0,
+        execution_error_count: 0,
         score_sum: 0,
         tests: [],
       };
+      const runQualityCount = aggregateQualityCount(run);
       entry.eval_count += run.eval_count;
+      entry.quality_count += runQualityCount;
       entry.passed_count += run.passed_count;
-      entry.score_sum += run.avg_score * run.eval_count;
+      entry.execution_error_count += executionErrorCount(run);
+      entry.score_sum += run.avg_score * runQualityCount;
       for (const t of run.tests) entry.tests.push(t);
       cellMap.set(key, entry);
     }
@@ -124,9 +132,11 @@ export function AnalyticsTab({
         experiment: e.experiment,
         target: e.target,
         eval_count: e.eval_count,
+        quality_count: e.quality_count,
         passed_count: e.passed_count,
-        pass_rate: e.eval_count > 0 ? e.passed_count / e.eval_count : 0,
-        avg_score: e.eval_count > 0 ? e.score_sum / e.eval_count : 0,
+        execution_error_count: e.execution_error_count,
+        pass_rate: e.quality_count > 0 ? e.passed_count / e.quality_count : 0,
+        avg_score: e.quality_count > 0 ? e.score_sum / e.quality_count : 0,
         tests: [...dedup.values()].slice(-100),
       };
     });
@@ -442,6 +452,8 @@ function AggregatedRow({
 function MatrixCell({ cell }: { cell: CompareCell }) {
   const [expanded, setExpanded] = useState(false);
   const avgPct = Math.round(cell.avg_score * 100);
+  const qualityCount = aggregateQualityCount(cell);
+  const errors = executionErrorCount(cell);
   return (
     <div className="space-y-2">
       <button
@@ -455,10 +467,16 @@ function MatrixCell({ cell }: { cell: CompareCell }) {
           <span>
             <span className="text-emerald-400">{cell.passed_count}</span>
             <span className="text-gray-600"> / </span>
-            <span>{cell.eval_count}</span>
+            <span>{qualityCount}</span>
           </span>
           <span className="text-gray-700">·</span>
           <span>avg {avgPct}%</span>
+          {errors > 0 && (
+            <>
+              <span className="text-gray-700">·</span>
+              <span className="text-amber-400">{errors} errors</span>
+            </>
+          )}
         </div>
       </button>
       {expanded && <TestBreakdown tests={cell.tests} />}
@@ -477,20 +495,29 @@ function TestBreakdown({ tests }: { tests: CompareTestResult[] }) {
         Test cases
       </div>
       <ul className="space-y-1">
-        {tests.map((t) => (
-          <li key={t.test_id} className="flex items-center gap-2 text-xs">
-            <span
-              aria-hidden
-              className={`h-1.5 w-1.5 rounded-full ${t.passed ? 'bg-emerald-400' : 'bg-red-400'}`}
-            />
-            <span className="flex-1 truncate text-gray-300" title={t.test_id}>
-              {t.test_id}
-            </span>
-            <span className={`tabular-nums ${t.passed ? 'text-emerald-400' : 'text-red-400'}`}>
-              {Math.round(t.score * 100)}%
-            </span>
-          </li>
-        ))}
+        {tests.map((t) => {
+          const isError = t.execution_status === 'execution_error';
+          return (
+            <li key={t.test_id} className="flex items-center gap-2 text-xs">
+              <span
+                aria-hidden
+                className={`h-1.5 w-1.5 rounded-full ${
+                  isError ? 'bg-amber-400' : t.passed ? 'bg-emerald-400' : 'bg-red-400'
+                }`}
+              />
+              <span className="flex-1 truncate text-gray-300" title={t.test_id}>
+                {t.test_id}
+              </span>
+              <span
+                className={`tabular-nums ${
+                  isError ? 'text-amber-400' : t.passed ? 'text-emerald-400' : 'text-red-400'
+                }`}
+              >
+                {isError ? 'error' : `${Math.round(t.score * 100)}%`}
+              </span>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );
@@ -551,8 +578,8 @@ function PerRunView({
               <th className="px-4 py-3 font-medium text-gray-400">Tags</th>
               <th className="px-4 py-3 font-medium text-gray-400">Experiment</th>
               <th className="px-4 py-3 font-medium text-gray-400">Target</th>
-              <th className="px-4 py-3 text-right font-medium text-gray-400">Tests</th>
-              <th className="px-4 py-3 font-medium text-gray-400">Pass rate</th>
+              <th className="px-4 py-3 text-right font-medium text-gray-400">Quality Tests</th>
+              <th className="px-4 py-3 font-medium text-gray-400">Quality Pass Rate</th>
               <th className="px-4 py-3 text-right font-medium text-gray-400">Avg</th>
             </tr>
           </thead>
@@ -628,6 +655,8 @@ function PerRunRow({
   readOnly: boolean;
 }) {
   const avgPct = Math.round(run.avg_score * 100);
+  const qualityCount = aggregateQualityCount(run);
+  const errors = executionErrorCount(run);
   const canEdit = !readOnly;
   const tagsBtnRef = useRef<HTMLButtonElement>(null);
   const tags = run.tags ?? [];
@@ -704,7 +733,8 @@ function PerRunRow({
         <td className="px-4 py-3 align-middle text-gray-300">{run.experiment}</td>
         <td className="px-4 py-3 align-middle text-gray-300">{run.target}</td>
         <td className="px-4 py-3 align-middle text-right tabular-nums text-gray-400">
-          {run.eval_count}
+          <div>{qualityCount}</div>
+          {errors > 0 && <div className="text-xs text-amber-400">{errors} errors</div>}
         </td>
         <td className="px-4 py-3 align-middle">
           <PassRatePill rate={run.pass_rate} />
@@ -993,7 +1023,7 @@ function PerRunCompareView({
             </tr>
             <tr className="border-t border-gray-800/50 bg-gray-900/30">
               <th className="sticky left-0 z-10 bg-gray-900/80 px-4 py-2 text-xs font-medium uppercase tracking-wider text-gray-500 backdrop-blur">
-                Pass rate
+                Quality pass rate
               </th>
               {runs.map((run) => (
                 <th key={run.run_id} className="px-4 py-2">
@@ -1021,19 +1051,28 @@ function PerRunCompareView({
                   return (
                     <td key={runId} className="px-4 py-3">
                       <div className="flex items-center gap-2">
-                        <span
-                          aria-hidden
-                          className={`h-1.5 w-1.5 rounded-full ${
-                            t.passed ? 'bg-emerald-400' : 'bg-red-400'
-                          }`}
-                        />
-                        <span
-                          className={`tabular-nums ${
-                            t.passed ? 'text-emerald-400' : 'text-red-400'
-                          }`}
-                        >
-                          {Math.round(t.score * 100)}%
-                        </span>
+                        {t.execution_status === 'execution_error' ? (
+                          <>
+                            <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-amber-400" />
+                            <span className="tabular-nums text-amber-400">error</span>
+                          </>
+                        ) : (
+                          <>
+                            <span
+                              aria-hidden
+                              className={`h-1.5 w-1.5 rounded-full ${
+                                t.passed ? 'bg-emerald-400' : 'bg-red-400'
+                              }`}
+                            />
+                            <span
+                              className={`tabular-nums ${
+                                t.passed ? 'text-emerald-400' : 'text-red-400'
+                              }`}
+                            >
+                              {Math.round(t.score * 100)}%
+                            </span>
+                          </>
+                        )}
                       </div>
                     </td>
                   );

--- a/apps/dashboard/src/components/ExperimentsTab.tsx
+++ b/apps/dashboard/src/components/ExperimentsTab.tsx
@@ -9,6 +9,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 
 import { projectExperimentsOptions, useExperiments } from '~/lib/api';
+import { aggregateQualityCount, executionErrorCount } from '~/lib/result-summary';
 import type { ExperimentSummary } from '~/lib/types';
 
 import { PassRatePill } from './PassRatePill';
@@ -47,50 +48,58 @@ export function ExperimentsTab({ projectId }: ExperimentsTabProps) {
             <th className="px-4 py-3 font-medium text-gray-400">Experiment</th>
             <th className="px-4 py-3 text-right font-medium text-gray-400">Runs</th>
             <th className="px-4 py-3 text-right font-medium text-gray-400">Targets</th>
-            <th className="px-4 py-3 text-right font-medium text-gray-400">Evals</th>
-            <th className="px-4 py-3 font-medium text-gray-400">Pass Rate</th>
+            <th className="px-4 py-3 text-right font-medium text-gray-400">Quality Evals</th>
+            <th className="px-4 py-3 text-right font-medium text-gray-400">Execution Errors</th>
+            <th className="px-4 py-3 font-medium text-gray-400">Quality Pass Rate</th>
             <th className="px-4 py-3 font-medium text-gray-400">Last Run</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-800/50">
-          {experiments.map((exp: ExperimentSummary) => (
-            <tr key={exp.name} className="transition-colors hover:bg-gray-900/30">
-              <td className="px-4 py-3">
-                {projectId ? (
-                  <Link
-                    to="/projects/$projectId/experiments/$experimentName"
-                    params={{ projectId, experimentName: exp.name }}
-                    className="font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
-                  >
-                    {exp.name}
-                  </Link>
-                ) : (
-                  <Link
-                    to="/experiments/$experimentName"
-                    params={{ experimentName: exp.name }}
-                    className="font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
-                  >
-                    {exp.name}
-                  </Link>
-                )}
-              </td>
-              <td className="px-4 py-3 text-right tabular-nums text-gray-400">{exp.run_count}</td>
-              <td className="px-4 py-3 text-right tabular-nums text-gray-400">
-                {exp.target_count}
-              </td>
-              <td className="px-4 py-3 text-right tabular-nums text-gray-400">
-                <span className="text-emerald-400">{exp.passed_count}</span>
-                <span className="text-gray-600"> / </span>
-                {exp.eval_count}
-              </td>
-              <td className="px-4 py-3">
-                <PassRatePill rate={exp.pass_rate} />
-              </td>
-              <td className="px-4 py-3 text-gray-400" title={formatTimestamp(exp.last_run).full}>
-                {formatTimestamp(exp.last_run).date}
-              </td>
-            </tr>
-          ))}
+          {experiments.map((exp: ExperimentSummary) => {
+            const qualityCount = aggregateQualityCount(exp);
+            const errors = executionErrorCount(exp);
+            return (
+              <tr key={exp.name} className="transition-colors hover:bg-gray-900/30">
+                <td className="px-4 py-3">
+                  {projectId ? (
+                    <Link
+                      to="/projects/$projectId/experiments/$experimentName"
+                      params={{ projectId, experimentName: exp.name }}
+                      className="font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
+                    >
+                      {exp.name}
+                    </Link>
+                  ) : (
+                    <Link
+                      to="/experiments/$experimentName"
+                      params={{ experimentName: exp.name }}
+                      className="font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
+                    >
+                      {exp.name}
+                    </Link>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-right tabular-nums text-gray-400">{exp.run_count}</td>
+                <td className="px-4 py-3 text-right tabular-nums text-gray-400">
+                  {exp.target_count}
+                </td>
+                <td className="px-4 py-3 text-right tabular-nums text-gray-400">
+                  <span className="text-emerald-400">{exp.passed_count}</span>
+                  <span className="text-gray-600"> / </span>
+                  {qualityCount}
+                </td>
+                <td className="px-4 py-3 text-right tabular-nums text-amber-400">
+                  {errors > 0 ? errors : <span className="text-gray-600">0</span>}
+                </td>
+                <td className="px-4 py-3">
+                  <PassRatePill rate={exp.pass_rate} />
+                </td>
+                <td className="px-4 py-3 text-gray-400" title={formatTimestamp(exp.last_run).full}>
+                  {formatTimestamp(exp.last_run).date}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/apps/dashboard/src/components/ProjectCard.tsx
+++ b/apps/dashboard/src/components/ProjectCard.tsx
@@ -7,6 +7,7 @@
 
 import { Link } from '@tanstack/react-router';
 
+import { executionErrorCount } from '~/lib/result-summary';
 import type { ProjectSummary } from '~/lib/types';
 
 function formatTimeAgo(timestamp: string | null): string {
@@ -25,6 +26,7 @@ function formatTimeAgo(timestamp: string | null): string {
 
 export function ProjectCard({ project }: { project: ProjectSummary }) {
   const passPercent = Math.round(project.pass_rate * 100);
+  const errors = executionErrorCount(project);
 
   return (
     <Link
@@ -41,13 +43,13 @@ export function ProjectCard({ project }: { project: ProjectSummary }) {
         </div>
       </div>
 
-      <div className="mt-4 grid grid-cols-3 gap-3">
+      <div className="mt-4 grid grid-cols-4 gap-3">
         <div>
           <p className="text-xs text-gray-500">Runs</p>
           <p className="text-lg font-semibold text-white">{project.run_count}</p>
         </div>
         <div>
-          <p className="text-xs text-gray-500">Pass Rate</p>
+          <p className="text-xs text-gray-500">Quality</p>
           <p
             className={`text-lg font-semibold ${
               project.run_count === 0
@@ -60,6 +62,12 @@ export function ProjectCard({ project }: { project: ProjectSummary }) {
             }`}
           >
             {project.run_count > 0 ? `${passPercent}%` : '--'}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-500">Errors</p>
+          <p className={`text-lg font-semibold ${errors > 0 ? 'text-amber-300' : 'text-gray-500'}`}>
+            {errors}
           </p>
         </div>
         <div>

--- a/apps/dashboard/src/components/RunDetail.tsx
+++ b/apps/dashboard/src/components/RunDetail.tsx
@@ -18,6 +18,7 @@ import { Link } from '@tanstack/react-router';
 import type { EvalResult } from '~/lib/types';
 
 import { isPassing, useRunLog, useStudioConfig } from '~/lib/api';
+import { isExecutionError, summarizeQuality } from '~/lib/result-summary';
 import { formatCategoryDisplay } from '~/lib/run-detail-context';
 
 import { PassRatePill } from './PassRatePill';
@@ -33,6 +34,7 @@ interface SuiteStats {
   name: string;
   passed: number;
   failed: number;
+  executionErrors: number;
   total: number;
   avgScore: number;
 }
@@ -45,14 +47,12 @@ interface CategoryGroup {
   total: number;
   passed: number;
   failed: number;
+  executionErrors: number;
   avgScore: number;
 }
 
 function buildCategoryGroups(results: EvalResult[], passThreshold: number): CategoryGroup[] {
-  const categoryMap = new Map<
-    string,
-    Map<string, { passed: number; failed: number; total: number; scoreSum: number }>
-  >();
+  const categoryMap = new Map<string, Map<string, EvalResult[]>>();
 
   for (const r of results) {
     const cat = r.category ?? 'Uncategorized';
@@ -60,28 +60,33 @@ function buildCategoryGroups(results: EvalResult[], passThreshold: number): Cate
     if (!categoryMap.has(cat)) categoryMap.set(cat, new Map());
     // biome-ignore lint/style/noNonNullAssertion: map entry guaranteed by line above
     const dsMap = categoryMap.get(cat)!;
-    const entry = dsMap.get(ds) ?? { passed: 0, failed: 0, total: 0, scoreSum: 0 };
-    entry.total += 1;
-    entry.scoreSum += r.score;
-    if (isPassing(r.score, passThreshold)) entry.passed += 1;
-    else entry.failed += 1;
+    const entry = dsMap.get(ds) ?? [];
+    entry.push(r);
     dsMap.set(ds, entry);
   }
 
   return Array.from(categoryMap.entries())
     .map(([catName, dsMap]) => {
       const suites = Array.from(dsMap.entries())
-        .map(([dsName, stats]) => ({
-          name: dsName,
-          ...stats,
-          avgScore: stats.total > 0 ? stats.scoreSum / stats.total : 0,
-        }))
+        .map(([dsName, suiteResults]) => {
+          const stats = summarizeQuality(suiteResults, passThreshold);
+          return {
+            name: dsName,
+            passed: stats.passed,
+            failed: stats.failed,
+            executionErrors: stats.executionErrors,
+            total: stats.total,
+            avgScore: stats.avgScore,
+          };
+        })
         .sort((a, b) => a.name.localeCompare(b.name));
 
       const total = suites.reduce((s, d) => s + d.total, 0);
       const passed = suites.reduce((s, d) => s + d.passed, 0);
       const failed = suites.reduce((s, d) => s + d.failed, 0);
-      const scoreSum = suites.reduce((s, d) => s + d.avgScore * d.total, 0);
+      const executionErrors = suites.reduce((s, d) => s + d.executionErrors, 0);
+      const qualityTotal = total - executionErrors;
+      const scoreSum = suites.reduce((s, d) => s + d.avgScore * (d.total - d.executionErrors), 0);
 
       const display = formatCategoryDisplay(catName);
 
@@ -93,7 +98,8 @@ function buildCategoryGroups(results: EvalResult[], passThreshold: number): Cate
         total,
         passed,
         failed,
-        avgScore: total > 0 ? scoreSum / total : 0,
+        executionErrors,
+        avgScore: qualityTotal > 0 ? scoreSum / qualityTotal : 0,
       };
     })
     .sort((a, b) => a.name.localeCompare(b.name));
@@ -104,9 +110,7 @@ export function RunDetail({ results, runId, projectId }: RunDetailProps) {
   const passThreshold = config?.threshold ?? config?.pass_threshold ?? 0.8;
 
   const total = results.length;
-  const passed = results.filter((r) => isPassing(r.score, passThreshold)).length;
-  const failed = total - passed;
-  const passRate = total > 0 ? passed / total : 0;
+  const summary = summarizeQuality(results, passThreshold);
   const totalCost = results.reduce((sum, r) => sum + (r.costUsd ?? 0), 0);
 
   const categories = buildCategoryGroups(results, passThreshold);
@@ -127,9 +131,10 @@ export function RunDetail({ results, runId, projectId }: RunDetailProps) {
     <div className="space-y-6">
       <StatsCards
         total={total}
-        passed={passed}
-        failed={failed}
-        passRate={passRate}
+        passed={summary.passed}
+        failed={summary.failed}
+        passRate={summary.passRate}
+        executionErrors={summary.executionErrors}
         totalCost={totalCost > 0 ? totalCost : undefined}
       />
 
@@ -141,9 +146,14 @@ export function RunDetail({ results, runId, projectId }: RunDetailProps) {
             <thead className="border-b border-gray-800 bg-gray-900/50">
               <tr>
                 <th className="px-4 py-2.5 font-medium text-gray-400">Category</th>
-                <th className="px-4 py-2.5 font-medium text-gray-400">Pass Rate</th>
+                <th className="px-4 py-2.5 font-medium text-gray-400">Quality Pass Rate</th>
                 <th className="px-4 py-2.5 text-right font-medium text-gray-400">Passed</th>
-                <th className="px-4 py-2.5 text-right font-medium text-gray-400">Failed</th>
+                <th className="px-4 py-2.5 text-right font-medium text-gray-400">
+                  Quality Failures
+                </th>
+                <th className="px-4 py-2.5 text-right font-medium text-gray-400">
+                  Execution Errors
+                </th>
                 <th className="px-4 py-2.5 text-right font-medium text-gray-400">Total</th>
               </tr>
             </thead>
@@ -187,13 +197,26 @@ export function RunDetail({ results, runId, projectId }: RunDetailProps) {
                       )}
                     </td>
                     <td className="px-4 py-2.5">
-                      <PassRatePill rate={cat.total > 0 ? cat.passed / cat.total : 0} />
+                      <PassRatePill
+                        rate={
+                          cat.total - cat.executionErrors > 0
+                            ? cat.passed / (cat.total - cat.executionErrors)
+                            : 0
+                        }
+                      />
                     </td>
                     <td className="px-4 py-2.5 text-right tabular-nums text-emerald-400">
                       {cat.passed}
                     </td>
                     <td className="px-4 py-2.5 text-right tabular-nums text-red-400">
                       {cat.failed > 0 ? cat.failed : <span className="text-gray-600">0</span>}
+                    </td>
+                    <td className="px-4 py-2.5 text-right tabular-nums text-amber-400">
+                      {cat.executionErrors > 0 ? (
+                        cat.executionErrors
+                      ) : (
+                        <span className="text-gray-600">0</span>
+                      )}
                     </td>
                     <td className="px-4 py-2.5 text-right tabular-nums text-gray-400">
                       {cat.total}
@@ -216,14 +239,14 @@ export function RunDetail({ results, runId, projectId }: RunDetailProps) {
                 <th className="w-8 px-4 py-3" />
                 <th className="px-4 py-3 font-medium text-gray-400">Test ID</th>
                 <th className="px-4 py-3 font-medium text-gray-400">Target</th>
-                <th className="w-48 px-4 py-3 font-medium text-gray-400">Score</th>
+                <th className="w-48 px-4 py-3 font-medium text-gray-400">Quality Score</th>
                 <th className="px-4 py-3 text-right font-medium text-gray-400">Duration</th>
                 <th className="px-4 py-3 text-right font-medium text-gray-400">Cost</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-800/50">
               {results.map((result, idx) => {
-                const isError = result.executionStatus === 'execution_error';
+                const isError = isExecutionError(result);
                 const passing = isPassing(result.score, passThreshold);
                 return (
                   <tr
@@ -233,7 +256,7 @@ export function RunDetail({ results, runId, projectId }: RunDetailProps) {
                     {/* Status dot */}
                     <td className="px-4 py-3 text-center">
                       {isError ? (
-                        <span className="text-base font-bold text-red-400">!</span>
+                        <span className="text-base font-bold text-amber-400">!</span>
                       ) : (
                         <span
                           className={`text-base font-bold ${passing ? 'text-emerald-400' : 'text-red-400'}`}
@@ -264,8 +287,8 @@ export function RunDetail({ results, runId, projectId }: RunDetailProps) {
                     <td className="px-4 py-3 text-gray-400">{result.target ?? '-'}</td>
                     <td className="px-4 py-3">
                       {isError ? (
-                        <span className="inline-flex rounded-full bg-red-900/50 px-2 py-0.5 text-xs font-medium text-red-400">
-                          ERR
+                        <span className="inline-flex rounded-full bg-amber-900/40 px-2 py-0.5 text-xs font-medium text-amber-300">
+                          Execution error
                         </span>
                       ) : (
                         <PassRatePill rate={result.score} />

--- a/apps/dashboard/src/components/RunList.tsx
+++ b/apps/dashboard/src/components/RunList.tsx
@@ -2,7 +2,7 @@
  * Sortable run table component.
  *
  * Displays all available runs with a pass/fail status dot, human-readable name,
- * source badge, date, test count, and coloured pass-rate pill.
+ * source badge, date, quality test count, execution-error count, and coloured pass-rate pill.
  * Clicking a row navigates to the run detail view.
  *
  * In-progress runs (status `starting` / `running`, surfaced by the backend
@@ -25,6 +25,7 @@ import {
   deleteRunApi,
   useStudioConfig,
 } from '~/lib/api';
+import { executionErrorCount } from '~/lib/result-summary';
 import { formatRunLabel } from '~/lib/run-label';
 import {
   buildCombineSuccessMessage,
@@ -334,21 +335,24 @@ export function RunList({
               <th className="w-8 px-4 py-3" />
               <th className="px-4 py-3 font-medium text-gray-400">Run</th>
               <th className="px-4 py-3 font-medium text-gray-400">Source</th>
-              <th className="px-4 py-3 text-right font-medium text-gray-400">Passed</th>
-              <th className="px-4 py-3 text-right font-medium text-gray-400">Failed</th>
-              <th className="px-4 py-3 text-right font-medium text-gray-400">Total</th>
-              <th className="px-4 py-3 font-medium text-gray-400">Pass Rate</th>
+              <th className="px-4 py-3 text-right font-medium text-gray-400">Quality Passed</th>
+              <th className="px-4 py-3 text-right font-medium text-gray-400">Quality Failures</th>
+              <th className="px-4 py-3 text-right font-medium text-gray-400">Errors</th>
+              <th className="px-4 py-3 text-right font-medium text-gray-400">Quality Total</th>
+              <th className="px-4 py-3 font-medium text-gray-400">Quality Pass Rate</th>
               <th className="px-4 py-3 font-medium text-gray-400">When</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-800/50">
             {runs.map((run) => {
               const ts = formatDate(run.timestamp);
-              const passing = run.pass_rate >= passThreshold;
               const isActive = run.status === 'starting' || run.status === 'running';
               const label = formatRunLabel(run);
-              const passedCount = Math.round(run.pass_rate * run.test_count);
-              const failedCount = run.test_count - passedCount;
+              const errors = executionErrorCount(run);
+              const qualityCount = Math.max(0, run.test_count - errors);
+              const passing = qualityCount > 0 ? run.pass_rate >= passThreshold : errors === 0;
+              const passedCount = Math.round(run.pass_rate * qualityCount);
+              const failedCount = qualityCount - passedCount;
               const selectionDisabledReason = runSelectionDisabledReason(run);
               const selectable =
                 !selectionDisabledReason && selectableRunIds.includes(run.filename);
@@ -372,7 +376,7 @@ export function RunList({
                       />
                     </td>
                   )}
-                  {/* Status dot — spinner for active runs, otherwise pass/fail */}
+                  {/* Status dot — spinner for active runs, otherwise quality pass/fail. */}
                   <td className="px-4 py-3 text-center">
                     {isActive ? (
                       <span
@@ -380,6 +384,10 @@ export function RunList({
                         title={run.status === 'starting' ? 'Starting…' : 'Running…'}
                         aria-label={run.status === 'starting' ? 'Starting' : 'Running'}
                       />
+                    ) : qualityCount === 0 && errors > 0 ? (
+                      <span className="text-base font-bold text-amber-300" title="Execution errors">
+                        !
+                      </span>
                     ) : (
                       <span
                         className={`text-base font-bold ${passing ? 'text-emerald-400' : 'text-red-400'}`}
@@ -440,8 +448,15 @@ export function RunList({
                   <td className="px-4 py-3 text-right tabular-nums text-red-400">
                     {failedCount > 0 ? failedCount : <span className="text-gray-600">0</span>}
                   </td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    {errors > 0 ? (
+                      <span className="text-amber-300">{errors}</span>
+                    ) : (
+                      <span className="text-gray-600">0</span>
+                    )}
+                  </td>
                   <td className="px-4 py-3 text-right tabular-nums text-gray-400">
-                    {run.test_count}
+                    {qualityCount}
                   </td>
 
                   {/* Pass rate pill */}
@@ -459,7 +474,7 @@ export function RunList({
             {(hasNextPage || isFetchingNextPage) && (
               <tr ref={sentinelRef}>
                 <td
-                  colSpan={enableCombine ? 9 : 8}
+                  colSpan={enableCombine ? 10 : 9}
                   className="px-4 py-3 text-center text-xs text-gray-500"
                 >
                   {isFetchingNextPage ? 'Loading more runs…' : 'Scroll to load more…'}

--- a/apps/dashboard/src/components/StatsCards.tsx
+++ b/apps/dashboard/src/components/StatsCards.tsx
@@ -1,7 +1,8 @@
 /**
  * Overview stat bar for a run — compact inline layout matching table width.
  *
- * Shows: pass rate, passed, failed, total (and optional cost) in a single row.
+ * Shows: quality pass rate, passed, quality failures, execution errors, total
+ * (and optional cost) in a single row.
  */
 
 interface StatsCardsProps {
@@ -9,19 +10,30 @@ interface StatsCardsProps {
   passed: number;
   failed: number;
   passRate: number;
+  executionErrors?: number;
   totalCost?: number;
 }
 
-export function StatsCards({ total, passed, failed, passRate, totalCost }: StatsCardsProps) {
+export function StatsCards({
+  total,
+  passed,
+  failed,
+  passRate,
+  executionErrors = 0,
+  totalCost,
+}: StatsCardsProps) {
   const pct = Math.round(passRate * 100);
   const rateColor = pct >= 80 ? 'text-cyan-400' : pct >= 60 ? 'text-amber-400' : 'text-red-400';
 
   return (
     <div className="flex flex-wrap items-center gap-6 rounded-lg border border-gray-800 bg-gray-900/60 px-5 py-3">
-      <Stat label="Pass Rate" value={`${pct}%`} accent={rateColor} large />
+      <Stat label="Quality Pass Rate" value={`${pct}%`} accent={rateColor} large />
       <div className="h-6 w-px bg-gray-700" />
       <Stat label="Passed" value={String(passed)} accent="text-emerald-400" />
-      <Stat label="Failed" value={String(failed)} accent="text-red-400" />
+      <Stat label="Quality Failures" value={String(failed)} accent="text-red-400" />
+      {executionErrors > 0 && (
+        <Stat label="Execution Errors" value={String(executionErrors)} accent="text-amber-400" />
+      )}
       <Stat label="Total" value={String(total)} />
       {totalCost !== undefined && (
         <>

--- a/apps/dashboard/src/components/TargetsTab.tsx
+++ b/apps/dashboard/src/components/TargetsTab.tsx
@@ -15,6 +15,7 @@ import {
   runListOptions,
   targetsOptions,
 } from '~/lib/api';
+import { aggregateQualityCount, executionErrorCount } from '~/lib/result-summary';
 import { dedupeSyncedRuns } from '~/lib/run-dedupe';
 import type { RunMeta, TargetsResponse } from '~/lib/types';
 
@@ -30,7 +31,9 @@ interface ExperimentRunGroup {
   runs: RunMeta[];
   latestTimestamp: string | null;
   evalCount: number;
+  qualityCount: number;
   passedCount: number;
+  executionErrorCount: number;
   passRate: number;
 }
 
@@ -112,38 +115,46 @@ export function TargetsTab({ projectId }: TargetsTabProps = {}) {
               <th className="px-4 py-3 font-medium text-gray-400">Target</th>
               <th className="px-4 py-3 text-right font-medium text-gray-400">Runs</th>
               <th className="px-4 py-3 text-right font-medium text-gray-400">Experiments</th>
-              <th className="px-4 py-3 font-medium text-gray-400">Pass Rate</th>
-              <th className="px-4 py-3 text-right font-medium text-gray-400">Evals</th>
+              <th className="px-4 py-3 font-medium text-gray-400">Quality Pass Rate</th>
+              <th className="px-4 py-3 text-right font-medium text-gray-400">Quality Evals</th>
+              <th className="px-4 py-3 text-right font-medium text-gray-400">Execution Errors</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-800/50">
-            {targets.map((target) => (
-              <tr key={target.name} className="transition-colors hover:bg-gray-900/30">
-                <td className="px-4 py-3">
-                  <button
-                    type="button"
-                    onClick={() => setSelectedTargetName(target.name)}
-                    className="font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
-                  >
-                    {target.name}
-                  </button>
-                </td>
-                <td className="px-4 py-3 text-right tabular-nums text-gray-400">
-                  {target.run_count}
-                </td>
-                <td className="px-4 py-3 text-right tabular-nums text-gray-400">
-                  {target.experiment_count}
-                </td>
-                <td className="px-4 py-3">
-                  <PassRatePill rate={target.pass_rate} />
-                </td>
-                <td className="px-4 py-3 text-right tabular-nums text-gray-400">
-                  <span className="text-emerald-400">{target.passed_count}</span>
-                  <span className="text-gray-600"> / </span>
-                  <span>{target.eval_count}</span>
-                </td>
-              </tr>
-            ))}
+            {targets.map((target) => {
+              const qualityCount = aggregateQualityCount(target);
+              const errors = executionErrorCount(target);
+              return (
+                <tr key={target.name} className="transition-colors hover:bg-gray-900/30">
+                  <td className="px-4 py-3">
+                    <button
+                      type="button"
+                      onClick={() => setSelectedTargetName(target.name)}
+                      className="font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
+                    >
+                      {target.name}
+                    </button>
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums text-gray-400">
+                    {target.run_count}
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums text-gray-400">
+                    {target.experiment_count}
+                  </td>
+                  <td className="px-4 py-3">
+                    <PassRatePill rate={target.pass_rate} />
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums text-gray-400">
+                    <span className="text-emerald-400">{target.passed_count}</span>
+                    <span className="text-gray-600"> / </span>
+                    <span>{qualityCount}</span>
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums text-amber-400">
+                    {errors > 0 ? errors : <span className="text-gray-600">0</span>}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>
@@ -170,7 +181,12 @@ export function TargetsTab({ projectId }: TargetsTabProps = {}) {
                 {selectedTarget.experiment_count === 1 ? '' : 's'} &middot;{' '}
                 <span className="text-emerald-400">{selectedTarget.passed_count}</span>
                 <span className="text-gray-600"> / </span>
-                {selectedTarget.eval_count} evals passed
+                {aggregateQualityCount(selectedTarget)} quality evals passed
+                {executionErrorCount(selectedTarget) > 0 && (
+                  <span className="ml-2 text-amber-400">
+                    &middot; {executionErrorCount(selectedTarget)} execution errors
+                  </span>
+                )}
               </p>
             </div>
             <div className="w-full max-w-52">
@@ -200,7 +216,12 @@ export function TargetsTab({ projectId }: TargetsTabProps = {}) {
                     {group.runs.length} run{group.runs.length === 1 ? '' : 's'} &middot;{' '}
                     <span className="text-emerald-400">{group.passedCount}</span>
                     <span className="text-gray-600"> / </span>
-                    {group.evalCount} evals passed
+                    {group.qualityCount} quality evals passed
+                    {group.executionErrorCount > 0 && (
+                      <span className="ml-2 text-amber-400">
+                        &middot; {group.executionErrorCount} execution errors
+                      </span>
+                    )}
                     {group.latestTimestamp && (
                       <span className="ml-2 text-gray-500">
                         &middot; Last run {formatTimestamp(group.latestTimestamp)}
@@ -223,12 +244,18 @@ export function TargetsTab({ projectId }: TargetsTabProps = {}) {
 
 function buildExperimentGroup(name: string, runs: RunMeta[]): ExperimentRunGroup {
   let evalCount = 0;
+  let qualityCount = 0;
   let passedCount = 0;
+  let executionErrorTotal = 0;
   let latestTimestamp: string | null = null;
 
   for (const run of runs) {
+    const runExecutionErrors = executionErrorCount(run);
+    const runQualityCount = Math.max(0, run.test_count - runExecutionErrors);
     evalCount += run.test_count;
-    passedCount += Math.round(run.pass_rate * run.test_count);
+    qualityCount += runQualityCount;
+    executionErrorTotal += runExecutionErrors;
+    passedCount += Math.round(run.pass_rate * runQualityCount);
     if (run.timestamp && (!latestTimestamp || run.timestamp > latestTimestamp)) {
       latestTimestamp = run.timestamp;
     }
@@ -239,8 +266,10 @@ function buildExperimentGroup(name: string, runs: RunMeta[]): ExperimentRunGroup
     runs,
     latestTimestamp,
     evalCount,
+    qualityCount,
     passedCount,
-    passRate: evalCount > 0 ? passedCount / evalCount : 0,
+    executionErrorCount: executionErrorTotal,
+    passRate: qualityCount > 0 ? passedCount / qualityCount : 0,
   };
 }
 

--- a/apps/dashboard/src/lib/result-summary.test.ts
+++ b/apps/dashboard/src/lib/result-summary.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test';
+
+import { aggregateQualityCount, executionErrorCount, summarizeQuality } from './result-summary';
+
+describe('result-summary', () => {
+  it('summarizes quality results separately from execution errors', () => {
+    const summary = summarizeQuality(
+      [
+        { score: 1, executionStatus: 'ok' },
+        { score: 0.2, executionStatus: 'quality_failure' },
+        { score: 0, executionStatus: 'execution_error' },
+      ],
+      0.8,
+    );
+
+    expect(summary).toEqual({
+      total: 3,
+      qualityTotal: 2,
+      passed: 1,
+      failed: 1,
+      executionErrors: 1,
+      passRate: 0.5,
+      avgScore: 0.6,
+    });
+  });
+
+  it('derives aggregate quality counts from snake_case API counters', () => {
+    expect(
+      aggregateQualityCount({
+        eval_count: 5,
+        execution_error_count: 2,
+      }),
+    ).toBe(3);
+    expect(executionErrorCount({ execution_error_count: 2 })).toBe(2);
+  });
+});

--- a/apps/dashboard/src/lib/result-summary.ts
+++ b/apps/dashboard/src/lib/result-summary.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared result-summary helpers for Dashboard views.
+ *
+ * AgentV result rows use `executionStatus` to separate rows that reached
+ * quality grading from rows that failed during execution. Use these helpers
+ * anywhere the UI shows pass rates, average scores, or failure counts so
+ * execution errors are visible but do not depress quality metrics.
+ */
+
+export interface ResultSummaryInput {
+  readonly score: number;
+  readonly executionStatus?: string;
+}
+
+export interface QualitySummary {
+  readonly total: number;
+  readonly qualityTotal: number;
+  readonly passed: number;
+  readonly failed: number;
+  readonly executionErrors: number;
+  readonly passRate: number;
+  readonly avgScore: number;
+}
+
+export function isExecutionError(result: ResultSummaryInput): boolean {
+  return result.executionStatus === 'execution_error';
+}
+
+export function summarizeQuality(
+  results: readonly ResultSummaryInput[],
+  passThreshold: number,
+): QualitySummary {
+  let qualityTotal = 0;
+  let passed = 0;
+  let executionErrors = 0;
+  let scoreSum = 0;
+
+  for (const result of results) {
+    if (isExecutionError(result)) {
+      executionErrors++;
+      continue;
+    }
+
+    qualityTotal++;
+    scoreSum += result.score;
+    if (result.score >= passThreshold) {
+      passed++;
+    }
+  }
+
+  const failed = qualityTotal - passed;
+  return {
+    total: results.length,
+    qualityTotal,
+    passed,
+    failed,
+    executionErrors,
+    passRate: qualityTotal > 0 ? passed / qualityTotal : 0,
+    avgScore: qualityTotal > 0 ? scoreSum / qualityTotal : 0,
+  };
+}
+
+export function executionErrorCount(value: { execution_error_count?: number }): number {
+  return value.execution_error_count ?? 0;
+}
+
+export function qualityTotal(value: { total: number; execution_error_count?: number }): number {
+  return Math.max(0, value.total - executionErrorCount(value));
+}
+
+export function aggregateQualityCount(value: {
+  readonly eval_count: number;
+  readonly quality_count?: number;
+  readonly execution_error_count?: number;
+}): number {
+  return value.quality_count ?? Math.max(0, value.eval_count - executionErrorCount(value));
+}

--- a/apps/dashboard/src/lib/types.ts
+++ b/apps/dashboard/src/lib/types.ts
@@ -13,6 +13,7 @@ export interface RunMeta {
   test_count: number;
   pass_rate: number;
   avg_score: number;
+  execution_error_count?: number;
   size_bytes: number;
   target?: string;
   experiment?: string;
@@ -106,6 +107,7 @@ export interface SuiteSummary {
   passed: number;
   failed: number;
   avg_score: number;
+  execution_error_count?: number;
 }
 
 export interface SuitesResponse {
@@ -123,6 +125,7 @@ export interface IndexEntry {
   test_count: number;
   pass_rate: number;
   avg_score: number;
+  execution_error_count?: number;
   total_cost_usd: number;
   timestamp: string;
 }
@@ -146,7 +149,9 @@ export interface ExperimentSummary {
   run_count: number;
   target_count: number;
   eval_count: number;
+  quality_count?: number;
   passed_count: number;
+  execution_error_count?: number;
   pass_rate: number;
   last_run: string;
 }
@@ -166,7 +171,9 @@ export interface CompareCell {
   experiment: string;
   target: string;
   eval_count: number;
+  quality_count?: number;
   passed_count: number;
+  execution_error_count?: number;
   pass_rate: number;
   avg_score: number;
   tests: CompareTestResult[];
@@ -195,7 +202,9 @@ export interface CompareRunEntry {
   metadata_dirty?: boolean;
   source: 'local' | 'remote';
   eval_count: number;
+  quality_count?: number;
   passed_count: number;
+  execution_error_count?: number;
   pass_rate: number;
   avg_score: number;
   tests: CompareTestResult[];
@@ -244,6 +253,8 @@ export interface TargetSummary {
   pass_rate: number;
   passed_count: number;
   eval_count: number;
+  quality_count?: number;
+  execution_error_count?: number;
 }
 
 export interface TargetsResponse {
@@ -272,6 +283,7 @@ export interface CategorySummary {
   passed: number;
   failed: number;
   avg_score: number;
+  execution_error_count?: number;
   suite_count: number;
 }
 
@@ -335,6 +347,7 @@ export interface ProjectSummary {
   last_opened_at: string;
   run_count: number;
   pass_rate: number;
+  execution_error_count?: number;
   last_run: string | null;
 }
 

--- a/apps/dashboard/src/routes/projects/$projectId_/runs/$runId_.category.$category.tsx
+++ b/apps/dashboard/src/routes/projects/$projectId_/runs/$runId_.category.$category.tsx
@@ -8,6 +8,7 @@ import { Link, createFileRoute } from '@tanstack/react-router';
 import { ScoreBar } from '~/components/ScoreBar';
 import { StatsCards } from '~/components/StatsCards';
 import { projectCategorySuitesOptions } from '~/lib/api';
+import { executionErrorCount, qualityTotal } from '~/lib/result-summary';
 
 export const Route = createFileRoute('/projects/$projectId_/runs/$runId_/category/$category')({
   component: ProjectCategoryPage,
@@ -43,8 +44,10 @@ function ProjectCategoryPage() {
   const suites = data?.suites ?? [];
   const total = suites.reduce((sum, suite) => sum + suite.total, 0);
   const passed = suites.reduce((sum, suite) => sum + suite.passed, 0);
-  const failed = total - passed;
-  const passRate = total > 0 ? passed / total : 0;
+  const failed = suites.reduce((sum, suite) => sum + suite.failed, 0);
+  const executionErrors = suites.reduce((sum, suite) => sum + executionErrorCount(suite), 0);
+  const qualityCount = total - executionErrors;
+  const passRate = qualityCount > 0 ? passed / qualityCount : 0;
 
   return (
     <div className="space-y-6">
@@ -53,7 +56,13 @@ function ProjectCategoryPage() {
         <p className="mt-1 text-sm text-gray-400">Category in run: {runId}</p>
       </div>
 
-      <StatsCards total={total} passed={passed} failed={failed} passRate={passRate} />
+      <StatsCards
+        total={total}
+        passed={passed}
+        failed={failed}
+        passRate={passRate}
+        executionErrors={executionErrors}
+      />
 
       {suites.length === 0 ? (
         <div className="rounded-lg border border-gray-800 bg-gray-900 p-8 text-center">
@@ -73,7 +82,7 @@ function ProjectCategoryPage() {
                 <div className="flex items-center justify-between">
                   <span className="truncate text-sm font-medium text-gray-200">{suite.name}</span>
                   <span className="ml-2 text-xs text-gray-500">
-                    {suite.passed}/{suite.total}
+                    {suite.passed}/{qualityTotal(suite)}
                   </span>
                 </div>
                 <div className="mt-2">
@@ -82,6 +91,11 @@ function ProjectCategoryPage() {
                 <div className="mt-1 flex gap-3 text-xs">
                   <span className="text-emerald-400">{suite.passed} passed</span>
                   {suite.failed > 0 && <span className="text-red-400">{suite.failed} failed</span>}
+                  {executionErrorCount(suite) > 0 && (
+                    <span className="text-amber-400">
+                      {executionErrorCount(suite)} execution errors
+                    </span>
+                  )}
                 </div>
               </Link>
             ))}

--- a/apps/dashboard/src/routes/projects/$projectId_/runs/$runId_.suite.$suite.tsx
+++ b/apps/dashboard/src/routes/projects/$projectId_/runs/$runId_.suite.$suite.tsx
@@ -6,7 +6,8 @@ import { Link, createFileRoute } from '@tanstack/react-router';
 
 import { PassRatePill } from '~/components/PassRatePill';
 import { StatsCards } from '~/components/StatsCards';
-import { isPassing, useProjectRunDetail, useStudioConfig } from '~/lib/api';
+import { useProjectRunDetail, useStudioConfig } from '~/lib/api';
+import { isExecutionError, summarizeQuality } from '~/lib/result-summary';
 
 export const Route = createFileRoute('/projects/$projectId_/runs/$runId_/suite/$suite')({
   component: ProjectSuitePage,
@@ -43,9 +44,7 @@ function ProjectSuitePage() {
     (result) => (result.suite ?? 'Uncategorized') === suite,
   );
   const total = results.length;
-  const passed = results.filter((result) => isPassing(result.score, passThreshold)).length;
-  const failed = total - passed;
-  const passRate = total > 0 ? passed / total : 0;
+  const summary = summarizeQuality(results, passThreshold);
   const totalCost = results.reduce((sum, result) => sum + (result.costUsd ?? 0), 0);
 
   return (
@@ -57,9 +56,10 @@ function ProjectSuitePage() {
 
       <StatsCards
         total={total}
-        passed={passed}
-        failed={failed}
-        passRate={passRate}
+        passed={summary.passed}
+        failed={summary.failed}
+        passRate={summary.passRate}
+        executionErrors={summary.executionErrors}
         totalCost={totalCost > 0 ? totalCost : undefined}
       />
 
@@ -74,7 +74,7 @@ function ProjectSuitePage() {
               <tr>
                 <th className="px-4 py-3 font-medium text-gray-400">Test ID</th>
                 <th className="px-4 py-3 font-medium text-gray-400">Target</th>
-                <th className="w-48 px-4 py-3 font-medium text-gray-400">Score</th>
+                <th className="w-48 px-4 py-3 font-medium text-gray-400">Quality Score</th>
                 <th className="px-4 py-3 text-right font-medium text-gray-400">Duration</th>
                 <th className="px-4 py-3 text-right font-medium text-gray-400">Cost</th>
               </tr>
@@ -96,9 +96,9 @@ function ProjectSuitePage() {
                   </td>
                   <td className="px-4 py-3 text-gray-400">{result.target ?? '-'}</td>
                   <td className="px-4 py-3">
-                    {result.executionStatus === 'execution_error' ? (
-                      <span className="inline-flex rounded-full bg-red-900/50 px-2 py-0.5 text-xs font-medium text-red-400">
-                        ERR
+                    {isExecutionError(result) ? (
+                      <span className="inline-flex rounded-full bg-amber-900/40 px-2 py-0.5 text-xs font-medium text-amber-300">
+                        Execution error
                       </span>
                     ) : (
                       <PassRatePill rate={result.score} />

--- a/apps/dashboard/src/routes/runs/$runId_.category.$category.tsx
+++ b/apps/dashboard/src/routes/runs/$runId_.category.$category.tsx
@@ -11,6 +11,7 @@ import { Link, createFileRoute } from '@tanstack/react-router';
 import { ScoreBar } from '~/components/ScoreBar';
 import { StatsCards } from '~/components/StatsCards';
 import { useCategorySuites } from '~/lib/api';
+import { executionErrorCount, qualityTotal } from '~/lib/result-summary';
 
 export const Route = createFileRoute('/runs/$runId_/category/$category')({
   component: CategoryPage,
@@ -44,8 +45,10 @@ function CategoryPage() {
   const suites = data?.suites ?? [];
   const total = suites.reduce((s, d) => s + d.total, 0);
   const passed = suites.reduce((s, d) => s + d.passed, 0);
-  const failed = total - passed;
-  const passRate = total > 0 ? passed / total : 0;
+  const failed = suites.reduce((s, d) => s + d.failed, 0);
+  const executionErrors = suites.reduce((s, d) => s + executionErrorCount(d), 0);
+  const qualityCount = total - executionErrors;
+  const passRate = qualityCount > 0 ? passed / qualityCount : 0;
 
   return (
     <div className="space-y-6">
@@ -54,7 +57,13 @@ function CategoryPage() {
         <p className="mt-1 text-sm text-gray-400">Category in run: {runId}</p>
       </div>
 
-      <StatsCards total={total} passed={passed} failed={failed} passRate={passRate} />
+      <StatsCards
+        total={total}
+        passed={passed}
+        failed={failed}
+        passRate={passRate}
+        executionErrors={executionErrors}
+      />
 
       {suites.length === 0 ? (
         <div className="rounded-lg border border-gray-800 bg-gray-900 p-8 text-center">
@@ -74,7 +83,7 @@ function CategoryPage() {
                 <div className="flex items-center justify-between">
                   <span className="text-sm font-medium text-gray-200 truncate">{ds.name}</span>
                   <span className="ml-2 text-xs text-gray-500">
-                    {ds.passed}/{ds.total}
+                    {ds.passed}/{qualityTotal(ds)}
                   </span>
                 </div>
                 <div className="mt-2">
@@ -83,6 +92,11 @@ function CategoryPage() {
                 <div className="mt-1 flex gap-3 text-xs">
                   <span className="text-emerald-400">{ds.passed} passed</span>
                   {ds.failed > 0 && <span className="text-red-400">{ds.failed} failed</span>}
+                  {executionErrorCount(ds) > 0 && (
+                    <span className="text-amber-400">
+                      {executionErrorCount(ds)} execution errors
+                    </span>
+                  )}
                 </div>
               </Link>
             ))}

--- a/apps/dashboard/src/routes/runs/$runId_.suite.$suite.tsx
+++ b/apps/dashboard/src/routes/runs/$runId_.suite.$suite.tsx
@@ -10,7 +10,8 @@ import { Link, createFileRoute } from '@tanstack/react-router';
 
 import { PassRatePill } from '~/components/PassRatePill';
 import { StatsCards } from '~/components/StatsCards';
-import { isPassing, useRunDetail, useStudioConfig } from '~/lib/api';
+import { useRunDetail, useStudioConfig } from '~/lib/api';
+import { isExecutionError, summarizeQuality } from '~/lib/result-summary';
 
 export const Route = createFileRoute('/runs/$runId_/suite/$suite')({
   component: SuitePage,
@@ -45,9 +46,7 @@ function SuitePage() {
 
   const results = (data?.results ?? []).filter((r) => (r.suite ?? 'Uncategorized') === suite);
   const total = results.length;
-  const passed = results.filter((r) => isPassing(r.score, passThreshold)).length;
-  const failed = total - passed;
-  const passRate = total > 0 ? passed / total : 0;
+  const summary = summarizeQuality(results, passThreshold);
   const totalCost = results.reduce((sum, r) => sum + (r.costUsd ?? 0), 0);
 
   return (
@@ -59,9 +58,10 @@ function SuitePage() {
 
       <StatsCards
         total={total}
-        passed={passed}
-        failed={failed}
-        passRate={passRate}
+        passed={summary.passed}
+        failed={summary.failed}
+        passRate={summary.passRate}
+        executionErrors={summary.executionErrors}
         totalCost={totalCost > 0 ? totalCost : undefined}
       />
 
@@ -76,7 +76,7 @@ function SuitePage() {
               <tr>
                 <th className="px-4 py-3 font-medium text-gray-400">Test ID</th>
                 <th className="px-4 py-3 font-medium text-gray-400">Target</th>
-                <th className="w-48 px-4 py-3 font-medium text-gray-400">Score</th>
+                <th className="w-48 px-4 py-3 font-medium text-gray-400">Quality Score</th>
                 <th className="px-4 py-3 text-right font-medium text-gray-400">Duration</th>
                 <th className="px-4 py-3 text-right font-medium text-gray-400">Cost</th>
               </tr>
@@ -98,9 +98,9 @@ function SuitePage() {
                   </td>
                   <td className="px-4 py-3 text-gray-400">{result.target ?? '-'}</td>
                   <td className="px-4 py-3">
-                    {result.executionStatus === 'execution_error' ? (
-                      <span className="inline-flex rounded-full px-2 py-0.5 text-xs font-medium bg-red-900/50 text-red-400">
-                        ERR
+                    {isExecutionError(result) ? (
+                      <span className="inline-flex rounded-full bg-amber-900/40 px-2 py-0.5 text-xs font-medium text-amber-300">
+                        Execution error
                       </span>
                     ) : (
                       <PassRatePill rate={result.score} />

--- a/packages/core/src/evaluation/evaluate.ts
+++ b/packages/core/src/evaluation/evaluate.ts
@@ -224,13 +224,15 @@ export interface MaterializedEvalConfig {
 export interface EvalSummary {
   /** Total number of test cases */
   readonly total: number;
-  /** Number of passing test cases (score >= threshold) */
+  /** Number of non-execution-error test cases whose score is >= threshold */
   readonly passed: number;
-  /** Number of failing test cases (score < threshold) */
+  /** Number of non-execution-error test cases whose score is < threshold */
   readonly failed: number;
+  /** Number of test cases that failed before quality could be evaluated */
+  readonly executionErrors: number;
   /** Total duration in milliseconds */
   readonly durationMs: number;
-  /** Mean score across all cases */
+  /** Mean score across non-execution-error cases */
   readonly meanScore: number;
 }
 
@@ -609,10 +611,12 @@ function computeSummary(
   threshold = DEFAULT_THRESHOLD,
 ): EvalSummary {
   const total = results.length;
+  const qualityResults = results.filter((r) => r.executionStatus !== 'execution_error');
+  const executionErrors = total - qualityResults.length;
   let passed = 0;
   let scoreSum = 0;
 
-  for (const r of results) {
+  for (const r of qualityResults) {
     scoreSum += r.score;
     if (r.score >= threshold) {
       passed++;
@@ -622,9 +626,10 @@ function computeSummary(
   return {
     total,
     passed,
-    failed: total - passed,
+    failed: qualityResults.length - passed,
+    executionErrors,
     durationMs,
-    meanScore: total > 0 ? scoreSum / total : 0,
+    meanScore: qualityResults.length > 0 ? scoreSum / qualityResults.length : 0,
   };
 }
 

--- a/packages/core/test/evaluation/evaluate-programmatic-api.test.ts
+++ b/packages/core/test/evaluation/evaluate-programmatic-api.test.ts
@@ -37,6 +37,44 @@ describe('evaluate() — programmatic API extensions', () => {
     PROGRAMMATIC_API_TIMEOUT_MS,
   );
 
+  it(
+    'excludes execution errors from quality summary counts',
+    async () => {
+      const { results, summary } = await evaluate({
+        tests: [
+          {
+            id: 'quality-pass',
+            input: 'ok',
+            assert: [{ type: 'contains', value: 'task ok' }],
+          },
+          {
+            id: 'provider-error',
+            input: 'explode',
+            assert: [{ type: 'contains', value: 'task ok' }],
+          },
+        ],
+        task: async (input) => {
+          if (input === 'explode') {
+            throw new Error('provider unavailable');
+          }
+          return 'task ok';
+        },
+        maxRetries: 0,
+      });
+
+      expect(results.map((result) => result.executionStatus).sort()).toEqual([
+        'execution_error',
+        'ok',
+      ]);
+      expect(summary.total).toBe(2);
+      expect(summary.passed).toBe(1);
+      expect(summary.failed).toBe(0);
+      expect(summary.executionErrors).toBe(1);
+      expect(summary.meanScore).toBe(1);
+    },
+    PROGRAMMATIC_API_TIMEOUT_MS,
+  );
+
   // ---------------------------------------------------------------------------
   // response cache
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Keep execution errors out of quality pass-rate / average-score calculations in benchmark artifacts, programmatic `evaluate()` summaries, Dashboard APIs, and Dashboard aggregate views.
- Add Dashboard display semantics for execution errors: quality pass-rate labels, separate execution-error counters, and amber execution-error row badges.
- Preserve existing result primitives (`execution_status`, `failure_stage`, `failure_reason_code`, `execution_error`) and add only optional snake_case API counters such as `execution_error_count` / `quality_count`.

## Existing Primitive Audit

Existing primitives already separated status at the row level: `executionStatus` / `execution_status`, failure stage/reason fields, JUnit `<error>` handling, CLI retry-error selection, and CLI summary semantics. The fix therefore changes aggregate consumers that were still treating every row as a quality row instead of adding a new status model.

## Execution-Error Frequency Counts

Command used: `bun /tmp/agentv-goc2-frequency.ts`

Row filter: JSONL rows with `test_id` and either `score` or `execution_status`. Full evidence: `/home/entity/projects/EntityProcess/agentv-assets-private/dogfood/av-goc-2-execution-errors/execution-error-frequency-counts.json` in private evidence repo commit `fdd8e44`.

| Repository | Result rows | Execution errors | Rate | Dominant error |
| --- | ---: | ---: | ---: | --- |
| agentv-examples-eval-results | 47 | 1 | 2.1% | `agent/provider_error` |
| financial-research-agent-evals | 2 | 0 | 0.0% | none |
| swe-evals-results | 3 | 0 | 0.0% | none |
| WTG.AI.Prompts.EvalResults | 16 | 13 | 81.3% | `setup/setup_error` |
| WiseTechAcademy.EvalResults | 18 | 2 | 11.1% | `agent/provider_error` |
| Aggregate | 86 | 16 | 18.6% | mixed |

Problem URL run note: the exact run from the live URL was found in the local project copy at `/home/entity/projects/EntityProcess/financial-research-agent/.agentv/results/runs/av-h60-live-codex-azure/2026-06-05T14-11-27-119Z/index.jsonl`, not in the bead-listed result-repo aggregate. It has 1 row and 1 execution error: `failure_stage=evaluator`, `failure_reason_code=evaluator_error`, with grader parse failure after 3 attempts plus 1 structure-fix attempt ending in `pi-ai call failed: HTTP 404 Resource not found`.

## Retry Recommendation

No retry code change in this PR.

Rationale:
- `agentv eval run --retry-errors` already re-runs only `execution_error` rows and merges preserved non-error rows.
- LLM grader parsing already performs 3 standard attempts plus 1 structure-fix attempt using a repair prompt that includes the invalid response, asks to preserve evaluation meaning, avoid re-grading, and return only a single JSON object.
- The live problem run failed because the structure-fix/provider call returned HTTP 404, not because AgentV lacked the “return the previous response in correct format” recovery path.

Recommended follow-up only if this recurs: investigate grader provider endpoint/config health and possibly add provider-fallback/healthcheck behavior for structure-repair calls. That is a provider reliability task, not needed for the scoring/display semantics fix.

## Verification

- `bun run build` passed.
- `bun run typecheck` passed; pre-push hook repeated typecheck successfully.
- `bun run lint` passed; pre-push hook repeated `biome check .` successfully.
- Focused tests passed: `bun test apps/cli/test/commands/eval/artifact-writer.test.ts apps/cli/test/commands/results/serve.test.ts apps/dashboard/src/lib/result-summary.test.ts packages/core/test/evaluation/evaluate-programmatic-api.test.ts` (`135 pass`).
- Full tests passed: `bun run test`.
- Dashboard bundle rebuild passed after final frontend edits: `bun --filter @agentv/dashboard build`.

## User-Facing Evidence

Private evidence repo: `/home/entity/projects/EntityProcess/agentv-assets-private`, commit `fdd8e44`.

- Red Dashboard API evidence: `dogfood/av-goc-2-execution-errors/red-dashboard-api-origin-main.json` shows old behavior: pass rate `0.3333`, suite failed `2`, no separate execution error count.
- Green Dashboard API evidence: `dogfood/av-goc-2-execution-errors/green-dashboard-api-branch.json` shows new behavior: pass rate `0.5`, avg score `0.75`, suite failed `1`, `execution_error_count: 1`.
- Browser evidence: `dogfood/av-goc-2-execution-errors/dashboard-run-detail-green-loaded.png` and `dashboard-run-detail-green-large.png` show “Quality Pass Rate”, “Quality Failures”, “Execution Errors”, and an amber “Execution error” row badge.
- Exact problem-run summary: `dogfood/av-goc-2-execution-errors/live-problem-run-summary.json`.

## Blockers / Coordination Notes

- Agent Mail contact approval for `TurquoiseBrook` under `/home/entity/ntm_Dev/agentv` could not be completed because `respond_contact` requires that identity's registration token/auth in this MCP session. I continued implementation and documented this blocker.
- `apps/dashboard/src/components/RunDetail.tsx` had an advisory reservation conflict with `codex-goc-mobile`; I sent coordination mail and received no response before completing the narrow scoring-display edits.
