### PR TITLE
feat(trace): write trace envelope sidecars

### DIFF
--- a/apps/cli/src/commands/eval/artifact-writer.ts
+++ b/apps/cli/src/commands/eval/artifact-writer.ts
@@ -9,11 +9,12 @@ import {
   type Message,
   type TargetDefinition,
   type TraceSummary,
+  buildTraceEnvelopeFromEvaluationResult,
   buildTraceFromMessages,
   extractLastAssistantContent,
+  toTraceEnvelopeWire,
   traceToTranscriptJsonLines,
 } from '@agentv/core';
-import { toSnakeCaseDeep } from '../../utils/case-conversion.js';
 import { RESULT_INDEX_FILENAME } from './result-layout.js';
 import {
   type MaterializedTaskBundlePaths,
@@ -330,6 +331,76 @@ function buildEvaluators(scores: readonly GraderResult[] | undefined): GradingAr
     assertions: s.assertions,
     details: s.details,
   }));
+}
+
+function toIndexAssertion(
+  assertion: EvaluationResult['assertions'][number],
+): Record<string, unknown> {
+  return {
+    text: assertion.text,
+    passed: assertion.passed,
+    evidence: assertion.evidence,
+  };
+}
+
+function toIndexScore(score: GraderResult): Record<string, unknown> {
+  return {
+    name: score.name,
+    type: score.type,
+    score: score.score,
+    weight: score.weight,
+    verdict: score.verdict,
+    assertions: score.assertions.map(toIndexAssertion),
+    raw_request: score.rawRequest,
+    input: score.input,
+    target: score.target,
+    scores: score.scores?.map(toIndexScore),
+    details: score.details,
+    token_usage: score.tokenUsage,
+    duration_ms: score.durationMs,
+    started_at: score.startedAt,
+    ended_at: score.endedAt,
+  };
+}
+
+function toIndexScores(scores: readonly GraderResult[] | undefined): IndexArtifactEntry['scores'] {
+  return scores?.map(toIndexScore) as IndexArtifactEntry['scores'];
+}
+
+function dropUndefined(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+function toIndexRerunSource(value: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  return dropUndefined({
+    mode: value.mode,
+    source_run_dir: value.sourceRunDir,
+    source_index_path: value.sourceIndexPath,
+    source_artifact_dir: value.sourceArtifactDir,
+    source_task_dir: value.sourceTaskDir,
+    source_test_id: value.sourceTestId,
+    source_target: value.sourceTarget,
+    source_timestamp: value.sourceTimestamp,
+  });
+}
+
+function toIndexMetadata(
+  metadata: EvaluationResult['metadata'] | undefined,
+): IndexArtifactEntry['metadata'] {
+  if (!metadata) {
+    return undefined;
+  }
+  const rerunSource = toIndexRerunSource(metadata.rerunSource);
+  if (!rerunSource) {
+    return { ...metadata };
+  }
+  return {
+    ...Object.fromEntries(Object.entries(metadata).filter(([key]) => key !== 'rerunSource')),
+    rerun_source: rerunSource,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -649,6 +720,49 @@ function buildTaskBundleIndexFields(
   };
 }
 
+function findResultSourceTest(
+  result: EvaluationResult,
+  testByTestId: ReadonlyMap<string, EvalTest>,
+): EvalTest | undefined {
+  return testByTestId.get(result.testId ?? 'unknown');
+}
+
+function resolveEnvelopeEvalPath(
+  result: EvaluationResult,
+  testByTestId: ReadonlyMap<string, EvalTest>,
+  fallbackEvalFile?: string,
+): string | undefined {
+  const source = findResultSourceTest(result, testByTestId)?.source;
+  return source?.evalFileRepoPath ?? source?.evalFilePath ?? fallbackEvalFile;
+}
+
+async function writeTraceEnvelopeSidecar(params: {
+  readonly result: EvaluationResult;
+  readonly outputDir: string;
+  readonly outputsDir: string;
+  readonly evalPath?: string;
+  readonly experiment?: string;
+}): Promise<void> {
+  const hasTranscript = params.result.output.length > 0 || params.result.trace.messages.length > 0;
+  const envelope = buildTraceEnvelopeFromEvaluationResult(params.result, {
+    evalPath: params.evalPath,
+    runId: path.basename(params.outputDir),
+    experiment: params.experiment,
+    source: { path: RESULT_INDEX_FILENAME },
+    artifacts: {
+      envelope_path: 'outputs/trace-envelope.json',
+      answer_path: params.result.output.length > 0 ? 'outputs/answer.md' : undefined,
+      response_path: params.result.output.length > 0 ? 'outputs/response.md' : undefined,
+      transcript_path: hasTranscript ? 'outputs/transcript.jsonl' : undefined,
+    },
+  });
+  await writeFile(
+    path.join(params.outputsDir, 'trace-envelope.json'),
+    `${JSON.stringify(toTraceEnvelopeWire(envelope), null, 2)}\n`,
+    'utf8',
+  );
+}
+
 export function buildIndexArtifactEntry(
   result: EvaluationResult,
   options: {
@@ -677,9 +791,7 @@ export function buildIndexArtifactEntry(
     duration_ms: result.durationMs,
     start_time: result.startTime,
     end_time: result.endTime,
-    scores: result.scores
-      ? (toSnakeCaseDeep(result.scores) as IndexArtifactEntry['scores'])
-      : undefined,
+    scores: toIndexScores(result.scores),
     execution_status: result.executionStatus,
     error: result.error,
     failure_stage: result.failureStage,
@@ -706,7 +818,7 @@ export function buildIndexArtifactEntry(
       ? toRelativeArtifactPath(options.outputDir, options.responsePath)
       : undefined,
     ...buildTaskBundleIndexFields(options.outputDir, options.taskBundle),
-    metadata: result.metadata,
+    metadata: toIndexMetadata(result.metadata),
   };
 }
 
@@ -732,9 +844,7 @@ export function buildResultIndexArtifact(
     duration_ms: result.durationMs,
     start_time: result.startTime,
     end_time: result.endTime,
-    scores: result.scores
-      ? (toSnakeCaseDeep(result.scores) as IndexArtifactEntry['scores'])
-      : undefined,
+    scores: toIndexScores(result.scores),
     execution_status: result.executionStatus,
     error: result.error,
     failure_stage: result.failureStage,
@@ -765,15 +875,13 @@ export function buildResultIndexArtifact(
             : {}),
         }
       : {}),
-    metadata: result.metadata,
+    metadata: toIndexMetadata(result.metadata),
   };
 }
 
 async function writeJsonlFile(filePath: string, records: readonly unknown[]): Promise<void> {
   const content =
-    records.length === 0
-      ? ''
-      : `${records.map((record) => JSON.stringify(toSnakeCaseDeep(record))).join('\n')}\n`;
+    records.length === 0 ? '' : `${records.map((record) => JSON.stringify(record)).join('\n')}\n`;
   await writeFile(filePath, content, 'utf8');
 }
 
@@ -1140,17 +1248,24 @@ export async function writePerTestArtifacts(
     if (input) {
       await writeFile(path.join(testDir, 'input.md'), input, 'utf8');
     }
+    const outputsDir = path.join(testDir, 'outputs');
+    await mkdir(outputsDir, { recursive: true });
+    if (result.output.length > 0) {
+      await writeFile(path.join(outputsDir, 'answer.md'), result.output, 'utf8');
+      // Deprecated compatibility alias. New consumers should use answer.md
+      // for scored output or transcript.jsonl for the full execution record.
+      await writeFile(path.join(outputsDir, 'response.md'), result.output, 'utf8');
+    }
     if (result.output.length > 0 || result.trace.messages.length > 0) {
-      const outputsDir = path.join(testDir, 'outputs');
-      await mkdir(outputsDir, { recursive: true });
-      if (result.output.length > 0) {
-        await writeFile(path.join(outputsDir, 'answer.md'), result.output, 'utf8');
-        // Deprecated compatibility alias. New consumers should use answer.md
-        // for scored output or transcript.jsonl for the full execution record.
-        await writeFile(path.join(outputsDir, 'response.md'), result.output, 'utf8');
-      }
       await writeTranscriptJsonl(path.join(outputsDir, 'transcript.jsonl'), result);
     }
+    await writeTraceEnvelopeSidecar({
+      result,
+      outputDir,
+      outputsDir,
+      evalPath: resolveEnvelopeEvalPath(result, testByTestId),
+      experiment: options?.experiment,
+    });
 
     const taskBundle = await materializeTaskBundleForResult({
       result,
@@ -1213,17 +1328,24 @@ export async function writeArtifactsFromResults(
       await writeFile(path.join(testDir, 'input.md'), input, 'utf8');
     }
 
+    const outputsDir = path.join(testDir, 'outputs');
+    await mkdir(outputsDir, { recursive: true });
+    if (result.output.length > 0) {
+      await writeFile(path.join(outputsDir, 'answer.md'), result.output, 'utf8');
+      // Deprecated compatibility alias. New consumers should use answer.md
+      // for scored output or transcript.jsonl for the full execution record.
+      await writeFile(path.join(outputsDir, 'response.md'), result.output, 'utf8');
+    }
     if (result.output.length > 0 || result.trace.messages.length > 0) {
-      const outputsDir = path.join(testDir, 'outputs');
-      await mkdir(outputsDir, { recursive: true });
-      if (result.output.length > 0) {
-        await writeFile(path.join(outputsDir, 'answer.md'), result.output, 'utf8');
-        // Deprecated compatibility alias. New consumers should use answer.md
-        // for scored output or transcript.jsonl for the full execution record.
-        await writeFile(path.join(outputsDir, 'response.md'), result.output, 'utf8');
-      }
       await writeTranscriptJsonl(path.join(outputsDir, 'transcript.jsonl'), result);
     }
+    await writeTraceEnvelopeSidecar({
+      result,
+      outputDir,
+      outputsDir,
+      evalPath: resolveEnvelopeEvalPath(result, testByTestId, options?.evalFile),
+      experiment: options?.experiment,
+    });
 
     const taskBundle = await materializeTaskBundleForResult({
       result,

--- a/apps/cli/test/commands/eval/artifact-writer.test.ts
+++ b/apps/cli/test/commands/eval/artifact-writer.test.ts
@@ -6,6 +6,7 @@ import {
   type EvalTest,
   type EvaluationResult,
   type GraderResult,
+  TraceEnvelopeWireSchema,
   buildTraceFromMessages,
   parseYamlValue,
 } from '@agentv/core';
@@ -844,6 +845,27 @@ describe('writeArtifactsFromResults', () => {
         },
       },
     ]);
+
+    const envelope = TraceEnvelopeWireSchema.parse(
+      JSON.parse(
+        await readFile(
+          path.join(testDir, 'transcript-case', 'outputs', 'trace-envelope.json'),
+          'utf8',
+        ),
+      ),
+    );
+    expect(envelope.schema_version).toBe('agentv.trace_envelope.v1');
+    expect(envelope.eval.test_id).toBe('transcript-case');
+    expect(envelope.trace.spans.map((span) => span.attributes['gen_ai.operation.name'])).toEqual([
+      'invoke_agent',
+      'chat',
+      'execute_tool',
+    ]);
+
+    const indexLine = JSON.parse(
+      (await readFile(path.join(testDir, 'index.jsonl'), 'utf8')).trim(),
+    );
+    expect(indexLine).not.toHaveProperty('trace_envelope_path');
   });
 
   it('sanitizes test IDs for directory names', async () => {

--- a/packages/core/src/evaluation/trace-envelope.ts
+++ b/packages/core/src/evaluation/trace-envelope.ts
@@ -1,0 +1,1271 @@
+/**
+ * Trace envelope v1: AgentV-owned metadata around an OTel/OpenInference span graph.
+ *
+ * The envelope is the canonical full trace sidecar for eval artifacts. AgentV
+ * owns the outer structure, eval/replay identity, capture policy, warnings,
+ * artifact pointers, and score provenance. The trace body is a standards-shaped
+ * span graph, so attribute keys such as `gen_ai.operation.name` and
+ * `openinference.span.kind` are copied exactly and never case-converted.
+ *
+ * To extend the wire shape, add snake_case fields to the focused Zod schema,
+ * convert them explicitly in the matching to/from helper, and keep opaque maps
+ * (`attributes`, `metadata`, `details`, `evidence`) as direct pass-throughs.
+ */
+
+import { createHash } from 'node:crypto';
+import { z } from 'zod';
+import type { Message, ToolCall } from './providers/types.js';
+import {
+  NORMALIZED_TRAJECTORY_SCHEMA_VERSION,
+  type TokenUsage,
+  type TraceArtifact,
+  type TraceComputeResult,
+  type TraceEvent,
+  type TraceSourceKind,
+  type TraceSummary,
+} from './trace.js';
+import type { EvaluationResult, EvaluationVerdict, GraderKind } from './types.js';
+
+export const TRACE_ENVELOPE_SCHEMA_VERSION = 'agentv.trace_envelope.v1' as const;
+
+const TRACE_ENVELOPE_FORMAT = 'otlp_openinference_spans' as const;
+
+const CAPTURE_CONTENT_VALUES = ['none', 'metadata', 'full'] as const;
+const REDACTION_LEVEL_VALUES = ['none', 'partial', 'full'] as const;
+const WARNING_SEVERITY_VALUES = ['info', 'warning', 'error'] as const;
+const SPAN_STATUS_CODE_VALUES = ['UNSET', 'OK', 'ERROR'] as const;
+
+type CaptureContent = (typeof CAPTURE_CONTENT_VALUES)[number];
+type RedactionLevel = (typeof REDACTION_LEVEL_VALUES)[number];
+type WarningSeverity = (typeof WARNING_SEVERITY_VALUES)[number];
+type SpanStatusCode = (typeof SPAN_STATUS_CODE_VALUES)[number];
+
+export interface TraceEnvelopeEval {
+  readonly evalId?: string;
+  readonly evalPath?: string;
+  readonly suite?: string;
+  readonly testId: string;
+  readonly target: string;
+  readonly sourceTarget?: string;
+  readonly attempt?: number;
+  readonly variant?: string | null;
+  readonly runId?: string;
+  readonly category?: string;
+  readonly experiment?: string;
+}
+
+export interface TraceEnvelopeReplay {
+  readonly lookupKey?: Readonly<Record<string, unknown>>;
+  readonly fixtureId?: string;
+  readonly sourceFixturePath?: string;
+}
+
+export interface TraceEnvelopeSpanStatus {
+  readonly code: SpanStatusCode;
+  readonly message?: string;
+}
+
+export interface TraceEnvelopeSpanEvent {
+  readonly name: string;
+  readonly timeUnixNano?: string;
+  readonly attributes?: Readonly<Record<string, unknown>>;
+}
+
+export interface TraceEnvelopeSpan {
+  readonly traceId: string;
+  readonly spanId: string;
+  readonly parentSpanId?: string | null;
+  readonly name: string;
+  readonly kind: string;
+  readonly startTimeUnixNano: string;
+  readonly endTimeUnixNano: string;
+  readonly status: TraceEnvelopeSpanStatus;
+  readonly attributes: Readonly<Record<string, unknown>>;
+  readonly events?: readonly TraceEnvelopeSpanEvent[];
+}
+
+export interface TraceEnvelopeBody {
+  readonly format: typeof TRACE_ENVELOPE_FORMAT;
+  readonly traceId: string;
+  readonly rootSpanId: string;
+  readonly resource?: {
+    readonly attributes?: Readonly<Record<string, unknown>>;
+  };
+  readonly scope?: {
+    readonly name?: string;
+    readonly version?: string;
+  };
+  readonly spans: readonly TraceEnvelopeSpan[];
+}
+
+export interface TraceEnvelopeSource {
+  readonly kind: string;
+  readonly path?: string;
+  readonly provider?: string;
+  readonly format?: string;
+  readonly version?: string;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface TraceEnvelopeCapture {
+  readonly content: CaptureContent;
+  readonly redactionLevel: RedactionLevel;
+  readonly redactedFields?: readonly string[];
+  readonly policy?: Readonly<Record<string, unknown>>;
+}
+
+export interface TraceEnvelopeSourceRef {
+  readonly eventId?: string;
+  readonly messageId?: string;
+  readonly spanId?: string;
+  readonly traceId?: string;
+  readonly rawKind?: string;
+  readonly path?: string;
+  readonly line?: number;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface TraceEnvelopeConversionWarning {
+  readonly code: string;
+  readonly severity: WarningSeverity;
+  readonly spanId?: string;
+  readonly sourceRef?: TraceEnvelopeSourceRef;
+  readonly message: string;
+  readonly details?: Readonly<Record<string, unknown>>;
+}
+
+export interface TraceEnvelopeScore {
+  readonly name: string;
+  readonly type: GraderKind | string;
+  readonly score: number;
+  readonly weight?: number;
+  readonly verdict?: EvaluationVerdict;
+  readonly source?: string;
+  readonly evaluatedAt?: string;
+  readonly targetSpanId?: string;
+  readonly evidence?: Readonly<Record<string, unknown>>;
+}
+
+export interface TraceEnvelope {
+  readonly schemaVersion: typeof TRACE_ENVELOPE_SCHEMA_VERSION;
+  readonly envelopeId: string;
+  readonly createdAt: string;
+  readonly eval: TraceEnvelopeEval;
+  readonly replay?: TraceEnvelopeReplay;
+  readonly trace: TraceEnvelopeBody;
+  readonly source: TraceEnvelopeSource;
+  readonly capture: TraceEnvelopeCapture;
+  readonly conversionWarnings?: readonly TraceEnvelopeConversionWarning[];
+  readonly artifacts?: Readonly<Record<string, string>>;
+  readonly scores?: readonly TraceEnvelopeScore[];
+}
+
+const AttributeMapWireSchema = z.record(z.string(), z.unknown());
+
+export const TraceEnvelopeEvalWireSchema = z
+  .object({
+    eval_id: z.string().optional(),
+    eval_path: z.string().optional(),
+    suite: z.string().optional(),
+    test_id: z.string(),
+    target: z.string(),
+    source_target: z.string().optional(),
+    attempt: z.number().int().nonnegative().optional(),
+    variant: z.string().nullable().optional(),
+    run_id: z.string().optional(),
+    category: z.string().optional(),
+    experiment: z.string().optional(),
+  })
+  .strict();
+
+export const TraceEnvelopeReplayWireSchema = z
+  .object({
+    lookup_key: z.record(z.string(), z.unknown()).optional(),
+    fixture_id: z.string().optional(),
+    source_fixture_path: z.string().optional(),
+  })
+  .strict();
+
+export const TraceEnvelopeSpanStatusWireSchema = z
+  .object({
+    code: z.enum(SPAN_STATUS_CODE_VALUES),
+    message: z.string().optional(),
+  })
+  .strict();
+
+export const TraceEnvelopeSpanEventWireSchema = z
+  .object({
+    name: z.string(),
+    time_unix_nano: z.string().optional(),
+    attributes: AttributeMapWireSchema.optional(),
+  })
+  .strict();
+
+export const TraceEnvelopeSpanWireSchema = z
+  .object({
+    trace_id: z.string(),
+    span_id: z.string(),
+    parent_span_id: z.string().nullable().optional(),
+    name: z.string(),
+    kind: z.string(),
+    start_time_unix_nano: z.string(),
+    end_time_unix_nano: z.string(),
+    status: TraceEnvelopeSpanStatusWireSchema,
+    attributes: AttributeMapWireSchema,
+    events: z.array(TraceEnvelopeSpanEventWireSchema).optional(),
+  })
+  .strict();
+
+export const TraceEnvelopeBodyWireSchema = z
+  .object({
+    format: z.literal(TRACE_ENVELOPE_FORMAT),
+    trace_id: z.string(),
+    root_span_id: z.string(),
+    resource: z
+      .object({
+        attributes: AttributeMapWireSchema.optional(),
+      })
+      .strict()
+      .optional(),
+    scope: z
+      .object({
+        name: z.string().optional(),
+        version: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    spans: z.array(TraceEnvelopeSpanWireSchema),
+  })
+  .strict();
+
+export const TraceEnvelopeSourceWireSchema = z
+  .object({
+    kind: z.string(),
+    path: z.string().optional(),
+    provider: z.string().optional(),
+    format: z.string().optional(),
+    version: z.string().optional(),
+    metadata: AttributeMapWireSchema.optional(),
+  })
+  .strict();
+
+export const TraceEnvelopeCaptureWireSchema = z
+  .object({
+    content: z.enum(CAPTURE_CONTENT_VALUES),
+    redaction_level: z.enum(REDACTION_LEVEL_VALUES),
+    redacted_fields: z.array(z.string()).optional(),
+    policy: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+
+export const TraceEnvelopeSourceRefWireSchema = z
+  .object({
+    event_id: z.string().optional(),
+    message_id: z.string().optional(),
+    span_id: z.string().optional(),
+    trace_id: z.string().optional(),
+    raw_kind: z.string().optional(),
+    path: z.string().optional(),
+    line: z.number().int().nonnegative().optional(),
+    metadata: AttributeMapWireSchema.optional(),
+  })
+  .strict();
+
+export const TraceEnvelopeConversionWarningWireSchema = z
+  .object({
+    code: z.string(),
+    severity: z.enum(WARNING_SEVERITY_VALUES),
+    span_id: z.string().optional(),
+    source_ref: TraceEnvelopeSourceRefWireSchema.optional(),
+    message: z.string(),
+    details: AttributeMapWireSchema.optional(),
+  })
+  .strict();
+
+export const TraceEnvelopeScoreWireSchema = z
+  .object({
+    name: z.string(),
+    type: z.string(),
+    score: z.number(),
+    weight: z.number().optional(),
+    verdict: z.string().optional(),
+    source: z.string().optional(),
+    evaluated_at: z.string().optional(),
+    target_span_id: z.string().optional(),
+    evidence: AttributeMapWireSchema.optional(),
+  })
+  .strict();
+
+export const TraceEnvelopeWireSchema = z
+  .object({
+    schema_version: z.literal(TRACE_ENVELOPE_SCHEMA_VERSION),
+    envelope_id: z.string(),
+    created_at: z.string(),
+    eval: TraceEnvelopeEvalWireSchema,
+    replay: TraceEnvelopeReplayWireSchema.optional(),
+    trace: TraceEnvelopeBodyWireSchema,
+    source: TraceEnvelopeSourceWireSchema,
+    capture: TraceEnvelopeCaptureWireSchema,
+    conversion_warnings: z.array(TraceEnvelopeConversionWarningWireSchema).optional(),
+    artifacts: z.record(z.string(), z.string()).optional(),
+    scores: z.array(TraceEnvelopeScoreWireSchema).optional(),
+  })
+  .strict();
+
+export type TraceEnvelopeWire = z.infer<typeof TraceEnvelopeWireSchema>;
+export type TraceEnvelopeEvalWire = z.infer<typeof TraceEnvelopeEvalWireSchema>;
+export type TraceEnvelopeReplayWire = z.infer<typeof TraceEnvelopeReplayWireSchema>;
+export type TraceEnvelopeBodyWire = z.infer<typeof TraceEnvelopeBodyWireSchema>;
+export type TraceEnvelopeSpanWire = z.infer<typeof TraceEnvelopeSpanWireSchema>;
+export type TraceEnvelopeSourceWire = z.infer<typeof TraceEnvelopeSourceWireSchema>;
+export type TraceEnvelopeCaptureWire = z.infer<typeof TraceEnvelopeCaptureWireSchema>;
+export type TraceEnvelopeConversionWarningWire = z.infer<
+  typeof TraceEnvelopeConversionWarningWireSchema
+>;
+export type TraceEnvelopeScoreWire = z.infer<typeof TraceEnvelopeScoreWireSchema>;
+
+export interface BuildTraceEnvelopeOptions {
+  readonly evalId?: string;
+  readonly evalPath?: string;
+  readonly sourceTarget?: string;
+  readonly attempt?: number;
+  readonly variant?: string | null;
+  readonly runId?: string;
+  readonly experiment?: string;
+  readonly source?: Partial<TraceEnvelopeSource>;
+  readonly replay?: TraceEnvelopeReplay;
+  readonly capture?: Partial<TraceEnvelopeCapture>;
+  readonly artifacts?: Readonly<Record<string, string | undefined>>;
+  readonly now?: () => Date;
+}
+
+function dropUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined)) as T;
+}
+
+function definedStringRecord(
+  value: Readonly<Record<string, string | undefined>> | undefined,
+): Record<string, string> | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, string] => typeof entry[1] === 'string',
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function hashHex(parts: readonly unknown[], length: number): string {
+  const stable = parts
+    .map((part) => (typeof part === 'string' ? part : JSON.stringify(part)))
+    .join('\0');
+  return createHash('sha256').update(stable).digest('hex').slice(0, length);
+}
+
+function parseTimeMs(timestamp: string | undefined): number | undefined {
+  if (!timestamp) {
+    return undefined;
+  }
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function msToUnixNano(ms: number): string {
+  return String(BigInt(Math.round(ms)) * 1_000_000n);
+}
+
+function unixNanoToIso(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  try {
+    return new Date(Number(BigInt(value) / 1_000_000n)).toISOString();
+  } catch {
+    return undefined;
+  }
+}
+
+function durationMsFromSpan(span: TraceEnvelopeSpan): number | undefined {
+  try {
+    const start = BigInt(span.startTimeUnixNano);
+    const end = BigInt(span.endTimeUnixNano);
+    if (end < start) {
+      return undefined;
+    }
+    return Number(end - start) / 1_000_000;
+  } catch {
+    return undefined;
+  }
+}
+
+function deriveTiming(input: {
+  readonly startTime?: string;
+  readonly endTime?: string;
+  readonly durationMs?: number;
+  readonly fallbackStartMs: number;
+  readonly fallbackEndMs: number;
+}): { readonly startMs: number; readonly endMs: number } {
+  const startMs = parseTimeMs(input.startTime) ?? input.fallbackStartMs;
+  const endMs =
+    parseTimeMs(input.endTime) ??
+    (input.durationMs !== undefined ? startMs + input.durationMs : input.fallbackEndMs);
+  return { startMs, endMs: Math.max(startMs, endMs) };
+}
+
+function tokenUsageAttributes(usage: TokenUsage | undefined): Record<string, unknown> {
+  if (!usage) {
+    return {};
+  }
+  return dropUndefined({
+    'gen_ai.usage.input_tokens': usage.input,
+    'gen_ai.usage.output_tokens': usage.output,
+    'gen_ai.usage.cache_read.input_tokens': usage.cached,
+    'gen_ai.usage.reasoning.output_tokens': usage.reasoning,
+    'llm.token_count.prompt': usage.input,
+    'llm.token_count.completion': usage.output,
+  });
+}
+
+function sourceFromResult(
+  result: EvaluationResult,
+  options: BuildTraceEnvelopeOptions,
+): TraceEnvelopeSource {
+  const traceProvider =
+    typeof result.trace.metadata?.provider === 'string'
+      ? result.trace.metadata.provider
+      : undefined;
+  return {
+    kind: options.source?.kind ?? 'agentv_run',
+    path: options.source?.path,
+    provider: options.source?.provider ?? traceProvider ?? result.target,
+    format: options.source?.format ?? 'agentv_result',
+    version: options.source?.version ?? '1',
+    metadata: options.source?.metadata,
+  };
+}
+
+function capturePolicy(options: BuildTraceEnvelopeOptions): TraceEnvelopeCapture {
+  return {
+    content: options.capture?.content ?? 'metadata',
+    redactionLevel: options.capture?.redactionLevel ?? 'partial',
+    redactedFields: options.capture?.redactedFields ?? [
+      'gen_ai.input.messages',
+      'gen_ai.output.messages',
+      'gen_ai.tool.call.arguments',
+      'gen_ai.tool.call.result',
+    ],
+    policy: options.capture?.policy ?? {
+      tool_arguments: 'metadata',
+      tool_results: 'metadata',
+      message_text: 'metadata',
+      screenshots: 'none',
+      thinking: 'none',
+    },
+  };
+}
+
+function assistantMessages(
+  messages: readonly Message[],
+): readonly { message: Message; index: number }[] {
+  return messages
+    .map((message, index) => ({ message, index }))
+    .filter((entry) => entry.message.role === 'assistant');
+}
+
+function maybeContentAttributes(
+  message: Message,
+  capture: TraceEnvelopeCapture,
+): Record<string, unknown> {
+  if (capture.content !== 'full' || message.content === undefined) {
+    return {};
+  }
+  return { 'gen_ai.output.messages': message.content };
+}
+
+function maybeToolContentAttributes(
+  toolCall: ToolCall,
+  capture: TraceEnvelopeCapture,
+): Record<string, unknown> {
+  if (capture.content !== 'full') {
+    return {};
+  }
+  return dropUndefined({
+    'gen_ai.tool.call.arguments': toolCall.input,
+    'gen_ai.tool.call.result': toolCall.output,
+  });
+}
+
+function spanStatusFromResult(result: EvaluationResult): TraceEnvelopeSpanStatus {
+  if (result.executionStatus === 'execution_error' || result.error) {
+    return { code: 'ERROR', message: result.error };
+  }
+  return { code: 'OK' };
+}
+
+function scoreSource(type: string): string {
+  if (type === 'code-grader') {
+    return 'code';
+  }
+  if (type === 'llm-grader') {
+    return 'llm';
+  }
+  return 'agentv';
+}
+
+function scoresFromResult(
+  result: EvaluationResult,
+  targetSpanId: string,
+): readonly TraceEnvelopeScore[] | undefined {
+  if (!result.scores || result.scores.length === 0) {
+    return undefined;
+  }
+  return result.scores.map((score) => ({
+    name: score.name,
+    type: score.type,
+    score: score.score,
+    weight: score.weight,
+    verdict: score.verdict,
+    source: scoreSource(score.type),
+    evaluatedAt: score.endedAt ?? score.startedAt ?? result.timestamp,
+    targetSpanId,
+    evidence: dropUndefined({
+      span_ids: [targetSpanId],
+      assertions: score.assertions.map((assertion) =>
+        dropUndefined({
+          text: assertion.text,
+          passed: assertion.passed,
+          evidence: assertion.evidence,
+        }),
+      ),
+      details: score.details,
+    }),
+  }));
+}
+
+export function buildTraceEnvelopeFromEvaluationResult(
+  result: EvaluationResult,
+  options: BuildTraceEnvelopeOptions = {},
+): TraceEnvelope {
+  const now = options.now?.() ?? new Date();
+  const capture = capturePolicy(options);
+  const source = sourceFromResult(result, options);
+  const traceId = hashHex(
+    ['trace-envelope', result.timestamp, result.suite, result.testId, result.target, options.runId],
+    32,
+  );
+  const rootSpanId = hashHex([traceId, 'root'], 16);
+  const rootStartMs =
+    parseTimeMs(result.startTime ?? result.trace.startTime ?? result.timestamp) ?? 0;
+  const rootEndMs =
+    parseTimeMs(result.endTime ?? result.trace.endTime) ??
+    (result.durationMs !== undefined ? rootStartMs + result.durationMs : rootStartMs);
+  const rootStatus = spanStatusFromResult(result);
+  const conversionWarnings: TraceEnvelopeConversionWarning[] = [];
+  const spans: TraceEnvelopeSpan[] = [];
+
+  const rootAttributes = dropUndefined({
+    'gen_ai.operation.name': 'invoke_agent',
+    'gen_ai.provider.name': 'agentv',
+    'gen_ai.agent.name': result.target,
+    'openinference.span.kind': 'AGENT',
+    'agentv.test_id': result.testId,
+    'agentv.target': result.target,
+    'agentv.suite': result.suite,
+    'agentv.category': result.category,
+    'agentv.eval_path': options.evalPath,
+    'agentv.run_id': options.runId,
+    'agentv.attempt': options.attempt,
+    'agentv.variant': options.variant ?? undefined,
+    'agentv.execution_status': result.executionStatus,
+    'agentv.failure_stage': result.failureStage,
+    'agentv.failure_reason_code': result.failureReasonCode,
+    'agentv.trace.duration_ms': result.durationMs,
+    'agentv.trace.cost_usd': result.costUsd,
+    ...tokenUsageAttributes(result.tokenUsage),
+  });
+
+  spans.push({
+    traceId,
+    spanId: rootSpanId,
+    parentSpanId: null,
+    name: `invoke_agent ${result.target}`,
+    kind: 'INTERNAL',
+    startTimeUnixNano: msToUnixNano(rootStartMs),
+    endTimeUnixNano: msToUnixNano(Math.max(rootStartMs, rootEndMs)),
+    status: rootStatus,
+    attributes: rootAttributes,
+    events: result.error
+      ? [
+          {
+            name: 'exception',
+            timeUnixNano: msToUnixNano(Math.max(rootStartMs, rootEndMs)),
+            attributes: { 'exception.message': result.error },
+          },
+        ]
+      : [],
+  });
+
+  const assistantEntries = assistantMessages(result.trace.messages);
+  const chatEntries =
+    assistantEntries.length > 0
+      ? assistantEntries
+      : result.output.length > 0
+        ? [{ message: { role: 'assistant', content: result.output } as Message, index: 0 }]
+        : [];
+
+  for (const [chatOrdinal, entry] of chatEntries.entries()) {
+    const { message, index: messageIndex } = entry;
+    const model =
+      typeof message.metadata?.model === 'string'
+        ? message.metadata.model
+        : typeof result.trace.metadata?.model === 'string'
+          ? result.trace.metadata.model
+          : result.target;
+    const chatSpanId = hashHex([traceId, 'chat', messageIndex, chatOrdinal], 16);
+    const chatTiming = deriveTiming({
+      startTime: message.startTime,
+      endTime: message.endTime,
+      durationMs: message.durationMs,
+      fallbackStartMs: rootStartMs,
+      fallbackEndMs: rootEndMs,
+    });
+    const tokenUsage =
+      message.tokenUsage ??
+      (chatEntries.length === 1 || chatOrdinal === chatEntries.length - 1
+        ? result.tokenUsage
+        : undefined);
+
+    spans.push({
+      traceId,
+      spanId: chatSpanId,
+      parentSpanId: rootSpanId,
+      name: `chat ${model}`,
+      kind: 'INTERNAL',
+      startTimeUnixNano: msToUnixNano(chatTiming.startMs),
+      endTimeUnixNano: msToUnixNano(chatTiming.endMs),
+      status: { code: 'OK' },
+      attributes: dropUndefined({
+        'gen_ai.operation.name': 'chat',
+        'gen_ai.provider.name': source.provider,
+        'gen_ai.request.model': model,
+        'gen_ai.response.model': model,
+        'openinference.span.kind': 'LLM',
+        'agentv.message.index': messageIndex,
+        'agentv.turn_index': chatOrdinal,
+        ...tokenUsageAttributes(tokenUsage),
+        ...maybeContentAttributes(message, capture),
+      }),
+      events: [],
+    });
+
+    for (const [toolIndex, toolCall] of (message.toolCalls ?? []).entries()) {
+      const toolSpanId = hashHex([traceId, 'tool', messageIndex, toolIndex, toolCall.tool], 16);
+      const toolTiming = deriveTiming({
+        startTime: toolCall.startTime,
+        endTime: toolCall.endTime,
+        durationMs: toolCall.durationMs,
+        fallbackStartMs: chatTiming.startMs,
+        fallbackEndMs: chatTiming.endMs,
+      });
+      const generatedToolCallId =
+        toolCall.id ??
+        `agentv-tool-${hashHex([result.testId, result.target, messageIndex, toolIndex], 12)}`;
+
+      if (!toolCall.id) {
+        conversionWarnings.push({
+          code: 'missing_tool_call_id',
+          severity: 'warning',
+          spanId: toolSpanId,
+          sourceRef: {
+            eventId: `message-${messageIndex}-tool-${toolIndex}`,
+          },
+          message: 'Deterministic tool call id generated from source order.',
+        });
+      }
+
+      spans.push({
+        traceId,
+        spanId: toolSpanId,
+        parentSpanId: chatSpanId,
+        name: `execute_tool ${toolCall.tool}`,
+        kind: 'INTERNAL',
+        startTimeUnixNano: msToUnixNano(toolTiming.startMs),
+        endTimeUnixNano: msToUnixNano(toolTiming.endMs),
+        status: { code: 'OK' },
+        attributes: dropUndefined({
+          'gen_ai.operation.name': 'execute_tool',
+          'gen_ai.tool.name': toolCall.tool,
+          'gen_ai.tool.call.id': generatedToolCallId,
+          'openinference.span.kind': 'TOOL',
+          'tool.name': toolCall.tool,
+          'tool.id': generatedToolCallId,
+          'agentv.message.index': messageIndex,
+          'agentv.tool.index': toolIndex,
+          'agentv.generated_tool_call_id': toolCall.id ? undefined : true,
+          ...maybeToolContentAttributes(toolCall, capture),
+        }),
+        events: [],
+      });
+    }
+  }
+
+  const envelopeId = `trace-env-${hashHex([traceId, result.timestamp, result.score], 20)}`;
+  const evalIdentity: TraceEnvelopeEval = {
+    evalId: options.evalId,
+    evalPath: options.evalPath,
+    suite: result.suite,
+    testId: result.testId,
+    target: result.target,
+    sourceTarget: options.sourceTarget,
+    attempt: options.attempt,
+    variant: options.variant,
+    runId: options.runId,
+    category: result.category,
+    experiment: options.experiment,
+  };
+
+  return {
+    schemaVersion: TRACE_ENVELOPE_SCHEMA_VERSION,
+    envelopeId,
+    createdAt: now.toISOString(),
+    eval: evalIdentity,
+    replay: options.replay,
+    trace: {
+      format: TRACE_ENVELOPE_FORMAT,
+      traceId,
+      rootSpanId,
+      resource: { attributes: { 'service.name': 'agentv' } },
+      scope: { name: 'agentv' },
+      spans,
+    },
+    source,
+    capture,
+    conversionWarnings: conversionWarnings.length > 0 ? conversionWarnings : undefined,
+    artifacts: definedStringRecord(options.artifacts),
+    scores: scoresFromResult(result, rootSpanId),
+  };
+}
+
+export function toTraceEnvelopeWire(envelope: TraceEnvelope): TraceEnvelopeWire {
+  return TraceEnvelopeWireSchema.parse(
+    dropUndefined({
+      schema_version: envelope.schemaVersion,
+      envelope_id: envelope.envelopeId,
+      created_at: envelope.createdAt,
+      eval: toTraceEnvelopeEvalWire(envelope.eval),
+      replay: envelope.replay ? toTraceEnvelopeReplayWire(envelope.replay) : undefined,
+      trace: toTraceEnvelopeBodyWire(envelope.trace),
+      source: toTraceEnvelopeSourceWire(envelope.source),
+      capture: toTraceEnvelopeCaptureWire(envelope.capture),
+      conversion_warnings: envelope.conversionWarnings?.map(toTraceEnvelopeConversionWarningWire),
+      artifacts: envelope.artifacts,
+      scores: envelope.scores?.map(toTraceEnvelopeScoreWire),
+    }),
+  );
+}
+
+export function fromTraceEnvelopeWire(input: unknown): TraceEnvelope {
+  const wire = TraceEnvelopeWireSchema.parse(input);
+  return {
+    schemaVersion: wire.schema_version,
+    envelopeId: wire.envelope_id,
+    createdAt: wire.created_at,
+    eval: fromTraceEnvelopeEvalWire(wire.eval),
+    replay: wire.replay ? fromTraceEnvelopeReplayWire(wire.replay) : undefined,
+    trace: fromTraceEnvelopeBodyWire(wire.trace),
+    source: fromTraceEnvelopeSourceWire(wire.source),
+    capture: fromTraceEnvelopeCaptureWire(wire.capture),
+    conversionWarnings: wire.conversion_warnings?.map(fromTraceEnvelopeConversionWarningWire),
+    artifacts: wire.artifacts,
+    scores: wire.scores?.map(fromTraceEnvelopeScoreWire),
+  };
+}
+
+function toTraceEnvelopeEvalWire(evaluation: TraceEnvelopeEval): TraceEnvelopeEvalWire {
+  return TraceEnvelopeEvalWireSchema.parse(
+    dropUndefined({
+      eval_id: evaluation.evalId,
+      eval_path: evaluation.evalPath,
+      suite: evaluation.suite,
+      test_id: evaluation.testId,
+      target: evaluation.target,
+      source_target: evaluation.sourceTarget,
+      attempt: evaluation.attempt,
+      variant: evaluation.variant,
+      run_id: evaluation.runId,
+      category: evaluation.category,
+      experiment: evaluation.experiment,
+    }),
+  );
+}
+
+function fromTraceEnvelopeEvalWire(evaluation: TraceEnvelopeEvalWire): TraceEnvelopeEval {
+  return {
+    evalId: evaluation.eval_id,
+    evalPath: evaluation.eval_path,
+    suite: evaluation.suite,
+    testId: evaluation.test_id,
+    target: evaluation.target,
+    sourceTarget: evaluation.source_target,
+    attempt: evaluation.attempt,
+    variant: evaluation.variant,
+    runId: evaluation.run_id,
+    category: evaluation.category,
+    experiment: evaluation.experiment,
+  };
+}
+
+function toTraceEnvelopeReplayWire(replay: TraceEnvelopeReplay): TraceEnvelopeReplayWire {
+  return TraceEnvelopeReplayWireSchema.parse(
+    dropUndefined({
+      lookup_key: replay.lookupKey,
+      fixture_id: replay.fixtureId,
+      source_fixture_path: replay.sourceFixturePath,
+    }),
+  );
+}
+
+function fromTraceEnvelopeReplayWire(replay: TraceEnvelopeReplayWire): TraceEnvelopeReplay {
+  return {
+    lookupKey: replay.lookup_key,
+    fixtureId: replay.fixture_id,
+    sourceFixturePath: replay.source_fixture_path,
+  };
+}
+
+function toTraceEnvelopeBodyWire(trace: TraceEnvelopeBody): TraceEnvelopeBodyWire {
+  return TraceEnvelopeBodyWireSchema.parse(
+    dropUndefined({
+      format: trace.format,
+      trace_id: trace.traceId,
+      root_span_id: trace.rootSpanId,
+      resource: trace.resource,
+      scope: trace.scope,
+      spans: trace.spans.map(toTraceEnvelopeSpanWire),
+    }),
+  );
+}
+
+function fromTraceEnvelopeBodyWire(trace: TraceEnvelopeBodyWire): TraceEnvelopeBody {
+  return {
+    format: trace.format,
+    traceId: trace.trace_id,
+    rootSpanId: trace.root_span_id,
+    resource: trace.resource,
+    scope: trace.scope,
+    spans: trace.spans.map(fromTraceEnvelopeSpanWire),
+  };
+}
+
+function toTraceEnvelopeSpanWire(span: TraceEnvelopeSpan): TraceEnvelopeSpanWire {
+  return TraceEnvelopeSpanWireSchema.parse(
+    dropUndefined({
+      trace_id: span.traceId,
+      span_id: span.spanId,
+      parent_span_id: span.parentSpanId,
+      name: span.name,
+      kind: span.kind,
+      start_time_unix_nano: span.startTimeUnixNano,
+      end_time_unix_nano: span.endTimeUnixNano,
+      status: span.status,
+      attributes: span.attributes,
+      events: span.events?.map(toTraceEnvelopeSpanEventWire),
+    }),
+  );
+}
+
+function fromTraceEnvelopeSpanWire(span: TraceEnvelopeSpanWire): TraceEnvelopeSpan {
+  return {
+    traceId: span.trace_id,
+    spanId: span.span_id,
+    parentSpanId: span.parent_span_id,
+    name: span.name,
+    kind: span.kind,
+    startTimeUnixNano: span.start_time_unix_nano,
+    endTimeUnixNano: span.end_time_unix_nano,
+    status: span.status,
+    attributes: span.attributes,
+    events: span.events?.map(fromTraceEnvelopeSpanEventWire),
+  };
+}
+
+function toTraceEnvelopeSpanEventWire(event: TraceEnvelopeSpanEvent) {
+  return TraceEnvelopeSpanEventWireSchema.parse(
+    dropUndefined({
+      name: event.name,
+      time_unix_nano: event.timeUnixNano,
+      attributes: event.attributes,
+    }),
+  );
+}
+
+function fromTraceEnvelopeSpanEventWire(
+  event: z.infer<typeof TraceEnvelopeSpanEventWireSchema>,
+): TraceEnvelopeSpanEvent {
+  return {
+    name: event.name,
+    timeUnixNano: event.time_unix_nano,
+    attributes: event.attributes,
+  };
+}
+
+function toTraceEnvelopeSourceWire(source: TraceEnvelopeSource): TraceEnvelopeSourceWire {
+  return TraceEnvelopeSourceWireSchema.parse(
+    dropUndefined({
+      kind: source.kind,
+      path: source.path,
+      provider: source.provider,
+      format: source.format,
+      version: source.version,
+      metadata: source.metadata,
+    }),
+  );
+}
+
+function fromTraceEnvelopeSourceWire(source: TraceEnvelopeSourceWire): TraceEnvelopeSource {
+  return {
+    kind: source.kind,
+    path: source.path,
+    provider: source.provider,
+    format: source.format,
+    version: source.version,
+    metadata: source.metadata,
+  };
+}
+
+function toTraceEnvelopeCaptureWire(capture: TraceEnvelopeCapture): TraceEnvelopeCaptureWire {
+  return TraceEnvelopeCaptureWireSchema.parse(
+    dropUndefined({
+      content: capture.content,
+      redaction_level: capture.redactionLevel,
+      redacted_fields: capture.redactedFields,
+      policy: capture.policy,
+    }),
+  );
+}
+
+function fromTraceEnvelopeCaptureWire(capture: TraceEnvelopeCaptureWire): TraceEnvelopeCapture {
+  return {
+    content: capture.content,
+    redactionLevel: capture.redaction_level,
+    redactedFields: capture.redacted_fields,
+    policy: capture.policy,
+  };
+}
+
+function toTraceEnvelopeSourceRefWire(sourceRef: TraceEnvelopeSourceRef) {
+  return TraceEnvelopeSourceRefWireSchema.parse(
+    dropUndefined({
+      event_id: sourceRef.eventId,
+      message_id: sourceRef.messageId,
+      span_id: sourceRef.spanId,
+      trace_id: sourceRef.traceId,
+      raw_kind: sourceRef.rawKind,
+      path: sourceRef.path,
+      line: sourceRef.line,
+      metadata: sourceRef.metadata,
+    }),
+  );
+}
+
+function fromTraceEnvelopeSourceRefWire(
+  sourceRef: z.infer<typeof TraceEnvelopeSourceRefWireSchema>,
+): TraceEnvelopeSourceRef {
+  return {
+    eventId: sourceRef.event_id,
+    messageId: sourceRef.message_id,
+    spanId: sourceRef.span_id,
+    traceId: sourceRef.trace_id,
+    rawKind: sourceRef.raw_kind,
+    path: sourceRef.path,
+    line: sourceRef.line,
+    metadata: sourceRef.metadata,
+  };
+}
+
+function toTraceEnvelopeConversionWarningWire(
+  warning: TraceEnvelopeConversionWarning,
+): TraceEnvelopeConversionWarningWire {
+  return TraceEnvelopeConversionWarningWireSchema.parse(
+    dropUndefined({
+      code: warning.code,
+      severity: warning.severity,
+      span_id: warning.spanId,
+      source_ref: warning.sourceRef ? toTraceEnvelopeSourceRefWire(warning.sourceRef) : undefined,
+      message: warning.message,
+      details: warning.details,
+    }),
+  );
+}
+
+function fromTraceEnvelopeConversionWarningWire(
+  warning: TraceEnvelopeConversionWarningWire,
+): TraceEnvelopeConversionWarning {
+  return {
+    code: warning.code,
+    severity: warning.severity,
+    spanId: warning.span_id,
+    sourceRef: warning.source_ref ? fromTraceEnvelopeSourceRefWire(warning.source_ref) : undefined,
+    message: warning.message,
+    details: warning.details,
+  };
+}
+
+function toTraceEnvelopeScoreWire(score: TraceEnvelopeScore): TraceEnvelopeScoreWire {
+  return TraceEnvelopeScoreWireSchema.parse(
+    dropUndefined({
+      name: score.name,
+      type: score.type,
+      score: score.score,
+      weight: score.weight,
+      verdict: score.verdict,
+      source: score.source,
+      evaluated_at: score.evaluatedAt,
+      target_span_id: score.targetSpanId,
+      evidence: score.evidence,
+    }),
+  );
+}
+
+function fromTraceEnvelopeScoreWire(score: TraceEnvelopeScoreWire): TraceEnvelopeScore {
+  return {
+    name: score.name,
+    type: score.type,
+    score: score.score,
+    weight: score.weight,
+    verdict: score.verdict as EvaluationVerdict | undefined,
+    source: score.source,
+    evaluatedAt: score.evaluated_at,
+    targetSpanId: score.target_span_id,
+    evidence: score.evidence,
+  };
+}
+
+function isToolSpan(span: TraceEnvelopeSpan): boolean {
+  return (
+    span.attributes['gen_ai.operation.name'] === 'execute_tool' ||
+    span.attributes['openinference.span.kind'] === 'TOOL'
+  );
+}
+
+function isChatSpan(span: TraceEnvelopeSpan): boolean {
+  return (
+    span.attributes['gen_ai.operation.name'] === 'chat' ||
+    span.attributes['openinference.span.kind'] === 'LLM'
+  );
+}
+
+function stringAttribute(
+  attributes: Readonly<Record<string, unknown>>,
+  key: string,
+): string | undefined {
+  const value = attributes[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function numberAttribute(
+  attributes: Readonly<Record<string, unknown>>,
+  key: string,
+): number | undefined {
+  const value = attributes[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function tokenUsageFromAttributes(
+  attributes: Readonly<Record<string, unknown>>,
+): TokenUsage | undefined {
+  const input = numberAttribute(attributes, 'gen_ai.usage.input_tokens');
+  const output = numberAttribute(attributes, 'gen_ai.usage.output_tokens');
+  if (input === undefined || output === undefined) {
+    return undefined;
+  }
+  return {
+    input,
+    output,
+    cached: numberAttribute(attributes, 'gen_ai.usage.cache_read.input_tokens'),
+    reasoning: numberAttribute(attributes, 'gen_ai.usage.reasoning.output_tokens'),
+  };
+}
+
+function toolCallFromSpan(span: TraceEnvelopeSpan): ToolCall {
+  const attributes = span.attributes;
+  return {
+    tool:
+      stringAttribute(attributes, 'gen_ai.tool.name') ??
+      stringAttribute(attributes, 'tool.name') ??
+      span.name.replace(/^execute_tool\s+/, ''),
+    id:
+      stringAttribute(attributes, 'gen_ai.tool.call.id') ??
+      stringAttribute(attributes, 'tool.id') ??
+      span.spanId,
+    input: attributes['gen_ai.tool.call.arguments'],
+    output: attributes['gen_ai.tool.call.result'],
+    startTime: unixNanoToIso(span.startTimeUnixNano),
+    endTime: unixNanoToIso(span.endTimeUnixNano),
+    durationMs: durationMsFromSpan(span),
+  };
+}
+
+export function traceEnvelopeToMessages(envelope: TraceEnvelope): readonly Message[] {
+  const spans = [...envelope.trace.spans].sort((first, second) =>
+    first.startTimeUnixNano.localeCompare(second.startTimeUnixNano),
+  );
+  const toolSpansByParent = new Map<string, TraceEnvelopeSpan[]>();
+  for (const span of spans.filter(isToolSpan)) {
+    const parentSpanId = span.parentSpanId ?? envelope.trace.rootSpanId;
+    const existing = toolSpansByParent.get(parentSpanId) ?? [];
+    existing.push(span);
+    toolSpansByParent.set(parentSpanId, existing);
+  }
+
+  return spans.filter(isChatSpan).map((span) => ({
+    role: 'assistant',
+    content: span.attributes['gen_ai.output.messages'] as Message['content'],
+    toolCalls: toolSpansByParent.get(span.spanId)?.map(toolCallFromSpan),
+    startTime: unixNanoToIso(span.startTimeUnixNano),
+    endTime: unixNanoToIso(span.endTimeUnixNano),
+    durationMs: durationMsFromSpan(span),
+    tokenUsage: tokenUsageFromAttributes(span.attributes),
+    metadata: {
+      span_id: span.spanId,
+      trace_id: span.traceId,
+    },
+  }));
+}
+
+export function traceEnvelopeToTraceSummary(envelope: TraceEnvelope): TraceComputeResult {
+  const toolCallCounts: Record<string, number> = {};
+  const toolDurations: Record<string, number[]> = {};
+  let totalToolCalls = 0;
+  let errorCount = 0;
+  let llmCallCount = 0;
+  let hasAnyDuration = false;
+
+  for (const span of envelope.trace.spans) {
+    if (isChatSpan(span)) {
+      llmCallCount++;
+    }
+    if (!isToolSpan(span)) {
+      continue;
+    }
+    const toolName =
+      stringAttribute(span.attributes, 'gen_ai.tool.name') ??
+      stringAttribute(span.attributes, 'tool.name') ??
+      span.name.replace(/^execute_tool\s+/, '');
+    toolCallCounts[toolName] = (toolCallCounts[toolName] ?? 0) + 1;
+    totalToolCalls++;
+    if (span.status.code === 'ERROR') {
+      errorCount++;
+    }
+    const durationMs = durationMsFromSpan(span);
+    if (durationMs !== undefined) {
+      hasAnyDuration = true;
+      if (!toolDurations[toolName]) {
+        toolDurations[toolName] = [];
+      }
+      toolDurations[toolName].push(durationMs);
+    }
+  }
+
+  const rootSpan = envelope.trace.spans.find((span) => span.spanId === envelope.trace.rootSpanId);
+  const rootTokenUsage = rootSpan ? tokenUsageFromAttributes(rootSpan.attributes) : undefined;
+  const rootCost = rootSpan
+    ? numberAttribute(rootSpan.attributes, 'agentv.trace.cost_usd')
+    : undefined;
+  const rootDuration = rootSpan
+    ? (numberAttribute(rootSpan.attributes, 'agentv.trace.duration_ms') ??
+      durationMsFromSpan(rootSpan))
+    : undefined;
+
+  return {
+    trace: {
+      eventCount: totalToolCalls,
+      toolCalls: toolCallCounts,
+      errorCount,
+      llmCallCount,
+      ...(hasAnyDuration ? { toolDurations } : {}),
+    },
+    tokenUsage: rootTokenUsage,
+    costUsd: rootCost,
+    durationMs: rootDuration,
+    startTime: rootSpan ? unixNanoToIso(rootSpan.startTimeUnixNano) : undefined,
+    endTime: rootSpan ? unixNanoToIso(rootSpan.endTimeUnixNano) : undefined,
+  };
+}
+
+export function traceEnvelopeToTraceArtifact(envelope: TraceEnvelope): TraceArtifact {
+  const events: TraceEvent[] = [];
+  let ordinal = 0;
+  for (const span of envelope.trace.spans) {
+    if (isChatSpan(span)) {
+      events.push({
+        eventId: `span-${span.spanId}`,
+        parentEventId: span.parentSpanId ? `span-${span.parentSpanId}` : undefined,
+        ordinal: ordinal++,
+        type: 'model_turn',
+        timestamp: unixNanoToIso(span.startTimeUnixNano),
+        durationMs: durationMsFromSpan(span),
+        model: {
+          provider: stringAttribute(span.attributes, 'gen_ai.provider.name'),
+          name:
+            stringAttribute(span.attributes, 'gen_ai.response.model') ??
+            stringAttribute(span.attributes, 'gen_ai.request.model'),
+          tokenUsage: tokenUsageFromAttributes(span.attributes),
+        },
+        sourceRef: {
+          spanId: span.spanId,
+          traceId: span.traceId,
+        },
+      });
+    }
+    if (isToolSpan(span)) {
+      const toolCall = toolCallFromSpan(span);
+      events.push({
+        eventId: `span-${span.spanId}`,
+        parentEventId: span.parentSpanId ? `span-${span.parentSpanId}` : undefined,
+        ordinal: ordinal++,
+        type: 'tool_call',
+        timestamp: unixNanoToIso(span.startTimeUnixNano),
+        durationMs: durationMsFromSpan(span),
+        tool: {
+          name: toolCall.tool,
+          callId: toolCall.id,
+          input: toolCall.input,
+          output: toolCall.output,
+          status: span.status.code === 'ERROR' ? 'error' : 'ok',
+        },
+        sourceRef: {
+          spanId: span.spanId,
+          traceId: span.traceId,
+        },
+      });
+    }
+  }
+
+  const summary = traceEnvelopeToTraceSummary(envelope);
+  return {
+    schemaVersion: NORMALIZED_TRAJECTORY_SCHEMA_VERSION,
+    source: {
+      kind: envelope.source.kind as TraceSourceKind,
+      path: envelope.source.path,
+      provider: envelope.source.provider,
+      format: envelope.source.format,
+      version: envelope.source.version,
+      metadata: envelope.source.metadata,
+    },
+    session: {
+      sessionId: envelope.eval.runId,
+      conversationId: envelope.eval.evalId,
+    },
+    events,
+    tokenUsage: summary.tokenUsage,
+    costUsd: summary.costUsd,
+    durationMs: summary.durationMs,
+    startedAt: summary.startTime,
+    endedAt: summary.endTime,
+  };
+}
+
+export function getTraceEnvelopeSummary(envelope: TraceEnvelope): TraceSummary {
+  return traceEnvelopeToTraceSummary(envelope).trace;
+}

--- a/packages/core/src/import/types.ts
+++ b/packages/core/src/import/types.ts
@@ -16,8 +16,7 @@
 
 import { readFile } from 'node:fs/promises';
 
-import { toCamelCaseDeep, toSnakeCaseDeep } from '../evaluation/case-conversion.js';
-import type { Message, ProviderTokenUsage } from '../evaluation/providers/types.js';
+import type { Message, ProviderTokenUsage, ToolCall } from '../evaluation/providers/types.js';
 import { type Trace, buildTraceFromMessages } from '../evaluation/trace.js';
 
 /**
@@ -101,6 +100,70 @@ export interface TranscriptReplayEntry {
   readonly source: TranscriptSource;
 }
 
+function dropUndefined(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+function toTranscriptTokenUsage(
+  usage: ProviderTokenUsage | undefined,
+): TranscriptJsonLine['token_usage'] | undefined {
+  if (!usage) {
+    return undefined;
+  }
+  return dropUndefined({
+    input: usage.input,
+    output: usage.output,
+    cached: usage.cached,
+    reasoning: usage.reasoning,
+  }) as TranscriptJsonLine['token_usage'];
+}
+
+function toTranscriptToolCall(toolCall: ToolCall): Record<string, unknown> {
+  return dropUndefined({
+    tool: toolCall.tool,
+    input: toolCall.input,
+    output: toolCall.output,
+    id: toolCall.id,
+    start_time: toolCall.startTime,
+    end_time: toolCall.endTime,
+    duration_ms: toolCall.durationMs,
+  });
+}
+
+function toTranscriptMessageFields(
+  message: Message,
+): Omit<
+  TranscriptJsonLine,
+  | 'test_id'
+  | 'target'
+  | 'message_index'
+  | 'source'
+  | 'transcript_token_usage'
+  | 'transcript_duration_ms'
+  | 'transcript_cost_usd'
+> {
+  return dropUndefined({
+    role: message.role,
+    name: message.name,
+    content: message.content,
+    tool_calls: message.toolCalls?.map(toTranscriptToolCall),
+    start_time: message.startTime,
+    end_time: message.endTime,
+    duration_ms: message.durationMs,
+    metadata: message.metadata,
+    token_usage: toTranscriptTokenUsage(message.tokenUsage),
+  }) as Omit<
+    TranscriptJsonLine,
+    | 'test_id'
+    | 'target'
+    | 'message_index'
+    | 'source'
+    | 'transcript_token_usage'
+    | 'transcript_duration_ms'
+    | 'transcript_cost_usd'
+  >;
+}
+
 /**
  * Convert a parsed TranscriptEntry to per-message JSONL rows.
  */
@@ -132,16 +195,7 @@ export function toTranscriptJsonLines(
     test_id: testId,
     target,
     message_index: index,
-    ...(toSnakeCaseDeep(message) as Omit<
-      TranscriptJsonLine,
-      | 'test_id'
-      | 'target'
-      | 'message_index'
-      | 'source'
-      | 'transcript_token_usage'
-      | 'transcript_duration_ms'
-      | 'transcript_cost_usd'
-    >),
+    ...toTranscriptMessageFields(message),
     transcript_token_usage: transcriptTokenUsage,
     transcript_duration_ms: entry.durationMs,
     transcript_cost_usd: entry.costUsd,
@@ -207,29 +261,59 @@ export function traceFromTranscriptJsonLines(lines: readonly TranscriptJsonLine[
   });
 }
 
-function buildReplayMessage(line: TranscriptJsonLine): Message {
-  const camelCased = toCamelCaseDeep(line) as {
-    role: string;
-    name?: string;
-    content?: Message['content'];
-    toolCalls?: Message['toolCalls'];
-    startTime?: string;
-    endTime?: string;
-    durationMs?: number;
-    metadata?: Record<string, unknown>;
-    tokenUsage?: ProviderTokenUsage;
-  };
-
+function fromTranscriptTokenUsage(
+  usage: TranscriptJsonLine['token_usage'],
+): ProviderTokenUsage | undefined {
+  if (!usage) {
+    return undefined;
+  }
   return {
-    role: camelCased.role,
-    name: camelCased.name,
-    content: camelCased.content,
-    toolCalls: camelCased.toolCalls,
-    startTime: camelCased.startTime,
-    endTime: camelCased.endTime,
-    durationMs: camelCased.durationMs,
-    metadata: camelCased.metadata,
-    tokenUsage: camelCased.tokenUsage,
+    input: usage.input,
+    output: usage.output,
+    cached: usage.cached,
+    reasoning: usage.reasoning,
+  };
+}
+
+function readOptionalString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function readOptionalNumber(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function fromTranscriptToolCall(wire: Record<string, unknown>): ToolCall | undefined {
+  const tool = readOptionalString(wire, 'tool');
+  if (!tool) {
+    return undefined;
+  }
+  return {
+    tool,
+    input: wire.input,
+    output: wire.output,
+    id: readOptionalString(wire, 'id'),
+    startTime: readOptionalString(wire, 'start_time'),
+    endTime: readOptionalString(wire, 'end_time'),
+    durationMs: readOptionalNumber(wire, 'duration_ms'),
+  };
+}
+
+function buildReplayMessage(line: TranscriptJsonLine): Message {
+  return {
+    role: line.role,
+    name: line.name,
+    content: line.content as Message['content'],
+    toolCalls: line.tool_calls
+      ?.map(fromTranscriptToolCall)
+      .filter((toolCall): toolCall is ToolCall => toolCall !== undefined),
+    startTime: line.start_time,
+    endTime: line.end_time,
+    durationMs: line.duration_ms,
+    metadata: line.metadata,
+    tokenUsage: fromTranscriptTokenUsage(line.token_usage),
   };
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from './evaluation/content.js';
 export * from './evaluation/types.js';
 export * from './evaluation/trace.js';
+export * from './evaluation/trace-envelope.js';
 export * from './evaluation/replay-fixtures.js';
 export { parseYamlValue } from './evaluation/yaml-loader.js';
 export * from './evaluation/yaml-parser.js';

--- a/packages/core/test/evaluation/trace-envelope.test.ts
+++ b/packages/core/test/evaluation/trace-envelope.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { Message } from '../../src/evaluation/providers/types.js';
+import {
+  TRACE_ENVELOPE_SCHEMA_VERSION,
+  TraceEnvelopeWireSchema,
+  buildTraceEnvelopeFromEvaluationResult,
+  fromTraceEnvelopeWire,
+  toTraceEnvelopeWire,
+  traceEnvelopeToMessages,
+  traceEnvelopeToTraceSummary,
+} from '../../src/evaluation/trace-envelope.js';
+import { buildTraceFromMessages, computeTraceSummary } from '../../src/evaluation/trace.js';
+import type { EvaluationResult } from '../../src/evaluation/types.js';
+
+function jsonComparable(value: unknown): unknown {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function makeResult(overrides: Partial<EvaluationResult> = {}): EvaluationResult {
+  const input: readonly Message[] = [{ role: 'user', content: 'Inspect the repository' }];
+  const output: readonly Message[] = [{ role: 'assistant', content: 'Done' }];
+  const base = {
+    timestamp: '2026-06-15T12:00:00.000Z',
+    testId: 'trace-case',
+    suite: 'trace-evaluation',
+    category: 'showcase',
+    score: 1,
+    assertions: [{ text: 'ok', passed: true }],
+    target: 'replay_coding_agent',
+    tokenUsage: { input: 100, output: 20, cached: 5, reasoning: 3 },
+    costUsd: 0.012,
+    durationMs: 4200,
+    startTime: '2026-06-15T12:00:00.000Z',
+    endTime: '2026-06-15T12:00:04.200Z',
+    input,
+    output: 'Done',
+    executionStatus: 'ok',
+  } satisfies Partial<EvaluationResult>;
+  const result = { ...base, ...overrides } as EvaluationResult;
+  return {
+    ...result,
+    trace:
+      result.trace ??
+      buildTraceFromMessages({
+        input: result.input,
+        output,
+        finalOutput: result.output,
+        tokenUsage: result.tokenUsage,
+        costUsd: result.costUsd,
+        durationMs: result.durationMs,
+        startTime: result.startTime,
+        endTime: result.endTime,
+        provider: 'replay',
+        target: result.target,
+        testId: result.testId,
+      }),
+  };
+}
+
+describe('trace envelope v1', () => {
+  it('validates and round-trips the explicit snake_case wire shape', () => {
+    const envelope = buildTraceEnvelopeFromEvaluationResult(makeResult(), {
+      evalPath: 'examples/showcase/trace-evaluation/evals/coding-agent-replay.eval.yaml',
+      runId: 'run-123',
+      experiment: 'trace-envelope-v1',
+      now: () => new Date('2026-06-15T12:00:05.000Z'),
+      source: {
+        metadata: {
+          source_provider: 'replay',
+          providerCamelKey: 'kept',
+        },
+      },
+      artifacts: {
+        envelope_path: 'outputs/trace-envelope.json',
+        transcript_path: 'outputs/transcript.jsonl',
+      },
+    });
+
+    const wire = toTraceEnvelopeWire(envelope);
+
+    expect(wire.schema_version).toBe(TRACE_ENVELOPE_SCHEMA_VERSION);
+    expect(wire.envelope_id).toMatch(/^trace-env-/);
+    expect(wire.created_at).toBe('2026-06-15T12:00:05.000Z');
+    expect(wire.eval.eval_path).toContain('coding-agent-replay.eval.yaml');
+    expect(wire.trace.format).toBe('otlp_openinference_spans');
+    expect(wire.trace.spans[0]?.attributes['gen_ai.operation.name']).toBe('invoke_agent');
+    expect(wire.trace.spans[0]?.attributes['openinference.span.kind']).toBe('AGENT');
+    expect(wire.source.metadata).toMatchObject({
+      source_provider: 'replay',
+      providerCamelKey: 'kept',
+    });
+    expect(wire.source.metadata).not.toHaveProperty('sourceProvider');
+    expect(wire.source.metadata).not.toHaveProperty('provider_camel_key');
+    expect(TraceEnvelopeWireSchema.parse(wire).trace.spans.length).toBeGreaterThanOrEqual(2);
+    expect(jsonComparable(fromTraceEnvelopeWire(wire))).toEqual(jsonComparable(envelope));
+  });
+
+  it('defaults to metadata-only capture while preserving trace structure', () => {
+    const envelope = buildTraceEnvelopeFromEvaluationResult(makeResult());
+    const spans = envelope.trace.spans;
+    const root = spans.find((span) => span.spanId === envelope.trace.rootSpanId);
+    const chat = spans.find((span) => span.attributes['gen_ai.operation.name'] === 'chat');
+
+    expect(envelope.capture.content).toBe('metadata');
+    expect(envelope.capture.redactionLevel).toBe('partial');
+    expect(root?.name).toBe('invoke_agent replay_coding_agent');
+    expect(root?.attributes['openinference.span.kind']).toBe('AGENT');
+    expect(chat?.attributes['openinference.span.kind']).toBe('LLM');
+    expect(chat?.attributes).not.toHaveProperty('gen_ai.output.messages');
+    expect(spans).toHaveLength(2);
+  });
+
+  it('creates ordered tool spans with chat parentage and deterministic generated IDs', () => {
+    const output: readonly Message[] = [
+      {
+        role: 'assistant',
+        content: 'I will inspect and edit.',
+        startTime: '2026-06-15T12:00:01.000Z',
+        endTime: '2026-06-15T12:00:04.000Z',
+        toolCalls: [
+          {
+            tool: 'Read',
+            id: 'call-read',
+            input: { file_path: 'src/config.ts' },
+            output: { content: 'timeout = 0' },
+            startTime: '2026-06-15T12:00:02.000Z',
+            endTime: '2026-06-15T12:00:02.120Z',
+          },
+          {
+            tool: 'Edit',
+            input: { file_path: 'src/config.ts' },
+            output: { changed: true },
+            durationMs: 40,
+            startTime: '2026-06-15T12:00:03.000Z',
+          },
+        ],
+      },
+    ];
+    const result = makeResult({
+      output: 'I will inspect and edit.',
+      trace: buildTraceFromMessages({
+        input: [{ role: 'user', content: 'Fix config' }],
+        output,
+        finalOutput: 'I will inspect and edit.',
+        target: 'codex',
+        testId: 'tool-case',
+      }),
+    });
+
+    const first = buildTraceEnvelopeFromEvaluationResult(result);
+    const second = buildTraceEnvelopeFromEvaluationResult(result);
+    const toolSpans = first.trace.spans.filter(
+      (span) => span.attributes['gen_ai.operation.name'] === 'execute_tool',
+    );
+    const chat = first.trace.spans.find(
+      (span) => span.attributes['gen_ai.operation.name'] === 'chat',
+    );
+
+    expect(toolSpans.map((span) => span.attributes['gen_ai.tool.name'])).toEqual(['Read', 'Edit']);
+    expect(toolSpans.map((span) => span.parentSpanId)).toEqual([chat?.spanId, chat?.spanId]);
+    expect(toolSpans[0]?.attributes['gen_ai.tool.call.id']).toBe('call-read');
+    expect(toolSpans[1]?.attributes['agentv.generated_tool_call_id']).toBe(true);
+    expect(toolSpans[1]?.attributes['gen_ai.tool.call.id']).toBe(
+      second.trace.spans.find((span) => span.name === 'execute_tool Edit')?.attributes[
+        'gen_ai.tool.call.id'
+      ],
+    );
+    expect(first.conversionWarnings).toEqual([
+      {
+        code: 'missing_tool_call_id',
+        severity: 'warning',
+        spanId: toolSpans[1]?.spanId,
+        sourceRef: { eventId: 'message-1-tool-1' },
+        message: 'Deterministic tool call id generated from source order.',
+      },
+    ]);
+  });
+
+  it('keeps opaque full-capture payload keys unchanged', () => {
+    const content = [
+      {
+        type: 'image',
+        media_type: 'image/png',
+        providerCamelKey: 'content stays camelCase',
+      },
+    ] as unknown as Message['content'];
+    const toolInput = {
+      snake_value: 'input stays snake_case',
+      providerCamelKey: 'input stays camelCase',
+    };
+    const toolOutput = {
+      snake_value: 'output stays snake_case',
+      providerCamelKey: 'output stays camelCase',
+    };
+    const result = makeResult({
+      output: 'Used a tool',
+      trace: buildTraceFromMessages({
+        output: [
+          {
+            role: 'assistant',
+            content,
+            metadata: {
+              snake_value: 'metadata stays snake_case',
+              providerCamelKey: 'metadata stays camelCase',
+            },
+            toolCalls: [
+              { tool: 'Inspect', id: 'call-inspect', input: toolInput, output: toolOutput },
+            ],
+          },
+        ],
+        finalOutput: 'Used a tool',
+        target: 'codex',
+        testId: 'opaque-case',
+      }),
+    });
+
+    const wire = toTraceEnvelopeWire(
+      buildTraceEnvelopeFromEvaluationResult(result, {
+        capture: { content: 'full', redactionLevel: 'none', redactedFields: [] },
+      }),
+    );
+    const chat = wire.trace.spans.find(
+      (span) => span.attributes['gen_ai.operation.name'] === 'chat',
+    );
+    const tool = wire.trace.spans.find(
+      (span) => span.attributes['gen_ai.operation.name'] === 'execute_tool',
+    );
+
+    expect(chat?.attributes['gen_ai.output.messages']).toEqual(content);
+    expect(tool?.attributes['gen_ai.tool.call.arguments']).toEqual(toolInput);
+    expect(tool?.attributes['gen_ai.tool.call.result']).toEqual(toolOutput);
+    for (const payload of [
+      (chat?.attributes['gen_ai.output.messages'] as Record<string, unknown>[])[0],
+      tool?.attributes['gen_ai.tool.call.arguments'] as Record<string, unknown>,
+      tool?.attributes['gen_ai.tool.call.result'] as Record<string, unknown>,
+    ]) {
+      expect(payload).toHaveProperty('providerCamelKey');
+      expect(payload).not.toHaveProperty('provider_camel_key');
+      expect(payload).not.toHaveProperty('snakeValue');
+    }
+  });
+
+  it('maps metrics, execution status, and score provenance', () => {
+    const result = makeResult({
+      executionStatus: 'execution_error',
+      error: 'Provider timed out',
+      scores: [
+        {
+          name: 'expected-tool-sequence',
+          type: 'tool-trajectory',
+          score: 1,
+          verdict: 'pass',
+          assertions: [{ text: 'Read before Edit', passed: true, evidence: 'span evidence' }],
+          details: {
+            snake_value: 'score detail stays snake_case',
+            providerCamelKey: 'score detail stays camelCase',
+          },
+          endedAt: '2026-06-15T12:00:05.000Z',
+        },
+      ],
+    });
+
+    const envelope = buildTraceEnvelopeFromEvaluationResult(result);
+    const root = envelope.trace.spans.find((span) => span.spanId === envelope.trace.rootSpanId);
+    const summary = traceEnvelopeToTraceSummary(envelope);
+
+    expect(root?.status).toEqual({ code: 'ERROR', message: 'Provider timed out' });
+    expect(root?.attributes['gen_ai.usage.input_tokens']).toBe(100);
+    expect(root?.attributes['agentv.trace.cost_usd']).toBe(0.012);
+    expect(summary.tokenUsage).toEqual({ input: 100, output: 20, cached: 5, reasoning: 3 });
+    expect(summary.costUsd).toBe(0.012);
+    expect(summary.durationMs).toBe(4200);
+    expect(envelope.scores?.[0]).toMatchObject({
+      name: 'expected-tool-sequence',
+      type: 'tool-trajectory',
+      source: 'agentv',
+      evaluatedAt: '2026-06-15T12:00:05.000Z',
+      targetSpanId: envelope.trace.rootSpanId,
+    });
+    expect(envelope.scores?.[0]?.evidence?.details).toMatchObject({
+      snake_value: 'score detail stays snake_case',
+      providerCamelKey: 'score detail stays camelCase',
+    });
+  });
+
+  it('projects TraceSummary and Message tool calls from envelope spans', () => {
+    const output: readonly Message[] = [
+      {
+        role: 'assistant',
+        toolCalls: [
+          { tool: 'Read', id: 'call-read', durationMs: 10 },
+          { tool: 'Edit', id: 'call-edit', durationMs: 20 },
+        ],
+      },
+    ];
+    const result = makeResult({
+      trace: buildTraceFromMessages({
+        input: [{ role: 'user', content: 'Fix it' }],
+        output,
+        target: 'codex',
+        testId: 'projection-case',
+      }),
+    });
+    const envelope = buildTraceEnvelopeFromEvaluationResult(result);
+
+    expect(traceEnvelopeToTraceSummary(envelope).trace).toEqual(computeTraceSummary(output).trace);
+    expect(
+      traceEnvelopeToMessages(envelope)[0]?.toolCalls?.map((toolCall) => toolCall.tool),
+    ).toEqual(['Read', 'Edit']);
+  });
+});

--- a/packages/core/test/import/transcript-provider.test.ts
+++ b/packages/core/test/import/transcript-provider.test.ts
@@ -93,4 +93,73 @@ describe('TranscriptProvider', () => {
     const provider = await TranscriptProvider.fromFile(transcriptPath);
     expect(provider.lineCount).toBe(2);
   });
+
+  it('preserves opaque content, metadata, and tool payload keys', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'agentv-transcript-provider-'));
+    tempDirs.push(dir);
+    const transcriptPath = path.join(dir, 'transcript.jsonl');
+    const content = [
+      {
+        type: 'image',
+        media_type: 'image/png',
+        providerCamelKey: 'content stays camelCase',
+      },
+    ];
+    const metadata = {
+      snake_value: 'metadata stays snake_case',
+      providerCamelKey: 'metadata stays camelCase',
+    };
+    const input = {
+      file_path: 'src/config.ts',
+      providerCamelKey: 'input stays camelCase',
+    };
+    const output = {
+      snake_value: 'output stays snake_case',
+      providerCamelKey: 'output stays camelCase',
+    };
+    const transcript: TranscriptEntry = {
+      messages: [
+        {
+          role: 'assistant',
+          content: content as TranscriptEntry['messages'][number]['content'],
+          metadata,
+          toolCalls: [{ tool: 'Inspect', id: 'call-inspect', input, output }],
+        },
+      ],
+      source: {
+        provider: 'codex',
+        sessionId: 'opaque-session',
+      },
+    };
+
+    const lines = toTranscriptJsonLines(transcript, {
+      testId: 'opaque-case',
+      target: 'offline-codex',
+    });
+    await writeFile(
+      transcriptPath,
+      `${lines.map((line) => JSON.stringify(line)).join('\n')}\n`,
+      'utf8',
+    );
+
+    const row = lines[0] as unknown as {
+      content: Array<Record<string, unknown>>;
+      metadata: Record<string, unknown>;
+      tool_calls: Array<{ input: Record<string, unknown>; output: Record<string, unknown> }>;
+    };
+    expect(row.content[0]).toMatchObject(content[0]);
+    expect(row.metadata).toMatchObject(metadata);
+    expect(row.tool_calls[0].input).toMatchObject(input);
+    expect(row.tool_calls[0].output).toMatchObject(output);
+    expect(row.content[0]).not.toHaveProperty('provider_camel_key');
+    expect(row.metadata).not.toHaveProperty('snakeValue');
+
+    const provider = await TranscriptProvider.fromFile(transcriptPath);
+    const response = await provider.invoke({ question: 'ignored' });
+    const message = response.output?.[0];
+    expect(message?.content).toEqual(content);
+    expect(message?.metadata).toEqual(metadata);
+    expect(message?.toolCalls?.[0]?.input).toEqual(input);
+    expect(message?.toolCalls?.[0]?.output).toEqual(output);
+  });
 });


### PR DESCRIPTION
## Summary
AgentV eval runs now emit a canonical `agentv.trace_envelope.v1` sidecar per test at `outputs/trace-envelope.json`. The envelope wraps an OTLP/OpenInference-shaped span graph with AgentV-owned eval identity, capture policy, conversion warnings, artifact pointers, and score provenance, while existing result artifacts and replay transcript outputs stay stable.

This also replaces the risky deep case conversion on touched transcript/index paths with explicit serializers. Provider/user/tool payloads under content, tool input/output, metadata, raw evidence, and score evidence keep their original key casing; only AgentV-owned wire fields are translated to snake_case.

## Design Notes
- Default capture is metadata-only; prompts, tool arguments/results, screenshots, and reasoning blocks are not persisted unless full capture is explicitly requested by the converter.
- Missing tool call IDs get deterministic generated IDs and a `missing_tool_call_id` conversion warning.
- `index.jsonl` intentionally does not get a `trace_envelope_path` field in this slice.
- Replay fixture output from the merged replay work is unchanged; the envelope is additive.
- Nested/subagent trace import/export remains follow-up scope because current fixtures do not provide enough source evidence.

## Testing
- `bun test packages/core/test/evaluation/trace-envelope.test.ts packages/core/test/evaluation/trace-trajectory.test.ts packages/core/test/evaluation/replay-fixtures.test.ts packages/core/test/import/transcript-provider.test.ts apps/cli/test/commands/eval/artifact-writer.test.ts apps/cli/test/commands/eval/output-messages.test.ts apps/cli/test/commands/runs/rerun.test.ts`
- `bun test packages/core/test/observability/otel-exporter.test.ts packages/core/test/observability/file-exporters.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- Pre-push hook reran `bun run typecheck` and `bun run lint`

## Manual Red/Green UAT
Red on `origin/main` (`/tmp/agentv-trace-envelope-red2`): replay showcase passed with transcripts present and no `outputs/trace-envelope.json` sidecars.

Green on this branch (`/tmp/agentv-trace-envelope-green-final`): replay showcase passed, both per-test `outputs/trace-envelope.json` files validated with `TraceEnvelopeWireSchema`, each had schema `agentv.trace_envelope.v1`, and `index.jsonl` still had no `trace_envelope_path`. Transcript JSONL files matched the red baseline by `diff`.

Command used:
```bash
bun apps/cli/src/cli.ts eval examples/showcase/trace-evaluation/evals/coding-agent-replay.eval.yaml --target replay_coding_agent --output /tmp/agentv-trace-envelope-green-final
```

## Code Review
Local simplify/review pass completed. The larger multi-agent Tier 2 review path was not run because this Codex session only allows subagent spawning when the user explicitly requests delegation.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: this is a local CLI/core artifact-writing change with no production service rollout. Healthy signals are CI passing, replay showcase artifacts containing valid `agentv.trace_envelope.v1` sidecars, existing transcript diffs staying empty, and no new `trace_envelope_path` field in `index.jsonl`. Failure signals are schema validation errors on sidecars, changed transcript JSONL, or CLI artifact writer regressions in CI.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
