### PR TITLE
ci(release): gate finalize before bump and use GH_MODELS_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,6 @@ concurrency:
 permissions:
   contents: read
   id-token: write
-  models: read
 
 jobs:
   publish:
@@ -61,13 +60,13 @@ jobs:
             fi
           fi
 
-      # Latest promotion is blocked on a tiny live contract eval. Next-channel
-      # publishes stay fast; failures here stop before npm publish runs.
+      # Latest promotion is blocked on a tiny live contract eval. The gate uses
+      # a Models-capable PAT secret, while npm publish still uses NPM_TOKEN.
       - name: Run contract eval gate
         if: steps.channel.outputs.action == 'publish-latest'
         run: bun run contract-eval
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_MODELS_TOKEN: ${{ secrets.GH_MODELS_TOKEN }}
           CONTRACT_EVAL_MODEL: ${{ vars.CONTRACT_EVAL_MODEL || 'openai/gpt-4.1-mini' }}
 
       - name: Publish to npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,16 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # Finalize/stable releases promote to latest, so block before any version
+      # bump/tag if the live contract eval fails. The gate uses a Models-capable
+      # PAT secret and does not override the workflow GITHUB_TOKEN.
+      - name: Contract eval gate
+        if: inputs.channel == 'finalize' || inputs.channel == 'stable'
+        run: bun run contract-eval
+        env:
+          GH_MODELS_TOKEN: ${{ secrets.GH_MODELS_TOKEN }}
+          CONTRACT_EVAL_MODEL: ${{ vars.CONTRACT_EVAL_MODEL || 'openai/gpt-4.1-mini' }}
+
       - name: Bump version, commit, and tag
         run: |
           if [ "${{ inputs.channel }}" = "next" ]; then

--- a/examples/contract/.agentv/targets.yaml
+++ b/examples/contract/.agentv/targets.yaml
@@ -3,7 +3,7 @@ targets:
     provider: openai
     api_format: chat
     base_url: https://models.github.ai/inference
-    api_key: ${{ GITHUB_TOKEN }}
+    api_key: ${{ GH_MODELS_TOKEN }}
     model: ${{ CONTRACT_EVAL_MODEL }}
     temperature: 0
     max_output_tokens: 512

--- a/scripts/run-contract-eval.ts
+++ b/scripts/run-contract-eval.ts
@@ -5,6 +5,9 @@
  * The CLI source imports workspace packages through their built dist outputs,
  * so callers should run the root `contract-eval` package script rather than
  * invoking this file directly.
+ *
+ * Local usage:
+ * GH_MODELS_TOKEN=$(gh auth token) bun run contract-eval
  */
 
 process.env.CONTRACT_EVAL_MODEL ||= 'openai/gpt-4.1-mini';


### PR DESCRIPTION
## Summary

Fixes av-z8v. Publish failed in run 27595199948 because the contract-eval gate authenticated GitHub Models with the Actions `GITHUB_TOKEN`, which is not authorized for Models in this org. Local runs passed with a PAT, so the gate now uses the dedicated `GH_MODELS_TOKEN` secret instead.

This also moves the live contract-eval gate into `release.yml` before `Bump version, commit, and tag` for `finalize` and `stable`, so a failing latest-promotion gate aborts before any bump/tag is created. `next` remains ungated.

## Changes

- `examples/contract/.agentv/targets.yaml` reads `GH_MODELS_TOKEN` instead of `GITHUB_TOKEN`.
- `release.yml` runs `bun run contract-eval` after dependency install and before the bump for `finalize`/`stable` only.
- `publish.yml` keeps the defense-in-depth gate for `publish-latest`, switches it to `GH_MODELS_TOKEN`, and removes the now-unneeded `models: read` permission.
- Local usage docs in `scripts/run-contract-eval.ts` now show `GH_MODELS_TOKEN=$(gh auth token) bun run contract-eval`.

## Red/Green Evidence

Red, on `origin/main`: `release.yml` had no `Contract eval gate` before the bump, and `publish.yml` gate env keys were `GITHUB_TOKEN, CONTRACT_EVAL_MODEL` with `models: read` permission.

Green, on this branch:

- `GH_MODELS_TOKEN=$(gh auth token) bun run contract-eval` passed 3x.
- Each run passed both eval files: `release-gate` 2/2 at 100%, `repo-materialization` 1/1 at 100%.
- `bun run verify` passed.
- `bun run validate:examples` passed: 60 valid, 0 invalid.

## Workflow Reasoning

Parsed the workflow YAML and asserted:

- `release.yml`: gate runs after install and before bump; only for `finalize`/`stable`; `next` is ungated; gate env uses `GH_MODELS_TOKEN` and does not override `GITHUB_TOKEN`.
- `publish.yml`: gate runs before npm publish; only for `publish-latest`; `publish-next` is ungated; gate env uses `GH_MODELS_TOKEN` and does not override `GITHUB_TOKEN`; npm publish still uses `NODE_AUTH_TOKEN: secrets.NPM_TOKEN`.
- Removed `models: read` from `publish.yml` because the PAT-backed `GH_MODELS_TOKEN` authenticates the Models request.