### PR TITLE
feat(dashboard): move project context to top bar

### DIFF
--- a/apps/dashboard/src/components/Layout.tsx
+++ b/apps/dashboard/src/components/Layout.tsx
@@ -1,8 +1,9 @@
 /**
- * App shell: sidebar + breadcrumbs + main content area.
+ * App shell: sidebar + project context + breadcrumbs + main content area.
  *
- * The sidebar provides navigation, breadcrumbs show the current
- * location, and the main area renders the active route via Outlet.
+ * The sidebar provides app navigation, the top bar shows active project
+ * context, breadcrumbs show the current location, and the main area renders
+ * the active route via Outlet.
  *
  * Responsive behavior:
  * - md+ (≥768px): sidebar always visible as a fixed left panel.
@@ -11,11 +12,10 @@
 
 import { Outlet } from '@tanstack/react-router';
 
-import { DEFAULT_APP_NAME, useStudioConfig } from '~/lib/api';
-import { SidebarProvider, useSidebarContext } from '~/lib/sidebar-context';
+import { SidebarProvider } from '~/lib/sidebar-context';
 
-import { BrandName } from './BrandName';
 import { Breadcrumbs } from './Breadcrumbs';
+import { ProjectContextBar } from './ProjectContextBar';
 import { Sidebar } from './Sidebar';
 
 export function Layout() {
@@ -27,47 +27,12 @@ export function Layout() {
 }
 
 function LayoutInner() {
-  const { toggle } = useSidebarContext();
-  const { data: config } = useStudioConfig();
-  const appName = config?.app_name ?? DEFAULT_APP_NAME;
-
   return (
     <div className="flex h-screen overflow-hidden">
       <Sidebar />
 
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-        {/* Mobile top bar — only visible below md breakpoint */}
-        <header className="flex items-center gap-3 border-b border-gray-800 bg-gray-900/50 px-4 py-3 md:hidden">
-          <button
-            type="button"
-            onClick={toggle}
-            className="text-gray-400 hover:text-gray-200"
-            aria-label="Toggle navigation"
-          >
-            {/* Hamburger icon */}
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              role="img"
-              aria-label="Toggle navigation"
-            >
-              <line x1="3" y1="6" x2="21" y2="6" />
-              <line x1="3" y1="12" x2="21" y2="12" />
-              <line x1="3" y1="18" x2="21" y2="18" />
-            </svg>
-          </button>
-          <span className="text-sm font-semibold text-white">
-            <BrandName appName={appName} />
-          </span>
-        </header>
-
+        <ProjectContextBar />
         <Breadcrumbs />
         <main className="flex-1 overflow-y-auto p-6">
           <Outlet />

