### PR TITLE
fix(dashboard): compact run labels

### DIFF
--- a/apps/dashboard/src/components/RunList.mobile.spec.tsx
+++ b/apps/dashboard/src/components/RunList.mobile.spec.tsx
@@ -45,4 +45,22 @@ describe('buildRunListItemView', () => {
     expect(view.isActive).toBe(true);
     expect(view.passing).toBe(false);
   });
+
+  it('uses compact run display without duplicating the pass-rate column', () => {
+    const view = buildRunListItemView(
+      runMeta({
+        display_name: '2026-03-27T05-00-00-000Z',
+        filename: 'remote::2026-03-27T05-00-00-000Z',
+        target: 'remote-target',
+        timestamp: '2026-03-27T05:00:00.000Z',
+        pass_rate: 1,
+        source: 'remote',
+      }),
+      0.8,
+    );
+
+    expect(view.display.primary).toBe('27/03 05:00');
+    expect(view.display.secondary).toBe('remote-target');
+    expect(view.label).toBe('27/03 05:00 · remote-target');
+  });
 });

--- a/apps/dashboard/src/components/RunList.tsx
+++ b/apps/dashboard/src/components/RunList.tsx
@@ -30,7 +30,7 @@ import {
   useStudioConfig,
 } from '~/lib/api';
 import { executionErrorCount } from '~/lib/result-summary';
