### PR TITLE
feat(results): periodic WIP checkpoints for in-progress eval runs

### DIFF
--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -32,7 +32,11 @@ import {
 } from '@agentv/core';
 
 import { enforceRequiredVersion } from '../../version-check.js';
-import { maybeAutoExportRunArtifacts } from '../results/remote.js';
+import {
+  getRelativeRunPath,
+  loadNormalizedResultsConfig,
+  maybeAutoExportRunArtifacts,
+} from '../results/remote.js';
 import {
   aggregateRunDir,
   buildTestTargetKey,
@@ -60,6 +64,7 @@ import {
 } from './statistics.js';
 import { type TargetSelection, selectMultipleTargets, selectTarget } from './targets.js';
 import type { TaskBundleTargetSelection } from './task-bundle.js';
+import { WipCheckpointLoop } from './wip-checkpoint.js';
 
 const DEFAULT_WORKERS = 3;
 
@@ -1543,6 +1548,23 @@ export async function runEvalCommand(
     });
   }
 
+  // Periodic WIP checkpoint loop: push partial results to a unique non-default
+  // branch every ~60s so pod loss doesn't discard completed-test output.
+  // Only active when a results repo with auto_push is configured; otherwise a no-op.
+  let wipLoop: WipCheckpointLoop | undefined;
+  let wipCleanedUp = false;
+  {
+    const wipConfig = await loadNormalizedResultsConfig(cwd).catch(() => undefined);
+    if (wipConfig?.auto_push) {
+      wipLoop = new WipCheckpointLoop({
+        config: wipConfig,
+        runDir,
+        destinationPath: getRelativeRunPath(cwd, runDir),
+      });
+      await wipLoop.start();
+    }
+  }
+
   // Eval files run sequentially; within each file, --workers N test cases run in parallel.
   // This matches industry practice (promptfoo, deepeval, OpenAI Evals) and avoids cross-file
   // workspace races without any grouping complexity.
@@ -1873,6 +1895,12 @@ export async function runEvalCommand(
       );
     }
 
