### PR TITLE
fix(dashboard): prevent mobile experiment table clipping

### DIFF
--- a/apps/dashboard/src/components/ExperimentsTab.tsx
+++ b/apps/dashboard/src/components/ExperimentsTab.tsx
@@ -3,6 +3,10 @@
  *
  * Displays experiment name, number of runs, targets, pass rate, and
  * last run timestamp. Each row links to the experiment detail page.
+ *
+ * The table keeps the desktop column layout on mobile by using the same
+ * overflow container + fixed minimum width pattern as other Dashboard summary
+ * tables, so right-side metrics remain reachable instead of being clipped.
  */
 
 import { useQuery } from '@tanstack/react-query';
@@ -41,8 +45,8 @@ export function ExperimentsTab({ projectId }: ExperimentsTabProps) {
   }
 
   return (
-    <div className="overflow-hidden rounded-lg border border-gray-800">
-      <table className="w-full text-left text-sm">
+    <div className="max-w-full overflow-x-auto rounded-lg border border-gray-800">
+      <table className="min-w-[760px] w-full whitespace-nowrap text-left text-sm">
         <thead className="border-b border-gray-800 bg-gray-900/50">
           <tr>
             <th className="px-4 py-3 font-medium text-gray-400">Experiment</th>
@@ -128,8 +132,8 @@ function formatTimestamp(ts: string | undefined | null): { date: string; full: s
 
 function LoadingSkeleton() {
   return (
-    <div className="overflow-hidden rounded-lg border border-gray-800">
-      <div className="animate-pulse">
+    <div className="max-w-full overflow-x-auto rounded-lg border border-gray-800">
+      <div className="min-w-[760px] animate-pulse">
         <div className="border-b border-gray-800 bg-gray-900/50 px-4 py-3">
           <div className="h-4 w-48 rounded bg-gray-800" />
         </div>


### PR DESCRIPTION
## Summary
- Wrap the Experiments tab table in a mobile-safe horizontal overflow container.
- Give the table a fixed minimum width and nowrap behavior, matching the recent Targets tab pattern.
- Keep the existing desktop table layout and column order unchanged.

Fixes #1351

## Verification
- `cd apps/dashboard && bun run build`
- `bun --filter @agentv/dashboard test`
- `bun run lint`
- `bun run build && bun run test`

## Manual red/green UAT
Tested with a local fixture served via `bun apps/cli/src/cli.ts dashboard --single --dir /tmp/agentv-1351-uat --port 4117` after rebuilding Dashboard static assets.

- Red before fix: `/tmp/agentv-1351-evidence/red-experiments-mobile.png` — wrapper was `overflow-hidden`; viewport wrapper width was 340px while table content was 609px, so right-side columns were clipped.
- Green after fix: `/tmp/agentv-1351-evidence/green-experiments-mobile.png` — wrapper is `overflow-x-auto`; horizontal scroll is available.
- Green scrolled right: `/tmp/agentv-1351-evidence/green-experiments-mobile-scrolled-right.png` — verified the table scrolls to the right-side metrics on a 390px mobile viewport.
