### PR TITLE
style(brand): uppercase visible AGENTV wordmark

### DIFF
--- a/apps/dashboard/src/components/BrandName.tsx
+++ b/apps/dashboard/src/components/BrandName.tsx
@@ -10,7 +10,7 @@ export function BrandName({ appName }: { appName: string }) {
       <span className="text-cyan-400" aria-hidden="true">
         A
       </span>
-      <span aria-hidden="true">gent</span>
+      <span aria-hidden="true">GENT</span>
       <span className="text-cyan-400" aria-hidden="true">
         V
       </span>

--- a/apps/web/src/components/BrandWordmark.astro
+++ b/apps/web/src/components/BrandWordmark.astro
@@ -8,7 +8,7 @@ const className = Astro.props.class;
 
 <span class:list={['av-brand-wordmark', className]} aria-label="AgentV" translate="no">
   <span class="av-brand-wordmark__letter" aria-hidden="true">A</span>
-  <span aria-hidden="true">gent</span>
+  <span aria-hidden="true">GENT</span>
   <span class="av-brand-wordmark__letter" aria-hidden="true">V</span>
 </span>
 


### PR DESCRIPTION
## Summary

The visible product wordmark now reads `AGENTV`, matching the cyan A/V treatment with an all-caps white `GENT` segment. Lowercase `agentv` command/package/path references are unchanged.

## Verification

- `bunx biome check apps/dashboard/src/components/BrandName.tsx apps/web/src/components/BrandWordmark.astro`
- `bun --filter @agentv/dashboard test`
- `bun --filter @agentv/dashboard build`
- `bun --filter @agentv/web build`
- Pre-push hook: workspace typecheck and `biome check .`

## Evidence

Screenshots for landing, docs, 404, and Dashboard were saved under `dogfood/av-goc-5-uppercase-branding/` in the private evidence repo.

Evidence commit: `agentv-assets-private@c903d365ca8553c4a5fca172d28fa4d8f3183b89`