### PR TITLE
feat(dashboard): render structured transcript artifacts

### DIFF
--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -10,6 +10,8 @@
  *   - GET /api/runs   — list available run workspaces with metadata
  *   - GET /api/runs/:filename — load results from a specific run workspace
  *   - GET /api/runs/:filename/log — stream the captured console.log for a run
+ *   - GET /api/runs/:filename/evals/:evalId/files/* — read artifact files as JSON,
+ *     or as raw/downloadable text with ?raw=1 / ?download=1
  *   - GET /api/feedback  — read feedback reviews
  *   - POST /api/feedback — write feedback reviews
  *   - GET /api/projects  — list registered projects
@@ -254,6 +256,21 @@ function inferLanguage(filePath: string): string {
     '.patch': 'diff',
   };
   return langMap[ext] ?? 'plaintext';
+}
+
+function inferRawContentType(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === '.json') return 'application/json; charset=utf-8';
+  // Raw artifact links should be inspectable in a tab instead of rendered as
+  // same-origin HTML/SVG. The explicit ?download=1 path adds
+  // Content-Disposition for users that want a file.
+  if (ext === '.jsonl') return 'text/plain; charset=utf-8';
+  if (ext === '.md') return 'text/markdown; charset=utf-8';
+  return 'text/plain; charset=utf-8';
+}
+
+function contentDispositionFilename(filePath: string): string {
+  return path.basename(filePath).replace(/["\\\r\n]/g, '_');
 }
 
 function stripHeavyFields(results: readonly EvaluationResult[]) {
@@ -800,6 +817,8 @@ async function handleEvalFiles(c: C, { searchDir, projectId }: DataContext) {
       record.input_path,
       record.output_path,
       record.response_path,
+      record.answer_path,
+      record.transcript_path,
       record.task_dir,
       record.eval_path,
       record.targets_path,
@@ -833,7 +852,13 @@ async function handleEvalFileContent(c: C, { searchDir, projectId }: DataContext
   // Extract the wildcard suffix without depending on decoded route params.
   const marker = '/files/';
   const markerIdx = c.req.path.indexOf(marker);
-  const filePath = markerIdx >= 0 ? c.req.path.slice(markerIdx + marker.length) : '';
+  const encodedFilePath = markerIdx >= 0 ? c.req.path.slice(markerIdx + marker.length) : '';
+  let filePath = '';
+  try {
+    filePath = encodedFilePath ? decodeURIComponent(encodedFilePath) : '';
+  } catch {
+    return c.json({ error: 'Invalid file path encoding' }, 400);
+  }
 
   if (!filePath) return c.json({ error: 'No file path specified' }, 400);
 
@@ -855,6 +880,16 @@ async function handleEvalFileContent(c: C, { searchDir, projectId }: DataContext
 
   try {
     const fileContent = readFileSync(absolutePath, 'utf8');
+    if (c.req.query('raw') === '1' || c.req.query('download') === '1') {
+      c.header('Content-Type', inferRawContentType(absolutePath));
+      if (c.req.query('download') === '1') {
+        c.header(
+          'Content-Disposition',
+          `attachment; filename="${contentDispositionFilename(absolutePath)}"`,
+        );
+      }
+      return c.body(fileContent);
+    }
     const language = inferLanguage(absolutePath);
     return c.json({ content: fileContent, language });
   } catch {

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -2330,6 +2330,47 @@ describe('serve app', () => {
       const data = (await res.json()) as { content: string };
       expect(data.content).toContain('Hello, Alice!');
     });
+
+    it('serves transcript JSONL artifacts as browser-visible raw text and downloads', async () => {
+      const runsDir = path.join(tempDir, '.agentv', 'results', 'runs', 'with-transcript');
+      const runId = 'with-transcript::2026-03-25T10-00-00-000Z';
+      const timestampDir = path.join(runsDir, '2026-03-25T10-00-00-000Z');
+      const artifactPath = 'demo/test-greeting/outputs/transcript.jsonl';
+      const transcriptPath = path.join(timestampDir, artifactPath);
+      const transcriptJsonl = `${JSON.stringify({
+        test_id: 'test-greeting',
+        target: 'gpt-4o',
+        message_index: 0,
+        role: 'user',
+        content: 'Hello',
+      })}\n`;
+
+      mkdirSync(path.dirname(transcriptPath), { recursive: true });
+      writeFileSync(transcriptPath, transcriptJsonl);
+      writeFileSync(
+        path.join(timestampDir, 'index.jsonl'),
+        toJsonl({
+          ...RESULT_A,
+          experiment: 'with-transcript',
+          transcript_path: artifactPath,
+        }),
+      );
+
+      const app = createApp([], tempDir, tempDir, undefined, { studioDir });
+      const artifactUrl = `/api/runs/${encodeURIComponent(runId)}/evals/test-greeting/files/${artifactPath}`;
+
+      const rawRes = await app.request(`${artifactUrl}?raw=1`);
+      expect(rawRes.status).toBe(200);
+      expect(rawRes.headers.get('content-type')).toContain('text/plain');
+      expect(await rawRes.text()).toBe(transcriptJsonl);
+
+      const downloadRes = await app.request(`${artifactUrl}?download=1`);
+      expect(downloadRes.status).toBe(200);
+      expect(downloadRes.headers.get('content-disposition')).toBe(
+        'attachment; filename="transcript.jsonl"',
+      );
+      expect(await downloadRes.text()).toBe(transcriptJsonl);
+    });
   });
 
   // ── GET /api/compare (tag filter) ───────────────────────────────────

--- a/apps/dashboard/src/components/EvalDetail.tsx
+++ b/apps/dashboard/src/components/EvalDetail.tsx
@@ -6,10 +6,11 @@
  * Assertions are grouped by grader name.
  */
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
 import {
+  artifactFileContentUrl,
   isPassing,
   projectEvalFileContentOptions,
   projectEvalFilesOptions,
@@ -31,6 +32,12 @@ import type { FileNode } from './FileTree';
 import { FileTree } from './FileTree';
 import { MonacoViewer } from './MonacoViewer';
 import { ScoreBar } from './ScoreBar';
+import {
+  TranscriptTimeline,
+  findAnswerPath,
+  findTranscriptPath,
+  parseTranscriptJsonl,
+} from './TranscriptTimeline';
 
 interface EvalDetailProps {
   eval: EvalResult;
@@ -38,7 +45,7 @@ interface EvalDetailProps {
   projectId?: string;
 }
 
-type Tab = 'checks' | 'source' | 'files' | 'feedback';
+type Tab = 'checks' | 'transcript' | 'source' | 'files' | 'feedback';
 
 /** Recursively find the first file node in the tree. */
 function findFirstFile(nodes: FileNode[]): string | null {
@@ -54,15 +61,22 @@ function findFirstFile(nodes: FileNode[]): string | null {
 
 export function EvalDetail({ eval: result, runId, projectId }: EvalDetailProps) {
   const [activeTab, setActiveTab] = useState<Tab>('checks');
+  const [selectedFilePath, setSelectedFilePath] = useState<string | null>(null);
   const { data: config } = useStudioConfig(projectId);
   const isReadOnly = config?.read_only === true;
 
   const tabs: { id: Tab; label: string }[] = [
     { id: 'checks', label: 'Checks' },
+    { id: 'transcript', label: 'Transcript' },
     { id: 'source', label: 'Source' },
     { id: 'files', label: 'Files' },
     ...(isReadOnly ? [] : [{ id: 'feedback' as const, label: 'Feedback' }]),
   ];
+
+  const openFile = (filePath: string) => {
+    setSelectedFilePath(filePath);
+    setActiveTab('files');
+  };
 
   return (
     <div className="flex min-h-full flex-col">
@@ -95,7 +109,23 @@ export function EvalDetail({ eval: result, runId, projectId }: EvalDetailProps) 
         )}
         {activeTab === 'files' && (
           <div className="h-full p-4">
-            <FilesTab result={result} runId={runId} projectId={projectId} />
+            <FilesTab
+              result={result}
+              runId={runId}
+              projectId={projectId}
+              selectedPath={selectedFilePath}
+              onSelectedPathChange={setSelectedFilePath}
+            />
+          </div>
+        )}
+        {activeTab === 'transcript' && (
+          <div className="overflow-auto p-4">
+            <TranscriptTab
+              result={result}
+              runId={runId}
+              projectId={projectId}
+              onOpenFile={openFile}
+            />
           </div>
         )}
         {activeTab === 'source' && (
@@ -406,11 +436,162 @@ function ChecksTab({ result, projectId }: { result: EvalResult; projectId?: stri
   );
 }
 
+function containsFilePath(nodes: FileNode[], filePath: string | null): boolean {
+  if (!filePath) return false;
+  for (const node of nodes) {
+    if (node.type === 'file' && node.path === filePath) return true;
+    if (node.children && containsFilePath(node.children, filePath)) return true;
+  }
+  return false;
+}
+
+function TranscriptTab({
+  result,
+  runId,
+  projectId,
+  onOpenFile,
+}: {
+  result: EvalResult;
+  runId: string;
+  projectId?: string;
+  onOpenFile: (path: string) => void;
+}) {
+  const evalId = result.testId;
+  const { data: filesData, isLoading: isLoadingFiles } = projectId
+    ? useQuery(projectEvalFilesOptions(projectId, runId, evalId))
+    : useEvalFiles(runId, evalId);
+  const files = filesData?.files ?? [];
+  const transcriptPath = findTranscriptPath(files);
+  const answerPath = findAnswerPath(files);
+
+  const { data: transcriptContentData, isLoading: isLoadingTranscript } = projectId
+    ? useQuery(projectEvalFileContentOptions(projectId, runId, evalId, transcriptPath ?? ''))
+    : useEvalFileContent(runId, evalId, transcriptPath ?? '');
+  const { data: answerContentData } = projectId
+    ? useQuery(projectEvalFileContentOptions(projectId, runId, evalId, answerPath ?? ''))
+    : useEvalFileContent(runId, evalId, answerPath ?? '');
+
+  const parsedTranscript = useMemo(
+    () => parseTranscriptJsonl(transcriptContentData?.content ?? ''),
+    [transcriptContentData?.content],
+  );
+
+  if (isLoadingFiles) {
+    return (
+      <div className="rounded-lg border border-gray-800 bg-gray-900 p-4 text-sm text-gray-500">
+        Loading transcript artifacts...
+      </div>
+    );
+  }
+
+  if (!transcriptPath) {
+    return (
+      <div className="rounded-lg border border-gray-800 bg-gray-900 p-4">
+        <h3 className="text-sm font-medium text-gray-300">No structured transcript</h3>
+        <p className="mt-2 text-sm text-gray-500">
+          This run does not include canonical <code>outputs/transcript.jsonl</code>. Dashboard does
+          not parse <code>response.md</code> or markdown transcripts for this view.
+        </p>
+      </div>
+    );
+  }
+
+  if (isLoadingTranscript) {
+    return (
+      <div className="rounded-lg border border-gray-800 bg-gray-900 p-4 text-sm text-gray-500">
+        Loading <code>{transcriptPath}</code>...
+      </div>
+    );
+  }
+
+  if (parsedTranscript.error) {
+    return (
+      <div className="rounded-lg border border-red-900/50 bg-red-950/20 p-4">
+        <h3 className="text-sm font-medium text-red-300">Transcript could not be parsed</h3>
+        <p className="mt-2 text-sm text-gray-300">{parsedTranscript.error}</p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => onOpenFile(transcriptPath)}
+            className="rounded-md border border-gray-700 px-3 py-1.5 text-sm text-gray-300 transition-colors hover:border-cyan-900/60 hover:text-cyan-300"
+          >
+            Open raw JSONL in Files
+          </button>
+          <a
+            href={artifactFileContentUrl({
+              projectId,
+              runId,
+              evalId,
+              filePath: transcriptPath,
+              raw: true,
+            })}
+            target="_blank"
+            rel="noreferrer"
+            className="rounded-md px-3 py-1.5 text-sm text-cyan-400 transition-colors hover:text-cyan-300 hover:underline"
+          >
+            Open raw JSONL
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  if (parsedTranscript.entries.length === 0) {
+    return (
+      <div className="rounded-lg border border-gray-800 bg-gray-900 p-4">
+        <h3 className="text-sm font-medium text-gray-300">Empty transcript</h3>
+        <p className="mt-2 text-sm text-gray-500">
+          <code>{transcriptPath}</code> exists but contains no JSONL rows.
+        </p>
+      </div>
+    );
+  }
+
+  const answerHref = answerPath
+    ? artifactFileContentUrl({ projectId, runId, evalId, filePath: answerPath, raw: true })
+    : undefined;
+  const transcriptHref = artifactFileContentUrl({
+    projectId,
+    runId,
+    evalId,
+    filePath: transcriptPath,
+    raw: true,
+  });
+  const transcriptDownloadHref = artifactFileContentUrl({
+    projectId,
+    runId,
+    evalId,
+    filePath: transcriptPath,
+    download: true,
+  });
+
+  return (
+    <TranscriptTimeline
+      entries={parsedTranscript.entries}
+      finalAnswer={answerPath ? (answerContentData?.content ?? result.output) : undefined}
+      answerPath={answerPath}
+      transcriptPath={transcriptPath}
+      answerHref={answerHref}
+      transcriptHref={transcriptHref}
+      transcriptDownloadHref={transcriptDownloadHref}
+      onOpenFile={onOpenFile}
+    />
+  );
+}
+
 function FilesTab({
   result,
   runId,
   projectId,
-}: { result: EvalResult; runId: string; projectId?: string }) {
+  selectedPath,
+  onSelectedPathChange,
+}: {
+  result: EvalResult;
+  runId: string;
+  projectId?: string;
+  selectedPath: string | null;
+  onSelectedPathChange: (path: string) => void;
+}) {
   const evalId = result.testId;
 
   // Use project-scoped API hooks when projectId is present
@@ -419,10 +600,15 @@ function FilesTab({
     : useEvalFiles(runId, evalId);
   const files = filesData?.files ?? [];
 
-  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [localSelectedPath, setLocalSelectedPath] = useState<string | null>(null);
   const [mobileShowTree, setMobileShowTree] = useState(false);
 
-  const effectivePath = selectedPath ?? (files.length > 0 ? findFirstFile(files) : null);
+  const requestedPath = selectedPath ?? localSelectedPath;
+  const effectivePath = containsFilePath(files, requestedPath)
+    ? requestedPath
+    : files.length > 0
+      ? findFirstFile(files)
+      : null;
 
   const { data: fileContentData, isLoading: isLoadingContent } = projectId
     ? useQuery(projectEvalFileContentOptions(projectId, runId, evalId, effectivePath ?? ''))
@@ -448,7 +634,8 @@ function FilesTab({
           files={files}
           selectedPath={effectivePath}
           onSelect={(path) => {
-            setSelectedPath(path);
+            setLocalSelectedPath(path);
+            onSelectedPathChange(path);
             // On mobile, auto-switch to content viewer after selecting a file
             setMobileShowTree(false);
           }}

--- a/apps/dashboard/src/components/TranscriptTimeline.tsx
+++ b/apps/dashboard/src/components/TranscriptTimeline.tsx
@@ -1,0 +1,570 @@
+/**
+ * Structured transcript viewer for canonical `outputs/transcript.jsonl` files.
+ *
+ * The component intentionally reads only transcript JSONL rows derived from
+ * AgentV trace data. It does not parse `response.md` or markdown transcripts;
+ * raw transcript/answer artifacts stay available through the Files tab or raw
+ * artifact links supplied by the caller.
+ */
+
+import type { ReactNode } from 'react';
+
+import type { FileNode } from '~/lib/types';
+
+interface TranscriptSource {
+  provider?: string;
+  session_id?: string;
+  model?: string;
+  timestamp?: string;
+  git_branch?: string;
+  cwd?: string;
+  version?: string;
+}
+
+interface TokenUsageWire {
+  input?: number;
+  output?: number;
+  cached?: number;
+  reasoning?: number;
+}
+
+export interface TranscriptJsonLine {
+  test_id: string;
+  target: string;
+  message_index: number;
+  role: string;
+  name?: string;
+  content?: unknown;
+  tool_calls?: readonly Record<string, unknown>[];
+  start_time?: string;
+  end_time?: string;
+  duration_ms?: number;
+  metadata?: Record<string, unknown>;
+  token_usage?: TokenUsageWire;
+  transcript_token_usage?: TokenUsageWire;
+  transcript_duration_ms?: number;
+  transcript_cost_usd?: number | null;
+  source?: TranscriptSource;
+}
+
+export interface TranscriptParseResult {
+  entries: TranscriptJsonLine[];
+  error?: string;
+}
+
+interface TranscriptTimelineProps {
+  entries: readonly TranscriptJsonLine[];
+  finalAnswer?: string;
+  answerPath?: string;
+  transcriptPath?: string;
+  answerHref?: string;
+  transcriptHref?: string;
+  transcriptDownloadHref?: string;
+  onOpenFile?: (path: string) => void;
+}
+
+const ROLE_STYLES: Record<
+  string,
+  { container: string; badge: string; label: string; accent: string }
+> = {
+  system: {
+    container: 'border-gray-800 bg-gray-900/70',
+    badge: 'border-gray-700 bg-gray-800 text-gray-300',
+    label: 'System',
+    accent: 'text-gray-400',
+  },
+  user: {
+    container: 'border-cyan-900/60 bg-cyan-950/20',
+    badge: 'border-cyan-900/60 bg-cyan-950/30 text-cyan-300',
+    label: 'User',
+    accent: 'text-cyan-300',
+  },
+  assistant: {
+    container: 'border-gray-800 bg-gray-900',
+    badge: 'border-gray-700 bg-gray-800 text-gray-200',
+    label: 'Assistant',
+    accent: 'text-gray-300',
+  },
+  tool: {
+    container: 'border-amber-900/60 bg-amber-950/20',
+    badge: 'border-amber-900/60 bg-amber-950/30 text-amber-300',
+    label: 'Tool result',
+    accent: 'text-amber-300',
+  },
+  function: {
+    container: 'border-amber-900/60 bg-amber-950/20',
+    badge: 'border-amber-900/60 bg-amber-950/30 text-amber-300',
+    label: 'Function result',
+    accent: 'text-amber-300',
+  },
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isTranscriptJsonLine(value: unknown): value is TranscriptJsonLine {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.test_id === 'string' &&
+    typeof value.target === 'string' &&
+    typeof value.message_index === 'number' &&
+    Number.isFinite(value.message_index) &&
+    typeof value.role === 'string'
+  );
+}
+
+export function parseTranscriptJsonl(rawJsonl: string): TranscriptParseResult {
+  const entries: TranscriptJsonLine[] = [];
+  const lines = rawJsonl.split(/\r?\n/);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index].trim();
+    if (!line) continue;
+
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (!isTranscriptJsonLine(parsed)) {
+        return {
+          entries,
+          error: `Line ${index + 1} is not a transcript JSONL row.`,
+        };
+      }
+      entries.push(parsed);
+    } catch (error) {
+      return {
+        entries,
+        error: `Line ${index + 1} is invalid JSON: ${(error as Error).message}`,
+      };
+    }
+  }
+
+  return { entries };
+}
+
+export function flattenFileNodes(nodes: readonly FileNode[]): FileNode[] {
+  const files: FileNode[] = [];
+  for (const node of nodes) {
+    if (node.type === 'file') {
+      files.push(node);
+    } else if (node.children) {
+      files.push(...flattenFileNodes(node.children));
+    }
+  }
+  return files;
+}
+
+function normalizePath(filePath: string): string {
+  return filePath.replace(/\\/g, '/');
+}
+
+function findFilePathBySuffix(
+  nodes: readonly FileNode[],
+  suffixes: readonly string[],
+): string | undefined {
+  const files = flattenFileNodes(nodes);
+  for (const suffix of suffixes) {
+    const match = files.find((file) => {
+      const normalized = normalizePath(file.path);
+      return normalized === suffix || normalized.endsWith(`/${suffix}`);
+    });
+    if (match) return match.path;
+  }
+  return undefined;
+}
+
+export function findTranscriptPath(nodes: readonly FileNode[]): string | undefined {
+  return findFilePathBySuffix(nodes, ['outputs/transcript.jsonl']);
+}
+
+export function findAnswerPath(nodes: readonly FileNode[]): string | undefined {
+  return findFilePathBySuffix(nodes, ['outputs/answer.md']);
+}
+
+function formatDurationMs(value: number | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  if (value < 1000) return `${Math.round(value)}ms`;
+  return `${(value / 1000).toFixed(1)}s`;
+}
+
+function formatCurrency(value: number | null | undefined): string | undefined {
+  if (typeof value !== 'number') return undefined;
+  return `$${value.toFixed(4)}`;
+}
+
+function formatTokenUsage(value: TokenUsageWire | undefined): string | undefined {
+  if (!value) return undefined;
+  const parts: string[] = [];
+  if (typeof value.input === 'number') parts.push(`${value.input} in`);
+  if (typeof value.output === 'number') parts.push(`${value.output} out`);
+  if (typeof value.reasoning === 'number') parts.push(`${value.reasoning} reasoning`);
+  if (typeof value.cached === 'number') parts.push(`${value.cached} cached`);
+  return parts.length > 0 ? parts.join(' / ') : undefined;
+}
+
+function formatUnknown(value: unknown): string {
+  if (value === undefined) return '';
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function formatContent(value: unknown): string {
+  if (Array.isArray(value)) {
+    const textBlocks = value
+      .map((block) => {
+        if (isRecord(block) && block.type === 'text' && typeof block.text === 'string') {
+          return block.text;
+        }
+        return undefined;
+      })
+      .filter((text): text is string => text !== undefined);
+    if (textBlocks.length === value.length && textBlocks.length > 0) {
+      return textBlocks.join('\n');
+    }
+  }
+  return formatUnknown(value);
+}
+
+function pickString(record: Record<string, unknown>, keys: readonly string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+  return undefined;
+}
+
+function pickPayload(record: Record<string, unknown>, keys: readonly string[]): unknown {
+  for (const key of keys) {
+    if (record[key] !== undefined) return record[key];
+  }
+  return undefined;
+}
+
+function nestedRecord(
+  record: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const value = record[key];
+  return isRecord(value) ? value : undefined;
+}
+
+function toolCallName(call: Record<string, unknown>, index: number): string {
+  const functionRecord = nestedRecord(call, 'function');
+  return (
+    pickString(call, ['tool', 'name', 'tool_name']) ??
+    (functionRecord ? pickString(functionRecord, ['name']) : undefined) ??
+    `Tool ${index + 1}`
+  );
+}
+
+function toolCallInput(call: Record<string, unknown>): unknown {
+  const functionRecord = nestedRecord(call, 'function');
+  return (
+    pickPayload(call, ['input', 'arguments', 'args', 'parameters']) ??
+    (functionRecord ? pickPayload(functionRecord, ['arguments']) : undefined)
+  );
+}
+
+function toolCallOutput(call: Record<string, unknown>): unknown {
+  return pickPayload(call, ['output', 'result', 'content']);
+}
+
+function hasValue(value: unknown): boolean {
+  return (
+    value !== undefined && value !== null && !(typeof value === 'string' && value.length === 0)
+  );
+}
+
+function JsonBlock({
+  label,
+  value,
+  tone = 'default',
+}: { label: string; value: unknown; tone?: 'default' | 'error' }) {
+  if (!hasValue(value)) return null;
+  return (
+    <div className="space-y-1">
+      <div
+        className={
+          tone === 'error'
+            ? 'text-xs font-medium text-red-300'
+            : 'text-xs font-medium text-gray-400'
+        }
+      >
+        {label}
+      </div>
+      <pre className="max-h-80 overflow-auto rounded-md border border-gray-800 bg-gray-950 p-3 text-xs text-gray-200">
+        <code>{formatUnknown(value)}</code>
+      </pre>
+    </div>
+  );
+}
+
+function MetadataPill({ children }: { children: ReactNode }) {
+  return (
+    <span className="rounded-md border border-gray-800 bg-gray-950 px-2 py-0.5 text-xs text-gray-400">
+      {children}
+    </span>
+  );
+}
+
+function ActionLink({
+  href,
+  children,
+  download = false,
+}: { href?: string; children: ReactNode; download?: boolean }) {
+  if (!href) return null;
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      download={download}
+      className="rounded-md px-3 py-1.5 text-sm text-cyan-400 transition-colors hover:text-cyan-300 hover:underline"
+    >
+      {children}
+    </a>
+  );
+}
+
+function OpenFileButton({
+  path,
+  onOpenFile,
+  children,
+}: { path?: string; onOpenFile?: (path: string) => void; children: ReactNode }) {
+  if (!path || !onOpenFile) return null;
+  return (
+    <button
+      type="button"
+      onClick={() => onOpenFile(path)}
+      className="rounded-md border border-gray-700 px-3 py-1.5 text-sm text-gray-300 transition-colors hover:border-cyan-900/60 hover:text-cyan-300"
+    >
+      {children}
+    </button>
+  );
+}
+
+function ToolCallDetails({ call, index }: { call: Record<string, unknown>; index: number }) {
+  const name = toolCallName(call, index);
+  const callId = pickString(call, ['id', 'call_id', 'tool_call_id']);
+  const status = pickString(call, ['status']);
+  const duration =
+    typeof call.duration_ms === 'number' ? formatDurationMs(call.duration_ms) : undefined;
+  const metadata = isRecord(call.metadata) ? call.metadata : undefined;
+
+  return (
+    <details className="rounded-md border border-gray-800 bg-gray-950/80 p-3">
+      <summary className="cursor-pointer text-sm font-medium text-gray-200">
+        <span>Tool call</span>
+        <span className="ml-2 rounded-md border border-amber-900/60 bg-amber-950/30 px-2 py-0.5 text-xs text-amber-300">
+          {name}
+        </span>
+        {status && <span className="ml-2 text-xs text-gray-500">{status}</span>}
+        {duration && <span className="ml-2 tabular-nums text-xs text-gray-500">{duration}</span>}
+      </summary>
+      <div className="mt-3 space-y-3">
+        <div className="flex flex-wrap gap-2">
+          {callId && <MetadataPill>id: {callId}</MetadataPill>}
+          {duration && <MetadataPill>duration: {duration}</MetadataPill>}
+          {status && <MetadataPill>status: {status}</MetadataPill>}
+        </div>
+        <JsonBlock label="Arguments" value={toolCallInput(call)} />
+        <JsonBlock label="Result" value={toolCallOutput(call)} />
+        <JsonBlock label="Error" value={call.error} tone="error" />
+        <JsonBlock label="Metadata" value={metadata} />
+      </div>
+    </details>
+  );
+}
+
+function ToolResultDetails({ line }: { line: TranscriptJsonLine }) {
+  const duration = formatDurationMs(line.duration_ms);
+  const tokenUsage = formatTokenUsage(line.token_usage);
+  return (
+    <details className="rounded-md border border-amber-900/50 bg-gray-950/60 p-3">
+      <summary className="cursor-pointer text-sm font-medium text-amber-300">
+        {line.name ? `Tool result · ${line.name}` : 'Tool result'}
+        {duration && <span className="ml-2 tabular-nums text-xs text-gray-500">{duration}</span>}
+      </summary>
+      <div className="mt-3 space-y-3">
+        <div className="flex flex-wrap gap-2">
+          {line.name && <MetadataPill>name: {line.name}</MetadataPill>}
+          {duration && <MetadataPill>duration: {duration}</MetadataPill>}
+          {tokenUsage && <MetadataPill>tokens: {tokenUsage}</MetadataPill>}
+        </div>
+        <JsonBlock label="Result" value={line.content} />
+        <JsonBlock label="Metadata" value={line.metadata} />
+      </div>
+    </details>
+  );
+}
+
+function TranscriptMessageCard({ line, ordinal }: { line: TranscriptJsonLine; ordinal: number }) {
+  const roleStyle = ROLE_STYLES[line.role] ?? {
+    container: 'border-gray-800 bg-gray-900',
+    badge: 'border-gray-700 bg-gray-800 text-gray-300',
+    label: line.role,
+    accent: 'text-gray-300',
+  };
+  const content = formatContent(line.content);
+  const duration = formatDurationMs(line.duration_ms);
+  const tokenUsage = formatTokenUsage(line.token_usage);
+  const toolCalls = line.tool_calls?.filter(isRecord) ?? [];
+
+  return (
+    <article className={`rounded-lg border p-4 ${roleStyle.container}`}>
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className={`rounded-md border px-2 py-0.5 text-xs font-medium ${roleStyle.badge}`}>
+            {roleStyle.label}
+          </span>
+          {line.name && (
+            <span className={`truncate text-sm font-medium ${roleStyle.accent}`}>{line.name}</span>
+          )}
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500">
+          <span className="tabular-nums">#{ordinal + 1}</span>
+          {line.start_time && <span>{line.start_time}</span>}
+          {duration && <span className="tabular-nums">{duration}</span>}
+          {tokenUsage && <span>{tokenUsage}</span>}
+        </div>
+      </header>
+
+      <div className="mt-3 space-y-3">
+        {line.role === 'tool' || line.role === 'function' ? (
+          <ToolResultDetails line={line} />
+        ) : content.trim().length > 0 ? (
+          <pre className="whitespace-pre-wrap break-words text-sm leading-6 text-gray-200">
+            {content}
+          </pre>
+        ) : (
+          <p className="text-sm text-gray-500">No message content recorded.</p>
+        )}
+
+        {toolCalls.length > 0 && (
+          <div className="space-y-2">
+            {toolCalls.map((call, index) => (
+              <ToolCallDetails key={`${line.message_index}-${index}`} call={call} index={index} />
+            ))}
+          </div>
+        )}
+
+        {line.metadata && line.role !== 'tool' && line.role !== 'function' && (
+          <details className="rounded-md border border-gray-800 bg-gray-950/60 p-3">
+            <summary className="cursor-pointer text-xs font-medium text-gray-400">
+              Message metadata
+            </summary>
+            <div className="mt-3">
+              <JsonBlock label="Metadata" value={line.metadata} />
+            </div>
+          </details>
+        )}
+      </div>
+    </article>
+  );
+}
+
+function TranscriptSummary({
+  entries,
+  transcriptPath,
+}: { entries: readonly TranscriptJsonLine[]; transcriptPath?: string }) {
+  const first = entries[0];
+  const provider = first?.source?.provider;
+  const model = first?.source?.model;
+  const sessionId = first?.source?.session_id;
+  const duration = formatDurationMs(first?.transcript_duration_ms);
+  const tokenUsage = formatTokenUsage(first?.transcript_token_usage);
+  const cost = formatCurrency(first?.transcript_cost_usd);
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <MetadataPill>{entries.length} messages</MetadataPill>
+      {provider && <MetadataPill>provider: {provider}</MetadataPill>}
+      {model && <MetadataPill>model: {model}</MetadataPill>}
+      {sessionId && <MetadataPill>session: {sessionId}</MetadataPill>}
+      {duration && <MetadataPill>duration: {duration}</MetadataPill>}
+      {tokenUsage && <MetadataPill>tokens: {tokenUsage}</MetadataPill>}
+      {cost && <MetadataPill>cost: {cost}</MetadataPill>}
+      {transcriptPath && <MetadataPill>{transcriptPath}</MetadataPill>}
+    </div>
+  );
+}
+
+export function TranscriptTimeline({
+  entries,
+  finalAnswer,
+  answerPath,
+  transcriptPath,
+  answerHref,
+  transcriptHref,
+  transcriptDownloadHref,
+  onOpenFile,
+}: TranscriptTimelineProps) {
+  const sortedEntries = [...entries].sort(
+    (first, second) => first.message_index - second.message_index,
+  );
+  const hasCanonicalAnswer = !!answerPath;
+
+  return (
+    <div className="space-y-4">
+      <section className="rounded-lg border border-emerald-900/50 bg-emerald-950/20 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-medium text-emerald-300">Final answer</h3>
+            <p className="mt-1 text-xs text-gray-500">
+              Highlighted from canonical <code>outputs/answer.md</code>; transcript context stays
+              below.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <OpenFileButton path={answerPath} onOpenFile={onOpenFile}>
+              Open answer.md in Files
+            </OpenFileButton>
+            <ActionLink href={answerHref}>Open answer.md</ActionLink>
+          </div>
+        </div>
+        {hasCanonicalAnswer ? (
+          <pre className="mt-3 max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-md border border-emerald-900/40 bg-gray-950/80 p-3 text-sm leading-6 text-gray-100">
+            {finalAnswer && finalAnswer.trim().length > 0 ? finalAnswer : 'answer.md is empty.'}
+          </pre>
+        ) : (
+          <p className="mt-3 rounded-md border border-gray-800 bg-gray-950/60 p-3 text-sm text-gray-400">
+            No canonical <code>outputs/answer.md</code> artifact was found. The transcript viewer
+            does not fall back to <code>response.md</code>.
+          </p>
+        )}
+      </section>
+
+      <section className="rounded-lg border border-gray-800 bg-gray-900 p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium text-gray-300">Transcript timeline</h3>
+            <TranscriptSummary entries={sortedEntries} transcriptPath={transcriptPath} />
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <OpenFileButton path={transcriptPath} onOpenFile={onOpenFile}>
+              Open raw JSONL in Files
+            </OpenFileButton>
+            <ActionLink href={transcriptHref}>Open raw JSONL</ActionLink>
+            <ActionLink href={transcriptDownloadHref} download>
+              Download JSONL
+            </ActionLink>
+          </div>
+        </div>
+      </section>
+
+      <div className="space-y-3">
+        {sortedEntries.map((entry, index) => (
+          <TranscriptMessageCard
+            key={`${entry.message_index}-${entry.role}-${index}`}
+            line={entry}
+            ordinal={index}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/TranscriptTimeline.tsx
+++ b/apps/dashboard/src/components/TranscriptTimeline.tsx
@@ -105,6 +105,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isTranscriptJsonLine(value: unknown): value is TranscriptJsonLine {
   if (!isRecord(value)) return false;
+  if (value.tool_calls !== undefined && !Array.isArray(value.tool_calls)) return false;
   return (
     typeof value.test_id === 'string' &&
     typeof value.target === 'string' &&
@@ -412,7 +413,7 @@ function TranscriptMessageCard({ line, ordinal }: { line: TranscriptJsonLine; or
   const content = formatContent(line.content);
   const duration = formatDurationMs(line.duration_ms);
   const tokenUsage = formatTokenUsage(line.token_usage);
-  const toolCalls = line.tool_calls?.filter(isRecord) ?? [];
+  const toolCalls = Array.isArray(line.tool_calls) ? line.tool_calls.filter(isRecord) : [];
 
   return (
     <article className={`rounded-lg border p-4 ${roleStyle.container}`}>

--- a/apps/dashboard/src/components/__fixtures__/structured-transcript.ts
+++ b/apps/dashboard/src/components/__fixtures__/structured-transcript.ts
@@ -1,0 +1,91 @@
+import type { FileNode } from '~/lib/types';
+
+export const structuredTranscriptJsonl = [
+  {
+    test_id: 'final-json-answer',
+    target: 'codex',
+    message_index: 0,
+    role: 'user',
+    content: 'Inspect the workspace and return the final JSON only.',
+    source: { provider: 'codex', session_id: 'session-123', model: 'gpt-5-codex' },
+    transcript_token_usage: { input: 120, output: 80 },
+    transcript_duration_ms: 2450,
+    transcript_cost_usd: 0.0123,
+  },
+  {
+    test_id: 'final-json-answer',
+    target: 'codex',
+    message_index: 1,
+    role: 'assistant',
+    content: 'I will inspect the file before answering.',
+    tool_calls: [
+      {
+        id: 'call-read-1',
+        tool: 'read_file',
+        input: { path: 'src/app.ts' },
+        duration_ms: 32,
+        metadata: { cwd: '/tmp/agentv-fixture' },
+      },
+    ],
+    source: { provider: 'codex', session_id: 'session-123', model: 'gpt-5-codex' },
+  },
+  {
+    test_id: 'final-json-answer',
+    target: 'codex',
+    message_index: 2,
+    role: 'tool',
+    name: 'read_file',
+    content: { ok: true, text: 'export const answer = 42;' },
+    duration_ms: 32,
+    source: { provider: 'codex', session_id: 'session-123', model: 'gpt-5-codex' },
+  },
+  {
+    test_id: 'final-json-answer',
+    target: 'codex',
+    message_index: 3,
+    role: 'assistant',
+    content: '{"answer":42,"source":"src/app.ts"}',
+    source: { provider: 'codex', session_id: 'session-123', model: 'gpt-5-codex' },
+  },
+]
+  .map((line) => JSON.stringify(line))
+  .join('\n');
+
+export const structuredTranscriptFiles: FileNode[] = [
+  {
+    name: 'final-json-answer__codex',
+    path: 'final-json-answer__codex',
+    type: 'dir',
+    children: [
+      { name: 'grading.json', path: 'final-json-answer__codex/grading.json', type: 'file' },
+      {
+        name: 'transcript.jsonl',
+        path: 'final-json-answer__codex/transcript.jsonl',
+        type: 'file',
+      },
+      { name: 'answer.md', path: 'final-json-answer__codex/answer.md', type: 'file' },
+      {
+        name: 'outputs',
+        path: 'final-json-answer__codex/outputs',
+        type: 'dir',
+        children: [
+          {
+            name: 'answer.md',
+            path: 'final-json-answer__codex/outputs/answer.md',
+            type: 'file',
+          },
+          {
+            name: 'transcript.jsonl',
+            path: 'final-json-answer__codex/outputs/transcript.jsonl',
+            type: 'file',
+          },
+          {
+            name: 'response.md',
+            path: 'final-json-answer__codex/outputs/response.md',
+            type: 'file',
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/apps/dashboard/src/components/transcript-timeline.test.tsx
+++ b/apps/dashboard/src/components/transcript-timeline.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import {
+  TranscriptTimeline,
+  findAnswerPath,
+  findTranscriptPath,
+  parseTranscriptJsonl,
+} from './TranscriptTimeline';
+import {
+  structuredTranscriptFiles,
+  structuredTranscriptJsonl,
+} from './__fixtures__/structured-transcript';
+
+describe('TranscriptTimeline', () => {
+  it('parses canonical transcript JSONL rows in chronological order', () => {
+    const parsed = parseTranscriptJsonl(structuredTranscriptJsonl);
+
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.entries.map((entry) => entry.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'assistant',
+    ]);
+    expect(parsed.entries[1].tool_calls?.[0]?.tool).toBe('read_file');
+  });
+
+  it('finds canonical transcript and answer artifacts without selecting response.md', () => {
+    expect(findTranscriptPath(structuredTranscriptFiles)).toBe(
+      'final-json-answer__codex/outputs/transcript.jsonl',
+    );
+    expect(findAnswerPath(structuredTranscriptFiles)).toBe(
+      'final-json-answer__codex/outputs/answer.md',
+    );
+  });
+
+  it('renders final answer separately from prior assistant/tool context with raw JSONL access', () => {
+    const parsed = parseTranscriptJsonl(structuredTranscriptJsonl);
+    const html = renderToStaticMarkup(
+      <TranscriptTimeline
+        entries={parsed.entries}
+        finalAnswer={'{"answer":42,"source":"src/app.ts"}'}
+        answerPath="final-json-answer__codex/outputs/answer.md"
+        transcriptPath="final-json-answer__codex/outputs/transcript.jsonl"
+        answerHref="/api/raw-answer"
+        transcriptHref="/api/raw-transcript"
+        transcriptDownloadHref="/api/download-transcript"
+      />,
+    );
+
+    expect(html).toContain('Final answer');
+    expect(html).toContain('Transcript timeline');
+    expect(html).toContain('User');
+    expect(html).toContain('Assistant');
+    expect(html).toContain('Tool result');
+    expect(html).toContain('read_file');
+    expect(html).toContain('Arguments');
+    expect(html).toContain('Result');
+    expect(html).toContain('Open raw JSONL');
+    expect(html).toContain('Download JSONL');
+    expect(html).toContain('{&quot;answer&quot;:42,&quot;source&quot;:&quot;src/app.ts&quot;}');
+  });
+});

--- a/apps/dashboard/src/components/transcript-timeline.test.tsx
+++ b/apps/dashboard/src/components/transcript-timeline.test.tsx
@@ -26,6 +26,21 @@ describe('TranscriptTimeline', () => {
     expect(parsed.entries[1].tool_calls?.[0]?.tool).toBe('read_file');
   });
 
+  it('rejects malformed optional tool_calls fields before rendering', () => {
+    const parsed = parseTranscriptJsonl(
+      JSON.stringify({
+        test_id: 'final-json-answer',
+        target: 'codex',
+        message_index: 0,
+        role: 'assistant',
+        tool_calls: { id: 'call-1', tool: 'read_file' },
+      }),
+    );
+
+    expect(parsed.entries).toEqual([]);
+    expect(parsed.error).toBe('Line 1 is not a transcript JSONL row.');
+  });
+
   it('finds canonical transcript and answer artifacts without selecting response.md', () => {
     expect(findTranscriptPath(structuredTranscriptFiles)).toBe(
       'final-json-answer__codex/outputs/transcript.jsonl',

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -87,6 +87,32 @@ function flattenRunListPages(pages: RunListResponse[] | undefined): RunListRespo
   };
 }
 
+function encodeArtifactPath(filePath: string): string {
+  return filePath
+    .split('/')
+    .filter((segment) => segment.length > 0)
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+}
+
+export function artifactFileContentUrl(options: {
+  runId: string;
+  evalId: string;
+  filePath: string;
+  projectId?: string;
+  raw?: boolean;
+  download?: boolean;
+}): string {
+  const base = options.projectId
+    ? `${projectApiBase(options.projectId)}/runs/${encodeURIComponent(options.runId)}/evals/${encodeURIComponent(options.evalId)}/files/${encodeArtifactPath(options.filePath)}`
+    : `/api/runs/${encodeURIComponent(options.runId)}/evals/${encodeURIComponent(options.evalId)}/files/${encodeArtifactPath(options.filePath)}`;
+  const params = new URLSearchParams();
+  if (options.raw) params.set('raw', '1');
+  if (options.download) params.set('download', '1');
+  const query = params.toString();
+  return query ? `${base}?${query}` : base;
+}
+
 export const runListOptions = queryOptions({
   queryKey: ['runs'],
   queryFn: () => fetchJson<RunListResponse>('/api/runs'),
@@ -194,9 +220,7 @@ export function evalFileContentOptions(runId: string, evalId: string, filePath: 
   return queryOptions({
     queryKey: ['runs', runId, 'evals', evalId, 'files', filePath],
     queryFn: () =>
-      fetchJson<FileContentResponse>(
-        `/api/runs/${encodeURIComponent(runId)}/evals/${encodeURIComponent(evalId)}/files/${filePath}`,
-      ),
+      fetchJson<FileContentResponse>(artifactFileContentUrl({ runId, evalId, filePath })),
     enabled: !!runId && !!evalId && !!filePath,
   });
 }
@@ -477,7 +501,7 @@ export function projectEvalFileContentOptions(
     queryKey: ['projects', projectId, 'runs', runId, 'evals', evalId, 'files', filePath],
     queryFn: () =>
       fetchJson<FileContentResponse>(
-        `${projectApiBase(projectId)}/runs/${encodeURIComponent(runId)}/evals/${encodeURIComponent(evalId)}/files/${filePath}`,
+        artifactFileContentUrl({ projectId, runId, evalId, filePath }),
       ),
     enabled: !!projectId && !!runId && !!evalId && !!filePath,
   });

--- a/apps/dashboard/src/lib/types.ts
+++ b/apps/dashboard/src/lib/types.ts
@@ -125,7 +125,7 @@ export interface EvalResult {
   scores?: ScoreEntry[];
   assertions?: AssertionEntry[];
   input?: { role: string; content: string }[];
-  output?: { role: string; content: string }[];
+  output?: string;
   _toolCalls?: Record<string, unknown>;
   _graderDurationMs?: number;
   source_traceability?: SourceTraceability;


### PR DESCRIPTION
Closes #1363.

## Summary

- Adds a Dashboard Transcript tab that reads canonical `outputs/transcript.jsonl` and renders a chronological user/assistant/tool timeline.
- Highlights and links the canonical `outputs/answer.md` final answer separately from prior assistant/tool context.
- Adds collapsible tool call/result sections for arguments, results/errors, timing, metadata, and provider/session summary.
- Keeps raw JSONL accessible in Files, as a raw browser-visible link, and as an explicit download.
- Adds focused Dashboard fixtures/component tests and a serve API regression for raw/download transcript artifacts.

## Scope and limitations

- The viewer only discovers canonical `outputs/transcript.jsonl` and `outputs/answer.md` artifacts.
- It intentionally does **not** parse `response.md` or markdown transcripts.
- Raw artifact links serve JSONL as `text/plain` for in-browser inspection; `?download=1` adds `Content-Disposition` for file downloads.

## Verification

Automated:

- `bun --filter @agentv/dashboard test` — 87 pass (includes malformed `tool_calls` regression)
- `bun --filter @agentv/dashboard build` — rebuilt `apps/dashboard/dist` for UAT
- `bun --filter agentv test test/commands/results/serve.test.ts` — 87 pass
- `bun run validate:examples` — 58 valid / 0 invalid
- `bun run verify` — build, typecheck, lint, and all tests passed

Dashboard/browser UAT (headless `agent-browser`):

- RED/main: served `/tmp/agentv-dashboard-transcript-uat` with the fixture on port 3127; the eval detail page had `Checks Source Files Feedback` and no Transcript tab.
  - Screenshot: `/tmp/agentv-dashboard-transcript-uat/evidence/red-final-main-no-transcript.png`
  - Text capture: `/tmp/agentv-dashboard-transcript-uat/evidence/red-final-main-text.txt`
- GREEN/current branch: rebuilt `apps/dashboard/dist`, served the same fixture on port 3128, opened `/evals/uat%3A%3A2026-06-13T09-00-00-000Z/final-json-answer`, selected Transcript, and expanded all tool call/result details.
  - Structured transcript screenshot: `/tmp/agentv-dashboard-transcript-uat/evidence/green-final-transcript-expanded.png`
  - Text capture: `/tmp/agentv-dashboard-transcript-uat/evidence/green-final-transcript-text.txt`
  - `Open answer.md in Files` screenshot: `/tmp/agentv-dashboard-transcript-uat/evidence/green-final-answer-in-files.png`
  - Raw JSONL screenshot: `/tmp/agentv-dashboard-transcript-uat/evidence/green-final-raw-jsonl.png`
  - Raw JSONL text capture: `/tmp/agentv-dashboard-transcript-uat/evidence/green-final-raw-jsonl-text.txt`
  - `response.md` control proving the sentinel exists but is not displayed in the transcript viewer: `/tmp/agentv-dashboard-transcript-uat/evidence/green-final-response-md-control.txt`



## Review follow-up

- Fixed P2 from read-only review: malformed non-array `tool_calls` now fails transcript JSONL validation instead of crashing the Transcript tab; rendering also defensively guards the optional field shape.
- Re-ran focused checks after the fix: `bun --filter @agentv/dashboard test`, `bun --filter @agentv/dashboard build`, and `bun run lint`. Also regenerated the Dashboard/headless `agent-browser` transcript-viewer UAT evidence after the P2 fix and saved it in the private evidence repo.

## Private evidence (post-P2 UAT)

- Private repo: `EntityProcess/agentv-private`
- Private branch: `evidence/dashboard-transcript-viewer-2026-06-14`
- Private evidence commit: `7ea49d248f302a12de968b21d5b9aab063afb23e`
- Private path: `demos/dashboard-transcript-viewer/2026-06-14/`
- Local path: `/home/entity/projects/EntityProcess/agentv-private/demos/dashboard-transcript-viewer/2026-06-14/`
- README: `demos/dashboard-transcript-viewer/2026-06-14/README.md`
- Screenshots include Transcript expanded/collapsed/re-expanded, tool result/final assistant, `answer.md` in Files, and raw JSONL.
- Verification logs include `commands/dashboard-test.log`, `commands/dashboard-build.log`, `commands/dashboard-serve.log`, and `text/verification-summary.txt`; the response.md control shows sentinel count 1 in `response.md` and 0 in the Transcript tab.
