### PR TITLE
docs(results): document WIP checkpoints

### DIFF
--- a/apps/web/src/content/docs/docs/evaluation/running-evals.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/running-evals.mdx
@@ -301,7 +301,7 @@ agentv eval evals/my-eval.yaml --rerun-failed
 agentv eval evals/my-eval.yaml --retry-errors .agentv/results/runs/<timestamp>/index.jsonl
 ```
 
-After any failing run, the CLI prints the exact `--rerun-failed` command for the run dir that just completed — copy/paste it.
+After any failing run, the CLI prints the exact `--rerun-failed` command for the run dir that just completed — copy/paste it. If the process or pod disappeared before you could access the local run directory and results auto-push was enabled, recover the partial run from [WIP checkpoints](/docs/tools/wip-checkpoints/) first, then use the same `--resume` flow.
 
 The interactive wizard (`agentv eval` with no arguments) remembers the last run's artifact directory and surfaces a **"Resume last run"** entry in the main menu when one exists.
 

--- a/apps/web/src/content/docs/docs/index.mdx
+++ b/apps/web/src/content/docs/docs/index.mdx
@@ -42,6 +42,26 @@ AgentV is a CLI-first AI agent evaluation framework. It evaluates your agents lo
 - **Rubrics** — Structured criteria with weights for grading
 - **Results** — JSONL output with scores, reasoning, and execution traces
 
+## AI agent navigation map
+
+Use this topic map when you are an AI agent trying to decide which primitive or workflow to compose next:
+
+| Goal | Start here | Why |
+| --- | --- | --- |
+| Create a first eval | [Quickstart](/docs/getting-started/quickstart/) → [Eval files](/docs/evaluation/eval-files/) | Defines the smallest runnable YAML shape before adding advanced fields. |
+| Run or resume evals | [Running evals](/docs/evaluation/running-evals/) → [WIP checkpoints](/docs/tools/wip-checkpoints/) | Covers `agentv eval`, concurrency, `--resume`, `--rerun-failed`, and remote partial-run recovery. |
+| Choose graders | [Rubrics](/docs/evaluation/rubrics/) → [Code graders](/docs/graders/code-graders/) → [LLM graders](/docs/graders/llm-graders/) | Keeps deterministic checks, rubric scoring, and LLM judgment separate. |
+| Evaluate tool use or agents | [Tool trajectory](/docs/graders/tool-trajectory/) → [Coding agents](/docs/targets/coding-agents/) → [CLI provider](/docs/targets/cli-provider/) | Shows how targets, transcripts, and tool-call assertions compose. |
+| Share and inspect results | [Results](/docs/tools/results/) → [Dashboard](/docs/tools/dashboard/) | Explains local artifacts, reports, remote result repositories, and Dashboard review flows. |
+| Compare runs | [Compare](/docs/tools/compare/) → [Dashboard Analytics](/docs/tools/dashboard/#analytics) | Use CLI metrics for automation and Dashboard analytics for interactive inspection. |
+| Govern or improve an agent workflow | [Agent eval layers](/docs/guides/agent-eval-layers/) → [Skill improvement workflow](/docs/guides/skill-improvement-workflow/) → [Enterprise governance](/docs/guides/enterprise-governance/) | Moves from primitive eval design to iterative agent improvement and governance checks. |
+
+### Navigation strategy recommendation
+
+Keep the public Astro/Starlight docs as AgentV's canonical navigation layer, and add lightweight topic-map sections like the one above when agents need a faster path through related pages. This borrows the useful LLM Wiki convention of one-line index entries with dense cross-links, without introducing a separate wiki, custom schema, or runtime navigation code.
+
+That is the smallest fit for the current docs: Starlight already provides the sidebar, URLs, search, and link validation, while the source MDX files remain reviewable in ordinary PRs. A full LLM Wiki-style knowledge graph would add duplicate source-of-truth and maintenance overhead before AgentV has enough public docs or contradictory source material to justify provenance tracking. Revisit a richer topic-map or wiki only if a docs section grows beyond a scannable page index, or if multiple sources need explicit confidence/contradiction metadata.
+
 ## Features
 
 - **Multi-objective scoring**: Correctness, latency, cost, safety in one run

--- a/apps/web/src/content/docs/docs/tools/dashboard.mdx
+++ b/apps/web/src/content/docs/docs/tools/dashboard.mdx
@@ -245,7 +245,7 @@ IDs are derived from the directory name (e.g., `/home/user/repos/my-evals` becom
 
 ## Remote Results
 
-Dashboard can display runs pushed to a remote git repository by other machines or CI alongside your local runs. Each run in the list carries a source badge: **local** (green) or **remote** (amber).
+Dashboard can display runs pushed to a remote git repository by other machines or CI alongside your local runs. Each run in the list carries a source badge: **local** (green) or **remote** (amber). For in-progress eval durability before final publish, AgentV writes [WIP checkpoints](/docs/tools/wip-checkpoints/) to `agentv/inflight/...` branches; Dashboard lists them only after they are recovered locally or published to the normal results branch.
 
 ### Configuration
 
@@ -334,7 +334,7 @@ Each run writes to a unique timestamped directory, so concurrent pushes from mul
 
 Existing runs already present under `.agentv/results/runs/` stay exactly where they are and continue to appear in Dashboard as **local** runs.
 
-Adding a `results` block does **not** backfill those historical runs into the remote repo automatically. Auto-push only affects runs created after the remote results repo is configured.
+Adding a `results` block does **not** backfill those historical runs into the remote repo automatically. Auto-push only affects runs created after the remote results repo is configured. The same auto-push setting also enables best-effort WIP checkpoints for in-progress `agentv eval` runs.
 
 If you want older local-only runs in the remote repo, rerun them or copy the run directories into the managed clone manually before syncing the project.
 

--- a/apps/web/src/content/docs/docs/tools/results.mdx
+++ b/apps/web/src/content/docs/docs/tools/results.mdx
@@ -11,7 +11,7 @@ import resultsReportDetails from '../../../../assets/screenshots/results-report-
 
 The `results` command family works on existing local AgentV run workspaces and `index.jsonl` manifests. Use it after an eval run to inspect failures, validate manifests, export artifact layouts, combine/delete local run workspaces, or generate a shareable HTML report.
 
-Remote result repository exchange is intentionally not part of `agentv results`. New eval runs can auto-export to a configured results repo when `auto_push: true`; manual remote status and sync are Dashboard/API workflows. See [Dashboard Remote Results](/docs/tools/dashboard/#remote-results) for configuration and sync behavior.
+Remote result repository exchange is intentionally not part of `agentv results`. New eval runs can auto-export to a configured results repo when `auto_push: true`; manual remote status and sync are Dashboard/API workflows. See [Dashboard Remote Results](/docs/tools/dashboard/#remote-results) for configuration and sync behavior, and [WIP checkpoints](/docs/tools/wip-checkpoints/) for recovering in-progress runs before final publish.
 
 ## Subcommands
 
@@ -90,7 +90,7 @@ The CLI contract is deliberately narrow: `agentv results` manages local result a
 
 Use these supported remote workflows instead:
 
-- **Automatic publishing:** configure `projects[].results.sync.auto_push: true`; new `agentv eval` and `agentv pipeline bench` runs push their artifacts after the run completes. Add `projects[].results.branch` when the results repo stores artifacts on a non-default branch.
+- **Automatic publishing:** configure `projects[].results.sync.auto_push: true`; new `agentv eval` and `agentv pipeline bench` runs push their artifacts after the run completes. Add `projects[].results.branch` when the results repo stores artifacts on a non-default branch. While an eval is still running, [WIP checkpoints](/docs/tools/wip-checkpoints/) can keep partial run output durable on `agentv/inflight/...` branches.
 - **Manual Dashboard sync:** run `agentv dashboard`, open the project, and use **Sync Project**.
 - **Manual API sync:** while Dashboard is running, call `GET /api/projects/:projectId/remote/status` or `POST /api/projects/:projectId/remote/sync` for project-scoped automation. Single-project sessions also expose `GET /api/remote/status` and `POST /api/remote/sync`.
 - **Git escape hatch:** for advanced recovery, inspect or repair the configured `projects[].results.path` clone with `git` directly, then sync again.

--- a/apps/web/src/content/docs/docs/tools/wip-checkpoints.mdx
+++ b/apps/web/src/content/docs/docs/tools/wip-checkpoints.mdx
@@ -1,0 +1,93 @@
+---
+title: WIP checkpoints
+description: Recover in-progress eval runs from git-backed results repositories.
+sidebar:
+  order: 7
+---
+
+WIP checkpoints are best-effort snapshots of an eval run while it is still executing. They are designed for long-running evals in CI, pods, or remote agents where losing the process would otherwise lose the completed test rows that were already written locally.
+
+They are **not** a second results mode. They reuse the existing run workspace format and the configured git-backed results repository.
+
+## When checkpoints run
+
+WIP checkpoints are active only when AgentV can resolve a results repo configuration with auto-push enabled:
+
+- In a registered project: `projects[].results.sync.auto_push: true` in `$AGENTV_HOME/config.yaml`.
+- In the top-level fallback config: `results.auto_push: true`.
+
+If no results repo is configured, or auto-push is disabled, `agentv eval` still writes the local run workspace but does not create WIP branches.
+
+## What gets written
+
+| Location | Path or ref | What it contains |
+| --- | --- | --- |
+| Local project | `.agentv/results/runs/<experiment>/<run-id>/benchmark.json` | A run-start stub with `metadata.planned_test_count` and the eval file path when known. This lets Dashboard recognize incomplete local runs as resumable. |
+| Local project | `.agentv/results/runs/<experiment>/<run-id>/index.jsonl` | Result rows appended as test cases finish. Rows use the normal snake_case result JSONL format. |
+| Results repo remote | `agentv/inflight/<hostname>/<run-dir-basename>` | A forced-updated branch containing the checkpointed run under `.agentv/results/runs/<same-relative-run-path>/`. |
+| Results repo storage branch | Configured `results.branch`, or the repo default branch | The final published run after `agentv eval` completes and the normal auto-export succeeds. |
+
+The WIP branch name is derived from the current host and the run directory basename. Non-branch-safe characters are replaced with `-`; the host component is capped at 40 characters and the run component at 60 characters.
+
+## Lifecycle
+
+1. **Run start** — AgentV creates the local run directory and writes the initial `benchmark.json` stub. If auto-push is enabled, it creates a temporary git worktree for a branch named `agentv/inflight/<hostname>/<run-dir-basename>`, based on the configured results storage branch when `results.branch` is set.
+2. **While running** — about every 30 seconds, AgentV copies the current run directory into the WIP worktree, amends a single checkpoint commit, and force-pushes the WIP branch. If nothing changed, it skips the push.
+3. **Successful completion** — AgentV publishes the completed run to the normal results branch. After that publish is confirmed as `published` or `already_published`, it deletes the remote WIP branch.
+4. **Failure, interrupt, or final export failure** — AgentV stops the checkpoint loop and removes the temporary local worktree, but leaves the remote WIP branch intact for recovery.
+
+Checkpoint failures are warnings only. They never fail the eval run.
+
+## Recover from a WIP branch
+
+Use git to retrieve the WIP branch, copy the run workspace back into the eval project, then resume the run with the normal `--resume` flow.
+
+```bash
+# 1. Clone or enter the configured results repo.
+git clone <results-repo-url> /tmp/agentv-results-recovery
+cd /tmp/agentv-results-recovery
+
+# 2. Find WIP branches.
+git fetch origin --prune
+git branch -r --list 'origin/agentv/inflight/*'
+
+# 3. Check out the branch for the interrupted run.
+git switch --detach origin/agentv/inflight/<hostname>/<run-dir-basename>
+
+# 4. Inspect the checkpointed run path.
+find .agentv/results/runs -name benchmark.json
+
+# 5. Copy the run tree into the eval project, preserving paths under runs/.
+PROJECT=/path/to/eval-project
+mkdir -p "$PROJECT/.agentv/results/runs"
+rsync -a .agentv/results/runs/ "$PROJECT/.agentv/results/runs/"
+
+# 6. Resume from the recovered run directory.
+cd "$PROJECT"
+agentv eval <eval-file> --output .agentv/results/runs/<experiment>/<run-id> --resume
+```
+
+If the recovered `benchmark.json` contains `metadata.eval_file`, use that as `<eval-file>`. If the run lives directly under `.agentv/results/runs/<run-id>/` instead of an experiment directory, pass that path to `--output`.
+
+After the resumed run publishes successfully, AgentV cleans up any WIP branch it creates for the resumed run. Delete the original orphaned branch manually when you no longer need it:
+
+```bash
+git push origin --delete agentv/inflight/<hostname>/<run-dir-basename>
+```
+
+## Dashboard and `results` surfaces
+
+- **Dashboard local runs:** an interrupted local run can show the one-click **Resume run** and **Rerun failed** actions when `benchmark.json` has `metadata.planned_test_count` greater than the number of result rows, or when any row has `execution_status: execution_error`.
+- **Dashboard remote runs:** normal remote listing reads the configured results storage branch. It does not list `agentv/inflight/...` WIP branches. Recover the checkpoint into the project-local run directory first, or wait for the final publish branch to receive a completed run.
+- **`agentv results` CLI:** the command family manages local run workspaces and reports. It does not have a WIP branch subcommand; use git for remote checkpoint inspection and cleanup.
+
+## Operational caveats
+
+- The first remote checkpoint happens on the periodic interval, so a process that dies immediately after startup may only have the local `benchmark.json` stub.
+- The WIP branch is force-pushed and keeps one snapshot commit. Do not treat it as an audit log.
+- Checkpoint contents can include prompts, outputs, grader evidence, traces, and generated task bundles. Protect the results repo like any other eval artifact store.
+- Authentication and branch permissions are the same as normal results auto-push. If git or GitHub authentication is missing, AgentV warns and keeps evaluating locally.
+- If `results.branch` is configured, create that remote storage branch before running evals. WIP worktrees are based on it.
+- Failed or interrupted runs intentionally leave WIP branches behind. Periodically delete old `agentv/inflight/...` branches once recovered or obsolete.
+
+See also: [Resume an Interrupted Run](/docs/evaluation/running-evals/#resume-an-interrupted-run), [Results](/docs/tools/results/), and [Dashboard Remote Results](/docs/tools/dashboard/#remote-results).


### PR DESCRIPTION
## Summary

Users and agents now have one public docs page for WIP checkpoint recovery instead of having to infer the behavior from PR #1369 and scattered remote-results/resume docs. The page explains when checkpoints run, which local and remote artifacts exist during an in-progress eval, how `agentv/inflight/...` branches are created/cleaned up, how to recover and resume a run, and why Dashboard/`agentv results` do not list WIP branches directly.

The docs index now includes an AI-agent topic map and an explicit navigation strategy recommendation: keep Astro/Starlight as the canonical docs layer, borrow LLM Wiki-style one-line topic-map entries and dense cross-links, and avoid a custom schema/runtime/wiki until the docs surface is large enough to justify that overhead.

## Red/Green Evidence

- **Red:** `/tmp/agentv-av-4oy-evidence/red-docs-gap.txt` captured that current main docs had remote results and resume fragments, but no single WIP checkpoint explanation for `agentv/inflight/...`, checkpointed artifacts, Dashboard/results behavior, and caveats.
- **Green:** `bun --filter @agentv/web build` generated `/docs/tools/wip-checkpoints/index.html`; `/tmp/agentv-av-4oy-evidence/green-docs-evidence.txt` captures the generated page and the new cross-linked topic-map/recommendation text.

## Verification

- `bun --filter @agentv/web build`
- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `git diff --check`

## Review Notes

- Simplify: skipped as docs-only; performed a manual pass for wording/scope.
- Code review: skipped dedicated review (no Tier 1 tool in this harness; Tier 2 criteria not met for a small docs-only diff).
- Follow-up beads: none needed; the recommendation explicitly avoids a deeper docs restructuring for now.

## Post-Deploy Monitoring & Validation

No additional runtime monitoring required because this is a docs-only change.

- **Validation window/owner:** next docs deployment, PR author or docs maintainer.
- **Healthy signals:** docs deploy succeeds; `/docs/tools/wip-checkpoints/` returns 200; docs search/Pagefind indexes “WIP checkpoints”, `agentv/inflight`, and `planned_test_count`.
- **Failure signals:** docs build/deploy failure, broken internal links, or a 404 for `/docs/tools/wip-checkpoints/`.
- **Mitigation:** revert this docs commit or fix the broken MDX/link and redeploy.

Closes av-4oy

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5 Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
