### PR TITLE
fix(targets): add Pi SDK OpenAI target

### DIFF
--- a/.agentv/targets.yaml
+++ b/.agentv/targets.yaml
@@ -32,13 +32,13 @@ targets:
     provider: copilot-cli
     model: ${{ COPILOT_MODEL }}
     grader_target: grader
-    log_format: json
+    stream_log: raw
 
   - name: copilot-sdk
     provider: copilot-sdk
     model: ${{ COPILOT_MODEL }}
     grader_target: grader
-    log_format: json
+    stream_log: raw
 
   - name: copilot-sdk-azure
     provider: copilot-sdk
@@ -48,7 +48,7 @@ targets:
       base_url: ${{ AZURE_OPENAI_ENDPOINT }}
       api_key: ${{ AZURE_OPENAI_API_KEY }}
     grader_target: grader
-    log_format: json
+    stream_log: raw
 
   - name: claude
     provider: claude-cli
@@ -85,12 +85,23 @@ targets:
 
   - name: pi-sdk
     provider: pi-coding-agent
-    subprovider: openrouter
-    model: ${{ OPENROUTER_MODEL }}
-    api_key: ${{ OPENROUTER_API_KEY }}
-    grader_target: grader
-    tools: read,bash,edit,write
-    log_format: json
+    subprovider: openai
+    base_url: ${{ OPENAI_ENDPOINT }}
+    api_key: ${{ OPENAI_API_KEY }}
+    model: gpt-5.5
+    grader_target: openai
+    thinking: low
+    stream_log: raw
+
+  - name: pi-sdk-openai
+    provider: pi-coding-agent
+    subprovider: openai
+    base_url: ${{ OPENAI_ENDPOINT }}
+    api_key: ${{ OPENAI_API_KEY }}
+    model: gpt-5.5
+    grader_target: openai
+    thinking: low
+    stream_log: raw
 
   - name: pi-azure
     provider: pi-cli
@@ -104,11 +115,11 @@ targets:
     provider: pi-coding-agent
     subprovider: azure
     base_url: ${{ AZURE_OPENAI_ENDPOINT }}
-    model: ${{ AZURE_DEPLOYMENT_NAME }}
+    model: gpt-5.5
     api_key: ${{ AZURE_OPENAI_API_KEY }}
     grader_target: grader
-    tools: read,bash,edit,write
-    log_format: json
+    thinking: low
+    stream_log: raw
 
   - name: codex
     provider: codex

--- a/apps/cli/src/templates/.agentv/targets.yaml
+++ b/apps/cli/src/templates/.agentv/targets.yaml
@@ -24,7 +24,7 @@ targets:
     #   - ${{ CODEX_APPROVAL_PRESET }}
     cwd: ${{ CODEX_WORKSPACE_DIR }}            # Where scratch workspaces are created
     log_dir: ${{ CODEX_LOG_DIR }}              # Optional: where Codex CLI stream logs are stored (defaults to ./.agentv/logs/codex)
-    log_format: json                    # Optional: 'summary' (default) or 'json' for raw event logs
+    stream_log: raw                    # Optional: 'summary' for consolidated logs or 'raw' for per-event logs
 
   # Claude - Anthropic's Claude Agent SDK
   - name: claude
@@ -36,7 +36,7 @@ targets:
     # max_turns: 50                            # Optional: max conversation turns
     # max_budget_usd: 5.0                      # Optional: max cost budget in USD
     # log_dir: ${{ CLAUDE_LOG_DIR }}           # Optional: where stream logs are stored (defaults to ./.agentv/logs/claude)
-    log_format: json                           # Optional: 'summary' (default) or 'json' for raw event logs
+    stream_log: raw                           # Optional: 'summary' for consolidated logs or 'raw' for per-event logs
     # system_prompt: optional override (default instructs agent to include code in response)
 
   - name: azure-llm

