### PR TITLE
fix(web): dedupe landing wordmark

### DIFF
--- a/apps/web/src/components/BrandWordmark.astro
+++ b/apps/web/src/components/BrandWordmark.astro
@@ -36,18 +36,6 @@ const className = Astro.props.class;
     color: var(--av-brand-letter-color, #06b6d4);
   }
 
-  .av-brand-wordmark--hero {
-    --av-brand-text-color: var(--av-text);
-    font-size: clamp(1.35rem, 3vw, 2.15rem);
-    line-height: 1;
-  }
-
-  .av-brand-wordmark--terminal {
-    --av-brand-text-color: var(--av-text-muted);
-    font-size: 0.6875rem;
-    font-weight: 600;
-  }
-
   .av-brand-wordmark--inline {
     display: inline-flex;
     font-size: inherit;

--- a/apps/web/src/components/Lander.astro
+++ b/apps/web/src/components/Lander.astro
@@ -46,7 +46,6 @@ import BrandWordmark from './BrandWordmark.astro';
     <div class="av-hero-bg"></div>
     <div class="av-hero-inner">
       <div class="av-hero-text">
-        <p class="av-hero-brand"><BrandWordmark class="av-brand-wordmark--hero" /></p>
         <span class="av-hero-label">&gt; AI agent evaluation framework</span>
         <h1>Evaluate agents with<br/><span class="av-gradient-text">terminal precision</span></h1>
         <p class="av-hero-sub">
@@ -75,7 +74,7 @@ import BrandWordmark from './BrandWordmark.astro';
             <span class="av-terminal-dot av-dot-red"></span>
             <span class="av-terminal-dot av-dot-yellow"></span>
             <span class="av-terminal-dot av-dot-green"></span>
-            <span class="av-terminal-title"><BrandWordmark class="av-brand-wordmark--terminal" /></span>
+            <span class="av-terminal-title">eval run</span>
           </div>
           <div class="av-terminal-body">
             <!-- Scene 1: agentv eval -->
@@ -229,7 +228,7 @@ tests:
             <tbody>
               <tr>
                 <td>Evaluate</td>
-                <td class="av-col-highlight"><strong><BrandWordmark class="av-brand-wordmark--inline" /></strong></td>
+                <td class="av-col-highlight"><strong>AgentV</strong></td>
                 <td>Pre-production</td>
                 <td>Score agents, detect regressions, gate CI/CD</td>
               </tr>
@@ -569,10 +568,6 @@ tests:
   color: var(--av-indigo);
   margin-bottom: 1.5rem;
   letter-spacing: 0.01em;
-}
-
-.av-hero-brand {
-  margin: 0 0 1rem;
 }
 
 .av-hero-text h1 {


### PR DESCRIPTION
## Summary
The landing page no longer presents the AGENTV wordmark multiple times in the first viewport. The fixed top bar remains the only stylized full wordmark; the hero starts directly with the product category and the terminal chrome now reads as run context.

## Verification
- `bunx biome check apps/web/src/components/Lander.astro apps/web/src/components/BrandWordmark.astro`
- `bun --filter @agentv/web build`
- `agent-browser --session landing-wordmark-desktop get count .av-brand-wordmark` -> `1`
- `agent-browser --session landing-wordmark-mobile get count .av-brand-wordmark` -> `1`
- Desktop screenshot: `/tmp/agentv-landing-wordmark-desktop.png`
- Mobile screenshot: `/tmp/agentv-landing-wordmark-mobile.png`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5 Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
