### PR TITLE
fix(results): harden remote sync dogfood

### DIFF
--- a/apps/cli/src/commands/results/remote.ts
+++ b/apps/cli/src/commands/results/remote.ts
@@ -230,12 +230,25 @@ export async function syncRemoteResults(
     const status = await getResultsRepoSyncStatus(config);
     return {
       ...status,
-      run_count: 0,
+      run_count: await getRemoteRunCount(config, status),
       last_error: getStatusMessage(error),
       blocked: true,
       block_reason: getStatusMessage(error),
     };
   }
+}
+
+function dedupeSyncedRunCopies(runs: SourcedResultFileMeta[]): SourcedResultFileMeta[] {
+  const byRunId = new Map<string, SourcedResultFileMeta>();
+
+  for (const run of runs) {
+    const existing = byRunId.get(run.raw_filename);
+    if (!existing || (existing.source === 'remote' && run.source === 'local')) {
+      byRunId.set(run.raw_filename, run);
+    }
+  }
+
+  return [...byRunId.values()];
 }
 
 export async function listMergedResultFiles(
@@ -301,7 +314,7 @@ export async function listMergedResultFiles(
     );
   }
 
-  const merged = [...localRuns, ...remoteRuns].sort((a, b) =>
+  const merged = dedupeSyncedRunCopies([...localRuns, ...remoteRuns]).sort((a, b) =>
     b.timestamp.localeCompare(a.timestamp),
   );
   return {

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -899,6 +899,40 @@ describe('serve app', () => {
       expect(detailData.results[0]).toMatchObject({ testId: 'test-greeting' });
     }, 15000);
 
+    it('dedupes synced local and remote run copies in favor of the local run', async () => {
+      const { remoteDir, cloneDir } = initializeRemoteRepo(tempDir);
+      const runId = writeRemoteRunArtifact(
+        cloneDir,
+        'green-uat',
+        '2026-03-26T10-30-00-000Z',
+        RESULT_A,
+      );
+      writeLocalRunArtifact(tempDir, 'green-uat', '2026-03-26T10-30-00-000Z', RESULT_A);
+
+      mkdirSync(path.join(tempDir, '.agentv'), { recursive: true });
+      writeFileSync(
+        path.join(tempDir, '.agentv', 'config.yaml'),
+        `results:
+  mode: github
+  repo: file://${remoteDir}
+  path: ${cloneDir}
+`,
+      );
+
+      const app = createApp([], tempDir, tempDir, undefined, { studioDir });
+
+      const listRes = await app.request('/api/runs');
+      expect(listRes.status).toBe(200);
+      const listData = (await listRes.json()) as {
+        runs: Array<{ filename: string; source: string }>;
+      };
+      expect(listData.runs).toHaveLength(1);
+      expect(listData.runs[0]).toMatchObject({
+        filename: runId,
+        source: 'local',
+      });
+    }, 15000);
+
     it('computes git-native remote run list totals from materialized index rows', async () => {
       const { remoteDir, cloneDir } = initializeRemoteRepo(tempDir);
       const secondPass = {
@@ -1554,6 +1588,66 @@ describe('serve app', () => {
         expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, tempDir)).toContain(
           `.agentv/results/metadata/runs/project-sync-push/${runTimestamp}/tags.json`,
         );
+      } finally {
+        if (previousHome === undefined) {
+          process.env.AGENTV_HOME = undefined;
+        } else {
+          process.env.AGENTV_HOME = previousHome;
+        }
+      }
+    }, 15000);
+
+    it('keeps cached remote run count when project sync cannot fetch the remote', async () => {
+      const previousHome = process.env.AGENTV_HOME;
+      const homeDir = path.join(tempDir, 'agentv-home-project-sync-offline');
+      process.env.AGENTV_HOME = homeDir;
+
+      try {
+        const { remoteDir, cloneDir } = initializeRemoteRepo(tempDir);
+        const projectDir = path.join(tempDir, 'source-project-sync-offline');
+        mkdirSync(path.join(projectDir, '.agentv'), { recursive: true });
+        mkdirSync(homeDir, { recursive: true });
+        saveProjectRegistry({
+          projects: [
+            {
+              id: 'project-sync-offline',
+              name: 'Project Sync Offline',
+              path: projectDir,
+              results: {
+                mode: 'github',
+                repo: `file://${remoteDir}`,
+                path: cloneDir,
+                autoPush: true,
+              },
+              addedAt: '2026-01-01T00:00:00.000Z',
+              lastOpenedAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        });
+        writeRemoteRunArtifact(
+          cloneDir,
+          'project-sync-offline',
+          '2026-03-26T12-30-00-000Z',
+          RESULT_A,
+        );
+        git('git remote set-url origin "file:///tmp/agentv-missing-results-remote.git"', cloneDir);
+
+        const app = createApp([], tempDir, tempDir, undefined, { studioDir });
+        const res = await app.request('/api/projects/project-sync-offline/remote/sync', {
+          method: 'POST',
+        });
+
+        expect(res.status).toBe(200);
+        const data = (await res.json()) as {
+          available?: boolean;
+          blocked?: boolean;
+          block_reason?: string;
+          run_count?: number;
+        };
+        expect(data.available).toBe(true);
+        expect(data.blocked).toBe(true);
+        expect(data.block_reason).toContain('does not appear to be a git repository');
+        expect(data.run_count).toBe(1);
       } finally {
         if (previousHome === undefined) {
           process.env.AGENTV_HOME = undefined;


### PR DESCRIPTION
## Summary

Remote result sync is now safer under adversarial production-readiness scenarios: offline/auth-style sync failures keep reporting cached remote runs, and `/api/runs` no longer returns duplicate local plus `remote::` rows for the same synced run.

The durable `av-fis` dogfood report, throwaway-remote evidence, Dashboard screenshots, and production-readiness verdict are stored outside this public repository:

- Private repo: `EntityProcess/agentv-private`
- Private branch: `dogfood/av-fis-remote-sync-evidence`
- Private commit: `5d81c8d docs(dogfood): add av-fis remote sync evidence`
- Private path: `dogfood/av-fis/2026-06-08-remote-sync/`

This public PR contains only product/test code changes.

## Dogfood Coverage

Covered scenarios include:

- Remote tag add/edit/clear overlays, sync persistence, dirty-state behavior, and clean-clone verification.
- Local/remote discovery, local delete after sync, empty remote, missing metadata, corrupt `index.jsonl`, branch/default-branch mismatch, offline/missing remote, and multiple project isolation.
- Local combine/delete lifecycle, remote combine/delete rejection, safe dirty metadata push, unsafe dirty blocks, behind/ahead/diverged/conflicted states, interrupted retry simulation, and concurrent sync guarding.
- Dashboard/browser paths plus CLI-adjacent paths: eval auto-export, `agentv results combine`, `agentv results delete`, and confirmation that no direct `agentv results remote sync/status` command currently exists.

No production remote was touched. All remote dogfood used throwaway `/tmp` file remotes and temporary clones.

## Fixes

- `syncRemoteResults()` now computes `run_count` from the cached results clone in its error path, so a failed fetch no longer makes available cached remote runs appear empty.
- `listMergedResultFiles()` now dedupes merged local/remote run rows by canonical `raw_filename`, preferring the local copy before sorting and pagination.
- Added focused `serve.test.ts` regressions for both behaviors.

## Follow-Ups

- `av-fis.1`: Dashboard sync button can remain `Syncing...` after concurrent remote sync; data path is safe, presentation can be misleading until reload.
- `av-xqm`: Dashboard remote sync status can show stale `last_error` after a later conflict state.
- `av-fis.2`: Decide whether AgentV needs a first-class CLI contract for remote results sync/status.
- `av-fis.3`: Add committed regression coverage for interrupted sync retry; dogfood passed a simulated `.git/index.lock` retry, but coverage should be made durable before documenting retry guarantees.

## Verification

- `bun test apps/cli/test/commands/results/serve.test.ts`
  - `83 pass`, `0 fail`, `271 expect() calls`
- Pre-cleanup code verification, before private evidence relocation and with the same product fix shape:
  - `bun test packages/core/test/evaluation/results-repo.test.ts apps/cli/test/commands/results/remote-metadata.test.ts apps/cli/test/commands/results/delete.test.ts apps/cli/test/commands/results/combine.test.ts apps/cli/test/commands/results/serve.test.ts apps/dashboard/src/lib/run-dedupe.test.ts apps/dashboard/src/lib/project-sync-status.test.ts apps/dashboard/src/lib/run-list-actions.test.ts`
  - `121 pass`, `0 fail`, `381 expect() calls`
  - `bun run build` passed.
- `git show --check HEAD` passed.
- Public diff hygiene: PR diff against current `origin/main` includes only `apps/cli/src/commands/results/remote.ts` and `apps/cli/test/commands/results/serve.test.ts`; no dogfood report/evidence files remain in the public branch.
- Private evidence hygiene: `dashboard-setup.env` contains only throwaway `/tmp` fixture paths, and the private evidence tree was scanned for common secret/token patterns before commit.

Readiness verdict from the private report: the remote result data path is production-ready for controlled rollout after these fixes. The full Dashboard production experience still needs follow-up/waiver for `av-fis.1` and `av-xqm`, and `av-fis.3` should add durable retry regression coverage before documenting retry guarantees.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