--- a/packages/core/src/evaluation/validation/targets-validator.ts
+++ b/packages/core/src/evaluation/validation/targets-validator.ts
@@ -124,6 +124,7 @@ const COPILOT_SDK_SETTINGS = new Set([
   'timeout_seconds',
   'log_dir',
   'log_format',
+  'stream_log',
   'system_prompt',
   'byok',
 ]);
@@ -140,6 +141,7 @@ const COPILOT_CLI_SETTINGS = new Set([
   'timeout_seconds',
   'log_dir',
   'log_format',
+  'stream_log',
   'system_prompt',
 ]);
 
@@ -173,6 +175,7 @@ const CLAUDE_SETTINGS = new Set([
   'log_directory',
   'log_format',
   'log_output_format',
+  'stream_log',
   'system_prompt',
   'max_turns',
   'max_budget_usd',


### PR DESCRIPTION
## Summary
- Repoint the existing `pi-sdk` target to the standard OpenAI-compatible endpoint with `gpt-5.5` and `thinking: low`.
- Add a named `pi-sdk-openai` target with the same OpenAI-compatible Pi SDK config.
- Set `gpt-5.5`, `thinking: low`, and `stream_log: raw` on Pi SDK targets touched in this PR.
- Remove explicit `tools` allowlists from Pi SDK targets so Pi uses its default tool set.
- Replace tracked target/template `log_format: json` usages with `stream_log: raw`.
- Keep deprecated `log_format` compatibility in code, but allow `stream_log` in validation for providers that already consume it.

## Verification
- Live Pi SDK sample evals:
  ```bash
  NODE_PATH=/home/entity/.local/lib/node_modules bun apps/cli/src/cli.ts eval examples/features/basic/evals/dataset.eval.yaml \
    --targets .agentv/targets.yaml --target pi-sdk --test-id shorthand-string-example \
    --output .agentv/verification/age-33/basic-shorthand-pi-sdk-live-gpt55
  ```
  - PASS 1/1, target `pi-sdk`, provider log written.
  ```bash
  NODE_PATH=/home/entity/.local/lib/node_modules bun apps/cli/src/cli.ts eval examples/features/basic/evals/dataset.eval.yaml \
    --targets .agentv/targets.yaml --target pi-sdk-openai --test-id shorthand-string-example \
    --output .agentv/verification/age-33/basic-shorthand-pi-sdk-openai-live-gpt55
  ```
  - PASS 1/1, target `pi-sdk-openai`, provider log written.
- Export-screening Pi SDK execution smoke:
  ```bash
  NODE_PATH=/home/entity/.local/lib/node_modules bun apps/cli/src/cli.ts eval examples/showcase/export-screening/evals/dataset.eval.yaml \
    --targets .agentv/targets.yaml --target pi-sdk --test-id exp-high-001 \
    --output .agentv/verification/age-33/export-exp-high-001-pi-sdk-live-gpt55
  ```
  - Target executed successfully and final assistant message contained valid JSON with `riskLevel: High`.
  - The strict code-grader failed because agent transcript/tool output is included before the final JSON in `response.md`; this is an eval/grader compatibility issue for agent targets, not target execution failure.
- Deprecated-log-format warning check:
  ```bash
  bun --filter @agentv/core build
  bun apps/cli/src/cli.ts eval examples/features/basic/evals/dataset.eval.yaml \
    --targets .agentv/targets.yaml --target copilot-sdk --test-id shorthand-string-example --dry-run \
    --output .agentv/verification/age-33/basic-shorthand-copilot-sdk-stream-log-dry-run-fixed-rebuilt
  ```
  - PASS 1/1 dry-run.
  - Confirmed no `log_format` deprecation warning and no `Unknown setting 'stream_log'` warning.
- Pre-push hook passed:
  - `bun --filter @agentv/core typecheck`
  - `bun --filter @agentv/phoenix-adapter typecheck`
  - `bun --filter agentv typecheck`
  - `biome check .`

## Notes
For strict JSON classification evals, direct LLM targets are still a better fit than agent targets because agent target artifacts may include tool transcripts in addition to the final assistant answer.
