### PR TITLE
fix(eval): accept structured code grader content

### DIFF
--- a/packages/eval/src/schemas.ts
+++ b/packages/eval/src/schemas.ts
@@ -4,9 +4,11 @@
  *
  * ## Content model
  *
- * `Message.content` accepts `string | Content[]`:
+ * `Message.content` accepts `string | object[] | object`:
  * - `string` — backward-compatible plain text (most common case)
- * - `Content[]` — typed content blocks for multimodal messages
+ * - `object[]` — typed content blocks for multimodal messages, plus AgentV
+ *   eval input blocks such as `{ type: "file", value, path, text }`
+ * - `object` — structured YAML/JSON content such as expected outputs
  *
  * Content variants:
  * - `ContentText`  — `{ type: 'text', text: string }`
@@ -245,15 +247,20 @@ export const ContentSchema = z.discriminatedUnion('type', [
   ContentFileSchema,
 ]);
 
+const MessageContentBlockSchema = z.union([ContentSchema, z.record(z.unknown())]);
+
 /**
  * Unified message schema for input, expected, and output messages.
  *
- * `content` is either a plain string or a `Content[]` array of typed blocks.
- * Use `getTextContent()` from `@agentv/core` to extract plain text from either form.
+ * `content` is a plain string, an array of structured blocks, or a
+ * structured object from YAML/JSON eval files. Use `getTextContent()` from
+ * `@agentv/core` to extract plain text when the content is textual.
  */
 export const MessageSchema = z.object({
   role: z.enum(['assistant', 'user', 'system', 'tool']),
-  content: z.union([z.string(), z.array(ContentSchema)]).optional(),
+  content: z
+    .union([z.string(), z.array(MessageContentBlockSchema), z.record(z.unknown())])
+    .optional(),
   toolCalls: z.array(ToolCallSchema).optional(),
   name: z.string().optional(),
   startTime: z.string().optional(),

--- a/packages/eval/test/define-code-grader.test.ts
+++ b/packages/eval/test/define-code-grader.test.ts
@@ -127,6 +127,37 @@ describe('MessageSchema content variants', () => {
     expect(content.map((c) => c.type)).toEqual(['text', 'image', 'file']);
   });
 
+  it('accepts AgentV eval file/text input blocks', () => {
+    const msg = MessageSchema.parse({
+      role: 'user',
+      content: [
+        {
+          type: 'file',
+          value: '../skills/export-risk-assessment.md',
+          path: '../skills/export-risk-assessment.md',
+          text: '# instructions',
+          resolved_path: '/repo/examples/skills/export-risk-assessment.md',
+        },
+        {
+          type: 'text',
+          value: 'Assess export risk for this shipment',
+        },
+      ],
+    });
+    const content = msg.content as Record<string, unknown>[];
+    expect(content).toHaveLength(2);
+    expect(content[0].value).toBe('../skills/export-risk-assessment.md');
+    expect(content[1].value).toBe('Assess export risk for this shipment');
+  });
+
+  it('accepts structured object content from eval YAML', () => {
+    const msg = MessageSchema.parse({
+      role: 'assistant',
+      content: { riskLevel: 'High', reasoning: 'CHPL Tier 1 item' },
+    });
+    expect(msg.content).toEqual({ riskLevel: 'High', reasoning: 'CHPL Tier 1 item' });
+  });
+
   it('accepts undefined content', () => {
     const msg = MessageSchema.parse({ role: 'tool' });
     expect(msg.content).toBeUndefined();
@@ -229,6 +260,20 @@ describe('CodeGraderInputSchema', () => {
     const result = CodeGraderInputSchema.parse(inputWithContentArray);
     const content = result.input[0].content as { type: string }[];
     expect(content).toHaveLength(2);
+  });
+
+  it('accepts structured expectedOutput content objects', () => {
+    const inputWithStructuredExpectedOutput = {
+      ...validInput,
+      expectedOutput: [
+        {
+          role: 'assistant',
+          content: { riskLevel: 'High' },
+        },
+      ],
+    };
+    const result = CodeGraderInputSchema.parse(inputWithStructuredExpectedOutput);
+    expect(result.expectedOutput[0].content).toEqual({ riskLevel: 'High' });
   });
 });
 


### PR DESCRIPTION
## Summary
- Fixes code-grader input validation so graders can receive AgentV eval file/text content blocks and structured YAML/JSON expected output objects.
- Adds regression coverage for AgentV eval blocks and structured expected output content.
- Investigation note: project-scoped Dashboard eval runs already spawn with the registered project path as cwd; the reported 0% run failed because the code-grader SDK rejected the payload shape before grader logic ran.

## Root-cause investigation
- `/api/projects/:projectId/eval/run` resolves cwd through the project registry and spawns `agentv eval` with the selected project's `path`.
- The reported run artifact shows the code grader ran with cwd `/home/entity/projects/EntityProcess/agentv/examples/showcase/export-screening/evals`, not the Hermes deploy cwd.
- The failing grader received:
  - AgentV eval input blocks like `{ type: "file", value, path, text, resolved_path }`.
  - Structured expected output content like `{ risk_level: "High" }`.
- `@agentv/eval` only accepted `Message.content` as `string | Content[]`, where typed `file` blocks required stricter fields and object content was rejected. `defineCodeGrader` converted that schema error into a zero score.
- The separate `llm` target error is caused by `use_target: ${{ LLM_TARGET }}` with `LLM_TARGET` unset, which currently falls through to a less helpful `provider is required` error.

## Verification
- Red evidence: existing reported artifact `/home/entity/projects/EntityProcess/agentv/.agentv/results/runs/default/2026-06-11T12-02-05-558Z/index.jsonl` shows all code graders scoring 0 with `Code evaluator exited with code 1`.
- Green UAT: `bun apps/cli/src/cli.ts eval examples/showcase/export-screening/evals/dataset.eval.yaml --test-id exp-high-001 --threshold 0.75 --output /tmp/agentv-green-export-screening --verbose` now passes with score 1 and code-grader assertions passing.
- `bun test packages/eval/test/define-code-grader.test.ts`
- `bun --filter @agentv/eval build`
- `bun run build`
- `bun test packages/eval/test`
- `bun run verify`

## DX follow-up recommendations

### Quick fixes
1. Emit an actionable error when `use_target: ${{ LLM_TARGET }}` resolves empty: name the missing env var and suggest setting it in project `.env` or choosing a concrete target.
2. Preserve parsed code-grader JSON/errors even when the grader exits non-zero, so schema/runtime errors are visible instead of only `exited with code 1`.
3. Add a Dashboard run preflight summary: cwd, eval path, targets file, resolved target alias chain, loaded `.env` paths (names only), and missing env refs.
4. Display the active project path in the Dashboard Run Eval UI and warn/disable unscoped runs when no project is selected.

### Larger design changes
1. Add `agentv eval --preflight` or `agentv doctor eval <file> --target <name>` to resolve cwd/env/targets/code-grader commands without provider calls.
2. Consider project-scoped env preflight for Dashboard runs using the same loader as CLI eval, but avoid a second hidden env precedence model.
3. Avoid implicit global `.env` fallback by default; if needed, make it explicit and diagnostic-only. Exported shell env is already the global fallback.

