### PR TITLE
feat(copilot): support custom provider config

### DIFF
--- a/apps/web/src/content/docs/docs/targets/coding-agents.mdx
+++ b/apps/web/src/content/docs/docs/targets/coding-agents.mdx
@@ -153,11 +153,11 @@ targets:
       type: openai
       base_url: ${{ OPENAI_ENDPOINT }}
       api_key: ${{ OPENAI_API_KEY }}
-      wire_api: responses
+      wire_api: ${{ COPILOT_PROVIDER_WIRE_API }}
     grader_target: azure-base
 ```
 
-`copilot-sdk` also accepts `bearer_token` and `api_version` in the same block. For `copilot-cli`, AgentV maps `type`, `base_url`, and `api_key` to the CLI's provider environment variables before spawning `copilot`.
+Values can come from environment variables through `${{ ... }}` interpolation. For `copilot-cli`, AgentV maps this shared block to Copilot's documented provider environment variables before spawning `copilot`; omitted fields leave existing ambient `COPILOT_PROVIDER_*` values unchanged.
 
 ## Pi Coding Agent
 

--- a/apps/web/src/content/docs/docs/targets/coding-agents.mdx
+++ b/apps/web/src/content/docs/docs/targets/coding-agents.mdx
@@ -140,7 +140,24 @@ targets:
 |-------|----------|-------------|
 | `model` | No | Model to use (defaults to copilot's default) |
 | `cwd` | No | Working directory |
+| `custom_provider` | No | OpenAI-compatible provider endpoint for `copilot`, `copilot-cli`, or `copilot-sdk` |
 | `grader_target` | Yes | LLM target for evaluation |
+
+Route Copilot through an OpenAI-compatible endpoint:
+
+```yaml
+targets:
+  - name: copilot-openai
+    provider: copilot-cli
+    custom_provider:
+      type: openai
+      base_url: ${{ OPENAI_ENDPOINT }}
+      api_key: ${{ OPENAI_API_KEY }}
+      wire_api: responses
+    grader_target: azure-base
+```
+
+`copilot-sdk` also accepts `bearer_token` and `api_version` in the same block. For `copilot-cli`, AgentV maps `type`, `base_url`, and `api_key` to the CLI's provider environment variables before spawning `copilot`.
 
 ## Pi Coding Agent
 

--- a/packages/core/src/evaluation/providers/copilot-cli.ts
+++ b/packages/core/src/evaluation/providers/copilot-cli.ts
@@ -21,7 +21,7 @@ import {
 } from './copilot-utils.js';
 import { normalizeToolCall } from './normalize-tool-call.js';
 import { buildPromptDocument, normalizeInputFiles } from './preread.js';
-import type { CopilotCliResolvedConfig } from './targets.js';
+import type { CopilotCliResolvedConfig, CopilotCustomProviderConfig } from './targets.js';
 import type {
   Message,
   Provider,
@@ -82,6 +82,7 @@ export class CopilotCliProvider implements Provider {
 
     // Spawn the CLI process
     const agentProcess = spawn(executable, args, {
+      env: buildCopilotCliProviderEnv(process.env, this.config.customProvider),
       stdio: ['pipe', 'pipe', 'inherit'],
     });
     trackChild(agentProcess);
@@ -463,6 +464,24 @@ export class CopilotCliProvider implements Provider {
       return undefined;
     }
   }
+}
+
+export function buildCopilotCliProviderEnv(
+  baseEnv: NodeJS.ProcessEnv,
+  customProvider: CopilotCustomProviderConfig | undefined,
+): NodeJS.ProcessEnv {
+  const env = { ...baseEnv };
+  if (!customProvider) {
+    return env;
+  }
+  if (customProvider.type) {
+    env.COPILOT_PROVIDER_TYPE = customProvider.type;
+  }
+  env.COPILOT_PROVIDER_BASE_URL = customProvider.baseUrl;
+  if (customProvider.apiKey) {
+    env.COPILOT_PROVIDER_API_KEY = customProvider.apiKey;
+  }
+  return env;
 }
 
 async function waitForProcessSpawn(

--- a/packages/core/src/evaluation/providers/copilot-cli.ts
+++ b/packages/core/src/evaluation/providers/copilot-cli.ts
@@ -414,7 +414,12 @@ export class CopilotCliProvider implements Provider {
         timeoutMs: resolveCopilotTimeoutMs(this.config.timeoutMs),
         env,
         signal: request.signal,
-        onStdoutChunk: logger ? (chunk) => logger.handleEvent('stdout', { chunk }) : undefined,
+        onStdoutChunk: logger
+          ? (chunk) =>
+              logger.handleEvent('stdout', {
+                chunk: sanitizeSensitiveText(chunk, this.config.customProvider),
+              })
+          : undefined,
         onStderrChunk: logger
           ? (chunk) =>
               logger.handleEvent('stderr', {

--- a/packages/core/src/evaluation/providers/copilot-cli.ts
+++ b/packages/core/src/evaluation/providers/copilot-cli.ts
@@ -478,8 +478,16 @@ export function buildCopilotCliProviderEnv(
     env.COPILOT_PROVIDER_TYPE = customProvider.type;
   }
   env.COPILOT_PROVIDER_BASE_URL = customProvider.baseUrl;
-  if (customProvider.apiKey) {
+  if (customProvider.bearerToken) {
+    env.COPILOT_PROVIDER_BEARER_TOKEN = customProvider.bearerToken;
+  } else if (customProvider.apiKey) {
     env.COPILOT_PROVIDER_API_KEY = customProvider.apiKey;
+  }
+  if (customProvider.wireApi) {
+    env.COPILOT_PROVIDER_WIRE_API = customProvider.wireApi;
+  }
+  if (customProvider.apiVersion) {
+    env.COPILOT_PROVIDER_AZURE_API_VERSION = customProvider.apiVersion;
   }
   return env;
 }

--- a/packages/core/src/evaluation/providers/copilot-cli.ts
+++ b/packages/core/src/evaluation/providers/copilot-cli.ts
@@ -17,6 +17,7 @@ import {
   buildLogFilename,
   isLogStreamingDisabled,
   killProcess,
+  resolveCopilotTimeoutMs,
   resolvePlatformCliPath,
 } from './copilot-utils.js';
 import { normalizeToolCall } from './normalize-tool-call.js';
@@ -39,6 +40,28 @@ interface ToolCallInProgress {
   readonly startMs: number;
 }
 
+interface CopilotCliPromptRunOptions {
+  readonly executable: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly timeoutMs: number;
+  readonly env: NodeJS.ProcessEnv;
+  readonly signal?: AbortSignal;
+  readonly onStdoutChunk?: (chunk: string) => void;
+  readonly onStderrChunk?: (chunk: string) => void;
+}
+
+interface CopilotCliPromptRunResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+  readonly timedOut?: boolean;
+}
+
+type CopilotCliPromptRunner = (
+  options: CopilotCliPromptRunOptions,
+) => Promise<CopilotCliPromptRunResult>;
+
 /**
  * Copilot CLI provider using the Agent Client Protocol (ACP).
  *
@@ -59,11 +82,17 @@ export class CopilotCliProvider implements Provider {
   readonly supportsBatch = false;
 
   private readonly config: CopilotCliResolvedConfig;
+  private readonly runPromptMode: CopilotCliPromptRunner;
 
-  constructor(targetName: string, config: CopilotCliResolvedConfig) {
+  constructor(
+    targetName: string,
+    config: CopilotCliResolvedConfig,
+    promptRunner: CopilotCliPromptRunner = defaultCopilotCliPromptRunner,
+  ) {
     this.id = `copilot-cli:${targetName}`;
     this.targetName = targetName;
     this.config = config;
+    this.runPromptMode = promptRunner;
   }
 
   async invoke(request: ProviderRequest): Promise<ProviderResponse> {
@@ -74,7 +103,11 @@ export class CopilotCliProvider implements Provider {
     const startTime = new Date().toISOString();
     const startMs = Date.now();
 
-    const logger = await this.createStreamLogger(request).catch(() => undefined);
+    if (this.config.customProvider) {
+      return await this.invokePromptMode(request, startTime, startMs);
+    }
+
+    const logger = await this.createStreamLogger(request, 'acp').catch(() => undefined);
 
     // Build command args
     const executable = this.resolveExecutable();
@@ -358,6 +391,99 @@ export class CopilotCliProvider implements Provider {
     return args;
   }
 
+  private async invokePromptMode(
+    request: ProviderRequest,
+    startTime: string,
+    startMs: number,
+  ): Promise<ProviderResponse> {
+    const logger = await this.createStreamLogger(request, 'prompt').catch(() => undefined);
+    const executable = this.resolveExecutable();
+    const inputFiles = normalizeInputFiles(request.inputFiles);
+    const prompt = buildPromptDocument(request, inputFiles);
+    const systemPrompt = this.resolveSystemPrompt(request);
+    const promptText = systemPrompt ? `${systemPrompt}\n\n${prompt}` : prompt;
+    const args = this.buildPromptModeArgs(promptText);
+    const cwd = this.resolveCwd(request.cwd) ?? process.cwd();
+    const env = buildCopilotCliProviderEnv(process.env, this.config.customProvider);
+
+    try {
+      const result = await this.runPromptMode({
+        executable,
+        args,
+        cwd,
+        timeoutMs: resolveCopilotTimeoutMs(this.config.timeoutMs),
+        env,
+        signal: request.signal,
+        onStdoutChunk: logger ? (chunk) => logger.handleEvent('stdout', { chunk }) : undefined,
+        onStderrChunk: logger
+          ? (chunk) =>
+              logger.handleEvent('stderr', {
+                chunk: sanitizeSensitiveText(chunk, this.config.customProvider),
+              })
+          : undefined,
+      });
+
+      const sanitizedStderr = sanitizeSensitiveText(result.stderr, this.config.customProvider);
+      if (result.timedOut) {
+        throw new Error(
+          `Copilot CLI timed out after ${Math.ceil(resolveCopilotTimeoutMs(this.config.timeoutMs) / 1000)}s`,
+        );
+      }
+
+      if (result.exitCode !== 0) {
+        const detail = pickPromptModeDetail(
+          sanitizeSensitiveText(result.stderr, this.config.customProvider),
+          sanitizeSensitiveText(result.stdout, this.config.customProvider),
+        );
+        const prefix = `Copilot CLI exited with code ${result.exitCode}`;
+        throw new Error(detail ? `${prefix}: ${detail}` : prefix);
+      }
+
+      const assistantText = extractCopilotPromptResponse(result.stdout);
+      const endTime = new Date().toISOString();
+
+      return {
+        raw: {
+          model: this.config.model,
+          executable,
+          args,
+          stdout: result.stdout,
+          stderr: sanitizedStderr,
+          exitCode: result.exitCode,
+          logFile: logger?.filePath,
+        },
+        output: [{ role: 'assistant', content: assistantText }],
+        durationMs: Date.now() - startMs,
+        startTime,
+        endTime,
+      };
+    } catch (error) {
+      const err = error as Error & { code?: string };
+      if (err.code === 'ENOENT' || err.code === 'EINVAL') {
+        throw new Error(formatCopilotSpawnError(err, executable, this.targetName));
+      }
+      throw error;
+    } finally {
+      await logger?.close();
+    }
+  }
+
+  private buildPromptModeArgs(prompt: string): string[] {
+    const args = ['-s', '--allow-all-tools', '--no-color'];
+
+    if (this.config.model) {
+      args.push('--model', this.config.model);
+    }
+
+    if (this.config.args) {
+      args.push(...this.config.args);
+    }
+
+    args.push('-p', prompt);
+
+    return args;
+  }
+
   private resolveSystemPrompt(_request: ProviderRequest): string | undefined {
     return this.config.systemPrompt;
   }
@@ -366,10 +492,7 @@ export class CopilotCliProvider implements Provider {
     sendPromise: Promise<T>,
     agentProcess: ChildProcess,
   ): Promise<T> {
-    const timeoutMs = this.config.timeoutMs;
-    if (!timeoutMs) {
-      return sendPromise;
-    }
+    const timeoutMs = resolveCopilotTimeoutMs(this.config.timeoutMs);
 
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<never>((_, reject) => {
@@ -423,6 +546,7 @@ export class CopilotCliProvider implements Provider {
 
   private async createStreamLogger(
     request: ProviderRequest,
+    mode: 'acp' | 'prompt',
   ): Promise<CopilotStreamLogger | undefined> {
     const logDir = this.resolveLogDirectory();
     if (!logDir) {
@@ -446,10 +570,10 @@ export class CopilotCliProvider implements Provider {
           evalCaseId: request.evalCaseId,
           attempt: request.attempt,
           format: this.config.logFormat ?? 'summary',
-          headerLabel: 'Copilot CLI (ACP)',
-          chunkExtractor: extractAcpChunk,
+          headerLabel: mode === 'acp' ? 'Copilot CLI (ACP)' : 'Copilot CLI (prompt)',
+          chunkExtractor: mode === 'acp' ? extractAcpChunk : undefined,
         },
-        summarizeAcpEvent,
+        mode === 'acp' ? summarizeAcpEvent : summarizePromptModeEvent,
       );
       recordCopilotCliLogEntry({
         filePath,
@@ -599,4 +723,133 @@ function summarizeAcpEvent(eventType: string, data: unknown): string | undefined
     default:
       return undefined;
   }
+}
+
+function summarizePromptModeEvent(eventType: string, data: unknown): string | undefined {
+  if (!data || typeof data !== 'object') {
+    return eventType;
+  }
+  const chunk = (data as Record<string, unknown>).chunk;
+  if (typeof chunk !== 'string') {
+    return undefined;
+  }
+  const trimmed = chunk.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return `${trimmed.slice(0, 200)}${trimmed.length > 200 ? '...' : ''}`;
+}
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape stripping requires matching control characters
+const ANSI_ESCAPE_RE = /\x1B\[[0-9;]*[A-Za-z]/g;
+// biome-ignore lint/suspicious/noControlCharactersInRegex: OSC sequence stripping requires matching control characters
+const ANSI_OSC_RE = /\x1B\][^\x07]*\x07/g;
+
+function stripAnsiEscapes(text: string): string {
+  return text.replace(ANSI_ESCAPE_RE, '').replace(ANSI_OSC_RE, '');
+}
+
+function extractCopilotPromptResponse(stdout: string): string {
+  const cleaned = stripAnsiEscapes(stdout).trim();
+  if (cleaned.length === 0) {
+    throw new Error('Copilot CLI produced no output');
+  }
+  return cleaned;
+}
+
+function pickPromptModeDetail(stderr: string, stdout: string): string | undefined {
+  const errorText = stderr.trim();
+  if (errorText.length > 0) {
+    return errorText;
+  }
+  const stdoutText = stdout.trim();
+  return stdoutText.length > 0 ? stdoutText : undefined;
+}
+
+function sanitizeSensitiveText(
+  text: string,
+  customProvider: CopilotCustomProviderConfig | undefined,
+): string {
+  if (!customProvider) {
+    return text;
+  }
+  const secrets = [customProvider.apiKey, customProvider.bearerToken].filter(
+    (value): value is string => typeof value === 'string' && value.length > 0,
+  );
+  let sanitized = text;
+  for (const secret of secrets) {
+    sanitized = sanitized.split(secret).join('[redacted]');
+  }
+  return sanitized;
+}
+
+async function defaultCopilotCliPromptRunner(
+  options: CopilotCliPromptRunOptions,
+): Promise<CopilotCliPromptRunResult> {
+  return await new Promise<CopilotCliPromptRunResult>((resolve, reject) => {
+    const child = spawn(options.executable, options.args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    trackChild(child);
+
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+
+    const onAbort = (): void => {
+      killProcess(child);
+    };
+
+    if (options.signal) {
+      if (options.signal.aborted) {
+        onAbort();
+      } else {
+        options.signal.addEventListener('abort', onAbort, { once: true });
+      }
+    }
+
+    const timeoutHandle = setTimeout(() => {
+      timedOut = true;
+      killProcess(child);
+    }, options.timeoutMs);
+    timeoutHandle.unref?.();
+
+    child.stdout?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => {
+      stdout += chunk;
+      options.onStdoutChunk?.(chunk);
+    });
+
+    child.stderr?.setEncoding('utf8');
+    child.stderr?.on('data', (chunk: string) => {
+      stderr += chunk;
+      options.onStderrChunk?.(chunk);
+    });
+
+    child.stdin?.end();
+
+    const cleanup = (): void => {
+      clearTimeout(timeoutHandle);
+      if (options.signal) {
+        options.signal.removeEventListener('abort', onAbort);
+      }
+    };
+
+    child.on('error', (error) => {
+      cleanup();
+      reject(error);
+    });
+
+    child.on('close', (code) => {
+      cleanup();
+      resolve({
+        stdout,
+        stderr,
+        exitCode: typeof code === 'number' ? code : -1,
+        timedOut,
+      });
+    });
+  });
 }

--- a/packages/core/src/evaluation/providers/copilot-sdk.ts
+++ b/packages/core/src/evaluation/providers/copilot-sdk.ts
@@ -9,6 +9,7 @@ import {
   CopilotStreamLogger,
   buildLogFilename,
   isLogStreamingDisabled,
+  resolveCopilotTimeoutMs,
   resolvePlatformCliPath,
 } from './copilot-utils.js';
 import { normalizeToolCall } from './normalize-tool-call.js';
@@ -327,21 +328,19 @@ export class CopilotSdkProvider implements Provider {
 
   // biome-ignore lint/suspicious/noExplicitAny: SDK session type is dynamically loaded
   private async sendWithTimeout(session: any, prompt: string, timeoutMs?: number): Promise<void> {
-    if (!timeoutMs) {
-      await session.sendAndWait({ prompt });
-      return;
-    }
+    const effectiveTimeoutMs = resolveCopilotTimeoutMs(timeoutMs);
+    const sendPromise = session.sendAndWait({ prompt }, effectiveTimeoutMs);
 
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<never>((_, reject) => {
       timer = setTimeout(() => {
-        reject(new Error(`Copilot SDK timed out after ${Math.ceil(timeoutMs / 1000)}s`));
-      }, timeoutMs);
+        reject(new Error(`Copilot SDK timed out after ${Math.ceil(effectiveTimeoutMs / 1000)}s`));
+      }, effectiveTimeoutMs);
       timer.unref?.();
     });
 
     try {
-      await Promise.race([session.sendAndWait({ prompt }), timeoutPromise]);
+      await Promise.race([sendPromise, timeoutPromise]);
     } finally {
       if (timer) clearTimeout(timer);
     }

--- a/packages/core/src/evaluation/providers/copilot-sdk.ts
+++ b/packages/core/src/evaluation/providers/copilot-sdk.ts
@@ -13,7 +13,7 @@ import {
 } from './copilot-utils.js';
 import { normalizeToolCall } from './normalize-tool-call.js';
 import { buildPromptDocument, normalizeInputFiles } from './preread.js';
-import type { CopilotSdkResolvedConfig } from './targets.js';
+import type { CopilotCustomProviderConfig, CopilotSdkResolvedConfig } from './targets.js';
 import type {
   Message,
   Provider,
@@ -117,25 +117,24 @@ export class CopilotSdkProvider implements Provider {
       };
     }
 
-    // BYOK — pass a provider block to route requests through a user-provided endpoint
-    // instead of GitHub's Copilot infrastructure. See copilot-sdk docs/auth/byok.md.
-    if (this.config.byokBaseUrl) {
-      const byokType = this.config.byokType ?? 'openai';
+    const customProvider = resolveCustomProviderConfig(this.config);
+    if (customProvider) {
+      const providerType = customProvider.type ?? 'openai';
       // biome-ignore lint/suspicious/noExplicitAny: SDK provider config shape is dynamic
       const provider: any = {
-        type: byokType,
-        baseUrl: normalizeByokBaseUrl(this.config.byokBaseUrl, byokType),
+        type: providerType,
+        baseUrl: normalizeByokBaseUrl(customProvider.baseUrl, providerType),
       };
-      if (this.config.byokBearerToken) {
-        provider.bearerToken = this.config.byokBearerToken;
-      } else if (this.config.byokApiKey) {
-        provider.apiKey = this.config.byokApiKey;
+      if (customProvider.bearerToken) {
+        provider.bearerToken = customProvider.bearerToken;
+      } else if (customProvider.apiKey) {
+        provider.apiKey = customProvider.apiKey;
       }
-      if (this.config.byokWireApi) {
-        provider.wireApi = this.config.byokWireApi;
+      if (customProvider.wireApi) {
+        provider.wireApi = customProvider.wireApi;
       }
-      if (this.config.byokType === 'azure' && this.config.byokApiVersion) {
-        provider.azure = { apiVersion: this.config.byokApiVersion };
+      if (providerType === 'azure' && customProvider.apiVersion) {
+        provider.azure = { apiVersion: customProvider.apiVersion };
       }
       sessionOptions.provider = provider;
     }
@@ -411,6 +410,25 @@ export class CopilotSdkProvider implements Provider {
       return undefined;
     }
   }
+}
+
+function resolveCustomProviderConfig(
+  config: CopilotSdkResolvedConfig,
+): CopilotCustomProviderConfig | undefined {
+  if (config.customProvider) {
+    return config.customProvider;
+  }
+  if (!config.byokBaseUrl) {
+    return undefined;
+  }
+  return {
+    ...(config.byokType ? { type: config.byokType } : {}),
+    baseUrl: config.byokBaseUrl,
+    ...(config.byokApiKey ? { apiKey: config.byokApiKey } : {}),
+    ...(config.byokBearerToken ? { bearerToken: config.byokBearerToken } : {}),
+    ...(config.byokApiVersion ? { apiVersion: config.byokApiVersion } : {}),
+    ...(config.byokWireApi ? { wireApi: config.byokWireApi } : {}),
+  };
 }
 
 /**

--- a/packages/core/src/evaluation/providers/copilot-utils.ts
+++ b/packages/core/src/evaluation/providers/copilot-utils.ts
@@ -16,6 +16,12 @@ import { fileURLToPath } from 'node:url';
 
 import type { ProviderRequest } from './types.js';
 
+export const DEFAULT_COPILOT_TIMEOUT_MS = 90 * 60 * 1000;
+
+export function resolveCopilotTimeoutMs(timeoutMs: number | undefined): number {
+  return timeoutMs ?? DEFAULT_COPILOT_TIMEOUT_MS;
+}
+
 // ---------------------------------------------------------------------------
 // Platform binary resolution
 // ---------------------------------------------------------------------------

--- a/packages/core/src/evaluation/providers/index.ts
+++ b/packages/core/src/evaluation/providers/index.ts
@@ -52,6 +52,7 @@ export type {
   ClaudeResolvedConfig,
   CliResolvedConfig,
   CopilotCliResolvedConfig,
+  CopilotCustomProviderConfig,
   CopilotLogResolvedConfig,
   CopilotSdkResolvedConfig,
   GeminiResolvedConfig,

--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -446,6 +446,16 @@ export interface CopilotCliResolvedConfig {
   /** New stream_log field. false=no stream log (default), 'raw'=per-event, 'summary'=consolidated. */
   readonly streamLog?: false | 'raw' | 'summary';
   readonly systemPrompt?: string;
+  readonly customProvider?: CopilotCustomProviderConfig;
+}
+
+export interface CopilotCustomProviderConfig {
+  readonly type?: string;
+  readonly baseUrl: string;
+  readonly apiKey?: string;
+  readonly bearerToken?: string;
+  readonly apiVersion?: string;
+  readonly wireApi?: string;
 }
 
 export interface CopilotSdkResolvedConfig {
@@ -460,6 +470,7 @@ export interface CopilotSdkResolvedConfig {
   /** New stream_log field. false=no stream log (default), 'raw'=per-event, 'summary'=consolidated. */
   readonly streamLog?: false | 'raw' | 'summary';
   readonly systemPrompt?: string;
+  readonly customProvider?: CopilotCustomProviderConfig;
   /** BYOK provider type: "azure", "openai", or "anthropic". */
   readonly byokType?: string;
   /** BYOK base URL for the provider endpoint. */
@@ -1495,63 +1506,9 @@ function resolveCopilotSdkConfig(
       ? systemPromptSource.trim()
       : undefined;
 
-  // BYOK (Bring Your Own Key) — allows routing through a user-provided endpoint
-  // instead of GitHub's Copilot infrastructure. The byok block maps to the SDK's
-  // `provider` option on createSession(). See copilot-sdk docs/auth/byok.md.
-  const byok = target.byok as Record<string, unknown> | undefined;
-  let byokType: string | undefined;
-  let byokBaseUrl: string | undefined;
-  let byokApiKey: string | undefined;
-  let byokBearerToken: string | undefined;
-  let byokApiVersion: string | undefined;
-  let byokWireApi: string | undefined;
-
-  if (byok && typeof byok === 'object') {
-    byokType = resolveOptionalString(byok.type, env, `${target.name} byok type`, {
-      allowLiteral: true,
-      optionalEnv: true,
-    });
-
-    byokBaseUrl = resolveOptionalString(byok.base_url, env, `${target.name} byok base URL`, {
-      allowLiteral: true,
-      optionalEnv: true,
-    });
-
-    byokApiKey = resolveOptionalString(byok.api_key, env, `${target.name} byok API key`, {
-      allowLiteral: false,
-      optionalEnv: true,
-    });
-
-    byokBearerToken = resolveOptionalString(
-      byok.bearer_token,
-      env,
-      `${target.name} byok bearer token`,
-      {
-        allowLiteral: false,
-        optionalEnv: true,
-      },
-    );
-
-    byokApiVersion = resolveOptionalString(
-      byok.api_version,
-      env,
-      `${target.name} byok API version`,
-      {
-        allowLiteral: true,
-        optionalEnv: true,
-      },
-    );
-
-    byokWireApi = resolveOptionalString(byok.wire_api, env, `${target.name} byok wire API`, {
-      allowLiteral: true,
-      optionalEnv: true,
-    });
-
-    // base_url is required when byok is specified
-    if (!byokBaseUrl) {
-      throw new Error(`${target.name}: 'byok.base_url' is required when 'byok' is specified`);
-    }
-  }
+  const customProvider = resolveCopilotCustomProviderConfig(target, env, {
+    includeByokAlias: true,
+  });
 
   return {
     cliUrl,
@@ -1564,12 +1521,108 @@ function resolveCopilotSdkConfig(
     logFormat,
     streamLog: streamLogResult.streamLog,
     systemPrompt,
-    byokType,
-    byokBaseUrl,
-    byokApiKey,
-    byokBearerToken,
-    byokApiVersion,
-    byokWireApi,
+    ...(customProvider
+      ? {
+          customProvider,
+          byokType: customProvider.type,
+          byokBaseUrl: customProvider.baseUrl,
+          byokApiKey: customProvider.apiKey,
+          byokBearerToken: customProvider.bearerToken,
+          byokApiVersion: customProvider.apiVersion,
+          byokWireApi: customProvider.wireApi,
+        }
+      : {}),
+  };
+}
+
+function resolveCopilotCustomProviderConfig(
+  target: z.infer<typeof BASE_TARGET_SCHEMA>,
+  env: EnvLookup,
+  options: { readonly includeByokAlias?: boolean } = {},
+): CopilotCustomProviderConfig | undefined {
+  const hasCustomProvider = target.custom_provider !== undefined;
+  const hasByokAlias = options.includeByokAlias === true && target.byok !== undefined;
+  if (!hasCustomProvider && !hasByokAlias) {
+    return undefined;
+  }
+
+  const sourceName = hasCustomProvider ? 'custom_provider' : 'byok';
+  const raw =
+    sourceName === 'custom_provider'
+      ? (target.custom_provider as unknown)
+      : (target.byok as unknown);
+
+  if (raw === null) {
+    return undefined;
+  }
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`${target.name}: '${sourceName}' must be an object`);
+  }
+
+  const provider = raw as Record<string, unknown>;
+  const type = resolveOptionalString(provider.type, env, `${target.name} ${sourceName} type`, {
+    allowLiteral: true,
+    optionalEnv: true,
+  });
+  const baseUrl = resolveOptionalString(
+    provider.base_url,
+    env,
+    `${target.name} ${sourceName} base URL`,
+    {
+      allowLiteral: true,
+      optionalEnv: true,
+    },
+  );
+  const apiKey = resolveOptionalString(
+    provider.api_key,
+    env,
+    `${target.name} ${sourceName} API key`,
+    {
+      allowLiteral: false,
+      optionalEnv: true,
+    },
+  );
+  const bearerToken = resolveOptionalString(
+    provider.bearer_token,
+    env,
+    `${target.name} ${sourceName} bearer token`,
+    {
+      allowLiteral: false,
+      optionalEnv: true,
+    },
+  );
+  const apiVersion = resolveOptionalString(
+    provider.api_version,
+    env,
+    `${target.name} ${sourceName} API version`,
+    {
+      allowLiteral: true,
+      optionalEnv: true,
+    },
+  );
+  const wireApi = resolveOptionalString(
+    provider.wire_api,
+    env,
+    `${target.name} ${sourceName} wire API`,
+    {
+      allowLiteral: true,
+      optionalEnv: true,
+    },
+  );
+
+  if (!baseUrl) {
+    throw new Error(
+      `${target.name}: '${sourceName}.base_url' is required when '${sourceName}' is specified`,
+    );
+  }
+
+  return {
+    ...(type ? { type } : {}),
+    baseUrl,
+    ...(apiKey ? { apiKey } : {}),
+    ...(bearerToken ? { bearerToken } : {}),
+    ...(apiVersion ? { apiVersion } : {}),
+    ...(wireApi ? { wireApi } : {}),
   };
 }
 
@@ -1628,6 +1681,7 @@ function resolveCopilotCliConfig(
     typeof systemPromptSource === 'string' && systemPromptSource.trim().length > 0
       ? systemPromptSource.trim()
       : undefined;
+  const customProvider = resolveCopilotCustomProviderConfig(target, env);
 
   return {
     executable,
@@ -1639,6 +1693,7 @@ function resolveCopilotCliConfig(
     logFormat,
     streamLog: streamLogResult.streamLog,
     systemPrompt,
+    ...(customProvider ? { customProvider } : {}),
   };
 }
 

--- a/packages/core/src/evaluation/providers/types.ts
+++ b/packages/core/src/evaluation/providers/types.ts
@@ -433,7 +433,9 @@ export interface TargetDefinition {
   readonly cli_url?: string | unknown | undefined;
   readonly cli_path?: string | unknown | undefined;
   readonly github_token?: string | unknown | undefined;
-  // Copilot SDK BYOK (Bring Your Own Key) — routes through a user-provided endpoint
+  // Copilot custom provider fields
+  readonly custom_provider?: Record<string, unknown> | undefined;
+  // Copilot SDK BYOK compatibility alias
   readonly byok?: Record<string, unknown> | undefined;
   // Retry configuration fields
   readonly max_retries?: number | unknown | undefined;

--- a/packages/core/src/evaluation/validation/targets-validator.ts
+++ b/packages/core/src/evaluation/validation/targets-validator.ts
@@ -126,6 +126,7 @@ const COPILOT_SDK_SETTINGS = new Set([
   'log_format',
   'stream_log',
   'system_prompt',
+  'custom_provider',
   'byok',
 ]);
 
@@ -143,6 +144,7 @@ const COPILOT_CLI_SETTINGS = new Set([
   'log_format',
   'stream_log',
   'system_prompt',
+  'custom_provider',
 ]);
 
 const VSCODE_SETTINGS = new Set([

--- a/packages/core/test/evaluation/providers/copilot-cli.test.ts
+++ b/packages/core/test/evaluation/providers/copilot-cli.test.ts
@@ -1,16 +1,17 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
 
 import type { ChildProcess } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 
 import { DEFAULT_COPILOT_TIMEOUT_MS } from '../../../src/evaluation/providers/copilot-utils.js';
 import { extractLastAssistantContent } from '../../../src/evaluation/providers/types.js';
 
-let CopilotCliProvider: typeof import(
-  '../../../src/evaluation/providers/copilot-cli.js',
-).CopilotCliProvider;
-let buildCopilotCliProviderEnv: typeof import(
-  '../../../src/evaluation/providers/copilot-cli.js',
-).buildCopilotCliProviderEnv;
+type CopilotCliModule = typeof import('../../../src/evaluation/providers/copilot-cli.js');
+
+let CopilotCliProvider: CopilotCliModule['CopilotCliProvider'];
+let buildCopilotCliProviderEnv: CopilotCliModule['buildCopilotCliProviderEnv'];
 let originalLogEnv: string | undefined;
 
 beforeAll(async () => {
@@ -208,6 +209,51 @@ describe('CopilotCliProvider custom provider prompt mode', () => {
 
     expect(message).toContain('[redacted]');
     expect(message).not.toContain('secret-key');
+  });
+
+  it('redacts custom provider credentials from prompt-mode stream logs', async () => {
+    const logDir = await mkdtemp(path.join(tmpdir(), 'agentv-copilot-cli-logs-'));
+    Reflect.deleteProperty(process.env, 'AGENTV_COPILOT_CLI_STREAM_LOGS');
+
+    try {
+      const runner = mock(
+        async (options: {
+          readonly onStdoutChunk?: (chunk: string) => void;
+          readonly onStderrChunk?: (chunk: string) => void;
+        }) => {
+          options.onStdoutChunk?.('stdout included test-api-key');
+          options.onStderrChunk?.('stderr included test-api-key');
+          return {
+            stdout: 'done',
+            stderr: '',
+            exitCode: 0,
+          };
+        },
+      );
+      const provider = new CopilotCliProvider(
+        'copilot-cli-custom',
+        {
+          executable: '/usr/bin/copilot',
+          logDir,
+          customProvider: {
+            type: 'openai',
+            baseUrl: 'https://api.openai.example/v1',
+            apiKey: 'test-api-key',
+          },
+        },
+        runner,
+      );
+
+      const response = await provider.invoke({ question: 'Return done' });
+      const logFile = (response.raw as Record<string, unknown>).logFile;
+      expect(typeof logFile).toBe('string');
+
+      const log = await readFile(logFile as string, 'utf8');
+      expect(log).toContain('[redacted]');
+      expect(log).not.toContain('test-api-key');
+    } finally {
+      await rm(logDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/core/test/evaluation/providers/copilot-cli.test.ts
+++ b/packages/core/test/evaluation/providers/copilot-cli.test.ts
@@ -1,6 +1,41 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
 
-import { buildCopilotCliProviderEnv } from '../../../src/evaluation/providers/copilot-cli.js';
+import type { ChildProcess } from 'node:child_process';
+
+import { DEFAULT_COPILOT_TIMEOUT_MS } from '../../../src/evaluation/providers/copilot-utils.js';
+import { extractLastAssistantContent } from '../../../src/evaluation/providers/types.js';
+
+let CopilotCliProvider: typeof import(
+  '../../../src/evaluation/providers/copilot-cli.js',
+).CopilotCliProvider;
+let buildCopilotCliProviderEnv: typeof import(
+  '../../../src/evaluation/providers/copilot-cli.js',
+).buildCopilotCliProviderEnv;
+let originalLogEnv: string | undefined;
+
+beforeAll(async () => {
+  mock.module('@agentclientprotocol/sdk', () => ({
+    PROTOCOL_VERSION: 1,
+    ndJsonStream: mock(() => ({})),
+    ClientSideConnection: class MockClientSideConnection {},
+  }));
+  const module = await import('../../../src/evaluation/providers/copilot-cli.js');
+  CopilotCliProvider = module.CopilotCliProvider;
+  buildCopilotCliProviderEnv = module.buildCopilotCliProviderEnv;
+});
+
+beforeEach(() => {
+  originalLogEnv = process.env.AGENTV_COPILOT_CLI_STREAM_LOGS;
+  process.env.AGENTV_COPILOT_CLI_STREAM_LOGS = 'false';
+});
+
+afterEach(() => {
+  if (originalLogEnv === undefined) {
+    process.env.AGENTV_COPILOT_CLI_STREAM_LOGS = undefined;
+  } else {
+    process.env.AGENTV_COPILOT_CLI_STREAM_LOGS = originalLogEnv;
+  }
+});
 
 describe('buildCopilotCliProviderEnv', () => {
   it('maps custom provider config to known Copilot CLI env vars', () => {
@@ -64,3 +99,164 @@ describe('buildCopilotCliProviderEnv', () => {
     expect(env.COPILOT_PROVIDER_AZURE_API_VERSION).toBe('2024-10-21');
   });
 });
+
+describe('CopilotCliProvider custom provider prompt mode', () => {
+  it('uses non-ACP prompt mode with custom provider env and default long timeout', async () => {
+    const runner = mock(async () => ({
+      stdout: '\u001b[32magentv-copilot-gateway-ok\u001b[0m\n',
+      stderr: 'warning secret-key',
+      exitCode: 0,
+    }));
+    const provider = new CopilotCliProvider(
+      'copilot-cli-custom',
+      {
+        executable: '/usr/bin/copilot',
+        model: 'gpt-5-mini',
+        args: ['--extra-flag'],
+        customProvider: {
+          type: 'openai',
+          baseUrl: 'https://api.openai.example/v1',
+          apiKey: 'secret-key',
+          wireApi: 'responses',
+        },
+      },
+      runner,
+    );
+
+    const response = await provider.invoke({
+      question: 'Return exactly agentv-copilot-gateway-ok',
+      cwd: '/tmp/copilot-workspace',
+    });
+
+    expect(extractLastAssistantContent(response.output)).toBe('agentv-copilot-gateway-ok');
+    expect(runner).toHaveBeenCalledTimes(1);
+    const invocation = runner.mock.calls[0][0];
+    expect(invocation.executable).toBe('/usr/bin/copilot');
+    expect(invocation.cwd).toBe('/tmp/copilot-workspace');
+    expect(invocation.timeoutMs).toBe(DEFAULT_COPILOT_TIMEOUT_MS);
+    expect(invocation.env.COPILOT_PROVIDER_TYPE).toBe('openai');
+    expect(invocation.env.COPILOT_PROVIDER_BASE_URL).toBe('https://api.openai.example/v1');
+    expect(invocation.env.COPILOT_PROVIDER_API_KEY).toBe('secret-key');
+    expect(invocation.env.COPILOT_PROVIDER_WIRE_API).toBe('responses');
+    expect(invocation.args.slice(0, 6)).toEqual([
+      '-s',
+      '--allow-all-tools',
+      '--no-color',
+      '--model',
+      'gpt-5-mini',
+      '--extra-flag',
+    ]);
+    expect(invocation.args).not.toContain('--acp');
+    expect(invocation.args).not.toContain('--stdio');
+    expect(invocation.args.at(-2)).toBe('-p');
+    expect(invocation.args.at(-1)).toContain('agentv-copilot-gateway-ok');
+
+    const raw = response.raw as Record<string, unknown>;
+    expect(raw.stderr).toBe('warning [redacted]');
+  });
+
+  it('uses explicit timeout for custom provider prompt mode when configured', async () => {
+    const runner = mock(async () => ({
+      stdout: 'done',
+      stderr: '',
+      exitCode: 0,
+    }));
+    const provider = new CopilotCliProvider(
+      'copilot-cli-custom',
+      {
+        executable: '/usr/bin/copilot',
+        timeoutMs: 30_000,
+        customProvider: {
+          type: 'openai',
+          baseUrl: 'https://api.openai.example/v1',
+          apiKey: 'secret-key',
+        },
+      },
+      runner,
+    );
+
+    await provider.invoke({ question: 'Return done' });
+
+    expect(runner.mock.calls[0][0].timeoutMs).toBe(30_000);
+  });
+
+  it('redacts custom provider credentials from prompt-mode errors', async () => {
+    const runner = mock(async () => ({
+      stdout: '',
+      stderr: 'upstream rejected secret-key',
+      exitCode: 1,
+    }));
+    const provider = new CopilotCliProvider(
+      'copilot-cli-custom',
+      {
+        executable: '/usr/bin/copilot',
+        customProvider: {
+          type: 'openai',
+          baseUrl: 'https://api.openai.example/v1',
+          apiKey: 'secret-key',
+        },
+      },
+      runner,
+    );
+
+    let message = '';
+    try {
+      await provider.invoke({ question: 'Return done' });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toContain('[redacted]');
+    expect(message).not.toContain('secret-key');
+  });
+});
+
+describe('CopilotCliProvider ACP timeout guard', () => {
+  it('uses the 90-minute default timeout when none is configured', async () => {
+    const timeoutMs = await captureAcpTimeoutDelay(
+      new CopilotCliProvider('copilot-cli-acp', { executable: 'copilot' }),
+    );
+
+    expect(timeoutMs).toBe(DEFAULT_COPILOT_TIMEOUT_MS);
+  });
+
+  it('uses explicit timeout for ACP when configured', async () => {
+    const timeoutMs = await captureAcpTimeoutDelay(
+      new CopilotCliProvider('copilot-cli-acp', {
+        executable: 'copilot',
+        timeoutMs: 45_000,
+      }),
+    );
+
+    expect(timeoutMs).toBe(45_000);
+  });
+});
+
+async function captureAcpTimeoutDelay(provider: CopilotCliProvider): Promise<number | undefined> {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  let capturedDelay: number | undefined;
+
+  globalThis.setTimeout = ((_handler: Parameters<typeof setTimeout>[0], delay?: number) => {
+    capturedDelay = delay;
+    return { unref() {} } as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+  globalThis.clearTimeout = (() => {}) as typeof clearTimeout;
+
+  try {
+    const process = {
+      exitCode: null,
+      signalCode: null,
+      kill: mock(() => true),
+    } as unknown as ChildProcess;
+    await (
+      provider as unknown as {
+        raceWithTimeout<T>(sendPromise: Promise<T>, agentProcess: ChildProcess): Promise<T>;
+      }
+    ).raceWithTimeout(Promise.resolve('ok'), process);
+    return capturedDelay;
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+}

--- a/packages/core/test/evaluation/providers/copilot-cli.test.ts
+++ b/packages/core/test/evaluation/providers/copilot-cli.test.ts
@@ -16,7 +16,6 @@ describe('buildCopilotCliProviderEnv', () => {
         type: 'openai',
         baseUrl: 'https://api.openai.example/v1',
         apiKey: 'new-key',
-        bearerToken: 'bearer-token',
         wireApi: 'responses',
         apiVersion: '2024-10-21',
       },
@@ -26,9 +25,24 @@ describe('buildCopilotCliProviderEnv', () => {
     expect(env.COPILOT_PROVIDER_TYPE).toBe('openai');
     expect(env.COPILOT_PROVIDER_BASE_URL).toBe('https://api.openai.example/v1');
     expect(env.COPILOT_PROVIDER_API_KEY).toBe('new-key');
-    expect(env.COPILOT_PROVIDER_WIRE_API).toBe('ambient-wire-api');
-    expect(env.COPILOT_PROVIDER_BEARER_TOKEN).toBeUndefined();
-    expect(env.COPILOT_PROVIDER_API_VERSION).toBeUndefined();
+    expect(env.COPILOT_PROVIDER_WIRE_API).toBe('responses');
+    expect(env.COPILOT_PROVIDER_AZURE_API_VERSION).toBe('2024-10-21');
+  });
+
+  it('maps bearer token without overwriting ambient API key', () => {
+    const env = buildCopilotCliProviderEnv(
+      {
+        COPILOT_PROVIDER_API_KEY: 'ambient-key',
+      },
+      {
+        type: 'openai',
+        baseUrl: 'https://api.openai.example/v1',
+        bearerToken: 'bearer-token',
+      },
+    );
+
+    expect(env.COPILOT_PROVIDER_API_KEY).toBe('ambient-key');
+    expect(env.COPILOT_PROVIDER_BEARER_TOKEN).toBe('bearer-token');
   });
 
   it('preserves ambient Copilot provider env vars without a target override', () => {
@@ -37,6 +51,8 @@ describe('buildCopilotCliProviderEnv', () => {
         COPILOT_PROVIDER_TYPE: 'openai',
         COPILOT_PROVIDER_BASE_URL: 'https://ambient.example/v1',
         COPILOT_PROVIDER_API_KEY: 'ambient-key',
+        COPILOT_PROVIDER_WIRE_API: 'responses',
+        COPILOT_PROVIDER_AZURE_API_VERSION: '2024-10-21',
       },
       undefined,
     );
@@ -44,5 +60,7 @@ describe('buildCopilotCliProviderEnv', () => {
     expect(env.COPILOT_PROVIDER_TYPE).toBe('openai');
     expect(env.COPILOT_PROVIDER_BASE_URL).toBe('https://ambient.example/v1');
     expect(env.COPILOT_PROVIDER_API_KEY).toBe('ambient-key');
+    expect(env.COPILOT_PROVIDER_WIRE_API).toBe('responses');
+    expect(env.COPILOT_PROVIDER_AZURE_API_VERSION).toBe('2024-10-21');
   });
 });

--- a/packages/core/test/evaluation/providers/copilot-cli.test.ts
+++ b/packages/core/test/evaluation/providers/copilot-cli.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'bun:test';
+
+import { buildCopilotCliProviderEnv } from '../../../src/evaluation/providers/copilot-cli.js';
+
+describe('buildCopilotCliProviderEnv', () => {
+  it('maps custom provider config to known Copilot CLI env vars', () => {
+    const env = buildCopilotCliProviderEnv(
+      {
+        PATH: '/usr/bin',
+        COPILOT_PROVIDER_TYPE: 'azure',
+        COPILOT_PROVIDER_BASE_URL: 'https://old.example',
+        COPILOT_PROVIDER_API_KEY: 'old-key',
+        COPILOT_PROVIDER_WIRE_API: 'ambient-wire-api',
+      },
+      {
+        type: 'openai',
+        baseUrl: 'https://api.openai.example/v1',
+        apiKey: 'new-key',
+        bearerToken: 'bearer-token',
+        wireApi: 'responses',
+        apiVersion: '2024-10-21',
+      },
+    );
+
+    expect(env.PATH).toBe('/usr/bin');
+    expect(env.COPILOT_PROVIDER_TYPE).toBe('openai');
+    expect(env.COPILOT_PROVIDER_BASE_URL).toBe('https://api.openai.example/v1');
+    expect(env.COPILOT_PROVIDER_API_KEY).toBe('new-key');
+    expect(env.COPILOT_PROVIDER_WIRE_API).toBe('ambient-wire-api');
+    expect(env.COPILOT_PROVIDER_BEARER_TOKEN).toBeUndefined();
+    expect(env.COPILOT_PROVIDER_API_VERSION).toBeUndefined();
+  });
+
+  it('preserves ambient Copilot provider env vars without a target override', () => {
+    const env = buildCopilotCliProviderEnv(
+      {
+        COPILOT_PROVIDER_TYPE: 'openai',
+        COPILOT_PROVIDER_BASE_URL: 'https://ambient.example/v1',
+        COPILOT_PROVIDER_API_KEY: 'ambient-key',
+      },
+      undefined,
+    );
+
+    expect(env.COPILOT_PROVIDER_TYPE).toBe('openai');
+    expect(env.COPILOT_PROVIDER_BASE_URL).toBe('https://ambient.example/v1');
+    expect(env.COPILOT_PROVIDER_API_KEY).toBe('ambient-key');
+  });
+});

--- a/packages/core/test/evaluation/providers/copilot-sdk.test.ts
+++ b/packages/core/test/evaluation/providers/copilot-sdk.test.ts
@@ -8,6 +8,7 @@ import {
   consumeCopilotSdkLogEntries,
   subscribeToCopilotSdkLogEntries,
 } from '../../../src/evaluation/providers/copilot-sdk-log-tracker.js';
+import { DEFAULT_COPILOT_TIMEOUT_MS } from '../../../src/evaluation/providers/copilot-utils.js';
 import type { ProviderRequest } from '../../../src/evaluation/providers/types.js';
 import { extractLastAssistantContent } from '../../../src/evaluation/providers/types.js';
 
@@ -162,7 +163,7 @@ describe('CopilotSdkProvider', () => {
   it('handles timeout', async () => {
     const session = createMockSession();
     // Override sendAndWait to be slow
-    session.sendAndWait = mock(async () => new Promise((resolve) => setTimeout(resolve, 5000)));
+    session.sendAndWait = mock(async () => new Promise(() => {}));
     const client = createMockClient(session);
     const sdkMock = mockCopilotSdk(client);
 
@@ -174,6 +175,43 @@ describe('CopilotSdkProvider', () => {
     });
 
     await expect(provider.invoke({ question: 'Slow' })).rejects.toThrow(/timed out/i);
+    expect(session.sendAndWait.mock.calls[0][1]).toBe(100);
+  });
+
+  it('passes the 90-minute default timeout to sendAndWait when none is configured', async () => {
+    const session = createMockSession({
+      events: [{ type: 'assistant.message', data: { content: 'response' } }],
+    });
+    const client = createMockClient(session);
+    const sdkMock = mockCopilotSdk(client);
+
+    mock.module('@github/copilot-sdk', () => sdkMock);
+    const { CopilotSdkProvider } = await import('../../../src/evaluation/providers/copilot-sdk.js');
+
+    const provider = new CopilotSdkProvider('test-target', {});
+
+    await provider.invoke({ question: 'Test' });
+
+    expect(session.sendAndWait.mock.calls[0][1]).toBe(DEFAULT_COPILOT_TIMEOUT_MS);
+  });
+
+  it('passes configured timeout to sendAndWait', async () => {
+    const session = createMockSession({
+      events: [{ type: 'assistant.message', data: { content: 'response' } }],
+    });
+    const client = createMockClient(session);
+    const sdkMock = mockCopilotSdk(client);
+
+    mock.module('@github/copilot-sdk', () => sdkMock);
+    const { CopilotSdkProvider } = await import('../../../src/evaluation/providers/copilot-sdk.js');
+
+    const provider = new CopilotSdkProvider('test-target', {
+      timeoutMs: 1_800_000,
+    });
+
+    await provider.invoke({ question: 'Test' });
+
+    expect(session.sendAndWait.mock.calls[0][1]).toBe(1_800_000);
   });
 
   it('handles abort signal', async () => {

--- a/packages/core/test/evaluation/providers/copilot-sdk.test.ts
+++ b/packages/core/test/evaluation/providers/copilot-sdk.test.ts
@@ -439,6 +439,36 @@ describe('CopilotSdkProvider', () => {
     expect(sessionOptions.provider.wireApi).toBe('responses');
   });
 
+  it('passes customProvider block to createSession for openai-compatible endpoints', async () => {
+    const session = createMockSession({
+      events: [{ type: 'assistant.message', data: { content: 'response' } }],
+    });
+    const client = createMockClient(session);
+    const sdkMock = mockCopilotSdk(client);
+
+    mock.module('@github/copilot-sdk', () => sdkMock);
+    const { CopilotSdkProvider } = await import('../../../src/evaluation/providers/copilot-sdk.js');
+
+    const provider = new CopilotSdkProvider('test-target', {
+      customProvider: {
+        type: 'openai',
+        baseUrl: 'https://api.openai.example/v1',
+        apiKey: 'key',
+        wireApi: 'responses',
+      },
+    });
+
+    await provider.invoke({ question: 'Test' });
+
+    const sessionOptions = client.createSession.mock.calls[0][0];
+    expect(sessionOptions.provider).toEqual({
+      type: 'openai',
+      baseUrl: 'https://api.openai.example/v1',
+      apiKey: 'key',
+      wireApi: 'responses',
+    });
+  });
+
   it('does not set provider when byok is not configured', async () => {
     const session = createMockSession({
       events: [{ type: 'assistant.message', data: { content: 'response' } }],

--- a/packages/core/test/evaluation/providers/targets.test.ts
+++ b/packages/core/test/evaluation/providers/targets.test.ts
@@ -784,6 +784,44 @@ describe('resolveTargetDefinition', () => {
     expect(target.config.executable).toBe('copilot');
   });
 
+  it('resolves copilot-cli with custom_provider openai config', () => {
+    const env = {
+      OPENAI_ENDPOINT: 'https://api.openai.example/v1',
+      OPENAI_API_KEY: 'openai-secret',
+      OPTIONAL_BEARER_TOKEN: 'bearer-secret',
+    } satisfies Record<string, string>;
+
+    const target = resolveTargetDefinition(
+      {
+        name: 'copilot-cli-openai',
+        provider: 'copilot-cli',
+        custom_provider: {
+          type: 'openai',
+          base_url: '${{ OPENAI_ENDPOINT }}',
+          api_key: '${{ OPENAI_API_KEY }}',
+          bearer_token: '${{ OPTIONAL_BEARER_TOKEN }}',
+          wire_api: 'responses',
+          api_version: '2024-10-21',
+        },
+      },
+      env,
+    );
+
+    expect(target.kind).toBe('copilot-cli');
+    if (target.kind !== 'copilot-cli') {
+      throw new Error('expected copilot-cli target');
+    }
+
+    expect(target.config.customProvider).toEqual({
+      type: 'openai',
+      baseUrl: 'https://api.openai.example/v1',
+      apiKey: 'openai-secret',
+      bearerToken: 'bearer-secret',
+      wireApi: 'responses',
+      apiVersion: '2024-10-21',
+    });
+  });
+
   it('resolves copilot-sdk with byok azure config', () => {
     const env = {
       AZURE_OPENAI_ENDPOINT: 'https://my-resource.openai.azure.com',
@@ -845,6 +883,44 @@ describe('resolveTargetDefinition', () => {
     expect(target.config.byokType).toBe('openai');
     expect(target.config.byokBaseUrl).toBe('https://api.openai.com/v1');
     expect(target.config.byokApiKey).toBe('openai-secret');
+  });
+
+  it('resolves copilot-sdk with custom_provider openai config', () => {
+    const env = {
+      OPENAI_ENDPOINT: 'https://api.openai.example/v1',
+      OPENAI_API_KEY: 'openai-secret',
+    } satisfies Record<string, string>;
+
+    const target = resolveTargetDefinition(
+      {
+        name: 'copilot-sdk-openai-custom-provider',
+        provider: 'copilot-sdk',
+        model: 'gpt-5',
+        custom_provider: {
+          type: 'openai',
+          base_url: '${{ OPENAI_ENDPOINT }}',
+          api_key: '${{ OPENAI_API_KEY }}',
+          wire_api: 'responses',
+        },
+      },
+      env,
+    );
+
+    expect(target.kind).toBe('copilot-sdk');
+    if (target.kind !== 'copilot-sdk') {
+      throw new Error('expected copilot-sdk target');
+    }
+
+    expect(target.config.customProvider).toEqual({
+      type: 'openai',
+      baseUrl: 'https://api.openai.example/v1',
+      apiKey: 'openai-secret',
+      wireApi: 'responses',
+    });
+    expect(target.config.byokType).toBe('openai');
+    expect(target.config.byokBaseUrl).toBe('https://api.openai.example/v1');
+    expect(target.config.byokApiKey).toBe('openai-secret');
+    expect(target.config.byokWireApi).toBe('responses');
   });
 
   it('copilot-sdk byok defaults type to undefined when not specified', () => {
@@ -994,6 +1070,7 @@ describe('resolveTargetDefinition', () => {
     expect(target.config.byokType).toBeUndefined();
     expect(target.config.byokBaseUrl).toBeUndefined();
     expect(target.config.byokApiKey).toBeUndefined();
+    expect(target.config.customProvider).toBeUndefined();
   });
 
   it('rejects camelCase target fields', () => {

--- a/packages/core/test/evaluation/validation/targets-validator.test.ts
+++ b/packages/core/test/evaluation/validation/targets-validator.test.ts
@@ -122,6 +122,37 @@ describe('validateTargetsFile', () => {
     expect(result.valid).toBe(true);
   });
 
+  it('accepts custom_provider on copilot SDK and CLI targets', async () => {
+    const filePath = path.join(tempDir, 'copilot-custom-provider.yaml');
+    await writeFile(
+      filePath,
+      `targets:
+  - name: copilot-sdk-custom
+    provider: copilot-sdk
+    custom_provider:
+      type: openai
+      base_url: \${{ OPENAI_ENDPOINT }}
+      api_key: \${{ OPENAI_API_KEY }}
+  - name: copilot-cli-custom
+    provider: copilot-cli
+    custom_provider:
+      type: openai
+      base_url: \${{ OPENAI_ENDPOINT }}
+      api_key: \${{ OPENAI_API_KEY }}
+`,
+    );
+
+    const result = await validateTargetsFile(filePath);
+
+    expect(
+      result.errors.some(
+        (error) =>
+          error.severity === 'warning' &&
+          error.message.includes("Unknown setting 'custom_provider'"),
+      ),
+    ).toBe(false);
+  });
+
   it('accepts env-templated use_target values without resolving the env during validation', async () => {
     const filePath = path.join(tempDir, 'templated-use-target.yaml');
     await writeFile(


### PR DESCRIPTION
## Summary

Closes #1375.

Adds shared `custom_provider` config support for Copilot targets so both `copilot-sdk` and `copilot-cli` can run against OpenAI-compatible or BYOK provider endpoints.

- Reuses one parsed custom-provider shape across Copilot SDK and CLI targets.
- Maps `copilot-cli` custom provider config to documented `COPILOT_PROVIDER_*` environment variables.
- Preserves ambient `COPILOT_PROVIDER_*` values when YAML omits optional fields.
- Keeps existing `copilot-cli` ACP behavior when no `custom_provider` is configured.
- Uses Copilot CLI prompt mode for `copilot-cli + custom_provider`, because ACP BYOK failed live dogfood while prompt mode is the working CLI provider path.
- Applies a 90-minute effective Copilot wait default and passes effective timeout through `copilot-sdk.sendAndWait`.
- Redacts custom provider API key/bearer token from prompt-mode logs/errors.

## Validation

- `bun install`
- `bun run build`
- `bun test packages/core/test/evaluation/providers/copilot-cli.test.ts`
- `bun test packages/core/test/evaluation/providers/copilot-sdk.test.ts`
- `bun test packages/core/test/evaluation/providers/targets.test.ts`
- `bun test packages/core/test/evaluation/validation/targets-validator.test.ts`
- `bun run typecheck`
- `bun run lint`

## Live Dogfood

Real Copilot, no dry-run, using OpenAI-compatible gateway credentials from `.env`:

- `copilot-cli + custom_provider`: PASS, artifact `/tmp/agentv-1375-copilot-dogfood/copilot-cli-run-3`
- `copilot-sdk + custom_provider`: PASS, artifact `/tmp/agentv-1375-copilot-dogfood/copilot-sdk-run`

Both transcripts contained the expected marker `agentv-copilot-gateway-ok`.

## Notes

ACP BYOK/custom-provider behavior remains a follow-up candidate. It failed with `Authentication required (code -32000)` in this environment, while raw Copilot CLI prompt mode with the same provider env worked.