### PR TITLE
fix(dashboard): make targets table scroll on mobile

### DIFF
--- a/apps/dashboard/src/components/TargetsTab.tsx
+++ b/apps/dashboard/src/components/TargetsTab.tsx
@@ -4,6 +4,11 @@
  * The summary table opens a target detail view. That detail view groups runs
  * by experiment and reuses the existing run-detail routes for the final click,
  * so category breakdowns and individual test cases stay consistent everywhere.
+ *
+ * The target summary keeps its desktop table layout while using the same
+ * mobile-safe table pattern as run detail screens: a fixed minimum width inside
+ * an overflow container. This keeps every metric readable on phone viewports
+ * instead of clipping the right-side columns.
  */
 
 import { useQuery } from '@tanstack/react-query';
@@ -108,8 +113,8 @@ export function TargetsTab({ projectId }: TargetsTabProps = {}) {
 
   if (!selectedTarget) {
     return (
-      <div className="overflow-hidden rounded-lg border border-gray-800">
-        <table className="w-full text-left text-sm">
+      <div className="max-w-full overflow-x-auto rounded-lg border border-gray-800">
+        <table className="min-w-[720px] w-full whitespace-nowrap text-left text-sm">
           <thead className="border-b border-gray-800 bg-gray-900/50">
             <tr>
               <th className="px-4 py-3 font-medium text-gray-400">Target</th>


### PR DESCRIPTION
## Summary
Targets on phone-width Dashboard views no longer hide the right-side metrics behind a clipped table. The Targets summary now uses the same mobile-safe table treatment as existing run detail tables: a stable minimum width inside a horizontal overflow container, so users can scroll from target names through pass rate, eval counts, and execution errors while desktop continues to fill the available width.

## Verification
- `cd apps/dashboard && bun run build`
- `bun --filter @agentv/dashboard test`
- `bunx biome check apps/dashboard/src/components/TargetsTab.tsx`
- `bun run verify`
- Visual UAT with local Dashboard from current code via `bun apps/cli/src/cli.ts dashboard --port 3128` at `/projects/financial-research-agent?tab=targets`

## Evidence
- Mobile red case, before fix: `/tmp/agentv-evidence/targets-mobile-red.png` — columns after Pass Rate are clipped in the non-scrollable table.
- Mobile green case, after fix: `/tmp/agentv-evidence/targets-mobile-green-left.png` and `/tmp/agentv-evidence/targets-mobile-green-scrolled.png` — horizontal scrollbar is visible and the right-side Evals / Execution Errors columns are reachable.
- Desktop green case: `/tmp/agentv-evidence/targets-desktop-green.png` — table still fills the desktop content area without horizontal scrolling.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
