### PR TITLE
fix(dashboard): settle remote sync button state

### DIFF
--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -12,6 +12,7 @@ import {
   useQuery,
 } from '@tanstack/react-query';
 
+import { shouldPollRemoteStatus } from './project-sync-status';
 import type {
   CategoriesResponse,
   CombineDuplicateConflict,
@@ -232,6 +233,7 @@ export function remoteStatusOptions(projectId?: string) {
     queryKey: ['remote-status', projectId ?? ''],
     queryFn: () => fetchJson<RemoteStatusResponse>(url),
     staleTime: 5_000,
+    refetchInterval: (query) => (shouldPollRemoteStatus(query.state.data) ? 1_000 : false),
   });
 }
 

--- a/apps/dashboard/src/lib/project-sync-status.test.ts
+++ b/apps/dashboard/src/lib/project-sync-status.test.ts
@@ -6,6 +6,7 @@ import {
   buildRemoteStatusItems,
   formatRemoteRunCount,
   getProjectSyncView,
+  shouldPollRemoteStatus,
 } from './project-sync-status';
 
 describe('getProjectSyncView', () => {
@@ -46,6 +47,25 @@ describe('getProjectSyncView', () => {
     ).toMatchObject({
       state: 'ahead',
       actionLabel: 'Push Results',
+      canSync: true,
+    });
+  });
+
+  it('returns to a clean sync action when a status refetch settles an overlapping sync', () => {
+    const view = getProjectSyncView(
+      {
+        configured: true,
+        available: true,
+        sync_status: 'clean',
+        run_count: 1,
+        dirty_paths: [],
+      },
+      false,
+    );
+
+    expect(view).toMatchObject({
+      state: 'clean',
+      actionLabel: 'Sync Project',
       canSync: true,
     });
   });
@@ -152,5 +172,17 @@ describe('buildRemoteStatusItems', () => {
     expect(items).toContain('1 remote run');
     expect(items).toContain('Repo: WiseTechGlobal/WTG.AI.Prompts.EvalResults');
     expect(items.some((item) => item.startsWith('Last synced '))).toBe(true);
+  });
+});
+
+describe('shouldPollRemoteStatus', () => {
+  it('polls only while the server reports an overlapping sync in progress', () => {
+    expect(
+      shouldPollRemoteStatus({ configured: true, available: true, sync_status: 'syncing' }),
+    ).toBe(true);
+    expect(
+      shouldPollRemoteStatus({ configured: true, available: true, sync_status: 'clean' }),
+    ).toBe(false);
+    expect(shouldPollRemoteStatus(undefined)).toBe(false);
   });
 });

--- a/apps/dashboard/src/lib/project-sync-status.ts
+++ b/apps/dashboard/src/lib/project-sync-status.ts
@@ -63,6 +63,10 @@ export function buildRemoteStatusItems(
   ].filter((item): item is string => item !== undefined);
 }
 