+    // WIP cleanup on success: publish succeeded, so remove the WIP branch.
+    if (wipLoop) {
+      wipCleanedUp = true;
+      await wipLoop.stopAndDeleteWipBranch();
+    }
+
     return {
       executionErrorCount: summary.executionErrorCount,
       outputPath,
@@ -1883,6 +1911,11 @@ export async function runEvalCommand(
       budgetExceeded: runBudgetExceeded || undefined,
     };
   } finally {
+    // WIP cleanup on failure/interrupt: stop the loop but leave the remote
+    // WIP branch intact for manual recovery.
+    if (wipLoop && !wipCleanedUp) {
+      await wipLoop.stop().catch(() => undefined);
+    }
     unsubscribeCodexLogs();
     unsubscribePiLogs();
     unsubscribeCopilotSdkLogs();

--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -33,6 +33,7 @@ import {
 
 import { enforceRequiredVersion } from '../../version-check.js';
 import {
+  type RemoteExportStatus,
   getRelativeRunPath,
   loadNormalizedResultsConfig,
   maybeAutoExportRunArtifacts,
@@ -1553,6 +1554,7 @@ export async function runEvalCommand(
   // Only active when a results repo with auto_push is configured; otherwise a no-op.
   let wipLoop: WipCheckpointLoop | undefined;
   let wipCleanedUp = false;
+  let finalExportStatus: RemoteExportStatus = 'disabled';
   {
     const wipConfig = await loadNormalizedResultsConfig(cwd).catch(() => undefined);
     if (wipConfig?.auto_push) {
@@ -1847,7 +1849,7 @@ export async function runEvalCommand(
       // Persist last run path for `agentv results` commands
       await saveRunCache(cwd, outputPath).catch(() => undefined);
 
-      await maybeAutoExportRunArtifacts({
+      finalExportStatus = await maybeAutoExportRunArtifacts({
         cwd,
         run_dir: runDir,
         test_files: activeTestFiles,
@@ -1895,8 +1897,13 @@ export async function runEvalCommand(
       );
     }
 
-    // WIP cleanup on success: publish succeeded, so remove the WIP branch.
-    if (wipLoop) {
+    // WIP cleanup on success: remove the WIP branch only after the final
+    // results branch is confirmed published (or confirmed already up to date).
+    // If export failed, leave the remote WIP checkpoint as the durable copy.
+    if (
+      wipLoop &&
+      (finalExportStatus === 'published' || finalExportStatus === 'already_published')
+    ) {
       wipCleanedUp = true;
       await wipLoop.stopAndDeleteWipBranch();
     }

--- a/apps/cli/src/commands/eval/wip-checkpoint.ts
+++ b/apps/cli/src/commands/eval/wip-checkpoint.ts
@@ -1,0 +1,119 @@
+/**
+ * WIP (work-in-progress) checkpoint loop for in-progress eval runs.
+ *
+ * Periodically force-pushes the partial run output directory to a unique
+ * non-default branch (`agentv/inflight/<hostname>/<run-dir-basename>`) in the
+ * configured results repository. This protects against pod/process loss by
+ * keeping completed-test results durable without requiring PVC or S3.
+ *
+ * Branch lifecycle:
+ *   1. Start:   set up a persistent git worktree for the WIP branch.
+ *   2. Running: every ~30s, copy run dir → worktree, amend-commit, force-push.
+ *   3. Success: after final publish to the normal results branch, delete the WIP branch.
+ *   4. Failure: leave the WIP branch for manual recovery.
+ *
+ * Manual recovery from a WIP branch:
+ *   git clone <results-repo> /tmp/recovery
+ *   cd /tmp/recovery && git checkout agentv/inflight/<hostname>/<run-dir>
+ *   cp -r .agentv/results/runs/<run-dir> <project>/.agentv/results/runs/
+ *   agentv eval <eval-file> --output <project>/.agentv/results/runs/<run-dir> --resume
+ *
+ * All checkpoint operations are best-effort: failures are logged as warnings
+ * and never propagate to the eval run.
+ */
+
+import {
+  type NormalizedResultsConfig,
+  type WipWorktreeHandle,
+  buildWipBranchName,
+  deleteWipBranch,
+  pushWipCheckpoint,
+  setupWipWorktree,
+} from '@agentv/core';
+
+const WIP_CHECKPOINT_INTERVAL_MS = 30_000;
+
+function warnCheckpointError(context: string, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  console.warn(`WIP checkpoint: ${context}: ${message}`);
+}
+
+export class WipCheckpointLoop {
+  readonly wipBranch: string;
+  private readonly config: NormalizedResultsConfig;
+  private readonly runDir: string;
+  private readonly destinationPath: string;
+  private readonly intervalMs: number;
+  private handle: WipWorktreeHandle | undefined;
+  private timer: ReturnType<typeof setInterval> | undefined;
+  private active = false;
+
+  constructor(params: {
+    readonly config: NormalizedResultsConfig;
+    readonly runDir: string;
+    readonly destinationPath: string;
+    readonly intervalMs?: number;
+  }) {
+    this.config = params.config;
+    this.runDir = params.runDir;
+    this.destinationPath = params.destinationPath;
+    this.intervalMs = params.intervalMs ?? WIP_CHECKPOINT_INTERVAL_MS;
+    this.wipBranch = buildWipBranchName(params.runDir);
+  }
+
+  async start(): Promise<void> {
+    try {
+      this.handle = await setupWipWorktree({
+        config: this.config,
+        wipBranch: this.wipBranch,
+      });
+    } catch (err) {
+      warnCheckpointError('failed to set up WIP worktree', err);
+      return;
+    }
+    this.active = true;
+    this.timer = setInterval(() => {
+      if (!this.active) return;
+      this.checkpoint().catch((err) => warnCheckpointError('push failed', err));
+    }, this.intervalMs);
+    // Unref so the timer never prevents process exit.
+    this.timer.unref?.();
+  }
+
+  private async checkpoint(): Promise<void> {
+    if (!this.handle) return;
+    await pushWipCheckpoint({
+      handle: this.handle,
+      sourceDir: this.runDir,
+      destinationPath: this.destinationPath,
+    });
+  }
+
+  /** Stop the loop and clean up the local worktree. Does NOT delete the remote WIP branch. */
+  async stop(): Promise<void> {
+    this.active = false;
+    if (this.timer !== undefined) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+    if (this.handle) {
+      await this.handle
+        .cleanup()
+        .catch((err) => warnCheckpointError('worktree cleanup failed', err));
+      this.handle = undefined;
+    }
+  }
+
+  /**
+   * Stop the loop and delete the remote WIP branch.
+   * Call after a successful run to keep the results repo tidy.
+   */
+  async stopAndDeleteWipBranch(): Promise<void> {
+    await this.stop();
+    try {
+      await deleteWipBranch({ config: this.config, wipBranch: this.wipBranch });
+    } catch (err) {
+      warnCheckpointError(`failed to delete remote branch ${this.wipBranch}`, err);
+    }
+  }
+}

--- a/apps/cli/src/commands/eval/wip-checkpoint.ts
+++ b/apps/cli/src/commands/eval/wip-checkpoint.ts
@@ -33,6 +33,20 @@ import {
 
 const WIP_CHECKPOINT_INTERVAL_MS = 30_000;
 
+export interface WipCheckpointLoopDependencies {
+  readonly buildWipBranchName: (runDir: string) => string;
+  readonly deleteWipBranch: typeof deleteWipBranch;
+  readonly pushWipCheckpoint: typeof pushWipCheckpoint;
+  readonly setupWipWorktree: typeof setupWipWorktree;
+}
+
+const defaultDependencies: WipCheckpointLoopDependencies = {
+  buildWipBranchName,
+  deleteWipBranch,
+  pushWipCheckpoint,
+  setupWipWorktree,
+};
+
 function warnCheckpointError(context: string, error: unknown): void {
   const message = error instanceof Error ? error.message : String(error);
   console.warn(`WIP checkpoint: ${context}: ${message}`);
@@ -44,8 +58,10 @@ export class WipCheckpointLoop {
   private readonly runDir: string;
   private readonly destinationPath: string;
   private readonly intervalMs: number;
+  private readonly deps: WipCheckpointLoopDependencies;
   private handle: WipWorktreeHandle | undefined;
   private timer: ReturnType<typeof setInterval> | undefined;
+  private checkpointInFlight: Promise<void> | undefined;
   private active = false;
 
   constructor(params: {
@@ -53,17 +69,19 @@ export class WipCheckpointLoop {
     readonly runDir: string;
     readonly destinationPath: string;
     readonly intervalMs?: number;
+    readonly dependencies?: WipCheckpointLoopDependencies;
   }) {
     this.config = params.config;
     this.runDir = params.runDir;
     this.destinationPath = params.destinationPath;
     this.intervalMs = params.intervalMs ?? WIP_CHECKPOINT_INTERVAL_MS;
-    this.wipBranch = buildWipBranchName(params.runDir);
+    this.deps = params.dependencies ?? defaultDependencies;
+    this.wipBranch = this.deps.buildWipBranchName(params.runDir);
   }
 
   async start(): Promise<void> {
     try {
-      this.handle = await setupWipWorktree({
+      this.handle = await this.deps.setupWipWorktree({
         config: this.config,
         wipBranch: this.wipBranch,
       });
@@ -73,16 +91,24 @@ export class WipCheckpointLoop {
     }
     this.active = true;
     this.timer = setInterval(() => {
-      if (!this.active) return;
-      this.checkpoint().catch((err) => warnCheckpointError('push failed', err));
+      this.runCheckpointIfIdle();
     }, this.intervalMs);
     // Unref so the timer never prevents process exit.
     this.timer.unref?.();
   }
 
+  private runCheckpointIfIdle(): void {
+    if (!this.active || this.checkpointInFlight) return;
+    this.checkpointInFlight = this.checkpoint()
+      .catch((err) => warnCheckpointError('push failed', err))
+      .finally(() => {
+        this.checkpointInFlight = undefined;
+      });
+  }
+
   private async checkpoint(): Promise<void> {
     if (!this.handle) return;
-    await pushWipCheckpoint({
+    await this.deps.pushWipCheckpoint({
       handle: this.handle,
       sourceDir: this.runDir,
       destinationPath: this.destinationPath,
@@ -96,6 +122,7 @@ export class WipCheckpointLoop {
       clearInterval(this.timer);
       this.timer = undefined;
     }
+    await this.checkpointInFlight;
     if (this.handle) {
       await this.handle
         .cleanup()
@@ -111,7 +138,7 @@ export class WipCheckpointLoop {
   async stopAndDeleteWipBranch(): Promise<void> {
     await this.stop();
     try {
-      await deleteWipBranch({ config: this.config, wipBranch: this.wipBranch });
+      await this.deps.deleteWipBranch({ config: this.config, wipBranch: this.wipBranch });
     } catch (err) {
       warnCheckpointError(`failed to delete remote branch ${this.wipBranch}`, err);
     }

--- a/apps/cli/src/commands/results/remote.ts
+++ b/apps/cli/src/commands/results/remote.ts
@@ -102,6 +102,8 @@ export interface RemoteExportPayload {
   readonly experiment?: string;
 }
 
+export type RemoteExportStatus = 'disabled' | 'published' | 'already_published' | 'failed';
+
 export interface RemoteResultsStatus extends ResultsRepoStatus {
   readonly run_count: number;
 }
@@ -427,10 +429,12 @@ export async function clearRemoteRunTags(
   return deleteRemoteRunTags(config.path, meta.path);
 }
 
-export async function maybeAutoExportRunArtifacts(payload: RemoteExportPayload): Promise<void> {
+export async function maybeAutoExportRunArtifacts(
+  payload: RemoteExportPayload,
+): Promise<RemoteExportStatus> {
   const config = await loadNormalizedResultsConfig(payload.cwd);
   if (!config?.auto_push) {
-    return;
+    return 'disabled';
   }
 
   try {
@@ -448,12 +452,14 @@ export async function maybeAutoExportRunArtifacts(payload: RemoteExportPayload):
 
     if (!pushed) {
       console.warn('Warning: results export produced no git changes. Skipping push.');
-      return;
+      return 'already_published';
     }
 
     console.log(`Results pushed to ${config.repo} (${config.path}/${relativeRunPath})`);
+    return 'published';
   } catch (error) {
     console.warn(`Warning: skipping results export: ${getStatusMessage(error)}`);
     console.warn("Warning: Run 'gh auth login' if GitHub authentication is missing.");
+    return 'failed';
   }
 }

--- a/apps/cli/src/commands/results/remote.ts
+++ b/apps/cli/src/commands/results/remote.ts
@@ -120,7 +120,7 @@ function statusForResult(result: EvaluationResult): 'PASS' | 'FAIL' | 'ERROR' {
   return result.score >= DEFAULT_THRESHOLD ? 'PASS' : 'FAIL';
 }
 
-function getRelativeRunPath(cwd: string, runDir: string): string {
+export function getRelativeRunPath(cwd: string, runDir: string): string {
   const relative = path.relative(path.join(cwd, '.agentv', 'results', 'runs'), runDir);
   if (!relative.startsWith('..') && !path.isAbsolute(relative)) {
     return relative;
@@ -150,7 +150,7 @@ async function maybeWarnLargeArtifact(runDir: string): Promise<void> {
   }
 }
 
-async function loadNormalizedResultsConfig(
+export async function loadNormalizedResultsConfig(
   cwd: string,
   projectId?: string,
 ): Promise<NormalizedResultsConfig | undefined> {

--- a/apps/cli/test/commands/eval/wip-checkpoint.test.ts
+++ b/apps/cli/test/commands/eval/wip-checkpoint.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+
+import { WipCheckpointLoop } from '../../../src/commands/eval/wip-checkpoint.js';
+
+type Deferred<T> = {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+  readonly reject: (error: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 500;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error('Timed out waiting for condition');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+const cleanupMock = mock(async () => {});
+const deleteWipBranchMock = mock(async () => {});
+let pushWipCheckpointImplementation = async () => true;
+const pushWipCheckpointMock = mock(async () => pushWipCheckpointImplementation());
+
+afterEach(() => {
+  cleanupMock.mockClear();
+  deleteWipBranchMock.mockClear();
+  pushWipCheckpointMock.mockClear();
+  pushWipCheckpointImplementation = async () => true;
+});
+
+describe('WipCheckpointLoop', () => {
+  it('waits for an in-flight checkpoint before cleanup and remote branch deletion', async () => {
+    const checkpoint = deferred<boolean>();
+    pushWipCheckpointImplementation = async () => checkpoint.promise;
+
+    const loop = new WipCheckpointLoop({
+      config: {
+        mode: 'github',
+        repo: 'https://github.com/example/results.git',
+        branch: 'main',
+        path: '/tmp/results',
+        auto_push: true,
+        branch_prefix: 'agentv/results',
+      },
+      runDir: '/tmp/run-001',
+      destinationPath: 'default/run-001',
+      intervalMs: 1,
+      dependencies: {
+        buildWipBranchName: (runDir) => `agentv/inflight/test/${runDir.split('/').pop()}`,
+        deleteWipBranch: deleteWipBranchMock,
+        pushWipCheckpoint: pushWipCheckpointMock,
+        setupWipWorktree: mock(async ({ wipBranch }) => ({
+          wipBranch,
+          worktreeDir: '/tmp/wip-worktree',
+          cloneDir: '/tmp/wip-clone',
+          cleanup: cleanupMock,
+        })),
+      },
+    });
+
+    await loop.start();
+    await waitFor(() => pushWipCheckpointMock.mock.calls.length === 1);
+
+    const stopped = loop.stopAndDeleteWipBranch();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(cleanupMock).not.toHaveBeenCalled();
+    expect(deleteWipBranchMock).not.toHaveBeenCalled();
+
+    checkpoint.resolve(true);
+    await stopped;
+
+    expect(cleanupMock).toHaveBeenCalledTimes(1);
+    expect(deleteWipBranchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/cli/test/commands/results/remote-auto-export.test.ts
+++ b/apps/cli/test/commands/results/remote-auto-export.test.ts
@@ -102,15 +102,37 @@ describe('maybeAutoExportRunArtifacts', () => {
   let rootDir: string;
   let projectDir: string;
   let cloneDir: string;
+  let previousHome: string | undefined;
+  let previousXdgConfigHome: string | undefined;
 
   beforeEach(() => {
     rootDir = mkdtempSync(path.join(os.tmpdir(), 'agentv-remote-export-test-'));
     projectDir = path.join(rootDir, 'project');
     cloneDir = path.join(rootDir, 'results-clone');
     mkdirSync(projectDir, { recursive: true });
+
+    // CI runners do not always have a global Git identity configured. Keep the
+    // tests honest by making the results repo clone rely on AgentV's local
+    // identity setup rather than the developer machine's ~/.gitconfig.
+    previousHome = process.env.HOME;
+    previousXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.HOME = path.join(rootDir, 'empty-home');
+    process.env.XDG_CONFIG_HOME = path.join(rootDir, 'empty-xdg-config');
+    mkdirSync(process.env.HOME, { recursive: true });
+    mkdirSync(process.env.XDG_CONFIG_HOME, { recursive: true });
   });
 
   afterEach(() => {
+    if (previousHome === undefined) {
+      process.env.HOME = undefined;
+    } else {
+      process.env.HOME = previousHome;
+    }
+    if (previousXdgConfigHome === undefined) {
+      process.env.XDG_CONFIG_HOME = undefined;
+    } else {
+      process.env.XDG_CONFIG_HOME = previousXdgConfigHome;
+    }
     rmSync(rootDir, { recursive: true, force: true });
   });
 

--- a/apps/cli/test/commands/results/remote-auto-export.test.ts
+++ b/apps/cli/test/commands/results/remote-auto-export.test.ts
@@ -1,0 +1,185 @@
+import { execSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import type { EvaluationResult } from '@agentv/core';
+import { maybeAutoExportRunArtifacts } from '../../../src/commands/results/remote.js';
+
+function cleanGitEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && !(key.startsWith('GIT_') && key !== 'GIT_SSH_COMMAND')) {
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
+function git(cmd: string, cwd: string): string {
+  return execSync(cmd, {
+    cwd,
+    encoding: 'utf8',
+    env: cleanGitEnv(),
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function initializeRemoteRepo(rootDir: string): string {
+  const remoteDir = path.join(rootDir, 'results-remote.git');
+  git(`git init --bare --initial-branch=main --quiet "${remoteDir}"`, rootDir);
+
+  const seedDir = path.join(rootDir, 'results-seed');
+  git(`git clone --quiet "${remoteDir}" "${seedDir}"`, rootDir);
+  git('git config user.email "test@example.com"', seedDir);
+  git('git config user.name "Test User"', seedDir);
+  writeFileSync(path.join(seedDir, 'README.md'), '# results repo\n');
+  git('git add README.md && git commit --quiet -m "seed repo"', seedDir);
+  git('git push --quiet origin main', seedDir);
+  return remoteDir;
+}
+
+function writeProjectConfig(
+  projectDir: string,
+  params: { repo: string; path: string; autoPush: boolean },
+) {
+  mkdirSync(path.join(projectDir, '.agentv'), { recursive: true });
+  writeFileSync(
+    path.join(projectDir, '.agentv', 'config.yaml'),
+    `results:
+  mode: github
+  repo: ${JSON.stringify(params.repo)}
+  path: ${JSON.stringify(params.path)}
+  auto_push: ${params.autoPush}
+`,
+  );
+}
+
+function writeRunArtifacts(projectDir: string): string {
+  const runDir = path.join(projectDir, '.agentv', 'results', 'runs', 'default', 'run-001');
+  mkdirSync(runDir, { recursive: true });
+  writeFileSync(
+    path.join(runDir, 'index.jsonl'),
+    `${JSON.stringify({ test_id: 'alpha', score: 1 })}\n`,
+  );
+  writeFileSync(
+    path.join(runDir, 'benchmark.json'),
+    `${JSON.stringify({ eval_file: 'evals/example.eval.yaml', tests_run: 1 }, null, 2)}\n`,
+  );
+  return runDir;
+}
+
+function payload(projectDir: string, runDir: string) {
+  return {
+    cwd: projectDir,
+    run_dir: runDir,
+    test_files: [path.join(projectDir, 'evals', 'example.eval.yaml')],
+    results: [
+      {
+        testId: 'alpha',
+        score: 1,
+        assertions: [],
+        output: 'ok',
+        target: 'mock',
+        timestamp: '2026-06-13T00:00:00.000Z',
+        trace: {
+          schemaVersion: 'agentv.trace.v1',
+          messages: [],
+          events: [],
+          eventCount: 0,
+          toolCalls: {},
+          errorCount: 0,
+        },
+      } satisfies EvaluationResult,
+    ],
+    eval_summaries: [],
+  };
+}
+
+describe('maybeAutoExportRunArtifacts', () => {
+  let rootDir: string;
+  let projectDir: string;
+  let cloneDir: string;
+
+  beforeEach(() => {
+    rootDir = mkdtempSync(path.join(os.tmpdir(), 'agentv-remote-export-test-'));
+    projectDir = path.join(rootDir, 'project');
+    cloneDir = path.join(rootDir, 'results-clone');
+    mkdirSync(projectDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  it('returns published after final results are pushed', async () => {
+    const remoteDir = initializeRemoteRepo(rootDir);
+    const runDir = writeRunArtifacts(projectDir);
+    writeProjectConfig(projectDir, {
+      repo: `file://${remoteDir}`,
+      path: cloneDir,
+      autoPush: true,
+    });
+
+    const status = await maybeAutoExportRunArtifacts(payload(projectDir, runDir));
+
+    expect(status).toBe('published');
+    expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir)).toContain(
+      '.agentv/results/runs/default/run-001/index.jsonl',
+    );
+  }, 20_000);
+
+  it('returns already_published when the final results branch is already up to date', async () => {
+    const remoteDir = initializeRemoteRepo(rootDir);
+    const runDir = writeRunArtifacts(projectDir);
+    writeProjectConfig(projectDir, {
+      repo: `file://${remoteDir}`,
+      path: cloneDir,
+      autoPush: true,
+    });
+    await maybeAutoExportRunArtifacts(payload(projectDir, runDir));
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const status = await maybeAutoExportRunArtifacts(payload(projectDir, runDir));
+
+      expect(status).toBe('already_published');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  }, 20_000);
+
+  it('returns failed instead of throwing when the final push fails', async () => {
+    const runDir = writeRunArtifacts(projectDir);
+    writeProjectConfig(projectDir, {
+      repo: `file://${path.join(rootDir, 'missing-remote.git')}`,
+      path: cloneDir,
+      autoPush: true,
+    });
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const status = await maybeAutoExportRunArtifacts(payload(projectDir, runDir));
+
+      expect(status).toBe('failed');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  }, 20_000);
+
+  it('returns disabled when auto-push is not configured', async () => {
+    const remoteDir = initializeRemoteRepo(rootDir);
+    const runDir = writeRunArtifacts(projectDir);
+    writeProjectConfig(projectDir, {
+      repo: `file://${remoteDir}`,
+      path: cloneDir,
+      autoPush: false,
+    });
+
+    const status = await maybeAutoExportRunArtifacts(payload(projectDir, runDir));
+
+    expect(status).toBe('disabled');
+  });
+});

--- a/packages/core/src/evaluation/results-repo.ts
+++ b/packages/core/src/evaluation/results-repo.ts
@@ -1394,10 +1394,15 @@ export async function setupWipWorktree(params: {
   const normalized = normalizeResultsConfig(params.config);
   const cloneDir = await ensureResultsRepoClone(normalized);
   await fetchResultsRepo(cloneDir);
-  const baseBranch = await resolveDefaultBranch(cloneDir);
+  const baseRef = normalized.branch
+    ? await assertConfiguredResultsBranchExists(cloneDir, normalized)
+    : remoteBranchRef(await resolveDefaultBranch(cloneDir));
+  if (!baseRef) {
+    throw missingConfiguredBranchError(normalized);
+  }
   const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), 'agentv-wip-'));
   const worktreeDir = path.join(worktreeRoot, 'repo');
-  await runGit(['worktree', 'add', '-B', params.wipBranch, worktreeDir, `origin/${baseBranch}`], {
+  await runGit(['worktree', 'add', '-B', params.wipBranch, worktreeDir, baseRef], {
     cwd: cloneDir,
   });
   // Ensure commits work even without a global git user config.

--- a/packages/core/src/evaluation/results-repo.ts
+++ b/packages/core/src/evaluation/results-repo.ts
@@ -1356,6 +1356,119 @@ function parseGitBatchBlobs(output: Buffer): GitBatchBlob[] {
   return blobs;
 }
 
+// ── WIP (work-in-progress) branch helpers ─────────────────────────────────
+//
+// Periodic best-effort checkpoints push the partial run output to a unique
+// non-default branch (`agentv/inflight/<hostname>/<run-dir-basename>`) every ~30s.
+// The branch is force-pushed (single-writer) to avoid conflict handling and
+// noisy history. On successful run completion the branch is deleted.
+//
+// Manual recovery: if a pod is lost mid-run, an operator can clone the results
+// repo, checkout `agentv/inflight/<hostname>/<run-dir>`, and resume with:
+//   cp -r .agentv/results/runs/<run-dir> <local-workspace>
+//   agentv eval <eval-file> --output <local-workspace>/<run-dir> --resume
+
+export function buildWipBranchName(runDir: string): string {
+  const hostname = os
+    .hostname()
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .slice(0, 40);
+  const runBasename = path
+    .basename(runDir)
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .slice(0, 60);
+  return `agentv/inflight/${hostname}/${runBasename}`;
+}
+
+export interface WipWorktreeHandle {
+  readonly wipBranch: string;
+  readonly worktreeDir: string;
+  readonly cloneDir: string;
+  readonly cleanup: () => Promise<void>;
+}
+
+export async function setupWipWorktree(params: {
+  readonly config: ResultsConfig;
+  readonly wipBranch: string;
+}): Promise<WipWorktreeHandle> {
+  const normalized = normalizeResultsConfig(params.config);
+  const cloneDir = await ensureResultsRepoClone(normalized);
+  await fetchResultsRepo(cloneDir);
+  const baseBranch = await resolveDefaultBranch(cloneDir);
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), 'agentv-wip-'));
+  const worktreeDir = path.join(worktreeRoot, 'repo');
+  await runGit(['worktree', 'add', '-B', params.wipBranch, worktreeDir, `origin/${baseBranch}`], {
+    cwd: cloneDir,
+  });
+  // Ensure commits work even without a global git user config.
+  await runGit(['config', 'user.email', 'agentv@wip-checkpoint'], { cwd: worktreeDir });
+  await runGit(['config', 'user.name', 'AgentV WIP Checkpoint'], { cwd: worktreeDir });
+  return {
+    wipBranch: params.wipBranch,
+    worktreeDir,
+    cloneDir,
+    cleanup: async () => {
+      try {
+        await runGit(['worktree', 'remove', '--force', worktreeDir], { cwd: cloneDir });
+      } finally {
+        await rm(worktreeRoot, { recursive: true, force: true }).catch(() => undefined);
+      }
+    },
+  };
+}
+
+/**
+ * Snapshot the current run output into the WIP worktree and force-push to the
+ * remote WIP branch. Returns true if a push was performed, false if nothing changed.
+ *
+ * Uses `--amend` on the base-branch tip so the remote WIP branch always holds
+ * exactly one snapshot commit (no noisy history accumulation).
+ */
+export async function pushWipCheckpoint(params: {
+  readonly handle: WipWorktreeHandle;
+  readonly sourceDir: string;
+  readonly destinationPath: string;
+}): Promise<boolean> {
+  const destinationDir = path.join(
+    params.handle.worktreeDir,
+    RESULTS_REPO_RUNS_DIR,
+    params.destinationPath,
+  );
+  await stageResultsArtifacts({
+    repoDir: params.handle.worktreeDir,
+    sourceDir: params.sourceDir,
+    destinationDir,
+  });
+  await runGit(['add', '--all', '--', RESULTS_REPO_RESULTS_DIR], {
+    cwd: params.handle.worktreeDir,
+  });
+  const { stdout: status } = await runGit(['status', '--porcelain'], {
+    cwd: params.handle.worktreeDir,
+    check: false,
+  });
+  if (!status.trim()) {
+    return false;
+  }
+  const timestamp = new Date().toISOString();
+  await runGit(
+    ['commit', '--amend', '-m', `wip(results): checkpoint ${params.handle.wipBranch} ${timestamp}`],
+    { cwd: params.handle.worktreeDir },
+  );
+  await runGit(['push', '--force', 'origin', params.handle.wipBranch], {
+    cwd: params.handle.worktreeDir,
+  });
+  return true;
+}
+
+export async function deleteWipBranch(params: {
+  readonly config: ResultsConfig;
+  readonly wipBranch: string;
+}): Promise<void> {
+  const normalized = normalizeResultsConfig(params.config);
+  const cloneDir = await ensureResultsRepoClone(normalized);
+  await runGit(['push', 'origin', '--delete', params.wipBranch], { cwd: cloneDir });
+}
+
 export async function listGitRuns(repoDir: string, ref = 'origin/main'): Promise<GitListedRun[]> {
   const { stdout: treeOut } = await runGit(
     ['ls-tree', '-r', '--name-only', ref, RESULTS_REPO_RUNS_DIR],

--- a/packages/core/src/evaluation/results-repo.ts
+++ b/packages/core/src/evaluation/results-repo.ts
@@ -19,6 +19,8 @@ import type { ResultsConfig } from './loaders/config-loader.js';
 const execFileAsync = promisify(execFile);
 const RESULTS_REPO_RESULTS_DIR = '.agentv/results';
 const RESULTS_REPO_RUNS_DIR = `${RESULTS_REPO_RESULTS_DIR}/runs`;
+const RESULTS_REPO_COMMIT_EMAIL = 'agentv@results-repo';
+const RESULTS_REPO_COMMIT_NAME = 'AgentV Results';
 
 export interface ResultsRepoLocalPaths {
   readonly rootDir: string;
@@ -219,6 +221,11 @@ async function runGh(
   options?: { cwd?: string },
 ): Promise<{ stdout: string; stderr: string }> {
   return runCommand('gh', args, options);
+}
+
+async function ensureResultsRepoCommitIdentity(repoDir: string): Promise<void> {
+  await runGit(['config', 'user.email', RESULTS_REPO_COMMIT_EMAIL], { cwd: repoDir });
+  await runGit(['config', 'user.name', RESULTS_REPO_COMMIT_NAME], { cwd: repoDir });
 }
 
 async function resolveDefaultBranch(repoDir: string): Promise<string> {
@@ -839,6 +846,7 @@ export async function syncResultsRepoForProject(config: ResultsConfig): Promise<
 
       if (inspection.syncStatus === 'dirty') {
         await runGit(['add', '--all', '--', RESULTS_REPO_RESULTS_DIR], { cwd: repoDir });
+        await ensureResultsRepoCommitIdentity(repoDir);
         await runGit(
           [
             'commit',
@@ -1052,6 +1060,7 @@ export async function commitAndPushResultsBranch(params: {
     return false;
   }
 
+  await ensureResultsRepoCommitIdentity(params.repoDir);
   await runGit(['commit', '-m', params.commitMessage], { cwd: params.repoDir });
   await runGit(['push', '-u', 'origin', params.branchName], { cwd: params.repoDir });
   return true;
@@ -1185,6 +1194,7 @@ export async function directPushResults(params: {
     return false;
   }
 
+  await ensureResultsRepoCommitIdentity(repoDir);
   await runGit(['commit', '-m', params.commitMessage, '-m', `Agentv-Run: ${targetRunId}`], {
     cwd: repoDir,
   });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -77,6 +77,10 @@ export {
   pushResultsRepoBranch,
   createDraftResultsPr,
   directPushResults,
+  buildWipBranchName,
+  setupWipWorktree,
+  pushWipCheckpoint,
+  deleteWipBranch,
   listGitRuns,
   materializeGitRun,
   type CheckedOutResultsRepoBranch,
@@ -86,6 +90,7 @@ export {
   type ResultsRepoLocalPaths,
   type ResultsRepoSyncStatus,
   type ResultsRepoStatus,
+  type WipWorktreeHandle,
 } from './evaluation/results-repo.js';
 export {
   getAgentvConfigDir,

--- a/packages/core/test/evaluation/results-repo.test.ts
+++ b/packages/core/test/evaluation/results-repo.test.ts
@@ -7,11 +7,15 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import type { ResultsConfig } from '../../src/evaluation/loaders/config-loader.js';
 import {
+  buildWipBranchName,
+  deleteWipBranch,
   directPushResults,
   ensureResultsRepoClone,
   getResultsRepoSyncStatus,
   listGitRuns,
   materializeGitRun,
+  pushWipCheckpoint,
+  setupWipWorktree,
   syncResultsRepo,
   syncResultsRepoForProject,
 } from '../../src/evaluation/results-repo.js';
@@ -899,4 +903,139 @@ describe('results repo write path', () => {
     expect(status.last_error).not.toContain('auto_push is disabled');
     expect(status.conflicted_paths).toEqual([relativeMetadataPath]);
   }, 20000);
+});
+
+describe('buildWipBranchName', () => {
+  it('produces an agentv/inflight/<hostname>/<basename> branch name', () => {
+    const runDir = '/some/path/.agentv/results/runs/default/2026-01-15T10-00-00';
+    const branch = buildWipBranchName(runDir);
+    expect(branch).toMatch(/^agentv\/inflight\/[^/]+\/2026-01-15T10-00-00$/);
+  });
+
+  it('sanitizes special characters in hostname and run dir name', () => {
+    const branch = buildWipBranchName('/path/to/run dir with spaces!');
+    expect(branch).not.toMatch(/[ !]/);
+    expect(branch).toMatch(/^agentv\/inflight\//);
+  });
+});
+
+describe('WIP branch helpers', () => {
+  let rootDir: string;
+  let remoteDir: string;
+  let cloneDir: string;
+  let config: ResultsConfig;
+
+  beforeEach(() => {
+    rootDir = mkdtempSync(path.join(os.tmpdir(), 'agentv-wip-test-'));
+    const { remoteDir: remote, seedDir } = initializeRemoteRepo(rootDir);
+    remoteDir = remote;
+    cloneDir = path.join(rootDir, 'clone');
+    config = createResultsConfig(remoteDir, cloneDir);
+    // Keep seedDir reference to avoid lint warning
+    void seedDir;
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  it('setupWipWorktree creates a worktree on a new local branch', async () => {
+    const wipBranch = 'agentv/inflight/test-host/test-run-001';
+    const handle = await setupWipWorktree({ config, wipBranch });
+
+    try {
+      expect(handle.wipBranch).toBe(wipBranch);
+      expect(handle.worktreeDir).toBeTruthy();
+      // The worktree dir should be a git repo
+      const result = git('git rev-parse --is-inside-work-tree', handle.worktreeDir);
+      expect(result).toBe('true');
+      // Should be on the WIP branch
+      const branch = git('git branch --show-current', handle.worktreeDir);
+      expect(branch).toBe(wipBranch);
+    } finally {
+      await handle.cleanup();
+    }
+  }, 30000);
+
+  it('pushWipCheckpoint force-pushes run artifacts to the WIP branch', async () => {
+    const wipBranch = 'agentv/inflight/test-host/test-run-002';
+    const handle = await setupWipWorktree({ config, wipBranch });
+
+    // Write some run artifacts to push
+    const runDir = path.join(rootDir, 'run-output');
+    writeRunArtifacts(runDir, 'default', '2026-01-15T10-00-00');
+
+    try {
+      const pushed = await pushWipCheckpoint({
+        handle,
+        sourceDir: runDir,
+        destinationPath: 'default/2026-01-15T10-00-00',
+      });
+      expect(pushed).toBe(true);
+
+      // The remote WIP branch should now exist
+      const remoteBranches = git('git branch -r', cloneDir);
+      expect(remoteBranches).toContain(`origin/${wipBranch}`);
+    } finally {
+      await handle.cleanup();
+    }
+  }, 30000);
+
+  it('pushWipCheckpoint returns false when run output has not changed', async () => {
+    const wipBranch = 'agentv/inflight/test-host/test-run-003';
+    const handle = await setupWipWorktree({ config, wipBranch });
+
+    const runDir = path.join(rootDir, 'run-output-static');
+    writeRunArtifacts(runDir, 'default', '2026-01-15T11-00-00');
+
+    try {
+      // First push: creates content
+      const first = await pushWipCheckpoint({
+        handle,
+        sourceDir: runDir,
+        destinationPath: 'default/2026-01-15T11-00-00',
+      });
+      expect(first).toBe(true);
+
+      // Second push with identical content: should skip
+      const second = await pushWipCheckpoint({
+        handle,
+        sourceDir: runDir,
+        destinationPath: 'default/2026-01-15T11-00-00',
+      });
+      expect(second).toBe(false);
+    } finally {
+      await handle.cleanup();
+    }
+  }, 30000);
+
+  it('deleteWipBranch removes the remote WIP branch', async () => {
+    const wipBranch = 'agentv/inflight/test-host/test-run-004';
+    const handle = await setupWipWorktree({ config, wipBranch });
+    const runDir = path.join(rootDir, 'run-delete-test');
+    writeRunArtifacts(runDir, 'default', '2026-01-15T12-00-00');
+
+    try {
+      await pushWipCheckpoint({
+        handle,
+        sourceDir: runDir,
+        destinationPath: 'default/2026-01-15T12-00-00',
+      });
+    } finally {
+      await handle.cleanup();
+    }
+
+    // Verify branch exists on remote before deletion
+    await ensureResultsRepoClone(config);
+    git('git fetch --quiet --all --prune', cloneDir);
+    const branchesBefore = git('git branch -r', cloneDir);
+    expect(branchesBefore).toContain(`origin/${wipBranch}`);
+
+    // Delete it
+    await deleteWipBranch({ config, wipBranch });
+
+    git('git fetch --quiet --all --prune', cloneDir);
+    const branchesAfter = git('git branch -r', cloneDir);
+    expect(branchesAfter).not.toContain(`origin/${wipBranch}`);
+  }, 30000);
 });

--- a/packages/core/test/evaluation/results-repo.test.ts
+++ b/packages/core/test/evaluation/results-repo.test.ts
@@ -957,6 +957,29 @@ describe('WIP branch helpers', () => {
     }
   }, 30000);
 
+  it('setupWipWorktree bases the WIP branch on the configured storage branch', async () => {
+    const storageBranch = initializeRemoteStorageBranch(
+      path.join(rootDir, 'results-seed'),
+      'agentv-results',
+    );
+    const wipBranch = 'agentv/inflight/test-host/test-run-configured-branch';
+    const handle = await setupWipWorktree({
+      config: { ...config, branch: storageBranch },
+      wipBranch,
+    });
+
+    try {
+      const wipHead = git('git rev-parse HEAD', handle.worktreeDir);
+      const storageHead = git(`git rev-parse origin/${storageBranch}`, cloneDir);
+      const defaultHead = git('git rev-parse origin/main', cloneDir);
+
+      expect(wipHead).toBe(storageHead);
+      expect(wipHead).not.toBe(defaultHead);
+    } finally {
+      await handle.cleanup();
+    }
+  }, 30000);
+
   it('pushWipCheckpoint force-pushes run artifacts to the WIP branch', async () => {
     const wipBranch = 'agentv/inflight/test-host/test-run-002';
     const handle = await setupWipWorktree({ config, wipBranch });


### PR DESCRIPTION
## Summary

- Adds periodic best-effort WIP persistence for in-progress eval runs
- Every ~30s, force-pushes partial run output to `agentv/inflight/<hostname>/<run-dir>` in the configured results repository (single-writer branch, one amend-commit — no noisy history)
- On successful completion: publishes final results to the normal results branch and deletes the WIP branch
- On failure/abort: WIP branch is left intact for manual recovery

## Design

**Core helpers** (`packages/core/src/evaluation/results-repo.ts`):
- `buildWipBranchName(runDir)` — produces `agentv/inflight/<hostname>/<basename>`
- `setupWipWorktree` — clones results repo once and creates a persistent git worktree on the WIP branch (avoids per-checkpoint clone overhead)
- `pushWipCheckpoint` — copies run dir → worktree, `git commit --amend`, `git push --force`; returns `false` if no changes
- `deleteWipBranch` — `git push origin --delete <wipBranch>`

**Loop** (`apps/cli/src/commands/eval/wip-checkpoint.ts`):
- `WipCheckpointLoop` wraps `setInterval(...).unref()` so the timer never prevents process exit
- All checkpoint errors are best-effort (logged as warnings, never propagate to the eval)

**Integration** (`apps/cli/src/commands/eval/run-eval.ts`):
- Loop starts after `writeInitialBenchmarkArtifact`, gated on `auto_push` config flag (matches existing `maybeAutoExportRunArtifacts`)
- On success: `stopAndDeleteWipBranch()` — clean up remote WIP branch after normal publish
- `finally`: `stop()` — clean up local worktree on any exit path, leave remote branch for recovery

## Manual recovery

```bash
git clone <results-repo> /tmp/recovery
cd /tmp/recovery && git checkout agentv/inflight/<hostname>/<run-dir>
cp -r .agentv/results/runs/<run-dir> <project>/.agentv/results/runs/
agentv eval <eval-file> --output <project>/.agentv/results/runs/<run-dir> --resume
```

## Test plan

- [x] `bun run verify` — all 570 tests pass, lint clean, typecheck clean
- [x] 4 new integration tests covering `setupWipWorktree`, `pushWipCheckpoint` (with and without changes), and `deleteWipBranch` — using local bare git repos (same pattern as existing results-repo tests)
- [x] 2 new unit tests for `buildWipBranchName` (format + sanitization)

Closes #av-o3w

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Review follow-up (age-rev-18)

Addressed the two reviewer findings plus one adjacent WIP-branch correctness fix in `8b7c8898` and `63b6c5e4`:

- Serialized periodic checkpoint pushes with an in-flight guard and made `stop()` await any active checkpoint before local worktree cleanup or remote WIP branch deletion.
- Changed `maybeAutoExportRunArtifacts()` to return `published | already_published | failed | disabled`; `run-eval` now deletes the remote WIP branch only after final results are confirmed published/already-published. If final export fails, the WIP branch is preserved as the durable recovery copy.
- Ensured WIP worktrees are based on the configured results storage branch when `results.branch` is set, rather than always branching from the default branch.

Additional verification for the review fix:

- [x] `git diff --check`
- [x] `bun test apps/cli/test/commands/eval/wip-checkpoint.test.ts apps/cli/test/commands/results/remote-auto-export.test.ts`
- [x] `bun test packages/core/test/evaluation/results-repo.test.ts --test-name-pattern "WIP branch helpers"`
- [x] `bunx biome check apps/cli/src/commands/eval/wip-checkpoint.ts apps/cli/src/commands/eval/run-eval.ts apps/cli/src/commands/results/remote.ts apps/cli/test/commands/eval/wip-checkpoint.test.ts apps/cli/test/commands/results/remote-auto-export.test.ts`
- [x] `bun --filter agentv typecheck`
- [x] `bun --filter agentv build`
- [x] Push preflight: `bun --filter @agentv/core typecheck && bun --filter @agentv/phoenix-adapter typecheck && bun --filter agentv typecheck`, then `biome check .`

Note: full `bun --filter agentv test` was also attempted after rebuilding `@agentv/core`; it currently has unrelated existing failures in Dashboard/results/artifact tests due dist/default-threshold/test-environment drift. The targeted regression tests above pass.



## CI follow-up (2026-06-13)

Addressed fallback review and CI findings:
- Delete the remote WIP branch only after final results export reports `published` or `already_published`.
- Wait for any in-flight WIP checkpoint before local worktree cleanup or remote WIP branch deletion.
- Base WIP worktrees on the configured results storage branch when `results.branch` is set.
- Configure a local AgentV Git identity before managed results-repo commits so CI/containers without global `user.name` / `user.email` can still auto-export results.

Verification:
- `bun test packages/core/test/evaluation/results-repo.test.ts apps/cli/test/commands/eval/wip-checkpoint.test.ts apps/cli/test/commands/results/remote-auto-export.test.ts`
- `bun --filter @agentv/core build && bun test apps/cli/test/commands/results/remote-auto-export.test.ts apps/cli/test/commands/eval/wip-checkpoint.test.ts`
- `bun run verify`
