### PR TITLE
fix(results): retry interrupted direct result pushes

### DIFF
--- a/packages/core/src/evaluation/results-repo.ts
+++ b/packages/core/src/evaluation/results-repo.ts
@@ -985,6 +985,39 @@ export async function createDraftResultsPr(params: {
 
 const DIRECT_PUSH_MAX_RETRIES = 3;
 
+async function hasUnpushedCommits(repoDir: string, baseBranch: string): Promise<boolean> {
+  const { stdout } = await runGit(['rev-list', '--count', `origin/${baseBranch}..HEAD`], {
+    cwd: repoDir,
+    check: false,
+  });
+  return Number.parseInt(stdout.trim(), 10) > 0;
+}
+
+async function pushDirectResultsToBase(params: {
+  readonly normalized: Required<ResultsConfig>;
+  readonly repoDir: string;
+  readonly baseBranch: string;
+}): Promise<void> {
+  for (let attempt = 1; attempt <= DIRECT_PUSH_MAX_RETRIES; attempt++) {
+    try {
+      await runGit(['push', 'origin', `HEAD:${params.baseBranch}`], { cwd: params.repoDir });
+      updateStatusFile(params.normalized, {
+        last_synced_at: new Date().toISOString(),
+        last_error: undefined,
+      });
+      return;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (attempt < DIRECT_PUSH_MAX_RETRIES && message.includes('non-fast-forward')) {
+        await fetchResultsRepo(params.repoDir);
+        await runGit(['rebase', `origin/${params.baseBranch}`], { cwd: params.repoDir });
+      } else {
+        throw error;
+      }
+    }
+  }
+}
+
 /**
  * Push results directly to the base branch of the results repo.
  * Handles non-fast-forward conflicts by fetching, rebasing, and retrying.
@@ -1020,6 +1053,14 @@ export async function directPushResults(params: {
     check: false,
   });
   if (status.trim().length === 0) {
+    if (await hasUnpushedCommits(repoDir, baseBranch)) {
+      const aheadPaths = await getAheadPaths(repoDir, `origin/${baseBranch}`);
+      if (!areSafeResultsRepoPaths(aheadPaths)) {
+        throw new Error('Results repo has non-results committed changes');
+      }
+      await pushDirectResultsToBase({ normalized, repoDir, baseBranch });
+      return true;
+    }
     return false;
   }
 
@@ -1027,26 +1068,8 @@ export async function directPushResults(params: {
     cwd: repoDir,
   });
 
-  for (let attempt = 1; attempt <= DIRECT_PUSH_MAX_RETRIES; attempt++) {
-    try {
-      await runGit(['push', 'origin', `HEAD:${baseBranch}`], { cwd: repoDir });
-      updateStatusFile(normalized, {
-        last_synced_at: new Date().toISOString(),
-        last_error: undefined,
-      });
-      return true;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      if (attempt < DIRECT_PUSH_MAX_RETRIES && message.includes('non-fast-forward')) {
-        await fetchResultsRepo(repoDir);
-        await runGit(['rebase', `origin/${baseBranch}`], { cwd: repoDir });
-      } else {
-        throw error;
-      }
-    }
-  }
-
-  return false;
+  await pushDirectResultsToBase({ normalized, repoDir, baseBranch });
+  return true;
 }
 
 export interface GitListedRun {

--- a/packages/core/test/evaluation/results-repo.test.ts
+++ b/packages/core/test/evaluation/results-repo.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -307,6 +307,56 @@ describe('results repo write path', () => {
   afterEach(() => {
     rmSync(rootDir, { recursive: true, force: true });
   });
+
+  it('retries an interrupted direct push without dropping the committed run', async () => {
+    const { remoteDir } = initializeRemoteRepo(rootDir);
+    const cloneDir = path.join(rootDir, 'results-clone');
+    const sourceDir = path.join(rootDir, 'source-run');
+    const runTimestamp = '2026-05-22T11-00-00-000Z';
+    const destinationPath = path.join('retry', runTimestamp);
+    const config = createResultsConfig(remoteDir, cloneDir);
+    const hookPath = path.join(remoteDir, 'hooks', 'pre-receive');
+    writeRunArtifacts(sourceDir, 'retry', '2026-05-22T11:00:00.000Z');
+
+    await ensureResultsRepoClone(config);
+    git('git config user.email "test@example.com"', cloneDir);
+    git('git config user.name "Test User"', cloneDir);
+
+    writeFileSync(hookPath, '#!/usr/bin/env sh\necho "simulated interrupted push" >&2\nexit 1\n');
+    chmodSync(hookPath, 0o755);
+
+    await expect(
+      directPushResults({
+        config,
+        sourceDir,
+        destinationPath,
+        commitMessage: 'feat(results): retry - 1/1 PASS (1.000)',
+      }),
+    ).rejects.toThrow(/simulated interrupted push/);
+    expect(git('git rev-list --count origin/main..HEAD', cloneDir)).toBe('1');
+    expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir)).not.toContain(
+      `.agentv/results/runs/retry/${runTimestamp}/benchmark.json`,
+    );
+
+    rmSync(hookPath, { force: true });
+
+    await expect(
+      directPushResults({
+        config,
+        sourceDir,
+        destinationPath,
+        commitMessage: 'feat(results): retry - 1/1 PASS (1.000)',
+      }),
+    ).resolves.toBe(true);
+
+    expect(git('git rev-list --count origin/main..HEAD', cloneDir)).toBe('0');
+    expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir)).toContain(
+      `.agentv/results/runs/retry/${runTimestamp}/benchmark.json`,
+    );
+    expect(git(`git --git-dir "${remoteDir}" log -1 --pretty=%B main`, rootDir)).toContain(
+      `Agentv-Run: retry::${runTimestamp}`,
+    );
+  }, 20000);
 
   it('commits pushed runs into the configured clone with an Agentv-Run trailer', async () => {
     const { remoteDir } = initializeRemoteRepo(rootDir);


### PR DESCRIPTION
## Summary

Remote result sync is intended to be remote-first and idempotent: from the user's perspective, retrying a failed publish should ensure the configured remote results repo contains the run artifacts. Local Git commits are only an implementation detail.

This PR fixes the interruption window where AgentV has already committed result artifacts in the local results-repo clone, but the push to the remote failed before GitHub received the commit. Before this fix, a user could see the initial push error, retry the same publish, and AgentV could treat the retry as a no-op because the artifacts were already committed locally—even though the remote was still missing the run.

On retry, `directPushResults` now detects that safe local-ahead state, verifies the ahead commit only contains AgentV results paths, and pushes the existing commit. Unsafe local-ahead states with non-results changes still block with an explicit error instead of being pushed blindly.

This keeps the expected recovery flow simple:

1. First push fails and surfaces an error.
2. User retries.
3. AgentV ensures the remote gets the results, even if the local result commit already exists.

## Verification

Red/green UAT:
- Red before fix: `bun test packages/core/test/evaluation/results-repo.test.ts -t interrupted` failed with `Expected: true` / `Received: false` on the retry after a simulated rejected push.
- Green after fix: `bun test packages/core/test/evaluation/results-repo.test.ts -t interrupted` passed.

Additional checks:
- `bun test packages/core/test/evaluation/results-repo.test.ts` — 13 pass
- `bun run typecheck` — pass
- `bunx biome check packages/core/src/evaluation/results-repo.ts packages/core/test/evaluation/results-repo.test.ts` — pass
- Pre-push hook also ran `bun run typecheck` and `biome check .` — pass

## Post-Deploy Monitoring & Validation

- Log/search terms: `Results repo has non-results committed changes`, `Results repo push was rejected`, `non-fast-forward`, and direct result push failures around `directPushResults`.
- Healthy signal: rerunning a result publish after a transient push interruption leaves the results clone no longer ahead of `origin/<base>` and the remote contains the run artifact commit.
- Failure signal: repeated publish retries return no-op while the results clone remains ahead, or remote result runs are missing after retry.
- Validation window/owner: next production remote-sync dogfood run; AgentV maintainers should inspect Dashboard/CLI sync status and results repo history.
- Rollback trigger: if retries begin pushing non-results commits or cause unexpected base-branch updates, revert this PR and require manual results repo cleanup before retrying publishes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