+export function shouldPollRemoteStatus(status: RemoteStatusResponse | undefined): boolean {
+  return status?.sync_status === 'syncing';
+}
+
 export function getProjectSyncView(
   status: RemoteStatusResponse | undefined,
   syncInFlight = false,

--- a/apps/dashboard/src/routes/index.tsx
+++ b/apps/dashboard/src/routes/index.tsx
@@ -19,6 +19,7 @@ import { type RunSourceFilter, RunSourceToolbar } from '~/components/RunSourceTo
 import { TargetsTab } from '~/components/TargetsTab';
 import {
   addProjectApi,
+  remoteStatusOptions,
   syncRemoteResultsApi,
   useCompare,
   useEvalRuns,
@@ -248,17 +249,20 @@ function SingleProjectHome() {
     setSyncFeedback(null);
     try {
       const result = await syncRemoteResultsApi();
+      queryClient.setQueryData(remoteStatusOptions().queryKey, result);
       setSyncFeedback(buildProjectSyncFeedback(result));
-      await Promise.all([
+      void Promise.all([
         queryClient.invalidateQueries({ queryKey: ['runs'] }),
         queryClient.invalidateQueries({ queryKey: ['experiments'] }),
         queryClient.invalidateQueries({ queryKey: ['compare'] }),
         queryClient.invalidateQueries({ queryKey: ['targets'] }),
         queryClient.invalidateQueries({ queryKey: ['remote-status', ''] }),
-      ]);
+      ]).catch(() => undefined);
     } catch (err) {
       setSyncFeedback(buildProjectSyncErrorFeedback(err, remoteStatus));
-      await queryClient.invalidateQueries({ queryKey: ['remote-status', ''] });
+      void queryClient
+        .invalidateQueries({ queryKey: ['remote-status', ''] })
+        .catch(() => undefined);
     } finally {
       setSyncInFlight(false);
     }

--- a/apps/dashboard/src/routes/projects/$projectId.tsx
+++ b/apps/dashboard/src/routes/projects/$projectId.tsx
@@ -17,6 +17,7 @@ import { type RunSourceFilter, RunSourceToolbar } from '~/components/RunSourceTo
 import { TargetsTab } from '~/components/TargetsTab';
 import {
   projectCompareOptions,
+  remoteStatusOptions,
   syncRemoteResultsApi,
   useEvalRuns,
   useInfiniteProjectRunList,
@@ -150,18 +151,21 @@ function ProjectRunsTab({
     setSyncFeedback(null);
     try {
       const result = await syncRemoteResultsApi(projectId);
+      queryClient.setQueryData(remoteStatusOptions(projectId).queryKey, result);
       const feedback = buildProjectSyncFeedback(result);
       setSyncFeedback(feedback);
-      await Promise.all([
+      void Promise.all([
         queryClient.invalidateQueries({ queryKey: ['projects', projectId, 'runs'] }),
         queryClient.invalidateQueries({ queryKey: ['projects', projectId, 'experiments'] }),
         queryClient.invalidateQueries({ queryKey: ['projects', projectId, 'compare'] }),
         queryClient.invalidateQueries({ queryKey: ['projects', projectId, 'targets'] }),
         queryClient.invalidateQueries({ queryKey: ['remote-status', projectId] }),
-      ]);
+      ]).catch(() => undefined);
     } catch (err) {
       setSyncFeedback(buildProjectSyncErrorFeedback(err, remoteStatus));
-      await queryClient.invalidateQueries({ queryKey: ['remote-status', projectId] });
+      void queryClient
+        .invalidateQueries({ queryKey: ['remote-status', projectId] })
+        .catch(() => undefined);
     } finally {
       setSyncInFlight(false);
     }


### PR DESCRIPTION
## Summary

The Dashboard remote sync toolbar now settles back to the current remote status after syncs overlap. Before this fix, a project could clear its pending remote metadata while the button stayed disabled as `Syncing...` until reload; now the sync response updates the remote-status cache and status refetches can move the toolbar back to `Clean` / `Sync Project` without a page reload.

Remote status polling now runs only while the server reports `sync_status=syncing`, so a blocked concurrent sync response does not leave the UI stranded on stale in-progress state.

## Verification

- `(cd apps/dashboard && bun test src/lib/project-sync-status.test.ts)` — 12 pass
- `bun --filter @agentv/dashboard test` — 83 pass
- `bun --filter @agentv/dashboard build` — pass; rebuilt Dashboard dist before browser UAT
- `bun run lint` — pass
- Push hook also ran `bun --filter @agentv/core typecheck && bun --filter @agentv/phoenix-adapter typecheck && bun --filter agentv typecheck` and `biome check .` — pass

## Red/Green UAT Evidence

- Red: original dogfood evidence on `av-fis` showed `dashboard-project-after-sync-settled.png` stuck on `Syncing...` despite `/api/projects/av-fis-dashboard/remote/status` returning `sync_status=clean`, `dirty_paths=[]`.
- Green: with this branch, a temp project/results repo with dirty metadata showed `Sync Metadata`; after clicking it, the UI settled to `Clean` / `Sync Project` without reload and `/api/projects/project/remote/status` returned `sync_status=clean`, `dirty_paths=[]`.
- Green screenshot path from this session: `/tmp/age7-final-green-clean.png`.

## Post-Deploy Monitoring & Validation

- Validation window: first 24 hours after deploy; owner: AgentV maintainers watching remote-sync dogfood/production feedback.
- Watch browser/API reports for terms: `Syncing...`, `sync_status=syncing`, `remote/sync`, `remote/status`, `Results repo sync is already in progress`.
- Healthy signals: after a remote sync POST completes or a status refetch returns clean, Dashboard project rows show `Clean` and the sync button is enabled with `Sync Project` without reload.
- Failure signals: user reports or screenshots where `remote/status` is `clean` but the toolbar button remains disabled as `Syncing...` for more than one poll interval.
- Mitigation: reload clears the UI state; if reports recur, temporarily increase status refetch visibility/logging around `/remote/status` and revert this PR if polling/cache hydration causes unexpected Dashboard load.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.4_Codex-000000)
