### PR TITLE
feat(results): support configured storage branch

### DIFF
--- a/apps/cli/src/commands/results/remote.ts
+++ b/apps/cli/src/commands/results/remote.ts
@@ -5,7 +5,7 @@ import {
   DEFAULT_THRESHOLD,
   type EvaluationResult,
   type GitListedRun,
-  type ResultsConfig,
+  type NormalizedResultsConfig,
   type ResultsRepoStatus,
   directPushResults,
   directorySizeBytes,
@@ -37,32 +37,41 @@ import {
 
 // ── In-memory TTL cache for listGitRuns ────────────────────────────
 // Avoids repeated expensive git ls-tree + git cat-file --batch operations
-// on every API request. Cache key is repoDir, TTL is 60 seconds.
+// on every API request. Cache key is repoDir + ref, TTL is 60 seconds.
 const gitRunsCache = new Map<string, { data: Promise<GitListedRun[]>; expiresAt: number }>();
 const GIT_RUNS_CACHE_TTL_MS = 60_000;
 
-function cachedListGitRuns(repoDir: string) {
+function getResultsStorageRef(config: NormalizedResultsConfig): string | undefined {
+  return config.branch ? `origin/${config.branch}` : undefined;
+}
+
+function cachedListGitRuns(repoDir: string, ref?: string) {
   const now = Date.now();
-  const cached = gitRunsCache.get(repoDir);
+  const cacheKey = `${repoDir}\0${ref ?? ''}`;
+  const cached = gitRunsCache.get(cacheKey);
   if (cached && cached.expiresAt > now) {
     return cached.data;
   }
-  const promise = listGitRuns(repoDir);
-  gitRunsCache.set(repoDir, { data: promise, expiresAt: now + GIT_RUNS_CACHE_TTL_MS });
+  const promise = ref ? listGitRuns(repoDir, ref) : listGitRuns(repoDir);
+  gitRunsCache.set(cacheKey, { data: promise, expiresAt: now + GIT_RUNS_CACHE_TTL_MS });
   // Evict stale entry once the promise settles so a fresh fetch replaces it
   promise
     .catch(() => {})
     .finally(() => {
-      const entry = gitRunsCache.get(repoDir);
+      const entry = gitRunsCache.get(cacheKey);
       if (entry && entry.expiresAt <= Date.now()) {
-        gitRunsCache.delete(repoDir);
+        gitRunsCache.delete(cacheKey);
       }
     });
   return promise;
 }
 
 function invalidateGitRunsCache(repoDir: string): void {
-  gitRunsCache.delete(repoDir);
+  for (const key of gitRunsCache.keys()) {
+    if (key.startsWith(`${repoDir}\0`)) {
+      gitRunsCache.delete(key);
+    }
+  }
 }
 
 export type RunSource = 'local' | 'remote';
@@ -144,7 +153,7 @@ async function maybeWarnLargeArtifact(runDir: string): Promise<void> {
 async function loadNormalizedResultsConfig(
   cwd: string,
   projectId?: string,
-): Promise<Required<ResultsConfig> | undefined> {
+): Promise<NormalizedResultsConfig | undefined> {
   const repoRoot = (await findRepoRoot(cwd)) ?? cwd;
   const config = await loadConfig(path.join(cwd, '_'), repoRoot);
   const project =
@@ -155,6 +164,7 @@ async function loadNormalizedResultsConfig(
     ? {
         mode: 'github' as const,
         repo: project.results.repoUrl,
+        branch: project.results.branch,
         path: project.results.path,
         auto_push: project.results.sync?.autoPush,
         branch_prefix: project.results.branchPrefix,
@@ -193,13 +203,13 @@ export async function getRemoteResultsStatus(
 }
 
 async function getRemoteRunCount(
-  config: Required<ResultsConfig> | undefined,
+  config: NormalizedResultsConfig | undefined,
   status: ResultsRepoStatus,
 ): Promise<number> {
   let runCount = 0;
   if (config && status.available) {
     try {
-      runCount = (await cachedListGitRuns(config.path)).length;
+      runCount = (await cachedListGitRuns(config.path, getResultsStorageRef(config))).length;
     } catch {
       runCount = listResultFilesFromRunsDir(resolveResultsRepoRunsDir(config)).length;
     }
@@ -277,7 +287,7 @@ export async function listMergedResultFiles(
   let remoteRuns: SourcedResultFileMeta[] = [];
   if (config.mode === 'github') {
     try {
-      const gitRuns = await cachedListGitRuns(config.path);
+      const gitRuns = await cachedListGitRuns(config.path, getResultsStorageRef(config));
       remoteRuns = gitRuns.map((r) => ({
         filename: encodeRemoteRunId(r.run_id),
         raw_filename: r.run_id,
@@ -359,7 +369,7 @@ export async function ensureRemoteRunAvailable(
     '.agentv/results/runs',
     path.posix.dirname(relativeManifestPath),
   );
-  await materializeGitRun(config.path, relativeRunPath);
+  await materializeGitRun(config.path, relativeRunPath, getResultsStorageRef(config));
 }
 
 export async function readRemoteRunTagState(

--- a/apps/cli/src/commands/results/remote.ts
+++ b/apps/cli/src/commands/results/remote.ts
@@ -211,7 +211,9 @@ async function getRemoteRunCount(
     try {
       runCount = (await cachedListGitRuns(config.path, getResultsStorageRef(config))).length;
     } catch {
-      runCount = listResultFilesFromRunsDir(resolveResultsRepoRunsDir(config)).length;
+      if (!config.branch) {
+        runCount = listResultFilesFromRunsDir(resolveResultsRepoRunsDir(config)).length;
+      }
     }
   }
   return runCount;
@@ -301,16 +303,20 @@ export async function listMergedResultFiles(
         sizeBytes: r.size_bytes || 0,
       }));
     } catch (error) {
-      console.error('git-native listing failed, falling back', error);
-      remoteRuns = listResultFilesFromRunsDir(resolveResultsRepoRunsDir(config)).map(
-        (meta) =>
-          ({
-            ...meta,
-            filename: encodeRemoteRunId(meta.filename),
-            raw_filename: meta.filename,
-            source: 'remote' as const,
-          }) satisfies SourcedResultFileMeta,
-      );
+      if (config.branch) {
+        console.error('git-native listing failed for configured results branch', error);
+      } else {
+        console.error('git-native listing failed, falling back', error);
+        remoteRuns = listResultFilesFromRunsDir(resolveResultsRepoRunsDir(config)).map(
+          (meta) =>
+            ({
+              ...meta,
+              filename: encodeRemoteRunId(meta.filename),
+              raw_filename: meta.filename,
+              source: 'remote' as const,
+            }) satisfies SourcedResultFileMeta,
+        );
+      }
     }
   } else {
     remoteRuns = listResultFilesFromRunsDir(resolveResultsRepoRunsDir(config)).map(

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -968,6 +968,56 @@ describe('serve app', () => {
       });
     }, 15000);
 
+    it('does not fall back to checked-out default branch runs when the configured storage branch is missing', async () => {
+      const { remoteDir, cloneDir } = initializeRemoteRepo(tempDir);
+      const runId = writeRemoteRunArtifact(
+        cloneDir,
+        'main-only',
+        '2026-03-26T11-30-00-000Z',
+        RESULT_A,
+      );
+
+      mkdirSync(path.join(tempDir, '.agentv'), { recursive: true });
+      writeFileSync(
+        path.join(tempDir, '.agentv', 'config.yaml'),
+        `results:
+  mode: github
+  repo: file://${remoteDir}
+  branch: agentv-results
+  path: ${cloneDir}
+`,
+      );
+
+      const app = createApp([], tempDir, tempDir, undefined, { studioDir });
+
+      const statusRes = await app.request('/api/remote/status');
+      expect(statusRes.status).toBe(200);
+      const statusData = (await statusRes.json()) as {
+        available: boolean;
+        sync_status?: string;
+        run_count: number;
+        last_error?: string;
+      };
+      expect(statusData).toMatchObject({
+        available: false,
+        sync_status: 'unavailable',
+        run_count: 0,
+      });
+      expect(statusData.last_error ?? '').toContain(
+        "Results repo remote branch 'agentv-results' does not exist",
+      );
+
+      const listRes = await app.request('/api/runs');
+      expect(listRes.status).toBe(200);
+      const listData = (await listRes.json()) as {
+        runs: Array<{ filename: string; source: string }>;
+      };
+      expect(listData.runs).toHaveLength(0);
+
+      const detailRes = await app.request(`/api/runs/${encodeURIComponent(`remote::${runId}`)}`);
+      expect(detailRes.status).toBe(404);
+    }, 15000);
+
     it('dedupes synced local and remote run copies in favor of the local run', async () => {
       const { remoteDir, cloneDir } = initializeRemoteRepo(tempDir);
       const runId = writeRemoteRunArtifact(

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -118,6 +118,7 @@ function writeRemoteRunArtifact(
   experiment: string,
   timestamp: string,
   resultRecords: object | object[],
+  branch = 'main',
 ): string {
   const isoTimestamp = timestamp.replace(
     /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/,
@@ -148,7 +149,7 @@ function writeRemoteRunArtifact(
     ),
   );
   git(`git add "${runDir}" && git commit --quiet -m "add ${experiment}"`, cloneDir);
-  git('git push --quiet origin main', cloneDir);
+  git(`git push --quiet origin HEAD:${branch}`, cloneDir);
   git('git fetch --quiet origin --prune', cloneDir);
   return `${experiment}::${timestamp}`;
 }
@@ -924,6 +925,47 @@ describe('serve app', () => {
       expect(detailData.source).toBe('remote');
       expect(detailData.results).toHaveLength(1);
       expect(detailData.results[0]).toMatchObject({ testId: 'test-greeting' });
+    }, 15000);
+
+    it('lists git-native remote runs from the configured storage branch', async () => {
+      const { remoteDir, cloneDir } = initializeRemoteRepo(tempDir);
+      const storageBranch = 'agentv-results';
+      git(`git switch --quiet --orphan ${storageBranch}`, cloneDir);
+      git('git rm -rf --quiet . 2>/dev/null || true', cloneDir);
+      git('git commit --quiet --allow-empty -m "seed results branch"', cloneDir);
+      git(`git push --quiet origin HEAD:${storageBranch}`, cloneDir);
+      const runId = writeRemoteRunArtifact(
+        cloneDir,
+        'branch-green-uat',
+        '2026-03-26T11-00-00-000Z',
+        RESULT_A,
+        storageBranch,
+      );
+
+      mkdirSync(path.join(tempDir, '.agentv'), { recursive: true });
+      writeFileSync(
+        path.join(tempDir, '.agentv', 'config.yaml'),
+        `results:
+  mode: github
+  repo: file://${remoteDir}
+  branch: ${storageBranch}
+  path: ${cloneDir}
+`,
+      );
+
+      const app = createApp([], tempDir, tempDir, undefined, { studioDir });
+
+      const listRes = await app.request('/api/runs');
+      expect(listRes.status).toBe(200);
+      const listData = (await listRes.json()) as {
+        runs: Array<{ filename: string; source: string; experiment?: string }>;
+      };
+      expect(listData.runs).toHaveLength(1);
+      expect(listData.runs[0]).toMatchObject({
+        filename: `remote::${runId}`,
+        source: 'remote',
+        experiment: 'branch-green-uat',
+      });
     }, 15000);
 
     it('dedupes synced local and remote run copies in favor of the local run', async () => {

--- a/apps/web/src/content/docs/docs/tools/dashboard.mdx
+++ b/apps/web/src/content/docs/docs/tools/dashboard.mdx
@@ -260,12 +260,13 @@ projects:
     ref: main
     results:
       repo_url: git@github.com:EntityProcess/agentv-examples-eval-results.git
+      branch: agentv-results
       path: /home/entity/projects/EntityProcess/agentv-examples-eval-results
       sync:
         auto_push: true
 ```
 
-`results.path` is the filesystem location of the local clone AgentV manages for the results repo. It uses the same local-path field name as the source project. `results.repo_url` is the Git remote URL used for clone and push operations, so use HTTPS when credentials are HTTP-token based and SSH when the runtime has SSH keys configured.
+`results.path` is the filesystem location of the local clone AgentV manages for the results repo. It uses the same local-path field name as the source project. `results.repo_url` is the Git remote URL used for clone and push operations, so use HTTPS when credentials are HTTP-token based and SSH when the runtime has SSH keys configured. `results.branch` is optional; when present, AgentV reads and writes that existing storage branch instead of the results repo's default branch.
 
 You can also set a top-level global fallback in the same file. This is used when the current project is not registered or its registry entry has no `results` block:
 
@@ -273,6 +274,7 @@ You can also set a top-level global fallback in the same file. This is used when
 results:
   mode: github
   repo: EntityProcess/default-eval-results
+  branch: agentv-results
   path: /home/entity/projects/EntityProcess/default-eval-results
   auto_push: true
 ```
@@ -314,6 +316,7 @@ projects:
     ref: main
     results:
       repo_url: https://github.com/EntityProcess/agentv-eval-results.git
+      branch: agentv-results
       path: /home/entity/projects/EntityProcess/agentv-eval-results
       sync:
         auto_push: true
@@ -325,7 +328,7 @@ Use project-level **Sync Project** as the results exchange workflow. It handles 
 
 There is no separate `agentv results remote status` or `agentv results remote sync` command. The `agentv results` CLI stays focused on local run workspaces; manual remote exchange is Dashboard/API-only, with eval auto-export covering the common CI/publisher path.
 
-Each run writes to a unique timestamped directory, so concurrent pushes from multiple machines are safe — non-fast-forward conflicts are resolved automatically via rebase retry.
+Each run writes to a unique timestamped directory, so concurrent pushes from multiple machines are safe — non-fast-forward conflicts are resolved automatically via rebase retry. If `results.branch` is configured, create that remote branch once before syncing (for example with `git switch --orphan agentv-results` and `git push origin HEAD:agentv-results`). `branch_prefix` remains only the prefix for temporary result/PR branch names; it is not the storage branch.
 
 ### What happens to existing local runs?
 

--- a/apps/web/src/content/docs/docs/tools/results.mdx
+++ b/apps/web/src/content/docs/docs/tools/results.mdx
@@ -90,7 +90,7 @@ The CLI contract is deliberately narrow: `agentv results` manages local result a
 
 Use these supported remote workflows instead:
 
-- **Automatic publishing:** configure `projects[].results.auto_push: true`; new `agentv eval` and `agentv pipeline bench` runs push their artifacts after the run completes.
+- **Automatic publishing:** configure `projects[].results.sync.auto_push: true`; new `agentv eval` and `agentv pipeline bench` runs push their artifacts after the run completes. Add `projects[].results.branch` when the results repo stores artifacts on a non-default branch.
 - **Manual Dashboard sync:** run `agentv dashboard`, open the project, and use **Sync Project**.
 - **Manual API sync:** while Dashboard is running, call `GET /api/projects/:projectId/remote/status` or `POST /api/projects/:projectId/remote/sync` for project-scoped automation. Single-project sessions also expose `GET /api/remote/status` and `POST /api/remote/sync`.
 - **Git escape hatch:** for advanced recovery, inspect or repair the configured `projects[].results.path` clone with `git` directly, then sync again.

--- a/packages/core/src/evaluation/loaders/config-loader.ts
+++ b/packages/core/src/evaluation/loaders/config-loader.ts
@@ -40,6 +40,8 @@ export type ExecutionDefaults = {
 export type ResultsConfig = {
   readonly mode: 'github';
   readonly repo: string;
+  /** Optional remote branch used as the canonical git-backed results store. */
+  readonly branch?: string;
   /** Local filesystem path for the results clone. Optional; defaults to ~/.agentv/results/<slug>/. */
   readonly path?: string;
   readonly auto_push?: boolean;
@@ -610,6 +612,15 @@ export function parseResultsConfig(raw: unknown, configPath: string): ResultsCon
     return undefined;
   }
 
+  let branch: string | undefined;
+  if (obj.branch !== undefined) {
+    if (typeof obj.branch !== 'string' || obj.branch.trim().length === 0) {
+      logWarning(`Invalid results.branch in ${configPath}, expected non-empty string`);
+      return undefined;
+    }
+    branch = obj.branch.trim();
+  }
+
   let resultsPath: string | undefined;
   if (obj.path !== undefined) {
     if (typeof obj.path !== 'string' || obj.path.trim().length === 0) {
@@ -643,6 +654,7 @@ export function parseResultsConfig(raw: unknown, configPath: string): ResultsCon
   return {
     mode: 'github',
     repo,
+    ...(branch !== undefined && { branch }),
     ...(resultsPath !== undefined && { path: resultsPath }),
     ...(typeof obj.auto_push === 'boolean' && { auto_push: obj.auto_push }),
     ...(branchPrefix && { branch_prefix: branchPrefix }),

--- a/packages/core/src/evaluation/results-repo.ts
+++ b/packages/core/src/evaluation/results-repo.ts
@@ -723,6 +723,7 @@ export async function getResultsRepoSyncStatus(config?: ResultsConfig): Promise<
   } catch (error) {
     return {
       ...baseStatus,
+      ...(normalized.branch ? { available: false } : {}),
       sync_status: 'unavailable',
       last_error: getStatusMessage(error),
     };

--- a/packages/core/src/evaluation/results-repo.ts
+++ b/packages/core/src/evaluation/results-repo.ts
@@ -62,6 +62,15 @@ export interface ResultsRepoStatus {
   readonly commit_created?: boolean;
 }
 
+export interface NormalizedResultsConfig {
+  readonly mode: 'github';
+  readonly repo: string;
+  readonly branch?: string;
+  readonly path: string;
+  readonly auto_push: boolean;
+  readonly branch_prefix: string;
+}
+
 export interface CheckedOutResultsRepoBranch {
   readonly branchName: string;
   readonly baseBranch: string;
@@ -116,14 +125,16 @@ function expandHome(p: string): string {
   return p;
 }
 
-export function normalizeResultsConfig(config: ResultsConfig): Required<ResultsConfig> {
+export function normalizeResultsConfig(config: ResultsConfig): NormalizedResultsConfig {
   const repo = config.repo.trim();
+  const branch = config.branch?.trim();
   const resolvedPath = config.path
     ? expandHome(config.path.trim())
     : path.join(getAgentvDataDir(), 'results', sanitizeRepoSlug(repo));
   return {
     mode: 'github',
     repo,
+    ...(branch ? { branch } : {}),
     path: resolvedPath,
     auto_push: config.auto_push === true,
     branch_prefix: config.branch_prefix?.trim() || 'eval-results',
@@ -236,6 +247,78 @@ async function resolveDefaultBranch(repoDir: string): Promise<string> {
 
 async function fetchResultsRepo(repoDir: string): Promise<void> {
   await runGit(['fetch', 'origin', '--prune'], { cwd: repoDir });
+}
+
+function remoteBranchRef(branch: string): string {
+  return `origin/${branch}`;
+}
+
+function missingConfiguredBranchError(config: NormalizedResultsConfig): Error {
+  const branch = config.branch ?? '<unknown>';
+  return new Error(
+    [
+      `Results repo remote branch '${branch}' does not exist in ${config.repo}.`,
+      'Create the storage branch once, then retry. Example:',
+      `  git clone ${resolveResultsRepoUrl(config.repo)} /tmp/agentv-results-init`,
+      '  cd /tmp/agentv-results-init',
+      `  git switch --orphan ${branch}`,
+      '  git rm -rf .',
+      '  git commit --allow-empty -m "chore(results): initialize AgentV results branch"',
+      `  git push origin HEAD:${branch}`,
+    ].join('\n'),
+  );
+}
+
+async function assertConfiguredResultsBranchExists(
+  repoDir: string,
+  config: NormalizedResultsConfig,
+): Promise<string | undefined> {
+  if (!config.branch) {
+    return undefined;
+  }
+
+  const ref = remoteBranchRef(config.branch);
+  const { stdout } = await runGit(['rev-parse', '--verify', `${ref}^{commit}`], {
+    cwd: repoDir,
+    check: false,
+  });
+  if (!stdout.trim()) {
+    throw missingConfiguredBranchError(config);
+  }
+  return ref;
+}
+
+async function localBranchExists(repoDir: string, branch: string): Promise<boolean> {
+  const { stdout } = await runGit(['rev-parse', '--verify', `refs/heads/${branch}`], {
+    cwd: repoDir,
+    check: false,
+  });
+  return stdout.trim().length > 0;
+}
+
+async function checkoutConfiguredResultsBranch(
+  repoDir: string,
+  config: NormalizedResultsConfig,
+): Promise<string | undefined> {
+  const remoteRef = await assertConfiguredResultsBranchExists(repoDir, config);
+  if (!config.branch || !remoteRef) {
+    return undefined;
+  }
+
+  const currentBranch = await getCurrentBranch(repoDir);
+  if (currentBranch !== config.branch) {
+    if (await localBranchExists(repoDir, config.branch)) {
+      await runGit(['checkout', config.branch], { cwd: repoDir });
+    } else {
+      await runGit(['checkout', '--track', '-b', config.branch, remoteRef], { cwd: repoDir });
+    }
+  }
+  await runGit(['branch', '--set-upstream-to', remoteRef, config.branch], {
+    cwd: repoDir,
+    check: false,
+  });
+
+  return remoteRef;
 }
 
 async function isGitRepository(repoDir: string): Promise<boolean> {
@@ -360,7 +443,14 @@ async function getCurrentBranch(repoDir: string): Promise<string | undefined> {
   return sha.trim() ? `HEAD@${sha.trim()}` : undefined;
 }
 
-async function resolveComparisonRef(repoDir: string): Promise<string | undefined> {
+async function resolveComparisonRef(
+  repoDir: string,
+  config?: NormalizedResultsConfig,
+): Promise<string | undefined> {
+  if (config?.branch) {
+    return assertConfiguredResultsBranchExists(repoDir, config);
+  }
+
   const { stdout: upstream } = await runGit(
     ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'],
     { cwd: repoDir, check: false },
@@ -439,9 +529,12 @@ async function buildGitDiffSummary(
   return summaries.length > 0 ? summaries.join('\n') : undefined;
 }
 
-async function inspectResultsRepoGit(repoDir: string): Promise<ResultsRepoGitInspection> {
+async function inspectResultsRepoGit(
+  repoDir: string,
+  config?: NormalizedResultsConfig,
+): Promise<ResultsRepoGitInspection> {
   const branch = await getCurrentBranch(repoDir);
-  const upstream = await resolveComparisonRef(repoDir);
+  const upstream = await resolveComparisonRef(repoDir, config);
   const { stdout: porcelain } = await runGit(
     ['status', '--porcelain=v1', '--untracked-files=all'],
     {
@@ -591,10 +684,13 @@ function getPushTargetBranch(upstream: string | undefined, baseBranch: string): 
 }
 
 async function statusFromInspection(
-  normalized: Required<ResultsConfig>,
+  normalized: NormalizedResultsConfig,
   repoDir: string,
 ): Promise<ResultsRepoStatus> {
-  return withGitInspection(getResultsRepoStatus(normalized), await inspectResultsRepoGit(repoDir));
+  return withGitInspection(
+    getResultsRepoStatus(normalized),
+    await inspectResultsRepoGit(repoDir, normalized),
+  );
 }
 
 export async function getResultsRepoSyncStatus(config?: ResultsConfig): Promise<ResultsRepoStatus> {
@@ -619,7 +715,11 @@ export async function getResultsRepoSyncStatus(config?: ResultsConfig): Promise<
   }
 
   try {
-    return withGitInspection(baseStatus, await inspectResultsRepoGit(normalized.path));
+    if (normalized.branch) {
+      await fetchResultsRepo(normalized.path);
+      await checkoutConfiguredResultsBranch(normalized.path, normalized);
+    }
+    return withGitInspection(baseStatus, await inspectResultsRepoGit(normalized.path, normalized));
   } catch (error) {
     return {
       ...baseStatus,
@@ -635,6 +735,7 @@ export async function syncResultsRepo(config: ResultsConfig): Promise<ResultsRep
   try {
     const repoDir = await ensureResultsRepoClone(normalized);
     await fetchResultsRepo(repoDir);
+    await checkoutConfiguredResultsBranch(repoDir, normalized);
     updateStatusFile(normalized, {
       last_synced_at: new Date().toISOString(),
       last_error: undefined,
@@ -673,7 +774,8 @@ export async function syncResultsRepoForProject(config: ResultsConfig): Promise<
   try {
     const repoDir = await ensureResultsRepoClone(normalized);
     await fetchResultsRepo(repoDir);
-    let inspection = await inspectResultsRepoGit(repoDir);
+    await checkoutConfiguredResultsBranch(repoDir, normalized);
+    let inspection = await inspectResultsRepoGit(repoDir, normalized);
 
     if (inspection.syncStatus === 'conflicted') {
       const status = withGitInspection(getResultsRepoStatus(normalized), inspection);
@@ -720,9 +822,9 @@ export async function syncResultsRepoForProject(config: ResultsConfig): Promise<
         try {
           await runGit(['merge', '--ff-only', inspection.upstream], { cwd: repoDir });
           pullPerformed = true;
-          inspection = await inspectResultsRepoGit(repoDir);
+          inspection = await inspectResultsRepoGit(repoDir, normalized);
         } catch (error) {
-          inspection = await inspectResultsRepoGit(repoDir);
+          inspection = await inspectResultsRepoGit(repoDir, normalized);
           const status = withGitInspection(getResultsRepoStatus(normalized), inspection);
           const reason = `Results repo could not be fast-forwarded: ${getStatusMessage(error)}`;
           updateStatusFile(normalized, { last_error: reason });
@@ -749,7 +851,7 @@ export async function syncResultsRepoForProject(config: ResultsConfig): Promise<
           },
         );
         commitCreated = true;
-        inspection = await inspectResultsRepoGit(repoDir);
+        inspection = await inspectResultsRepoGit(repoDir, normalized);
       }
     }
 
@@ -781,9 +883,9 @@ export async function syncResultsRepoForProject(config: ResultsConfig): Promise<
       try {
         await runGit(['merge', '--ff-only', inspection.upstream], { cwd: repoDir });
         pullPerformed = true;
-        inspection = await inspectResultsRepoGit(repoDir);
+        inspection = await inspectResultsRepoGit(repoDir, normalized);
       } catch (error) {
-        inspection = await inspectResultsRepoGit(repoDir);
+        inspection = await inspectResultsRepoGit(repoDir, normalized);
         const status = withGitInspection(getResultsRepoStatus(normalized), inspection);
         const reason = `Results repo could not be fast-forwarded: ${getStatusMessage(error)}`;
         updateStatusFile(normalized, { last_error: reason });
@@ -819,16 +921,16 @@ export async function syncResultsRepoForProject(config: ResultsConfig): Promise<
         });
       }
 
-      const baseBranch = await resolveDefaultBranch(repoDir);
+      const baseBranch = normalized.branch ?? (await resolveDefaultBranch(repoDir));
       const targetBranch = getPushTargetBranch(inspection.upstream, baseBranch);
       try {
         await runGit(['push', 'origin', `HEAD:${targetBranch}`], { cwd: repoDir });
         pushPerformed = true;
         await fetchResultsRepo(repoDir);
-        inspection = await inspectResultsRepoGit(repoDir);
+        inspection = await inspectResultsRepoGit(repoDir, normalized);
       } catch (error) {
         await fetchResultsRepo(repoDir).catch(() => undefined);
-        inspection = await inspectResultsRepoGit(repoDir);
+        inspection = await inspectResultsRepoGit(repoDir, normalized);
         const status = withGitInspection(getResultsRepoStatus(normalized), inspection);
         const reason = `Results repo push was rejected: ${getStatusMessage(error)}`;
         updateStatusFile(normalized, { last_error: reason });
@@ -1000,22 +1102,23 @@ export async function createDraftResultsPr(params: {
 
 const DIRECT_PUSH_MAX_RETRIES = 3;
 
-async function hasUnpushedCommits(repoDir: string, baseBranch: string): Promise<boolean> {
-  const { stdout } = await runGit(['rev-list', '--count', `origin/${baseBranch}..HEAD`], {
+async function hasUnpushedCommits(repoDir: string, upstreamRef: string): Promise<boolean> {
+  const { stdout } = await runGit(['rev-list', '--count', `${upstreamRef}..HEAD`], {
     cwd: repoDir,
     check: false,
   });
   return Number.parseInt(stdout.trim(), 10) > 0;
 }
 
-async function pushDirectResultsToBase(params: {
-  readonly normalized: Required<ResultsConfig>;
+async function pushDirectResultsToStorageBranch(params: {
+  readonly normalized: NormalizedResultsConfig;
   readonly repoDir: string;
-  readonly baseBranch: string;
+  readonly storageBranch: string;
+  readonly upstreamRef: string;
 }): Promise<void> {
   for (let attempt = 1; attempt <= DIRECT_PUSH_MAX_RETRIES; attempt++) {
     try {
-      await runGit(['push', 'origin', `HEAD:${params.baseBranch}`], { cwd: params.repoDir });
+      await runGit(['push', 'origin', `HEAD:${params.storageBranch}`], { cwd: params.repoDir });
       updateStatusFile(params.normalized, {
         last_synced_at: new Date().toISOString(),
         last_error: undefined,
@@ -1025,7 +1128,7 @@ async function pushDirectResultsToBase(params: {
       const message = error instanceof Error ? error.message : String(error);
       if (attempt < DIRECT_PUSH_MAX_RETRIES && message.includes('non-fast-forward')) {
         await fetchResultsRepo(params.repoDir);
-        await runGit(['rebase', `origin/${params.baseBranch}`], { cwd: params.repoDir });
+        await runGit(['rebase', params.upstreamRef], { cwd: params.repoDir });
       } else {
         throw error;
       }
@@ -1034,7 +1137,7 @@ async function pushDirectResultsToBase(params: {
 }
 
 /**
- * Push results directly to the base branch of the results repo.
+ * Push results directly to the configured storage branch of the results repo.
  * Handles non-fast-forward conflicts by fetching, rebasing, and retrying.
  * Returns true if artifacts were pushed, false if no changes were detected.
  */
@@ -1046,8 +1149,10 @@ export async function directPushResults(params: {
 }): Promise<boolean> {
   const normalized = normalizeResultsConfig(params.config);
   const repoDir = await ensureResultsRepoClone(normalized);
-  const baseBranch = await resolveDefaultBranch(repoDir);
   await fetchResultsRepo(repoDir);
+  const configuredRef = await checkoutConfiguredResultsBranch(repoDir, normalized);
+  const storageBranch = normalized.branch ?? (await resolveDefaultBranch(repoDir));
+  const upstreamRef = configuredRef ?? remoteBranchRef(storageBranch);
   const targetRunId = buildGitRunId(params.destinationPath);
 
   const destinationDir = path.join(
@@ -1068,12 +1173,12 @@ export async function directPushResults(params: {
     check: false,
   });
   if (status.trim().length === 0) {
-    if (await hasUnpushedCommits(repoDir, baseBranch)) {
-      const aheadPaths = await getAheadPaths(repoDir, `origin/${baseBranch}`);
+    if (await hasUnpushedCommits(repoDir, upstreamRef)) {
+      const aheadPaths = await getAheadPaths(repoDir, upstreamRef);
       if (!areSafeResultsRepoPaths(aheadPaths)) {
         throw new Error('Results repo has non-results committed changes');
       }
-      await pushDirectResultsToBase({ normalized, repoDir, baseBranch });
+      await pushDirectResultsToStorageBranch({ normalized, repoDir, storageBranch, upstreamRef });
       return true;
     }
     return false;
@@ -1083,7 +1188,7 @@ export async function directPushResults(params: {
     cwd: repoDir,
   });
 
-  await pushDirectResultsToBase({ normalized, repoDir, baseBranch });
+  await pushDirectResultsToStorageBranch({ normalized, repoDir, storageBranch, upstreamRef });
   return true;
 }
 

--- a/packages/core/src/evaluation/validation/config-validator.ts
+++ b/packages/core/src/evaluation/validation/config-validator.ts
@@ -286,6 +286,18 @@ function validateProjectResultsConfig(
 
   validateGitRemoteUrl(errors, filePath, resultsRecord.repo_url, `${location}.repo_url`);
 
+  if (
+    resultsRecord.branch !== undefined &&
+    (typeof resultsRecord.branch !== 'string' || resultsRecord.branch.trim().length === 0)
+  ) {
+    errors.push({
+      severity: 'error',
+      filePath,
+      location: `${location}.branch`,
+      message: `Field '${location}.branch' must be a non-empty string`,
+    });
+  }
+
   if (resultsRecord.path !== undefined) {
     if (typeof resultsRecord.path !== 'string' || resultsRecord.path.trim().length === 0) {
       errors.push({
@@ -373,6 +385,18 @@ function validateResultsConfig(
     });
   }
   validateRequiredString(errors, filePath, resultsRecord.repo, `${location}.repo`);
+
+  if (
+    resultsRecord.branch !== undefined &&
+    (typeof resultsRecord.branch !== 'string' || resultsRecord.branch.trim().length === 0)
+  ) {
+    errors.push({
+      severity: 'error',
+      filePath,
+      location: `${location}.branch`,
+      message: `Field '${location}.branch' must be a non-empty string`,
+    });
+  }
 
   if (resultsRecord.path !== undefined) {
     if (typeof resultsRecord.path !== 'string' || resultsRecord.path.trim().length === 0) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -81,6 +81,7 @@ export {
   materializeGitRun,
   type CheckedOutResultsRepoBranch,
   type GitListedRun,
+  type NormalizedResultsConfig,
   type PreparedResultsRepoBranch,
   type ResultsRepoLocalPaths,
   type ResultsRepoSyncStatus,

--- a/packages/core/src/projects.ts
+++ b/packages/core/src/projects.ts
@@ -21,6 +21,7 @@
  *       ref: main
  *       results:
  *         repo_url: git@github.com:example/my-app-results.git
+ *         branch: agentv-results
  *         path: /srv/agentv/results/my-app
  *         sync:
  *           auto_push: true
@@ -62,6 +63,7 @@ export interface ProjectResultsSyncConfig {
 
 export interface ProjectResultsConfig {
   repoUrl: string;
+  branch?: string;
   path?: string;
   sync?: ProjectResultsSyncConfig;
   branchPrefix?: string;
@@ -99,6 +101,7 @@ interface ProjectResultsSyncYaml {
 
 interface ProjectResultsYaml {
   repo_url: string;
+  branch?: string;
   path?: string;
   sync?: ProjectResultsSyncYaml;
   branch_prefix?: string;
@@ -140,6 +143,9 @@ function fromYaml(raw: unknown): ProjectEntry | null {
       const sync = r.sync && typeof r.sync === 'object' ? r.sync : undefined;
       entry.results = {
         repoUrl: r.repo_url.trim(),
+        ...(typeof r.branch === 'string' && r.branch.trim().length > 0
+          ? { branch: r.branch.trim() }
+          : {}),
         ...(typeof r.path === 'string' && r.path.trim().length > 0 ? { path: r.path.trim() } : {}),
         ...(sync && typeof sync.auto_push === 'boolean'
           ? { sync: { autoPush: sync.auto_push } }
@@ -166,6 +172,7 @@ function toYaml(entry: ProjectEntry): ProjectEntryYaml {
   if (entry.results) {
     yaml.results = {
       repo_url: entry.results.repoUrl,
+      ...(entry.results.branch !== undefined && { branch: entry.results.branch }),
       ...(entry.results.path !== undefined && { path: entry.results.path }),
       ...(entry.results.sync?.autoPush !== undefined && {
         sync: { auto_push: entry.results.sync.autoPush },

--- a/packages/core/test/evaluation/loaders/config-loader.test.ts
+++ b/packages/core/test/evaluation/loaders/config-loader.test.ts
@@ -254,6 +254,7 @@ describe('parseResultsConfig', () => {
       {
         mode: 'github',
         repo: 'EntityProcess/agentv-evals',
+        branch: 'agentv-results',
         path: '~/data/agentv-results',
         auto_push: true,
         branch_prefix: 'eval-results',
@@ -264,6 +265,7 @@ describe('parseResultsConfig', () => {
     expect(result).toEqual({
       mode: 'github',
       repo: 'EntityProcess/agentv-evals',
+      branch: 'agentv-results',
       path: '~/data/agentv-results',
       auto_push: true,
       branch_prefix: 'eval-results',
@@ -351,6 +353,19 @@ describe('parseResultsConfig', () => {
       {
         mode: 'github',
         repo: 123,
+      },
+      '/tmp/.agentv/config.yaml',
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when branch is empty', () => {
+    const result = parseResultsConfig(
+      {
+        mode: 'github',
+        repo: 'EntityProcess/agentv-evals',
+        branch: '',
       },
       '/tmp/.agentv/config.yaml',
     );

--- a/packages/core/test/evaluation/results-repo.test.ts
+++ b/packages/core/test/evaluation/results-repo.test.ts
@@ -60,6 +60,15 @@ function initializeRemoteRepo(rootDir: string): { remoteDir: string; seedDir: st
   return { remoteDir, seedDir };
 }
 
+function initializeRemoteStorageBranch(seedDir: string, branch = 'agentv-results'): string {
+  git(`git switch --quiet --orphan ${branch}`, seedDir);
+  git('git rm -rf --quiet . 2>/dev/null || true', seedDir);
+  git('git commit --quiet --allow-empty -m "seed results branch"', seedDir);
+  git(`git push --quiet origin HEAD:${branch}`, seedDir);
+  git('git switch --quiet main', seedDir);
+  return branch;
+}
+
 function writeRunArtifacts(runDir: string, experiment: string, timestamp: string): void {
   mkdirSync(runDir, { recursive: true });
   writeFileSync(path.join(runDir, 'index.jsonl'), '{"test_id":"alpha"}\n');
@@ -295,6 +304,33 @@ describe('listGitRuns', () => {
       'hello from git\n',
     );
   });
+
+  it('lists and materializes runs from a non-default ref', async () => {
+    writeFileSync(path.join(repoDir, 'README.md'), '# test\n');
+    git('git add README.md && git commit -m "initial"', repoDir);
+    const defaultBranch = git('git branch --show-current', repoDir);
+    git('git checkout -b agentv-results', repoDir);
+
+    const runDir = path.join(
+      repoDir,
+      '.agentv',
+      'results',
+      'runs',
+      'branch-only',
+      '2026-06-12T10-00-00-000Z',
+    );
+    writeRunArtifacts(runDir, 'branch-only', '2026-06-12T10:00:00.000Z');
+    writeFileSync(path.join(runDir, 'attachments.txt'), 'from branch\n');
+    git('git add .agentv && git commit -m "seed branch run"', repoDir);
+    git(`git checkout ${defaultBranch}`, repoDir);
+
+    const runs = await listGitRuns(repoDir, 'agentv-results');
+    expect(runs).toHaveLength(1);
+    expect(runs[0].run_id).toBe('branch-only::2026-06-12T10-00-00-000Z');
+
+    await materializeGitRun(repoDir, 'branch-only/2026-06-12T10-00-00-000Z', 'agentv-results');
+    expect(readFileSync(path.join(runDir, 'attachments.txt'), 'utf8')).toBe('from branch\n');
+  });
 });
 
 describe('results repo write path', () => {
@@ -406,6 +442,63 @@ describe('results repo write path', () => {
     expect(runs[0].run_id).toBe(`with-skills::${runTimestamp}`);
   }, 20000);
 
+  it('pushes direct results to the configured storage branch', async () => {
+    const { remoteDir, seedDir } = initializeRemoteRepo(rootDir);
+    const storageBranch = initializeRemoteStorageBranch(seedDir);
+    const cloneDir = path.join(rootDir, 'results-clone');
+    const sourceDir = path.join(rootDir, 'source-run');
+    const runTimestamp = '2026-06-12T10-00-00-000Z';
+    const destinationPath = path.join('branch-storage', runTimestamp);
+    const config = {
+      ...createResultsConfig(remoteDir, cloneDir),
+      branch: storageBranch,
+    };
+    writeRunArtifacts(sourceDir, 'branch-storage', '2026-06-12T10:00:00.000Z');
+
+    await ensureResultsRepoClone(config);
+    git('git config user.email "test@example.com"', cloneDir);
+    git('git config user.name "Test User"', cloneDir);
+
+    const pushed = await directPushResults({
+      config,
+      sourceDir,
+      destinationPath,
+      commitMessage: 'feat(results): branch-storage - 1/1 PASS (1.000)',
+    });
+
+    expect(pushed).toBe(true);
+    expect(git('git branch --show-current', cloneDir)).toBe(storageBranch);
+    expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir)).not.toContain(
+      `.agentv/results/runs/branch-storage/${runTimestamp}/benchmark.json`,
+    );
+    expect(
+      git(`git --git-dir "${remoteDir}" ls-tree -r --name-only ${storageBranch}`, rootDir),
+    ).toContain(`.agentv/results/runs/branch-storage/${runTimestamp}/benchmark.json`);
+    expect(
+      git(`git --git-dir "${remoteDir}" log -1 --pretty=%B ${storageBranch}`, rootDir),
+    ).toContain(`Agentv-Run: branch-storage::${runTimestamp}`);
+  }, 20000);
+
+  it('fails clearly when a configured storage branch is missing', async () => {
+    const { remoteDir } = initializeRemoteRepo(rootDir);
+    const cloneDir = path.join(rootDir, 'results-clone');
+    const sourceDir = path.join(rootDir, 'source-run');
+    const config = {
+      ...createResultsConfig(remoteDir, cloneDir),
+      branch: 'agentv-results',
+    };
+    writeRunArtifacts(sourceDir, 'missing-branch', '2026-06-12T11:00:00.000Z');
+
+    await expect(
+      directPushResults({
+        config,
+        sourceDir,
+        destinationPath: path.join('missing-branch', '2026-06-12T11-00-00-000Z'),
+        commitMessage: 'feat(results): missing branch',
+      }),
+    ).rejects.toThrow(/git switch --orphan agentv-results/);
+  }, 20000);
+
   it('syncResultsRepo refreshes refs without checking out the base branch', async () => {
     const { remoteDir, seedDir } = initializeRemoteRepo(rootDir);
     const cloneDir = path.join(rootDir, 'results-clone');
@@ -491,6 +584,42 @@ describe('results repo write path', () => {
       blocked: false,
     });
     expect(readFileSync(path.join(cloneDir, 'REMOTE.md'), 'utf8')).toBe('remote update\n');
+  }, 20000);
+
+  it('fast-forwards the configured storage branch during project sync', async () => {
+    const { remoteDir, seedDir } = initializeRemoteRepo(rootDir);
+    const storageBranch = initializeRemoteStorageBranch(seedDir);
+    const cloneDir = path.join(rootDir, 'results-clone');
+    const config = {
+      ...createResultsConfig(remoteDir, cloneDir),
+      auto_push: false,
+      branch: storageBranch,
+    };
+
+    await ensureResultsRepoClone(config);
+    await syncResultsRepoForProject(config);
+    git(`git switch --quiet ${storageBranch}`, seedDir);
+    writeFileSync(path.join(seedDir, 'REMOTE_BRANCH.md'), 'branch remote update\n');
+    git('git add REMOTE_BRANCH.md && git commit --quiet -m "remote branch update"', seedDir);
+    git(`git push --quiet origin HEAD:${storageBranch}`, seedDir);
+
+    const status = await syncResultsRepoForProject(config);
+
+    expect(status).toMatchObject({
+      sync_status: 'clean',
+      pull_performed: true,
+      push_performed: false,
+      commit_created: false,
+      blocked: false,
+      branch: storageBranch,
+      upstream: `origin/${storageBranch}`,
+    });
+    expect(readFileSync(path.join(cloneDir, 'REMOTE_BRANCH.md'), 'utf8')).toBe(
+      'branch remote update\n',
+    );
+    expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir)).not.toContain(
+      'REMOTE_BRANCH.md',
+    );
   }, 20000);
 
   it('commits and pushes safe dirty result metadata when auto_push is enabled', async () => {

--- a/packages/core/test/evaluation/validation/config-validator.test.ts
+++ b/packages/core/test/evaluation/validation/config-validator.test.ts
@@ -53,6 +53,7 @@ describe('validateConfigFile', () => {
       `results:
   mode: github
   repo: EntityProcess/agentv-evals
+  branch: agentv-results
   auto_push: true
   branch_prefix: eval-results
 `,
@@ -91,6 +92,7 @@ describe('validateConfigFile', () => {
     ref: main
     results:
       repo_url: git@github.com:EntityProcess/agentv-results.git
+      branch: agentv-results
       path: /srv/agentv-results
       sync:
         auto_push: true
@@ -165,6 +167,7 @@ describe('validateConfigFile', () => {
     ref: ""
     results:
       repo_url: EntityProcess/results
+      branch: ""
       path: repo/subdir
       sync:
         auto_push: yes
@@ -184,6 +187,7 @@ describe('validateConfigFile', () => {
         expect.objectContaining({ severity: 'error', location: 'projects[0].path' }),
         expect.objectContaining({ severity: 'error', location: 'projects[0].ref' }),
         expect.objectContaining({ severity: 'error', location: 'projects[0].results.repo_url' }),
+        expect.objectContaining({ severity: 'error', location: 'projects[0].results.branch' }),
         expect.objectContaining({ severity: 'error', location: 'projects[0].results.path' }),
         expect.objectContaining({
           severity: 'error',

--- a/packages/core/test/projects.test.ts
+++ b/packages/core/test/projects.test.ts
@@ -144,6 +144,7 @@ describe('projects registry', () => {
     path: /srv/agentv/repo
     results:
       repo_url: https://github.com/EntityProcess/results-project-runs.git
+      branch: agentv-results
       path: /srv/agentv/results/results-project
       sync:
         auto_push: true
@@ -157,6 +158,7 @@ describe('projects registry', () => {
     const registry = loadProjectRegistry();
     expect(registry.projects[0].results).toEqual({
       repoUrl: 'https://github.com/EntityProcess/results-project-runs.git',
+      branch: 'agentv-results',
       path: '/srv/agentv/results/results-project',
       sync: { autoPush: true },
       branchPrefix: 'eval-results',
@@ -164,6 +166,7 @@ describe('projects registry', () => {
 
     saveProjectRegistry(registry);
     const yamlOnDisk = readFileSync(registryPath, 'utf-8');
+    expect(yamlOnDisk).toContain('branch: agentv-results');
     expect(yamlOnDisk).toContain('path: /srv/agentv/results/results-project');
     expect(yamlOnDisk).toContain('auto_push: true');
     expect(yamlOnDisk).toContain('branch_prefix: eval-results');


### PR DESCRIPTION
## Summary
- Add optional `results.branch` / `ProjectResultsConfig.branch` storage-branch support while preserving default-branch behavior when absent.
- Route git-native status/sync/direct-push/list/materialize flows to `origin/<branch>` when configured.
- Preserve project registry round-trips and document that `branch_prefix` is only for temporary result/PR branches.

## Result-portability framing
AgentV's positioning is that teams should build portable eval packs on AgentV instead of bespoke eval frameworks. Result portability is part of that claim: outputs, traces, and result artifacts should sync through boring git-native storage and remain inspectable by Dashboard/remote sync without custom scripts.

This PR makes non-default storage branches (for example `agentv-results`) a small, explicit AgentV capability rather than an implicit assumption about the results repo default branch. The capability is generic results storage only; it does **not** absorb Harvey/Irys-specific benchmark shapes or domain schemas into AgentV core.

Separate results repositories remain the preferred/current path for shared remote results because they isolate generated artifacts from source history and keep permissions/retention policies simple. This PR only lets that dedicated results repo use a configured storage branch when teams want the repo default branch reserved for docs, bootstrap material, or governance files.

## Design notes
- This is intentionally minimal: no storage-branch auto-creation. A configured branch must already exist.
- Missing configured branches fail with actionable orphan-branch initialization guidance.
- Cache keys now include the storage ref so Dashboard git-native run listing does not mix default-branch and configured-branch results.
- Schema restraint: `results.branch` is a storage ref, not a benchmark/result-shape extension point.

## Red/green UAT evidence
- **Red (before change):** direct push with runtime `branch: "agentv-results"` still pushed to default `main` (`files_on_main=2`, `files_on_agentv_results=0`).
- **Green (after change):** identical direct-push scenario checked out and pushed `agentv-results` (`clone_current_branch=agentv-results`, `files_on_main=0`, `files_on_agentv_results=2`).
- Operational proof is intentionally boring: Dashboard git-native listing, remote sync, materialization, and direct push all exercise the configured branch through existing AgentV flows, with no bespoke scripts.

## Verification
- `bun test packages/core/test/evaluation/loaders/config-loader.test.ts packages/core/test/projects.test.ts packages/core/test/evaluation/validation/config-validator.test.ts packages/core/test/evaluation/results-repo.test.ts apps/cli/test/commands/results/serve.test.ts`
- `bun test packages/core/test/evaluation/results-repo.test.ts apps/cli/test/commands/results/serve.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run validate:examples`
- `bun run build`
- Push hook also ran workspace typechecks + `biome check .` successfully.

## Unsupported edge cases / follow-ups
- Configured storage branch must already exist; initialize once with an orphan branch before syncing/pushing.
- Repos with no usable default branch may still fail the initial clone before AgentV can check out the configured storage branch.
- No changes to `branch_prefix` semantics.

## Post-Deploy Monitoring & Validation
- Watch GitHub Actions for build/typecheck/lint/test regressions.
- For configured projects, validate Dashboard/API remote status has no `last_error` and that new runs land on the configured storage branch, not the results repo default branch.
- Rollback path: remove `results.branch` from config/registry to return to prior default-branch behavior, or revert this PR.

## Review note
Manual review/simplification pass completed; no actionable findings. Subagent review was not run because this harness only permits subagent tools when the user explicitly requests them.


## Review fix: missing configured storage branch fallback
- Addressed reviewer finding that a missing configured `results.branch` could be masked by filesystem fallback from the clone's checked-out default branch.
- Fix: configured-branch status failures now report remote results as unavailable, and CLI run count/listing fallback no longer reads materialized files when a storage branch is configured.
- Red evidence: the regression test failed against the pre-fix PR code with `available=true` and `run_count=1` from the default branch despite `branch: agentv-results` being missing.
- Green evidence: the same test now passes with `available=false`, `sync_status=unavailable`, `run_count=0`, no remote run listed, and direct detail lookup returning 404.
