### PR TITLE
fix(dashboard): sort runs by timestamp

### DIFF
--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -411,6 +411,22 @@ function hasUsableTimestamp(timestamp: string | undefined): boolean {
   return !!timestamp && timestamp !== 'unknown' && !Number.isNaN(new Date(timestamp).getTime());
 }
 
+function compareRunsByTimestampDesc<T extends { timestamp: string; filename: string }>(
+  a: T,
+  b: T,
+): number {
+  const aTime = hasUsableTimestamp(a.timestamp) ? new Date(a.timestamp).getTime() : null;
+  const bTime = hasUsableTimestamp(b.timestamp) ? new Date(b.timestamp).getTime() : null;
+
+  if (aTime !== null && bTime !== null && aTime !== bTime) {
+    return bTime - aTime;
+  }
+  if (aTime !== null && bTime === null) return -1;
+  if (aTime === null && bTime !== null) return 1;
+
+  return b.filename.localeCompare(a.filename);
+}
+
 interface QualitySummaryInput {
   readonly score: number;
   readonly executionStatus?: string;
@@ -561,6 +577,7 @@ async function handleRuns(c: C, { searchDir, agentvDir, projectId }: DataContext
       };
     }),
   );
+  runs.sort(compareRunsByTimestampDesc);
   const page = paginateRuns(runs, cursor, limit);
   return c.json({
     runs: page.runs,
@@ -1646,7 +1663,7 @@ export function createApp(
       }
     }
 
-    allRuns.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+    allRuns.sort(compareRunsByTimestampDesc);
     return c.json({ runs: allRuns });
   });
 

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -628,6 +628,33 @@ describe('serve app', () => {
       expect(secondPage.next_cursor).toBeUndefined();
     });
 
+    it('sorts runs by displayed timestamp descending before pagination', async () => {
+      createLocalRun(tempDir, 'z-older-directory-name', {
+        ...RESULT_A,
+        timestamp: '2026-03-25T10:00:00.000Z',
+      });
+      createLocalRun(tempDir, 'a-newer-directory-name', {
+        ...RESULT_A,
+        timestamp: '2026-03-25T10:09:00.000Z',
+      });
+
+      const app = createApp([], tempDir, tempDir, undefined, { studioDir });
+
+      const res = await app.request('/api/runs?limit=1');
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as {
+        runs: Array<{ filename: string; timestamp: string }>;
+        next_cursor?: string;
+      };
+      expect(data.runs.map(({ filename, timestamp }) => ({ filename, timestamp }))).toEqual([
+        {
+          filename: 'a-newer-directory-name',
+          timestamp: '2026-03-25T10:09:00.000Z',
+        },
+      ]);
+      expect(data.next_cursor).toBe('a-newer-directory-name');
+    });
+
     it('returns an empty page for unknown cursors', async () => {
       createLocalRun(tempDir, '2026-03-25T10-00-00-000Z', RESULT_A);
       createLocalRun(tempDir, '2026-03-25T11-00-00-000Z', RESULT_A);


### PR DESCRIPTION
## Summary
Dashboard run lists now order rows by the same timestamp that powers the “When” column, so a run from 9 minutes ago appears above older runs even when run directory names sort differently.

The API now sorts enriched run metadata before applying cursor pagination, and the all-project runs endpoint uses the same timestamp ordering helper for consistency. This fixes the visible ordering bug without changing the run detail or result loading paths.

Fixes #1358

## Verification
- Red: `bun test apps/cli/test/commands/results/serve.test.ts -t "sorts runs by displayed timestamp"` initially failed with `z-older-directory-name` returned before `a-newer-directory-name`.
- Green: `bun test apps/cli/test/commands/results/serve.test.ts -t "sorts runs by displayed timestamp"`
- `bun test apps/cli/test/commands/results/serve.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