-import { formatRunLabel } from '~/lib/run-label';
+import { type RunDisplay, formatRunDisplay } from '~/lib/run-label';
 import {
   buildCombineSuccessMessage,
   buildDeleteSuccessMessage,
@@ -63,6 +63,7 @@ interface RunListItemView {
   ts: { date: string; full: string };
   isActive: boolean;
   label: string;
+  display: RunDisplay;
   errors: number;
   qualityCount: number;
   passing: boolean;
@@ -94,7 +95,8 @@ function formatDate(ts: string | undefined | null): { date: string; full: string
 export function buildRunListItemView(run: RunMeta, passThreshold: number): RunListItemView {
   const ts = formatDate(run.timestamp);
   const isActive = run.status === 'starting' || run.status === 'running';
-  const label = formatRunLabel(run);
+  const display = formatRunDisplay(run, { includePassRate: false });
+  const label = display.label;
   const errors = executionErrorCount(run);
   const qualityCount = Math.max(0, run.test_count - errors);
   const passing = qualityCount > 0 ? run.pass_rate >= passThreshold : errors === 0;
@@ -107,6 +109,7 @@ export function buildRunListItemView(run: RunMeta, passThreshold: number): RunLi
     ts,
     isActive,
     label,
+    display,
     errors,
     qualityCount,
     passing,
@@ -380,8 +383,17 @@ export function RunList({
       )}
       <div className="space-y-2 sm:hidden">
         {runViews.map((view) => {
-          const { run, ts, label, errors, qualityCount, passedCount, failedCount, metadataDirty } =
-            view;
+          const {
+            run,
+            ts,
+            label,
+            display,
+            errors,
+            qualityCount,
+            passedCount,
+            failedCount,
+            metadataDirty,
+          } = view;
           const selectionDisabledReason = runSelectionDisabledReason(run);
           const selectable = !selectionDisabledReason && selectableRunIds.includes(run.filename);
 
@@ -411,9 +423,15 @@ export function RunList({
                   <RunNameLink
                     projectId={projectId}
                     runId={run.filename}
-                    label={label}
-                    className="block break-all text-sm font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
+                    label={display.primary}
+                    title={display.title}
+                    className="block truncate text-sm font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
                   />
+                  {display.secondary ? (
+                    <p className="mt-0.5 truncate text-xs text-gray-500" title={display.title}>
+                      {display.secondary}
+                    </p>
+                  ) : null}
                   <div className="mt-2 flex flex-wrap items-center gap-2">
                     <SourceBadge source={run.source} />
                     {metadataDirty ? <PendingSyncBadge /> : null}
@@ -479,6 +497,7 @@ export function RunList({
                 run,
                 ts,
                 label,
+                display,
                 errors,
                 qualityCount,
                 passedCount,
@@ -514,14 +533,25 @@ export function RunList({
 
                   {/* Run name */}
                   <td className="w-[22rem] max-w-[22rem] px-4 py-3">
-                    <div className="flex min-w-0 items-center gap-2">
-                      <RunNameLink
-                        projectId={projectId}
-                        runId={run.filename}
-                        label={label}
-                        className="block min-w-0 truncate font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
-                      />
-                      {metadataDirty ? <PendingSyncBadge /> : null}
+                    <div className="min-w-0">
+                      <div className="flex min-w-0 items-center gap-2">
+                        <RunNameLink
+                          projectId={projectId}
+                          runId={run.filename}
+                          label={display.primary}
+                          title={display.title}
+                          className="block min-w-0 truncate font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
+                        />
+                        {metadataDirty ? <PendingSyncBadge /> : null}
+                      </div>
+                      {display.secondary ? (
+                        <div
+                          className="mt-0.5 truncate text-xs text-gray-500"
+                          title={display.title}
+                        >
+                          {display.secondary}
+                        </div>
+                      ) : null}
                     </div>
                   </td>
 
@@ -581,11 +611,13 @@ function RunNameLink({
   projectId,
   runId,
   label,
+  title,
   className,
 }: {
   projectId?: string;
   runId: string;
   label: string;
+  title: string;
   className: string;
 }) {
   return projectId ? (
@@ -593,12 +625,12 @@ function RunNameLink({
       to="/projects/$projectId/runs/$runId"
       params={{ projectId, runId }}
       className={className}
-      title={label}
+      title={title}
     >
       {label}
     </Link>
   ) : (
-    <Link to="/runs/$runId" params={{ runId }} className={className} title={label}>
+    <Link to="/runs/$runId" params={{ runId }} className={className} title={title}>
       {label}
     </Link>
   );

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -34,7 +34,7 @@ import {
   useStudioConfig,
 } from '~/lib/api';
 import { resolveProjectDisplayName } from '~/lib/project-display-name';
-import { formatRunLabel, timeAgo } from '~/lib/run-label';
+import { formatRunDisplay } from '~/lib/run-label';
 import { useSidebarContext } from '~/lib/sidebar-context';
 
 import { BrandName } from './BrandName';
@@ -85,6 +85,17 @@ function BrandHeader({ projectId }: { projectId?: string }) {
         <BrandName appName={appName} />
       </Link>
     </div>
+  );
+}
+
+function SidebarRunText({ display }: { display: ReturnType<typeof formatRunDisplay> }) {
+  return (
+    <>
+      <span className="block truncate">{display.primary}</span>
+      {display.secondary ? (
+        <span className="block truncate text-xs text-gray-600">{display.secondary}</span>
+      ) : null}
+    </>
   );
 }
 
@@ -274,6 +285,7 @@ function RunSidebar() {
         </div>
 
         {data?.runs.map((run) => {
+          const display = formatRunDisplay(run);
           const isActive =
             isHome === false &&
             runMatch &&
@@ -289,10 +301,9 @@ function RunSidebar() {
                 to="/projects/$projectId/runs/$runId"
                 params={{ projectId: run.project_id, runId: run.filename }}
                 className="mb-0.5 block rounded-md px-2 py-1.5 text-sm text-gray-400 transition-colors hover:bg-gray-800/50 hover:text-gray-200"
-                title={run.project_name}
+                title={`${display.title}\nProject: ${run.project_name}`}
               >
-                <span className="block truncate">{formatRunLabel(run)}</span>
-                <span className="block text-xs text-gray-600">{timeAgo(run.timestamp)}</span>
+                <SidebarRunText display={display} />
               </Link>
             );
           }
@@ -307,9 +318,9 @@ function RunSidebar() {
                   ? 'bg-gray-800 text-cyan-400'
                   : 'text-gray-400 hover:bg-gray-800/50 hover:text-gray-200'
               }`}
+              title={display.title}
             >
-              <span className="block truncate">{formatRunLabel(run)}</span>
-              <span className="block text-xs text-gray-600">{timeAgo(run.timestamp)}</span>
+              <SidebarRunText display={display} />
             </Link>
           );
         })}
@@ -507,6 +518,7 @@ function ProjectRunDetailSidebar({
           Runs
         </div>
         {data?.runs.map((run) => {
+          const display = formatRunDisplay(run);
           const isActive = currentRunId === run.filename;
           return (
             <Link
@@ -518,9 +530,9 @@ function ProjectRunDetailSidebar({
                   ? 'bg-gray-800 text-cyan-400'
                   : 'text-gray-400 hover:bg-gray-800/50 hover:text-gray-200'
               }`}
+              title={display.title}
             >
-              <span className="block truncate">{formatRunLabel(run)}</span>
-              <span className="block text-xs text-gray-600">{timeAgo(run.timestamp)}</span>
+              <SidebarRunText display={display} />
             </Link>
           );
         })}

--- a/apps/dashboard/src/lib/run-label.test.ts
+++ b/apps/dashboard/src/lib/run-label.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { formatRunLabel } from './run-label';
+import { formatRunDisplay, formatRunLabel } from './run-label';
 
 describe('formatRunLabel', () => {
   it('starts with the run display name when available', () => {
@@ -15,7 +15,7 @@ describe('formatRunLabel', () => {
     ).toBe('dogfood-run-a · 01/06 10:00 · codex · 100%');
   });
 
-  it('shows DD/MM HH:mm · target · experiment · score', () => {
+  it('uses a non-default experiment as the primary label when no display name is present', () => {
     expect(
       formatRunLabel({
         target: 'llm-dry-run',
@@ -23,7 +23,7 @@ describe('formatRunLabel', () => {
         timestamp: '2026-04-29T09:17:30.111Z',
         pass_rate: 0.8,
       }),
-    ).toBe('29/04 09:17 · llm-dry-run · issue-1198 · 80%');
+    ).toBe('issue-1198 · 29/04 09:17 · llm-dry-run · 80%');
   });
 
   it('omits experiment when it is the default', () => {
@@ -54,5 +54,64 @@ describe('formatRunLabel', () => {
         pass_rate: 0,
       }),
     ).toBe('07/05 10:56 · wtalms-stg · 0%');
+  });
+
+  it('uses one compact timestamp for remote timestamp-only run names', () => {
+    const display = formatRunDisplay({
+      display_name: '2026-03-27T05-00-00-000Z',
+      filename: 'remote::2026-03-27T05-00-00-000Z',
+      target: 'av-fis-target',
+      timestamp: '2026-03-27T05:00:00.000Z',
+      pass_rate: 1,
+    });
+
+    expect(display.primary).toBe('27/03 05:00');
+    expect(display.secondary).toBe('av-fis-target · 100%');
+    expect(display.label).toBe('27/03 05:00 · av-fis-target · 100%');
+    expect(display.label.match(/27\/03 05:00/g)).toHaveLength(1);
+    expect(display.title).toContain('Run ID: remote::2026-03-27T05-00-00-000Z');
+    expect(display.title).toContain('Display name: 2026-03-27T05-00-00-000Z');
+  });
+
+  it('keeps a local human display name as the primary label', () => {
+    const display = formatRunDisplay({
+      display_name: 'local fixture run',
+      filename: '2026-06-08T20-00-00-000Z',
+      target: 'local-target',
+      timestamp: '2026-06-08T20:00:00.000Z',
+      pass_rate: 1,
+    });
+
+    expect(display.primary).toBe('local fixture run');
+    expect(display.secondary).toBe('08/06 20:00 · local-target · 100%');
+    expect(display.label).toBe('local fixture run · 08/06 20:00 · local-target · 100%');
+  });
+
+  it('falls back to a non-default experiment before timestamp-only run IDs', () => {
+    const display = formatRunDisplay({
+      display_name: '2026-03-27T05-00-00-000Z',
+      filename: 'remote::smoke-regression::2026-03-27T05-00-00-000Z',
+      experiment: 'smoke-regression',
+      target: 'azure',
+      timestamp: '2026-03-27T05:00:00.000Z',
+      pass_rate: 0.5,
+    });
+
+    expect(display.primary).toBe('smoke-regression');
+    expect(display.secondary).toBe('27/03 05:00 · azure · 50%');
+  });
+
+  it('can omit pass rate when another UI column already shows it', () => {
+    const display = formatRunDisplay(
+      {
+        display_name: 'local fixture run',
+        target: 'local-target',
+        timestamp: '2026-06-08T20:00:00.000Z',
+        pass_rate: 1,
+      },
+      { includePassRate: false },
+    );
+
+    expect(display.label).toBe('local fixture run · 08/06 20:00 · local-target');
   });
 });

--- a/apps/dashboard/src/lib/run-label.ts
+++ b/apps/dashboard/src/lib/run-label.ts
@@ -1,7 +1,22 @@
 import type { RunMeta } from './types';
 
 type RunLabelInput = Pick<RunMeta, 'experiment' | 'target' | 'timestamp' | 'pass_rate'> &
-  Partial<Pick<RunMeta, 'display_name' | 'filename'>>;
+  Partial<Pick<RunMeta, 'display_name' | 'filename'>> & {
+    title?: string;
+  };
+
+export interface RunDisplay {
+  primary: string;
+  secondary: string;
+  label: string;
+  title: string;
+}
+
+interface RunDisplayOptions {
+  includePassRate?: boolean;
+}
+
+const REMOTE_RUN_PREFIX = 'remote::';
 
 /** DD/MM HH:mm — short human-readable slice of the run's timestamp. */
 function shortTimestamp(ts: string): string {
@@ -16,6 +31,100 @@ function shortTimestamp(ts: string): string {
   } catch {
     return ts.slice(0, 10);
   }
+}
+
+function cleanOptional(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function nonDefaultExperiment(experiment: string | undefined): string | undefined {
+  const trimmed = cleanOptional(experiment);
+  return trimmed && trimmed !== 'default' && trimmed !== '-' ? trimmed : undefined;
+}
+
+function normalizeTimestampCandidate(value: string): string {
+  let candidate = value.trim();
+  if (candidate.startsWith(REMOTE_RUN_PREFIX)) {
+    candidate = candidate.slice(REMOTE_RUN_PREFIX.length);
+  }
+  return candidate.replace(/\.(jsonl|json)$/i, '');
+}
+
+function parseRunTimestampLike(value: string): Date | undefined {
+  const candidate = normalizeTimestampCandidate(value);
+  const match = candidate.match(
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2})[:-](\d{2})[:-](\d{2})(?:[.-](\d{3}))?Z?$/,
+  );
+  if (!match) return undefined;
+
+  const [, year, month, day, hour, minute, second, millis = '000'] = match;
+  const parsed = new Date(`${year}-${month}-${day}T${hour}:${minute}:${second}.${millis}Z`);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+function isTimestampOnlyName(value: string | undefined, timestamp: string): boolean {
+  const trimmed = cleanOptional(value);
+  if (!trimmed) return false;
+
+  if (parseRunTimestampLike(trimmed)) {
+    return true;
+  }
+
+  return normalizeTimestampCandidate(trimmed) === shortTimestamp(timestamp);
+}
+
+function displayableFilename(filename: string | undefined, timestamp: string): string | undefined {
+  const trimmed = cleanOptional(filename);
+  if (!trimmed) return undefined;
+
+  const withoutSource = trimmed.startsWith(REMOTE_RUN_PREFIX)
+    ? trimmed.slice(REMOTE_RUN_PREFIX.length)
+    : trimmed;
+  const separatorIndex = withoutSource.lastIndexOf('::');
+  if (separatorIndex !== -1) {
+    const suffix = withoutSource.slice(separatorIndex + 2);
+    if (isTimestampOnlyName(suffix, timestamp)) {
+      return cleanOptional(withoutSource.slice(0, separatorIndex));
+    }
+  }
+
+  return withoutSource;
+}
+
+function firstHumanName(run: RunLabelInput): string | undefined {
+  const candidates = [
+    cleanOptional(run.display_name),
+    cleanOptional(run.title),
+    displayableFilename(run.filename, run.timestamp),
+  ];
+
+  return candidates.find(
+    (candidate): candidate is string =>
+      Boolean(candidate) && !isTimestampOnlyName(candidate, run.timestamp),
+  );
+}
+
+function formatPassRate(passRate: number): string {
+  return `${Math.round(passRate * 100)}%`;
+}
+
+function buildRunDisplayTitle(run: RunLabelInput, label: string): string {
+  const parts = [label];
+  const filename = cleanOptional(run.filename);
+  const displayName = cleanOptional(run.display_name);
+  const title = cleanOptional(run.title);
+
+  if (filename && filename !== label) parts.push(`Run ID: ${filename}`);
+  if (displayName && displayName !== filename && displayName !== label) {
+    parts.push(`Display name: ${displayName}`);
+  }
+  if (title && title !== displayName && title !== filename && title !== label) {
+    parts.push(`Title: ${title}`);
+  }
+  parts.push(`Timestamp: ${run.timestamp}`);
+
+  return parts.join('\n');
 }
 
 /** Human-readable relative time string, e.g. "4 hr ago". */
@@ -34,19 +143,48 @@ export function timeAgo(ts: string): string {
   }
 }
 
-/** Format a run label consistently across tables and nav surfaces. */
-export function formatRunLabel(run: RunLabelInput): string {
-  const primaryName = run.display_name || run.filename;
-  const parts: string[] = primaryName
-    ? [primaryName, shortTimestamp(run.timestamp)]
-    : [shortTimestamp(run.timestamp)];
+/**
+ * Build compact run display parts for Dashboard tables and sidebars.
+ *
+ * Primary text is a human name when one exists, otherwise a non-default
+ * experiment, otherwise a single compact timestamp. Raw run IDs stay available
+ * in the tooltip title so timestamp-only remote IDs do not crowd list cells.
+ */
+export function formatRunDisplay(run: RunLabelInput, options: RunDisplayOptions = {}): RunDisplay {
+  const timestampLabel = shortTimestamp(run.timestamp);
+  const experiment = nonDefaultExperiment(run.experiment);
+  const humanName = firstHumanName(run);
+  const experimentName =
+    experiment && !isTimestampOnlyName(experiment, run.timestamp) ? experiment : undefined;
+  const primary = humanName ?? experimentName ?? timestampLabel;
+  const includePassRate = options.includePassRate ?? true;
+  const secondaryParts: string[] = [];
 
-  if (run.target) parts.push(run.target);
-  if (run.experiment && run.experiment !== 'default' && run.experiment !== '-') {
-    parts.push(run.experiment);
+  if (primary !== timestampLabel) {
+    secondaryParts.push(timestampLabel);
+  }
+  if (run.target && run.target !== primary) {
+    secondaryParts.push(run.target);
+  }
+  if (experiment && experiment !== primary) {
+    secondaryParts.push(experiment);
+  }
+  if (includePassRate) {
+    secondaryParts.push(formatPassRate(run.pass_rate));
   }
 
-  parts.push(`${Math.round(run.pass_rate * 100)}%`);
+  const secondary = secondaryParts.join(' · ');
+  const label = secondary ? `${primary} · ${secondary}` : primary;
 
-  return parts.join(' · ');
+  return {
+    primary,
+    secondary,
+    label,
+    title: buildRunDisplayTitle(run, label),
+  };
+}
+
+/** Format a run label consistently across tables and nav surfaces. */
+export function formatRunLabel(run: RunLabelInput): string {
+  return formatRunDisplay(run).label;
 }

--- a/packages/core/src/evaluation/results-repo.ts
+++ b/packages/core/src/evaluation/results-repo.ts
@@ -1070,6 +1070,7 @@ type GitBatchBlob = {
 
 type GitRunBenchmark = {
   readonly metadata?: {
+    readonly display_name?: string;
     readonly timestamp?: string;
     readonly experiment?: string;
     readonly targets?: readonly string[];
@@ -1242,6 +1243,7 @@ export async function listGitRuns(repoDir: string, ref = 'origin/main'): Promise
     const relativeRunPath = path.posix.relative(RESULTS_REPO_RUNS_DIR, runDir);
     const runId = buildGitRunId(relativeRunPath);
     const timestamp = benchmark.metadata?.timestamp?.trim() || path.posix.basename(runDir);
+    const displayName = benchmark.metadata?.display_name?.trim() || path.posix.basename(runDir);
     const targets = benchmark.metadata?.targets ?? [];
     const passRate = computeAveragePassRate(benchmark.run_summary);
 
@@ -1254,7 +1256,7 @@ export async function listGitRuns(repoDir: string, ref = 'origin/main'): Promise
         ...(targets.length === 1 && targets[0] ? { target: targets[0] } : {}),
         manifest_path: path.posix.join(runDir, 'index.jsonl'),
         benchmark_path: benchmarkPath,
-        display_name: path.posix.basename(runDir),
+        display_name: displayName,
         test_count: benchmark.metadata?.tests_run?.length ?? 0,
         avg_score: 0,
         size_bytes: blob.size,

--- a/packages/core/test/evaluation/results-repo.test.ts
+++ b/packages/core/test/evaluation/results-repo.test.ts
@@ -143,6 +143,7 @@ describe('listGitRuns', () => {
       JSON.stringify(
         {
           metadata: {
+            display_name: 'remote friendly run',
             timestamp: '2026-05-21T11:00:00.000Z',
             experiment: 'with-skills',
             targets: ['claude-sonnet', 'gpt-4o'],
@@ -174,7 +175,7 @@ describe('listGitRuns', () => {
     expect(runs[0]).toMatchObject({
       experiment: 'with-skills',
       timestamp: '2026-05-21T11:00:00.000Z',
-      display_name: '2026-05-21T11-00-00-000Z',
+      display_name: 'remote friendly run',
       manifest_path: '.agentv/results/runs/with-skills/2026-05-21T11-00-00-000Z/index.jsonl',
       benchmark_path: '.agentv/results/runs/with-skills/2026-05-21T11-00-00-000Z/benchmark.json',
       test_count: 3,
@@ -184,6 +185,7 @@ describe('listGitRuns', () => {
     expect(runs[0].target).toBeUndefined();
     expect(runs[1]).toMatchObject({
       experiment: 'default',
+      display_name: '2026-05-20T10-00-00-000Z',
       target: 'gpt-4o',
       manifest_path: '.agentv/results/runs/default/2026-05-20T10-00-00-000Z/index.jsonl',
       test_count: 2,


### PR DESCRIPTION
## Summary
- Adds a shared Dashboard run display helper that returns primary text, secondary context, a one-line label, and tooltip/audit title text.
- Updates RunList table/mobile cards and Sidebar to use compact primary/secondary run labels instead of one long timestamp-heavy string.
- Preserves remote `benchmark.json` `metadata.display_name` in the run list so remote and local rows use the same friendly-name convention when the artifact provides one.
- Keeps Local/Remote source as the badge and preserves raw remote run IDs/display names in link `title` text.

## Root Cause
Remote run metadata can surface timestamp-only `display_name` / run IDs such as `2026-03-27T05-00-00-000Z`. The old formatter trusted that as the primary run name and then appended the formatted timestamp again, producing crowded labels like the reported remote screenshot while local runs with human display names looked fine.

The remote git-listing path also forced `display_name` to the run directory basename, so a remote artifact with `metadata.display_name` could still lose its friendly label before the Dashboard formatter saw it.

Reported evidence:
- Remote crowded row: https://raw.githubusercontent.com/EntityProcess/agentv/e64364ce33b9fd4b1de5fcc0630f365300488d1e/docs/dogfood-reports/evidence/2026-06-08-av-fis-remote-sync/dashboard-project-after-reload.png
- Local better row: https://raw.githubusercontent.com/EntityProcess/agentv/e64364ce33b9fd4b1de5fcc0630f365300488d1e/docs/dogfood-reports/evidence/2026-06-08-av-fis-remote-sync/dashboard-unsafe-dirty-blocked-desktop.png

## Validation
- `bun test packages/core/test/evaluation/results-repo.test.ts` (11 pass)
- `bun test apps/dashboard/src/lib/run-label.test.ts apps/dashboard/src/components/RunList.mobile.spec.tsx` (12 pass)
- `bunx biome check packages/core/src/evaluation/results-repo.ts packages/core/test/evaluation/results-repo.test.ts apps/dashboard/src/lib/run-label.ts apps/dashboard/src/lib/run-label.test.ts apps/dashboard/src/components/RunList.tsx apps/dashboard/src/components/RunList.mobile.spec.tsx apps/dashboard/src/components/Sidebar.tsx`
- `bun --filter @agentv/core build`
- `bun --filter @agentv/dashboard build`
- `bun --filter agentv build`
- Browser dogfood with isolated `AGENTV_HOME` / `AGENTV_DATA_DIR` and a throwaway local+remote fixture. API had a local `display_name: local fixture run` and a remote `metadata.display_name: remote fixture run` under a timestamp-only remote run directory; screenshots confirmed friendly primary labels for both, separate source badges, no horizontal overflow, and tooltip raw-ID auditability.

## Private Evidence
- Bead: `av-a15`
- Private repo branch: `EntityProcess/agentv-private` `dogfood/av-a15-compact-run-labels`
- Private evidence commit: `c6381597d0649374674c6a6679f501b3421133189`
- Friendly-label evidence paths:
  - `dogfood/av-a15/dashboard-friendly-run-labels-desktop.png`
  - `dogfood/av-a15/dashboard-friendly-run-labels-mobile-scrolled.png`
- Earlier timestamp-only fallback evidence commit: `2093088c1e499f3af520a6889d5634fd963d2039`