--- a/apps/dashboard/src/components/ProjectContextBar.tsx
+++ b/apps/dashboard/src/components/ProjectContextBar.tsx
@@ -1,0 +1,142 @@
+/**
+ * Top-level Dashboard context bar.
+ *
+ * Keeps project identity out of the sidebar so the left rail can stay focused
+ * on app navigation while the current project remains visible above the main
+ * review surface.
+ */
+
+import { useMatches, useNavigate } from '@tanstack/react-router';
+import type { ChangeEvent } from 'react';
+
+import { DEFAULT_APP_NAME, useProjectList, useStudioConfig } from '~/lib/api';
+import { resolveProjectDisplayName } from '~/lib/project-display-name';
+import { useSidebarContext } from '~/lib/sidebar-context';
+
+import { BrandName } from './BrandName';
+
+const ALL_PROJECTS_VALUE = '__all_projects__';
+
+function useCurrentProjectId(): string | undefined {
+  const matches = useMatches();
+
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const params = matches[i].params as Record<string, string>;
+    if (params.projectId) return params.projectId;
+  }
+
+  return undefined;
+}
+
+function formatProjectStat(project: {
+  run_count: number;
+  pass_rate: number;
+  execution_error_count?: number;
+}): string {
+  if (project.run_count === 0) return 'No runs';
+  const passRate = `${Math.round(project.pass_rate * 100)}% pass`;
+  if ((project.execution_error_count ?? 0) > 0) {
+    return `${passRate}, ${project.execution_error_count} errors`;
+  }
+  return `${passRate}, ${project.run_count} runs`;
+}
+
+export function ProjectContextBar() {
+  const navigate = useNavigate();
+  const { toggle } = useSidebarContext();
+  const { data: projectsData } = useProjectList();
+  const currentProjectId = useCurrentProjectId();
+  const { data: config } = useStudioConfig(currentProjectId);
+  const projects = projectsData?.projects ?? [];
+  const currentProject = currentProjectId
+    ? projects.find((project) => project.id === currentProjectId)
+    : undefined;
+  const projectName = currentProjectId
+    ? resolveProjectDisplayName(currentProjectId, projects)
+    : 'All projects';
+  const appName = config?.app_name ?? DEFAULT_APP_NAME;
+  const hasProjectSwitcher = projects.length > 0;
+
+  function handleProjectChange(event: ChangeEvent<HTMLSelectElement>) {
+    const nextProjectId = event.target.value;
+    if (nextProjectId === ALL_PROJECTS_VALUE) {
+      navigate({ to: '/' });
+      return;
+    }
+
+    navigate({
+      to: '/projects/$projectId',
+      params: { projectId: nextProjectId },
+      search: { tab: 'runs' } as Record<string, string>,
+    });
+  }
+
+  return (
+    <header className="flex min-h-14 items-center gap-3 border-b border-gray-800 bg-gray-950 px-4 py-2 md:px-6">
+      <button
+        type="button"
+        onClick={toggle}
+        className="shrink-0 text-gray-400 hover:text-gray-200 md:hidden"
+        aria-label="Toggle navigation"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          role="img"
+          aria-label="Toggle navigation"
+        >
+          <line x1="3" y1="6" x2="21" y2="6" />
+          <line x1="3" y1="12" x2="21" y2="12" />
+          <line x1="3" y1="18" x2="21" y2="18" />
+        </svg>
+      </button>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-3">
+          <span className="shrink-0 text-sm font-semibold text-white md:hidden">
+            <BrandName appName={appName} />
+          </span>
+
+          <div className="min-w-0 flex-1">
+            <div className="text-xs font-medium uppercase tracking-wider text-gray-500">
+              Project
+            </div>
+            {hasProjectSwitcher ? (
+              <select
+                value={currentProjectId ?? ALL_PROJECTS_VALUE}
+                onChange={handleProjectChange}
+                aria-label="Switch project"
+                className="mt-0.5 w-full max-w-full rounded-md border border-gray-700 bg-gray-950 px-2 py-1 text-sm font-medium text-gray-100 focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500 md:w-auto md:min-w-64"
+              >
+                <option value={ALL_PROJECTS_VALUE}>All projects</option>
+                {projects.map((project) => (
+                  <option key={project.id} value={project.id}>
+                    {resolveProjectDisplayName(project.id, projects)}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <div className="mt-0.5 truncate text-sm font-medium text-gray-100">{projectName}</div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {currentProject ? (
+        <div className="hidden shrink-0 text-right text-xs text-gray-500 sm:block">
+          <div className="tabular-nums">{formatProjectStat(currentProject)}</div>
+          {currentProject.name !== currentProject.id ? (
+            <div className="max-w-64 truncate">{currentProject.id}</div>
+          ) : null}
+        </div>
+      ) : null}
+    </header>
+  );
+}

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@
  * Context-aware sidebar navigation.
  *
  * Adapts its content based on the current route:
- * - At dashboard and project roots: shows global/project navigation
+ * - At dashboard and project roots: shows global navigation
  * - At run detail: shows nearby runs as local review context
  * - At eval detail: shows evals in the current run with pass/fail indicators
  * - At suite/category detail: shows the filtered review context
@@ -121,32 +121,14 @@ function sidebarLinkClass(isActive: boolean): string {
   }`;
 }
 
-function formatProjectStat(project: {
-  run_count: number;
-  pass_rate: number;
-  execution_error_count?: number;
-}): string {
-  if (project.run_count === 0) return 'No runs';
-  if ((project.execution_error_count ?? 0) > 0) {
-    return `${Math.round(project.pass_rate * 100)}% - ${project.execution_error_count} err`;
-  }
-  return `${Math.round(project.pass_rate * 100)}% - ${project.run_count} runs`;
-}
-
 function ProjectNavigationSidebar({ projectId }: { projectId?: string }) {
   const location = useLocation();
   const { data: projectData } = useProjectList();
-  const { data: evalRunsData } = useEvalRuns(projectId);
   const projects = projectData?.projects ?? [];
-  const project = projectId ? projects.find((p) => p.id === projectId) : undefined;
-  const projectName = projectId ? resolveProjectDisplayName(projectId, projects) : undefined;
   const search = location.search as Record<string, string>;
   const activeTab = projectNavItems.some((item) => item.id === search.tab)
     ? (search.tab as ProjectTabId)
     : 'runs';
-  const activeRunCount = (evalRunsData?.runs ?? []).filter(
-    (run) => run.status === 'starting' || run.status === 'running',
-  ).length;
   const showWorkspaceTabs = !projectId && projects.length === 0;
 
   return (
@@ -169,40 +151,6 @@ function ProjectNavigationSidebar({ projectId }: { projectId?: string }) {
           </Link>
         </div>
 
-        {projectId ? (
-          <div className="mb-4">
-            <div className="mb-2 px-2 text-xs font-medium uppercase tracking-wider text-gray-500">
-              Project
-            </div>
-            <div className="mb-2 rounded-md border border-gray-800 bg-gray-950/30 px-2 py-2">
-              <div className="truncate text-sm font-medium text-gray-200">{projectName}</div>
-              <div className="mt-1 truncate text-xs text-gray-500">
-                {project ? formatProjectStat(project) : projectId}
-              </div>
-              {activeRunCount > 0 ? (
-                <div className="mt-2 inline-flex items-center gap-1 rounded-full bg-cyan-900/40 px-2 py-0.5 text-xs text-cyan-400">
-                  <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-cyan-400" />
-                  {activeRunCount} running
-                </div>
-              ) : null}
-            </div>
-
-            {projectNavItems.map((item) => (
-              <Link
-                key={item.id}
-                to="/projects/$projectId"
-                params={{ projectId }}
-                search={{ tab: item.id } as Record<string, string>}
-                className={sidebarLinkClass(activeTab === item.id)}
-                title={item.description}
-              >
-                <span className="truncate">{item.label}</span>
-                <span className="shrink-0 text-xs text-gray-500">{item.description}</span>
-              </Link>
-            ))}
-          </div>
-        ) : null}
-
         {showWorkspaceTabs ? (
           <div className="mb-4">
             <div className="mb-2 px-2 text-xs font-medium uppercase tracking-wider text-gray-500">
@@ -220,35 +168,6 @@ function ProjectNavigationSidebar({ projectId }: { projectId?: string }) {
                 <span className="shrink-0 text-xs text-gray-500">{item.description}</span>
               </Link>
             ))}
-          </div>
-        ) : null}
-
-        {!projectId && projects.length > 0 ? (
-          <div>
-            <div className="mb-2 px-2 text-xs font-medium uppercase tracking-wider text-gray-500">
-              Projects
-            </div>
-            {projects.map((p) => {
-              const isActive = location.pathname.startsWith(`/projects/${p.id}`);
-              return (
-                <Link
-                  key={p.id}
-                  to="/projects/$projectId"
-                  params={{ projectId: p.id }}
-                  className={sidebarLinkClass(isActive)}
-                  title={p.path}
-                >
-                  <span className="min-w-0">
-                    <span className="block truncate">
-                      {resolveProjectDisplayName(p.id, projects)}
-                    </span>
-                    <span className="block truncate text-xs text-gray-600">
-                      {formatProjectStat(p)}
-                    </span>
-                  </span>
-                </Link>
-              );
-            })}
           </div>
         ) : null}
       </nav>

--- a/apps/dashboard/src/routes/projects/$projectId.tsx
+++ b/apps/dashboard/src/routes/projects/$projectId.tsx
@@ -10,7 +10,6 @@ import { useEffect, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { AnalyticsTab } from '~/components/AnalyticsTab';
 import { ExperimentsTab } from '~/components/ExperimentsTab';
-import { ProjectChromeTitle } from '~/components/ProjectChromeTitle';
 import { RunEvalModal } from '~/components/RunEvalModal';
 import { RunList } from '~/components/RunList';
 import { type RunSourceFilter, RunSourceToolbar } from '~/components/RunSourceToolbar';
@@ -31,11 +30,11 @@ import { dedupeSyncedRuns } from '~/lib/run-dedupe';
 
 type TabId = 'runs' | 'experiments' | 'analytics' | 'targets';
 
-const tabs: { id: TabId; label: string }[] = [
-  { id: 'runs', label: '🏃 Recent Runs' },
-  { id: 'experiments', label: '🧪 Experiments' },
-  { id: 'analytics', label: '📊 Analytics' },
-  { id: 'targets', label: '🤖 Targets' },
+const tabs: { id: TabId; label: string; title: string }[] = [
+  { id: 'runs', label: '🏃 Recent Runs', title: 'Recent Runs' },
+  { id: 'experiments', label: '🧪 Experiments', title: 'Experiments' },
+  { id: 'analytics', label: '📊 Analytics', title: 'Analytics' },
+  { id: 'targets', label: '🤖 Targets', title: 'Targets' },
 ];
 
 export const Route = createFileRoute('/projects/$projectId')({
@@ -55,11 +54,12 @@ function ProjectHomePage() {
   const projectName = resolveProjectDisplayName(projectId, projectData?.projects);
 
   const activeTab: TabId = tabs.some((t) => t.id === tab) ? (tab as TabId) : 'runs';
+  const activeTabTitle = tabs.find((t) => t.id === activeTab)?.title ?? 'Recent Runs';
 
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <ProjectChromeTitle projectId={projectId} displayName={projectName} />
+        <h1 className="text-2xl font-semibold text-white">{activeTabTitle}</h1>
         {!isReadOnly && (
           <button
             type="button"


### PR DESCRIPTION
## Summary
- move active project identity/switching into a top project context bar
- remove project list/current-project blocks from the sidebar on overview/project pages
- keep project tabs as the in-project content filters and rename the project page heading to the active surface

## Visual evidence
Private evidence on `agentv-private/main` commit `e83f72c`:
https://github.com/EntityProcess/agentv-private/tree/main/dogfood/dashboard-ux-phoenix-braintrust-2026-06-15/followup-phoenix-ia

Screenshots:
- `agentv-project-runs-top-project-desktop.png`
- `agentv-project-runs-top-project-mobile.png`
- `agentv-project-runs-top-project-mobile-drawer.png`
- `agentv-projects-top-context-desktop.png`

## Verification
- `bun --filter @agentv/dashboard test`
- `bun --filter @agentv/dashboard build`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `agent-browser --session av-phoenix-ia` desktop/mobile screenshots on local preview `http://127.0.0.1:3118/`
- top project selector verified project-to-project and back to all projects
