### PR TITLE
feat(results): publish runs to results branch

### DIFF
--- a/apps/cli/src/commands/eval/commands/run.ts
+++ b/apps/cli/src/commands/eval/commands/run.ts
@@ -65,6 +65,34 @@ export const evalRunCommand = command({
       long: 'experiment',
       description: 'Experiment label for canonical run output (default: default)',
     }),
+    resultsRepo: option({
+      type: optional(string),
+      long: 'results-repo',
+      description:
+        'Results Git repo override: current/. for the source repo, a local path, Git URL, or owner/repo',
+    }),
+    resultsBranch: option({
+      type: optional(string),
+      long: 'results-branch',
+      description: 'Results storage branch (default: agentv/results/v1)',
+    }),
+    resultsRemote: option({
+      type: optional(string),
+      long: 'results-remote',
+      description: 'Git remote name for results push/fetch (default: origin)',
+    }),
+    resultsPush: flag({
+      long: 'results-push',
+      description: 'Push the results branch after publishing the completed local run',
+    }),
+    noResultsPush: flag({
+      long: 'no-results-push',
+      description: 'Publish to the local results branch without pushing to the remote',
+    }),
+    resultsRequirePush: flag({
+      long: 'results-require-push',
+      description: 'Fail the eval command if the completed results branch cannot be pushed',
+    }),
     dryRun: flag({
       long: 'dry-run',
       description: 'Use mock provider responses instead of real LLM calls',
@@ -248,6 +276,10 @@ export const evalRunCommand = command({
       console.error('Error: --budget-usd must be a positive number.');
       process.exit(2);
     }
+    if (args.resultsPush && args.noResultsPush) {
+      console.error('Error: --results-push and --no-results-push cannot be used together.');
+      process.exit(2);
+    }
     const rawOptions: Record<string, unknown> = {
       target: args.target,
       targets: args.targets,
@@ -257,6 +289,12 @@ export const evalRunCommand = command({
       output: args.output,
       outputFormat: args.outputFormat,
       experiment: args.experiment,
+      resultsRepo: args.resultsRepo,
+      resultsBranch: args.resultsBranch,
+      resultsRemote: args.resultsRemote,
+      resultsPush: args.resultsPush,
+      noResultsPush: args.noResultsPush,
+      resultsRequirePush: args.resultsRequirePush,
       dryRun: args.dryRun,
       dryRunDelay: args.dryRunDelay,
       dryRunDelayMin: args.dryRunDelayMin,

--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -38,6 +38,7 @@ import {
 } from '../../version-check.js';
 import {
   type RemoteExportStatus,
+  type ResultsPublishOverrides,
   getRelativeRunPath,
   loadNormalizedResultsConfig,
   maybeAutoExportRunArtifacts,
@@ -137,6 +138,7 @@ interface NormalizedOptions {
   readonly experiment?: string;
   readonly budgetUsd?: number;
   readonly sourceMetadataByEvalFile?: ReadonlyMap<string, Record<string, unknown>>;
+  readonly resultsOverrides?: ResultsPublishOverrides;
 }
 
 function normalizeBoolean(value: unknown): boolean {
@@ -149,6 +151,27 @@ function normalizeString(value: unknown): string | undefined {
   }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function resultsRepoOverride(
+  value: string | undefined,
+): Pick<ResultsPublishOverrides, 'repo' | 'repo_path'> {
+  if (!value) {
+    return {};
+  }
+  if (
+    value === 'current' ||
+    value === '.' ||
+    value.startsWith('./') ||
+    value.startsWith('../') ||
+    value.startsWith('/') ||
+    value.startsWith('~/') ||
+    value.startsWith('~\\') ||
+    /^[A-Za-z]:[/\\]/.test(value)
+  ) {
+    return { repo_path: value === 'current' ? '.' : value };
+  }
+  return { repo: value };
 }
 
 export function resolveTimestampPlaceholder(value: string): string {
@@ -392,6 +415,21 @@ function normalizeOptions(
   const yamlWorkspacePath = normalizeString(yamlExecutionRecord?.workspace_path);
   const workspacePath = cliWorkspacePath ?? yamlWorkspacePath;
   const workspaceMode = cliWorkspacePath ? 'static' : (cliWorkspaceMode ?? yamlWorkspaceMode);
+  const resultsRepo = normalizeString(rawOptions.resultsRepo);
+  const resultsPush = normalizeBoolean(rawOptions.resultsPush);
+  const resultsNoPush = normalizeBoolean(rawOptions.noResultsPush);
+  const resultsRequirePush = normalizeBoolean(rawOptions.resultsRequirePush);
+  const resultsOverrides: ResultsPublishOverrides = {
+    ...resultsRepoOverride(resultsRepo),
+    ...(normalizeString(rawOptions.resultsBranch) !== undefined && {
+      branch: normalizeString(rawOptions.resultsBranch),
+    }),
+    ...(normalizeString(rawOptions.resultsRemote) !== undefined && {
+      remote: normalizeString(rawOptions.resultsRemote),
+    }),
+    ...(resultsPush || resultsNoPush ? { auto_push: resultsPush && !resultsNoPush } : {}),
+    ...(resultsRequirePush ? { require_push: true } : {}),
+  };
 
   return {
     target: singleTarget,
@@ -461,6 +499,7 @@ function normalizeOptions(
     sourceMetadataByEvalFile: normalizeSourceMetadataByEvalFile(
       rawOptions.sourceMetadataByEvalFile,
     ),
+    resultsOverrides: Object.keys(resultsOverrides).length > 0 ? resultsOverrides : undefined,
   } satisfies NormalizedOptions;
 }
 
@@ -1577,7 +1616,11 @@ export async function runEvalCommand(
   let wipCleanedUp = false;
   let finalExportStatus: RemoteExportStatus = 'disabled';
   {
-    const wipConfig = await loadNormalizedResultsConfig(cwd).catch(() => undefined);
+    const wipConfig = await loadNormalizedResultsConfig(
+      cwd,
+      undefined,
+      options.resultsOverrides,
+    ).catch(() => undefined);
     if (wipConfig?.auto_push) {
       wipLoop = new WipCheckpointLoop({
         config: wipConfig,
@@ -1903,6 +1946,7 @@ export async function runEvalCommand(
           })),
         })),
         experiment: normalizeExperimentName(options.experiment),
+        results_overrides: options.resultsOverrides,
       });
     }
 

--- a/apps/cli/src/commands/results/remote.ts
+++ b/apps/cli/src/commands/results/remote.ts
@@ -6,6 +6,7 @@ import {
   type EvaluationResult,
   type GitListedRun,
   type NormalizedResultsConfig,
+  type ResultsConfig,
   type ResultsRepoStatus,
   directPushResults,
   directorySizeBytes,
@@ -42,7 +43,7 @@ const gitRunsCache = new Map<string, { data: Promise<GitListedRun[]>; expiresAt:
 const GIT_RUNS_CACHE_TTL_MS = 60_000;
 
 function getResultsStorageRef(config: NormalizedResultsConfig): string | undefined {
-  return config.branch ? `origin/${config.branch}` : undefined;
+  return config.branch;
 }
 
 function cachedListGitRuns(repoDir: string, ref?: string) {
@@ -100,12 +101,23 @@ export interface RemoteExportPayload {
   readonly results: readonly EvaluationResult[];
   readonly eval_summaries: readonly RemoteEvalSummary[];
   readonly experiment?: string;
+  readonly results_overrides?: ResultsPublishOverrides;
 }
 
 export type RemoteExportStatus = 'disabled' | 'published' | 'already_published' | 'failed';
 
 export interface RemoteResultsStatus extends ResultsRepoStatus {
   readonly run_count: number;
+}
+
+export interface ResultsPublishOverrides {
+  readonly repo?: string;
+  readonly repo_url?: string;
+  readonly repo_path?: string;
+  readonly branch?: string;
+  readonly remote?: string;
+  readonly auto_push?: boolean;
+  readonly require_push?: boolean;
 }
 
 const REMOTE_RUN_PREFIX = 'remote::';
@@ -155,6 +167,7 @@ async function maybeWarnLargeArtifact(runDir: string): Promise<void> {
 export async function loadNormalizedResultsConfig(
   cwd: string,
   projectId?: string,
+  overrides?: ResultsPublishOverrides,
 ): Promise<NormalizedResultsConfig | undefined> {
   const repoRoot = (await findRepoRoot(cwd)) ?? cwd;
   const config = await loadConfig(path.join(cwd, '_'), repoRoot);
@@ -163,20 +176,92 @@ export async function loadNormalizedResultsConfig(
       ? getProject(projectId)
       : (getProjectForPath(repoRoot) ?? getProjectForPath(cwd));
   const projectResults = project?.results
-    ? {
+    ? ({
         mode: 'github' as const,
-        repo: project.results.repoUrl,
-        branch: project.results.branch,
-        path: project.results.path,
-        auto_push: project.results.sync?.autoPush,
-        branch_prefix: project.results.branchPrefix,
-      }
+        ...(project.results.repoUrl !== undefined && {
+          repo: project.results.repoUrl,
+          repo_url: project.results.repoUrl,
+        }),
+        ...(project.results.repoPath !== undefined && { repo_path: project.results.repoPath }),
+        ...(project.results.branch !== undefined && { branch: project.results.branch }),
+        ...(project.results.remote !== undefined && { remote: project.results.remote }),
+        ...(project.results.path !== undefined && { path: project.results.path }),
+        ...((project.results.sync?.autoPush !== undefined ||
+          project.results.sync?.requirePush !== undefined) && {
+          sync: {
+            ...(project.results.sync?.autoPush !== undefined && {
+              auto_push: project.results.sync.autoPush,
+            }),
+            ...(project.results.sync?.requirePush !== undefined && {
+              require_push: project.results.sync.requirePush,
+            }),
+          },
+        }),
+        ...(project.results.branchPrefix !== undefined && {
+          branch_prefix: project.results.branchPrefix,
+        }),
+      } satisfies ResultsConfig)
     : undefined;
   const resultsConfig = projectResults ?? resolveResultsConfigForProject(config, project?.id);
-  if (!resultsConfig) {
+  if (!resultsConfig && !overrides) {
     return undefined;
   }
-  return normalizeResultsConfig(resultsConfig);
+  const baseConfig = resultsConfig
+    ? normalizeResultsConfig(resultsConfig, { baseDir: project?.path ?? repoRoot })
+    : undefined;
+  const repoOverride = overrides?.repo ?? overrides?.repo_url ?? overrides?.repo_path;
+  if (!baseConfig && !repoOverride) {
+    return undefined;
+  }
+  if (!overrides) {
+    return baseConfig;
+  }
+
+  const merged: ResultsConfig = {
+    mode: 'github',
+    ...(overrides.repo !== undefined
+      ? { repo: overrides.repo }
+      : overrides.repo_url !== undefined
+        ? { repo_url: overrides.repo_url }
+        : overrides.repo_path !== undefined
+          ? { repo_path: overrides.repo_path }
+          : baseConfig?.repo_path
+            ? { repo_path: baseConfig.repo_path }
+            : baseConfig?.repo_url
+              ? { repo_url: baseConfig.repo_url }
+              : baseConfig?.repo
+                ? { repo: baseConfig.repo }
+                : {}),
+    ...(overrides.branch !== undefined
+      ? { branch: overrides.branch }
+      : baseConfig?.branch
+        ? { branch: baseConfig.branch }
+        : {}),
+    ...(overrides.remote !== undefined
+      ? { remote: overrides.remote }
+      : baseConfig?.remote
+        ? { remote: baseConfig.remote }
+        : {}),
+    ...(repoOverride === undefined && baseConfig?.repo_path === undefined && baseConfig?.path
+      ? { path: baseConfig.path }
+      : {}),
+    ...((overrides.auto_push !== undefined ||
+      overrides.require_push !== undefined ||
+      baseConfig?.auto_push !== undefined ||
+      baseConfig?.require_push !== undefined) && {
+      sync: {
+        ...((overrides.auto_push ?? baseConfig?.auto_push) !== undefined && {
+          auto_push: overrides.auto_push ?? baseConfig?.auto_push,
+        }),
+        ...((overrides.require_push ?? baseConfig?.require_push) !== undefined && {
+          require_push: overrides.require_push ?? baseConfig?.require_push,
+        }),
+      },
+    }),
+    ...(baseConfig?.branch_prefix ? { branch_prefix: baseConfig.branch_prefix } : {}),
+  };
+
+  return normalizeResultsConfig(merged, { baseDir: project?.path ?? repoRoot });
 }
 
 export function encodeRemoteRunId(filename: string): string {
@@ -432,8 +517,12 @@ export async function clearRemoteRunTags(
 export async function maybeAutoExportRunArtifacts(
   payload: RemoteExportPayload,
 ): Promise<RemoteExportStatus> {
-  const config = await loadNormalizedResultsConfig(payload.cwd);
-  if (!config?.auto_push) {
+  const config = await loadNormalizedResultsConfig(
+    payload.cwd,
+    undefined,
+    payload.results_overrides,
+  );
+  if (!config) {
     return 'disabled';
   }
 
@@ -451,13 +540,19 @@ export async function maybeAutoExportRunArtifacts(
     });
 
     if (!pushed) {
-      console.warn('Warning: results export produced no git changes. Skipping push.');
+      console.warn('Warning: results export produced no git changes.');
       return 'already_published';
     }
 
-    console.log(`Results pushed to ${config.repo} (${config.path}/${relativeRunPath})`);
+    const pushLabel = config.auto_push || config.require_push ? 'pushed' : 'published locally';
+    console.log(
+      `Results ${pushLabel} to ${config.repo} (${config.branch ?? 'default branch'}:${relativeRunPath})`,
+    );
     return 'published';
   } catch (error) {
+    if (config.require_push) {
+      throw error;
+    }
     console.warn(`Warning: skipping results export: ${getStatusMessage(error)}`);
     console.warn("Warning: Run 'gh auth login' if GitHub authentication is missing.");
     return 'failed';

--- a/apps/cli/test/commands/results/remote-auto-export.test.ts
+++ b/apps/cli/test/commands/results/remote-auto-export.test.ts
@@ -191,7 +191,7 @@ describe('maybeAutoExportRunArtifacts', () => {
     }
   }, 20_000);
 
-  it('returns disabled when auto-push is not configured', async () => {
+  it('publishes locally without pushing when auto-push is disabled', async () => {
     const remoteDir = initializeRemoteRepo(rootDir);
     const runDir = writeRunArtifacts(projectDir);
     writeProjectConfig(projectDir, {
@@ -202,6 +202,12 @@ describe('maybeAutoExportRunArtifacts', () => {
 
     const status = await maybeAutoExportRunArtifacts(payload(projectDir, runDir));
 
-    expect(status).toBe('disabled');
+    expect(status).toBe('published');
+    expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir)).not.toContain(
+      '.agentv/results/runs/default/run-001/index.jsonl',
+    );
+    expect(git('git ls-tree -r --name-only main', cloneDir)).toContain(
+      '.agentv/results/runs/default/run-001/index.jsonl',
+    );
   });
 });

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -968,7 +968,7 @@ describe('serve app', () => {
       });
     }, 15000);
 
-    it('does not fall back to checked-out default branch runs when the configured storage branch is missing', async () => {
+    it('auto-creates a missing storage branch without falling back to checked-out default branch runs', async () => {
       const { remoteDir, cloneDir } = initializeRemoteRepo(tempDir);
       const runId = writeRemoteRunArtifact(
         cloneDir,
@@ -994,18 +994,20 @@ describe('serve app', () => {
       expect(statusRes.status).toBe(200);
       const statusData = (await statusRes.json()) as {
         available: boolean;
+        branch?: string;
         sync_status?: string;
         run_count: number;
         last_error?: string;
       };
       expect(statusData).toMatchObject({
-        available: false,
-        sync_status: 'unavailable',
+        available: true,
+        branch: 'agentv-results',
+        sync_status: 'clean',
         run_count: 0,
       });
-      expect(statusData.last_error ?? '').toContain(
-        "Results repo remote branch 'agentv-results' does not exist",
-      );
+      expect(statusData.last_error).toBeUndefined();
+      expect(git('git branch --show-current', cloneDir)).toBe('agentv-results');
+      expect(git('git ls-tree -r --name-only agentv-results', cloneDir)).toBe('');
 
       const listRes = await app.request('/api/runs');
       expect(listRes.status).toBe(200);

--- a/apps/web/src/content/docs/docs/tools/dashboard.mdx
+++ b/apps/web/src/content/docs/docs/tools/dashboard.mdx
@@ -259,24 +259,43 @@ projects:
     path: /home/entity/projects/EntityProcess/agentv
     ref: main
     results:
+      repo_path: .
+      branch: agentv/results/v1
+      remote: origin
+      sync:
+        auto_push: false
+        require_push: false
+```
+
+`results.repo_path: .` stores completed run artifacts on a dedicated branch of the source repository without checking out that branch in the source worktree. The branch defaults to `agentv/results/v1` for `repo_path` configs. AgentV creates the branch automatically on first publish and commits only `.agentv/results/**` paths into it. `sync.auto_push: false` keeps the result commit local; set it to `true` to push the branch best-effort after each completed run. `sync.require_push: true` is for CI workflows where a push failure should fail the command after local artifacts are written.
+
+For a separate results repository, use `repo_url` and an optional managed clone `path`:
+
+```yaml
+projects:
+  - id: agentv
+    name: AgentV
+    path: /home/entity/projects/EntityProcess/agentv
+    results:
       repo_url: git@github.com:EntityProcess/agentv-examples-eval-results.git
-      branch: agentv-results
+      branch: agentv/results/v1
       path: /home/entity/projects/EntityProcess/agentv-examples-eval-results
       sync:
         auto_push: true
 ```
 
-`results.path` is the filesystem location of the local clone AgentV manages for the results repo. It uses the same local-path field name as the source project. `results.repo_url` is the Git remote URL used for clone and push operations, so use HTTPS when credentials are HTTP-token based and SSH when the runtime has SSH keys configured. `results.branch` is optional; when present, AgentV reads and writes that existing storage branch instead of the results repo's default branch.
+`results.path` is the filesystem location of the local clone AgentV manages for a `repo_url` results repo. It uses the same local-path field name as the source project. `results.repo_url` is the Git remote URL used for clone and push operations, so use HTTPS when credentials are HTTP-token based and SSH when the runtime has SSH keys configured.
 
 You can also set a top-level global fallback in the same file. This is used when the current project is not registered or its registry entry has no `results` block:
 
 ```yaml
 results:
-  mode: github
-  repo: EntityProcess/default-eval-results
-  branch: agentv-results
-  path: /home/entity/projects/EntityProcess/default-eval-results
-  auto_push: true
+  repo_path: .
+  branch: agentv/results/v1
+  remote: origin
+  sync:
+    auto_push: false
+    require_push: false
 ```
 
 Project-local `.agentv/config.yaml` is for portable eval defaults such as `execution`, `eval_patterns`, and `dashboard`. Do not put `projects` in project-local config; AgentV warns and ignores it there. `results_by_project` is deprecated; use `projects[].results` in `$AGENTV_HOME/config.yaml`.
@@ -316,7 +335,7 @@ projects:
     ref: main
     results:
       repo_url: https://github.com/EntityProcess/agentv-eval-results.git
-      branch: agentv-results
+      branch: agentv/results/v1
       path: /home/entity/projects/EntityProcess/agentv-eval-results
       sync:
         auto_push: true
@@ -328,13 +347,13 @@ Use project-level **Sync Project** as the results exchange workflow. It handles 
 
 There is no separate `agentv results remote status` or `agentv results remote sync` command. The `agentv results` CLI stays focused on local run workspaces; manual remote exchange is Dashboard/API-only, with eval auto-export covering the common CI/publisher path.
 
-Each run writes to a unique timestamped directory, so concurrent pushes from multiple machines are safe — non-fast-forward conflicts are resolved automatically via rebase retry. If `results.branch` is configured, create that remote branch once before syncing (for example with `git switch --orphan agentv-results` and `git push origin HEAD:agentv-results`). `branch_prefix` remains only the prefix for temporary result/PR branch names; it is not the storage branch.
+Each run writes to a unique timestamped directory, so concurrent pushes from multiple machines are safe. AgentV creates a missing storage branch automatically and pushes with a non-fast-forward retry. `branch_prefix` remains only the prefix for temporary result/PR branch names; it is not the storage branch.
 
 ### What happens to existing local runs?
 
 Existing runs already present under `.agentv/results/runs/` stay exactly where they are and continue to appear in Dashboard as **local** runs.
 
-Adding a `results` block does **not** backfill those historical runs into the remote repo automatically. Auto-push only affects runs created after the remote results repo is configured. The same auto-push setting also enables best-effort WIP checkpoints for in-progress `agentv eval` runs.
+Adding a `results` block does **not** backfill those historical runs into the results branch automatically. Result publishing only affects runs created after the results repo is configured. `sync.auto_push` controls network push and best-effort WIP checkpoints for in-progress `agentv eval` runs.
 
 If you want older local-only runs in the remote repo, rerun them or copy the run directories into the managed clone manually before syncing the project.
 

--- a/apps/web/src/content/docs/docs/tools/results.mdx
+++ b/apps/web/src/content/docs/docs/tools/results.mdx
@@ -11,7 +11,7 @@ import resultsReportDetails from '../../../../assets/screenshots/results-report-
 
 The `results` command family works on existing local AgentV run workspaces and `index.jsonl` manifests. Use it after an eval run to inspect failures, validate manifests, export artifact layouts, combine/delete local run workspaces, or generate a shareable HTML report.
 
-Remote result repository exchange is intentionally not part of `agentv results`. New eval runs can auto-export to a configured results repo when `auto_push: true`; manual remote status and sync are Dashboard/API workflows. See [Dashboard Remote Results](/docs/tools/dashboard/#remote-results) for configuration and sync behavior, and [WIP checkpoints](/docs/tools/wip-checkpoints/) for recovering in-progress runs before final publish.
+Remote result repository exchange is intentionally not part of `agentv results`. New eval runs publish completed artifacts to a configured results repo or branch; `sync.auto_push: true` additionally pushes that branch to the remote. Manual remote status and sync are Dashboard/API workflows. See [Dashboard Remote Results](/docs/tools/dashboard/#remote-results) for configuration and sync behavior, and [WIP checkpoints](/docs/tools/wip-checkpoints/) for recovering in-progress runs before final publish.
 
 ## Subcommands
 
@@ -115,7 +115,7 @@ The CLI contract is deliberately narrow: `agentv results` manages local result a
 
 Use these supported remote workflows instead:
 
-- **Automatic publishing:** configure `projects[].results.sync.auto_push: true`; new `agentv eval` and `agentv pipeline bench` runs push their artifacts after the run completes. Add `projects[].results.branch` when the results repo stores artifacts on a non-default branch. While an eval is still running, [WIP checkpoints](/docs/tools/wip-checkpoints/) can keep partial run output durable on `agentv/inflight/...` branches.
+- **Automatic publishing:** configure `projects[].results` or top-level `results`; new `agentv eval` and `agentv pipeline bench` runs publish completed artifacts after the run completes. Use `repo_path: .` with `branch: agentv/results/v1` to store results on a dedicated branch of the source repo. Set `sync.auto_push: true` to push after publish, or `sync.require_push: true` in CI to fail when that push fails. While an eval is still running, [WIP checkpoints](/docs/tools/wip-checkpoints/) can keep partial run output durable on `agentv/inflight/...` branches when auto-push is enabled.
 - **Manual Dashboard sync:** run `agentv dashboard`, open the project, and use **Sync Project**.
 - **Manual API sync:** while Dashboard is running, call `GET /api/projects/:projectId/remote/status` or `POST /api/projects/:projectId/remote/sync` for project-scoped automation. Single-project sessions also expose `GET /api/remote/status` and `POST /api/remote/sync`.
 - **Git escape hatch:** for advanced recovery, inspect or repair the configured `projects[].results.path` clone with `git` directly, then sync again.

--- a/apps/web/src/content/docs/docs/tools/wip-checkpoints.mdx
+++ b/apps/web/src/content/docs/docs/tools/wip-checkpoints.mdx
@@ -14,9 +14,9 @@ They are **not** a second results mode. They reuse the existing run workspace fo
 WIP checkpoints are active only when AgentV can resolve a results repo configuration with auto-push enabled:
 
 - In a registered project: `projects[].results.sync.auto_push: true` in `$AGENTV_HOME/config.yaml`.
-- In the top-level fallback config: `results.auto_push: true`.
+- In the top-level fallback config: `results.sync.auto_push: true`.
 
-If no results repo is configured, or auto-push is disabled, `agentv eval` still writes the local run workspace but does not create WIP branches.
+If no results repo is configured, or auto-push is disabled, `agentv eval` still writes the local run workspace and publishes completed runs to the configured local results branch, but does not create WIP branches.
 
 ## What gets written
 
@@ -25,13 +25,13 @@ If no results repo is configured, or auto-push is disabled, `agentv eval` still 
 | Local project | `.agentv/results/runs/<experiment>/<run-id>/benchmark.json` | A run-start stub with `metadata.planned_test_count` and the eval file path when known. This lets Dashboard recognize incomplete local runs as resumable. |
 | Local project | `.agentv/results/runs/<experiment>/<run-id>/index.jsonl` | Result rows appended as test cases finish. Rows use the normal snake_case result JSONL format. |
 | Results repo remote | `agentv/inflight/<hostname>/<run-dir-basename>` | A forced-updated branch containing the checkpointed run under `.agentv/results/runs/<same-relative-run-path>/`. |
-| Results repo storage branch | Configured `results.branch`, or the repo default branch | The final published run after `agentv eval` completes and the normal auto-export succeeds. |
+| Results repo storage branch | Configured `results.branch`; `repo_path` configs default to `agentv/results/v1` | The final published run after `agentv eval` completes and the normal auto-export succeeds. |
 
 The WIP branch name is derived from the current host and the run directory basename. Non-branch-safe characters are replaced with `-`; the host component is capped at 40 characters and the run component at 60 characters.
 
 ## Lifecycle
 
-1. **Run start** — AgentV creates the local run directory and writes the initial `benchmark.json` stub. If auto-push is enabled, it creates a temporary git worktree for a branch named `agentv/inflight/<hostname>/<run-dir-basename>`, based on the configured results storage branch when `results.branch` is set.
+1. **Run start** — AgentV creates the local run directory and writes the initial `benchmark.json` stub. If auto-push is enabled, it creates a temporary git worktree for a branch named `agentv/inflight/<hostname>/<run-dir-basename>`, based on the configured results storage branch. Missing storage branches are initialized automatically.
 2. **While running** — about every 30 seconds, AgentV copies the current run directory into the WIP worktree, amends a single checkpoint commit, and force-pushes the WIP branch. If nothing changed, it skips the push.
 3. **Successful completion** — AgentV publishes the completed run to the normal results branch. After that publish is confirmed as `published` or `already_published`, it deletes the remote WIP branch.
 4. **Failure, interrupt, or final export failure** — AgentV stops the checkpoint loop and removes the temporary local worktree, but leaves the remote WIP branch intact for recovery.
@@ -87,7 +87,7 @@ git push origin --delete agentv/inflight/<hostname>/<run-dir-basename>
 - The WIP branch is force-pushed and keeps one snapshot commit. Do not treat it as an audit log.
 - Checkpoint contents can include prompts, outputs, grader evidence, traces, and generated task bundles. Protect the results repo like any other eval artifact store.
 - Authentication and branch permissions are the same as normal results auto-push. If git or GitHub authentication is missing, AgentV warns and keeps evaluating locally.
-- If `results.branch` is configured, create that remote storage branch before running evals. WIP worktrees are based on it.
+- WIP worktrees are based on the configured storage branch. Missing storage branches are initialized automatically; missing remotes or authentication still prevent WIP pushes until Git credentials are available.
 - Failed or interrupted runs intentionally leave WIP branches behind. Periodically delete old `agentv/inflight/...` branches once recovered or obsolete.
 
 See also: [Resume an Interrupted Run](/docs/evaluation/running-evals/#resume-an-interrupted-run), [Results](/docs/tools/results/), and [Dashboard Remote Results](/docs/tools/dashboard/#remote-results).

--- a/packages/core/src/evaluation/loaders/config-loader.ts
+++ b/packages/core/src/evaluation/loaders/config-loader.ts
@@ -38,13 +38,23 @@ export type ExecutionDefaults = {
 };
 
 export type ResultsConfig = {
-  readonly mode: 'github';
-  readonly repo: string;
+  readonly mode?: 'github';
+  /** Legacy shorthand or Git remote URL for a managed results clone. */
+  readonly repo?: string;
+  /** Git remote URL for a managed results clone. Preferred in YAML wire config. */
+  readonly repo_url?: string;
+  /** Local Git repository path. `.` means the current project/source repository. */
+  readonly repo_path?: string;
   /** Optional remote branch used as the canonical git-backed results store. */
   readonly branch?: string;
+  readonly remote?: string;
   /** Local filesystem path for the results clone. Optional; defaults to ~/.agentv/results/<slug>/. */
   readonly path?: string;
   readonly auto_push?: boolean;
+  readonly sync?: {
+    readonly auto_push?: boolean;
+    readonly require_push?: boolean;
+  };
   readonly branch_prefix?: string;
 };
 
@@ -601,14 +611,21 @@ export function parseResultsConfig(raw: unknown, configPath: string): ResultsCon
 
   const obj = raw as Record<string, unknown>;
 
-  if (obj.mode !== 'github') {
+  if (obj.mode !== undefined && obj.mode !== 'github') {
     logWarning(`Invalid results.mode in ${configPath}, expected 'github'`);
     return undefined;
   }
 
-  const repo = typeof obj.repo === 'string' ? obj.repo.trim() : '';
-  if (!repo) {
-    logWarning(`Invalid results.repo in ${configPath}, expected non-empty string`);
+  const legacyRepo = typeof obj.repo === 'string' ? obj.repo.trim() : '';
+  const repoUrl = typeof obj.repo_url === 'string' ? obj.repo_url.trim() : '';
+  const repoPath = typeof obj.repo_path === 'string' ? obj.repo_path.trim() : '';
+  const repo = legacyRepo || repoUrl;
+  if (!repo && !repoPath) {
+    logWarning(`Invalid results in ${configPath}, expected repo_url/repo or repo_path`);
+    return undefined;
+  }
+  if (repo && repoPath) {
+    logWarning(`Invalid results in ${configPath}, set only one of repo_url/repo or repo_path`);
     return undefined;
   }
 
@@ -619,6 +636,15 @@ export function parseResultsConfig(raw: unknown, configPath: string): ResultsCon
       return undefined;
     }
     branch = obj.branch.trim();
+  }
+
+  let remote: string | undefined;
+  if (obj.remote !== undefined) {
+    if (typeof obj.remote !== 'string' || obj.remote.trim().length === 0) {
+      logWarning(`Invalid results.remote in ${configPath}, expected non-empty string`);
+      return undefined;
+    }
+    remote = obj.remote.trim();
   }
 
   let resultsPath: string | undefined;
@@ -642,6 +668,27 @@ export function parseResultsConfig(raw: unknown, configPath: string): ResultsCon
     return undefined;
   }
 
+  let sync: ResultsConfig['sync'];
+  if (obj.sync !== undefined) {
+    if (typeof obj.sync !== 'object' || obj.sync === null || Array.isArray(obj.sync)) {
+      logWarning(`Invalid results.sync in ${configPath}, expected object`);
+      return undefined;
+    }
+    const syncObj = obj.sync as Record<string, unknown>;
+    if (syncObj.auto_push !== undefined && typeof syncObj.auto_push !== 'boolean') {
+      logWarning(`Invalid results.sync.auto_push in ${configPath}, expected boolean`);
+      return undefined;
+    }
+    if (syncObj.require_push !== undefined && typeof syncObj.require_push !== 'boolean') {
+      logWarning(`Invalid results.sync.require_push in ${configPath}, expected boolean`);
+      return undefined;
+    }
+    sync = {
+      ...(typeof syncObj.auto_push === 'boolean' && { auto_push: syncObj.auto_push }),
+      ...(typeof syncObj.require_push === 'boolean' && { require_push: syncObj.require_push }),
+    };
+  }
+
   let branchPrefix: string | undefined;
   if (obj.branch_prefix !== undefined) {
     if (typeof obj.branch_prefix !== 'string' || obj.branch_prefix.trim().length === 0) {
@@ -653,10 +700,14 @@ export function parseResultsConfig(raw: unknown, configPath: string): ResultsCon
 
   return {
     mode: 'github',
-    repo,
+    ...(repo && { repo }),
+    ...(repoUrl && { repo_url: repoUrl }),
+    ...(repoPath && { repo_path: repoPath }),
     ...(branch !== undefined && { branch }),
+    ...(remote !== undefined && { remote }),
     ...(resultsPath !== undefined && { path: resultsPath }),
     ...(typeof obj.auto_push === 'boolean' && { auto_push: obj.auto_push }),
+    ...(sync && { sync }),
     ...(branchPrefix && { branch_prefix: branchPrefix }),
   };
 }

--- a/packages/core/src/evaluation/results-repo.ts
+++ b/packages/core/src/evaluation/results-repo.ts
@@ -8,7 +8,7 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import { cp, mkdtemp, readdir, rm, stat } from 'node:fs/promises';
+import { cp, lstat, mkdtemp, readdir, rm, stat } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -21,6 +21,8 @@ const RESULTS_REPO_RESULTS_DIR = '.agentv/results';
 const RESULTS_REPO_RUNS_DIR = `${RESULTS_REPO_RESULTS_DIR}/runs`;
 const RESULTS_REPO_COMMIT_EMAIL = 'agentv@results-repo';
 const RESULTS_REPO_COMMIT_NAME = 'AgentV Results';
+export const DEFAULT_RESULTS_BRANCH = 'agentv/results/v1';
+const GIT_EMPTY_TREE = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
 
 export interface ResultsRepoLocalPaths {
   readonly rootDir: string;
@@ -42,8 +44,10 @@ export interface ResultsRepoStatus {
   readonly configured: boolean;
   readonly available: boolean;
   readonly repo?: string;
+  readonly repo_path?: string;
   readonly path?: string;
   readonly auto_push?: boolean;
+  readonly require_push?: boolean;
   readonly branch_prefix?: string;
   readonly local_dir?: string;
   readonly last_synced_at?: string;
@@ -67,11 +71,17 @@ export interface ResultsRepoStatus {
 export interface NormalizedResultsConfig {
   readonly mode: 'github';
   readonly repo: string;
+  readonly repo_url?: string;
+  readonly repo_path?: string;
   readonly branch?: string;
+  readonly remote: string;
   readonly path: string;
   readonly auto_push: boolean;
+  readonly require_push: boolean;
   readonly branch_prefix: string;
 }
+
+type StorageBranchResultsConfig = NormalizedResultsConfig & { readonly branch: string };
 
 export interface CheckedOutResultsRepoBranch {
   readonly branchName: string;
@@ -127,18 +137,35 @@ function expandHome(p: string): string {
   return p;
 }
 
-export function normalizeResultsConfig(config: ResultsConfig): NormalizedResultsConfig {
-  const repo = config.repo.trim();
-  const branch = config.branch?.trim();
+export function normalizeResultsConfig(
+  config: ResultsConfig,
+  options?: { baseDir?: string },
+): NormalizedResultsConfig {
+  const repoUrl = (config.repo_url ?? config.repo)?.trim();
+  const repoPath = config.repo_path?.trim();
+  const repo = repoUrl ?? repoPath ?? '';
+  const branch = config.branch?.trim() || (repoPath ? DEFAULT_RESULTS_BRANCH : undefined);
+  const remote = config.remote?.trim() || 'origin';
+  const autoPush = config.sync?.auto_push ?? config.auto_push === true;
+  const requirePush = config.sync?.require_push === true;
+  const resolvedRepoPath = repoPath
+    ? path.resolve(options?.baseDir ?? process.cwd(), expandHome(repoPath))
+    : undefined;
   const resolvedPath = config.path
     ? expandHome(config.path.trim())
-    : path.join(getAgentvDataDir(), 'results', sanitizeRepoSlug(repo));
+    : repoUrl
+      ? path.join(getAgentvDataDir(), 'results', sanitizeRepoSlug(repoUrl))
+      : (resolvedRepoPath ?? path.join(getAgentvDataDir(), 'results', sanitizeRepoSlug(repo)));
   return {
     mode: 'github',
     repo,
+    ...(repoUrl ? { repo_url: repoUrl } : {}),
+    ...(resolvedRepoPath ? { repo_path: resolvedRepoPath } : {}),
     ...(branch ? { branch } : {}),
+    remote,
     path: resolvedPath,
-    auto_push: config.auto_push === true,
+    auto_push: autoPush,
+    require_push: requirePush,
     branch_prefix: config.branch_prefix?.trim() || 'eval-results',
   };
 }
@@ -206,14 +233,15 @@ function getGitEnv(): NodeJS.ProcessEnv {
       env[key] = value;
     }
   }
+  env.GIT_TERMINAL_PROMPT = '0';
   return env;
 }
 
 async function runGit(
   args: readonly string[],
-  options?: { cwd?: string; check?: boolean },
+  options?: { cwd?: string; check?: boolean; env?: NodeJS.ProcessEnv },
 ): Promise<{ stdout: string; stderr: string }> {
-  return runCommand('git', args, { ...options, env: getGitEnv() });
+  return runCommand('git', args, { ...options, env: { ...getGitEnv(), ...options?.env } });
 }
 
 async function runGh(
@@ -252,47 +280,44 @@ async function resolveDefaultBranch(repoDir: string): Promise<string> {
   return 'main';
 }
 
-async function fetchResultsRepo(repoDir: string): Promise<void> {
-  await runGit(['fetch', 'origin', '--prune'], { cwd: repoDir });
+async function fetchResultsRepo(repoDir: string, remote = 'origin'): Promise<void> {
+  await runGit(['fetch', remote, '--prune'], { cwd: repoDir });
 }
 
-function remoteBranchRef(branch: string): string {
-  return `origin/${branch}`;
+function remoteBranchRef(branch: string, remote = 'origin'): string {
+  return `${remote}/${branch}`;
 }
 
-function missingConfiguredBranchError(config: NormalizedResultsConfig): Error {
-  const branch = config.branch ?? '<unknown>';
-  return new Error(
-    [
-      `Results repo remote branch '${branch}' does not exist in ${config.repo}.`,
-      'Create the storage branch once, then retry. Example:',
-      `  git clone ${resolveResultsRepoUrl(config.repo)} /tmp/agentv-results-init`,
-      '  cd /tmp/agentv-results-init',
-      `  git switch --orphan ${branch}`,
-      '  git rm -rf .',
-      '  git commit --allow-empty -m "chore(results): initialize AgentV results branch"',
-      `  git push origin HEAD:${branch}`,
-    ].join('\n'),
-  );
+async function gitRefExists(repoDir: string, ref: string): Promise<boolean> {
+  const { stdout } = await runGit(['rev-parse', '--verify', `${ref}^{commit}`], {
+    cwd: repoDir,
+    check: false,
+  });
+  return stdout.trim().length > 0;
 }
 
-async function assertConfiguredResultsBranchExists(
+async function configuredResultsBranchRef(
   repoDir: string,
   config: NormalizedResultsConfig,
 ): Promise<string | undefined> {
   if (!config.branch) {
     return undefined;
   }
-
-  const ref = remoteBranchRef(config.branch);
-  const { stdout } = await runGit(['rev-parse', '--verify', `${ref}^{commit}`], {
-    cwd: repoDir,
-    check: false,
-  });
-  if (!stdout.trim()) {
-    throw missingConfiguredBranchError(config);
+  const remoteRef = remoteBranchRef(config.branch, config.remote);
+  if (await gitRefExists(repoDir, remoteRef)) {
+    return remoteRef;
   }
-  return ref;
+  if (await gitRefExists(repoDir, config.branch)) {
+    return config.branch;
+  }
+  return undefined;
+}
+
+async function assertConfiguredResultsBranchExists(
+  repoDir: string,
+  config: NormalizedResultsConfig,
+): Promise<string | undefined> {
+  return configuredResultsBranchRef(repoDir, config);
 }
 
 async function localBranchExists(repoDir: string, branch: string): Promise<boolean> {
@@ -307,25 +332,42 @@ async function checkoutConfiguredResultsBranch(
   repoDir: string,
   config: NormalizedResultsConfig,
 ): Promise<string | undefined> {
+  const branch = config.branch;
+  if (!branch) {
+    return undefined;
+  }
   const remoteRef = await assertConfiguredResultsBranchExists(repoDir, config);
-  if (!config.branch || !remoteRef) {
+  if (!remoteRef) {
+    await createOrphanResultsBranch(repoDir, branch);
+    await runGit(['checkout', branch], { cwd: repoDir });
     return undefined;
   }
 
   const currentBranch = await getCurrentBranch(repoDir);
-  if (currentBranch !== config.branch) {
-    if (await localBranchExists(repoDir, config.branch)) {
-      await runGit(['checkout', config.branch], { cwd: repoDir });
+  if (currentBranch !== branch) {
+    if (await localBranchExists(repoDir, branch)) {
+      await runGit(['checkout', branch], { cwd: repoDir });
     } else {
-      await runGit(['checkout', '--track', '-b', config.branch, remoteRef], { cwd: repoDir });
+      await runGit(['checkout', '--track', '-b', branch, remoteRef], { cwd: repoDir });
     }
   }
-  await runGit(['branch', '--set-upstream-to', remoteRef, config.branch], {
-    cwd: repoDir,
-    check: false,
-  });
+  if (remoteRef === remoteBranchRef(branch, config.remote)) {
+    await runGit(['branch', '--set-upstream-to', remoteRef, branch], {
+      cwd: repoDir,
+      check: false,
+    });
+  }
 
   return remoteRef;
+}
+
+async function createOrphanResultsBranch(repoDir: string, branch: string): Promise<void> {
+  await ensureResultsRepoCommitIdentity(repoDir);
+  const { stdout } = await runGit(
+    ['commit-tree', GIT_EMPTY_TREE, '-m', 'chore(results): initialize AgentV results branch'],
+    { cwd: repoDir },
+  );
+  await runGit(['update-ref', `refs/heads/${branch}`, stdout.trim()], { cwd: repoDir });
 }
 
 async function isGitRepository(repoDir: string): Promise<boolean> {
@@ -337,8 +379,18 @@ async function isGitRepository(repoDir: string): Promise<boolean> {
   }
 }
 
-function updateStatusFile(config: ResultsConfig, patch: PersistedStatus): void {
-  const cachePaths = getResultsRepoLocalPaths(config.repo);
+async function resolveGitTopLevel(repoDir: string): Promise<string> {
+  const { stdout } = await runGit(['rev-parse', '--show-toplevel'], { cwd: repoDir });
+  return stdout.trim() || repoDir;
+}
+
+function updateStatusFile(
+  config: ResultsConfig | NormalizedResultsConfig,
+  patch: PersistedStatus,
+): void {
+  const repo =
+    typeof config.repo === 'string' ? config.repo : (config.repo_url ?? config.repo_path ?? '');
+  const cachePaths = getResultsRepoLocalPaths(repo);
   const current = readPersistedStatus(cachePaths.statusFile);
   writePersistedStatus(cachePaths.statusFile, {
     ...current,
@@ -348,6 +400,13 @@ function updateStatusFile(config: ResultsConfig, patch: PersistedStatus): void {
 
 export async function ensureResultsRepoClone(config: ResultsConfig): Promise<string> {
   const normalized = normalizeResultsConfig(config);
+  if (normalized.repo_path) {
+    if (!(await isGitRepository(normalized.repo_path))) {
+      throw new Error(`Results repo_path is not a git repository: ${normalized.repo_path}`);
+    }
+    return resolveGitTopLevel(normalized.repo_path);
+  }
+
   const cachePaths = getResultsRepoLocalPaths(normalized.repo);
   const cloneDir = normalized.path;
   mkdirSync(cachePaths.rootDir, { recursive: true });
@@ -362,7 +421,7 @@ export async function ensureResultsRepoClone(config: ResultsConfig): Promise<str
       await runGit([
         'clone',
         '--filter=blob:none',
-        resolveResultsRepoUrl(normalized.repo),
+        resolveResultsRepoUrl(normalized.repo_url ?? normalized.repo),
         cloneDir,
       ]);
       return cloneDir;
@@ -398,8 +457,10 @@ export function getResultsRepoStatus(config?: ResultsConfig): ResultsRepoStatus 
     configured: true,
     available: existsSync(normalized.path),
     repo: normalized.repo,
+    ...(normalized.repo_path !== undefined && { repo_path: normalized.repo_path }),
     path: normalized.path,
     auto_push: normalized.auto_push,
+    require_push: normalized.require_push,
     branch_prefix: normalized.branch_prefix,
     local_dir: normalized.path,
     last_synced_at: persisted.last_synced_at,
@@ -468,7 +529,7 @@ async function resolveComparisonRef(
   }
 
   const baseBranch = await resolveDefaultBranch(repoDir);
-  const fallback = `origin/${baseBranch}`;
+  const fallback = `${config?.remote ?? 'origin'}/${baseBranch}`;
   const { stdout: fallbackSha } = await runGit(['rev-parse', '--verify', fallback], {
     cwd: repoDir,
     check: false,
@@ -495,6 +556,71 @@ async function getAheadBehind(
   return {
     ...(Number.isFinite(ahead) && { ahead }),
     ...(Number.isFinite(behind) && { behind }),
+  };
+}
+
+async function getAheadBehindForRefs(
+  repoDir: string,
+  leftRef: string,
+  rightRef: string,
+): Promise<{ ahead?: number; behind?: number }> {
+  const { stdout } = await runGit(
+    ['rev-list', '--left-right', '--count', `${leftRef}...${rightRef}`],
+    {
+      cwd: repoDir,
+      check: false,
+    },
+  );
+  const [aheadText, behindText] = stdout.trim().split(/\s+/);
+  const ahead = Number.parseInt(aheadText ?? '', 10);
+  const behind = Number.parseInt(behindText ?? '', 10);
+
+  return {
+    ...(Number.isFinite(ahead) && { ahead }),
+    ...(Number.isFinite(behind) && { behind }),
+  };
+}
+
+async function inspectResultsStorageBranchGit(
+  repoDir: string,
+  config: NormalizedResultsConfig,
+): Promise<ResultsRepoGitInspection> {
+  if (!config.branch) {
+    return {
+      syncStatus: 'clean',
+      dirtyPaths: [],
+      conflictedPaths: [],
+    };
+  }
+  const localRef = `refs/heads/${config.branch}`;
+  const upstream = remoteBranchRef(config.branch, config.remote);
+  const localExists = await gitRefExists(repoDir, localRef);
+  const remoteExists = await gitRefExists(repoDir, upstream);
+  const { ahead = 0, behind = 0 } =
+    localExists && remoteExists
+      ? await getAheadBehindForRefs(repoDir, localRef, upstream)
+      : {
+          ahead: localExists && !remoteExists ? 1 : 0,
+          behind: !localExists && remoteExists ? 1 : 0,
+        };
+
+  let syncStatus: ResultsRepoSyncStatus = 'clean';
+  if (ahead > 0 && behind > 0) {
+    syncStatus = 'diverged';
+  } else if (behind > 0) {
+    syncStatus = 'behind';
+  } else if (ahead > 0) {
+    syncStatus = 'ahead';
+  }
+
+  return {
+    syncStatus,
+    branch: config.branch,
+    ...(remoteExists && { upstream }),
+    ahead,
+    behind,
+    dirtyPaths: [],
+    conflictedPaths: [],
   };
 }
 
@@ -671,11 +797,12 @@ function areSafeResultsRepoPaths(paths: readonly string[]): boolean {
 async function getAheadPaths(
   repoDir: string,
   upstream: string | undefined,
+  branch = 'HEAD',
 ): Promise<readonly string[]> {
   if (!upstream) {
     return [];
   }
-  const { stdout } = await runGit(['diff', '--name-only', `${upstream}..HEAD`], {
+  const { stdout } = await runGit(['diff', '--name-only', `${upstream}..${branch}`], {
     cwd: repoDir,
     check: false,
   });
@@ -686,8 +813,13 @@ async function getAheadPaths(
     .sort();
 }
 
-function getPushTargetBranch(upstream: string | undefined, baseBranch: string): string {
-  return upstream?.startsWith('origin/') ? upstream.slice('origin/'.length) : baseBranch;
+function getPushTargetBranch(
+  upstream: string | undefined,
+  baseBranch: string,
+  remote = 'origin',
+): string {
+  const prefix = `${remote}/`;
+  return upstream?.startsWith(prefix) ? upstream.slice(prefix.length) : baseBranch;
 }
 
 async function statusFromInspection(
@@ -722,8 +854,15 @@ export async function getResultsRepoSyncStatus(config?: ResultsConfig): Promise<
   }
 
   try {
+    if (normalized.repo_path) {
+      await fetchResultsRepo(normalized.path, normalized.remote).catch(() => undefined);
+      return withGitInspection(
+        baseStatus,
+        await inspectResultsStorageBranchGit(normalized.path, normalized),
+      );
+    }
     if (normalized.branch) {
-      await fetchResultsRepo(normalized.path);
+      await fetchResultsRepo(normalized.path, normalized.remote).catch(() => undefined);
       await checkoutConfiguredResultsBranch(normalized.path, normalized);
     }
     return withGitInspection(baseStatus, await inspectResultsRepoGit(normalized.path, normalized));
@@ -742,8 +881,10 @@ export async function syncResultsRepo(config: ResultsConfig): Promise<ResultsRep
 
   try {
     const repoDir = await ensureResultsRepoClone(normalized);
-    await fetchResultsRepo(repoDir);
-    await checkoutConfiguredResultsBranch(repoDir, normalized);
+    await fetchResultsRepo(repoDir, normalized.remote);
+    if (!normalized.repo_path) {
+      await checkoutConfiguredResultsBranch(repoDir, normalized);
+    }
     updateStatusFile(normalized, {
       last_synced_at: new Date().toISOString(),
       last_error: undefined,
@@ -781,7 +922,59 @@ export async function syncResultsRepoForProject(config: ResultsConfig): Promise<
 
   try {
     const repoDir = await ensureResultsRepoClone(normalized);
-    await fetchResultsRepo(repoDir);
+    if (normalized.repo_path) {
+      try {
+        await fetchResultsRepo(repoDir, normalized.remote);
+      } catch (error) {
+        if (normalized.require_push) {
+          throw error;
+        }
+      }
+      if (normalized.auto_push || normalized.require_push) {
+        if (normalized.branch) {
+          const localRef = `refs/heads/${normalized.branch}`;
+          if (await gitRefExists(repoDir, localRef)) {
+            try {
+              await runGit(
+                [
+                  'push',
+                  '--porcelain',
+                  normalized.remote,
+                  `${localRef}:refs/heads/${normalized.branch}`,
+                ],
+                { cwd: repoDir },
+              );
+              pushPerformed = true;
+            } catch (error) {
+              updateStatusFile(normalized, { last_error: getStatusMessage(error) });
+              if (normalized.require_push) {
+                throw error;
+              }
+              const status = await getResultsRepoSyncStatus(normalized);
+              return withBlockedStatus(
+                status,
+                `Results repo push was rejected: ${getStatusMessage(error)}`,
+                {
+                  pullPerformed,
+                  pushPerformed,
+                  commitCreated,
+                },
+              );
+            }
+          }
+        }
+      }
+      updateStatusFile(normalized, {
+        last_synced_at: new Date().toISOString(),
+        last_error: undefined,
+      });
+      return withActionFlags(await getResultsRepoSyncStatus(normalized), {
+        pullPerformed,
+        pushPerformed,
+        commitCreated,
+      });
+    }
+    await fetchResultsRepo(repoDir, normalized.remote);
     await checkoutConfiguredResultsBranch(repoDir, normalized);
     let inspection = await inspectResultsRepoGit(repoDir, normalized);
 
@@ -931,14 +1124,14 @@ export async function syncResultsRepoForProject(config: ResultsConfig): Promise<
       }
 
       const baseBranch = normalized.branch ?? (await resolveDefaultBranch(repoDir));
-      const targetBranch = getPushTargetBranch(inspection.upstream, baseBranch);
+      const targetBranch = getPushTargetBranch(inspection.upstream, baseBranch, normalized.remote);
       try {
-        await runGit(['push', 'origin', `HEAD:${targetBranch}`], { cwd: repoDir });
+        await runGit(['push', normalized.remote, `HEAD:${targetBranch}`], { cwd: repoDir });
         pushPerformed = true;
-        await fetchResultsRepo(repoDir);
+        await fetchResultsRepo(repoDir, normalized.remote);
         inspection = await inspectResultsRepoGit(repoDir, normalized);
       } catch (error) {
-        await fetchResultsRepo(repoDir).catch(() => undefined);
+        await fetchResultsRepo(repoDir, normalized.remote).catch(() => undefined);
         inspection = await inspectResultsRepoGit(repoDir, normalized);
         const status = withGitInspection(getResultsRepoStatus(normalized), inspection);
         const reason = `Results repo push was rejected: ${getStatusMessage(error)}`;
@@ -978,8 +1171,10 @@ export async function checkoutResultsRepoBranch(
   const normalized = normalizeResultsConfig(config);
   const repoDir = await ensureResultsRepoClone(normalized);
   const baseBranch = await resolveDefaultBranch(repoDir);
-  await fetchResultsRepo(repoDir);
-  await runGit(['checkout', '-B', branchName, `origin/${baseBranch}`], { cwd: repoDir });
+  await fetchResultsRepo(repoDir, normalized.remote);
+  await runGit(['checkout', '-B', branchName, `${normalized.remote}/${baseBranch}`], {
+    cwd: repoDir,
+  });
   updateStatusFile(normalized, { last_error: undefined });
   return {
     branchName,
@@ -995,13 +1190,16 @@ export async function prepareResultsRepoBranch(
   const normalized = normalizeResultsConfig(config);
   const cloneDir = await ensureResultsRepoClone(normalized);
   const baseBranch = await resolveDefaultBranch(cloneDir);
-  await fetchResultsRepo(cloneDir);
+  await fetchResultsRepo(cloneDir, normalized.remote);
 
   const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), 'agentv-results-repo-'));
   const worktreeDir = path.join(worktreeRoot, 'repo');
-  await runGit(['worktree', 'add', '-B', branchName, worktreeDir, `origin/${baseBranch}`], {
-    cwd: cloneDir,
-  });
+  await runGit(
+    ['worktree', 'add', '-B', branchName, worktreeDir, `${normalized.remote}/${baseBranch}`],
+    {
+      cwd: cloneDir,
+    },
+  );
 
   return {
     branchName,
@@ -1072,7 +1270,7 @@ export async function pushResultsRepoBranch(
   cwd?: string,
 ): Promise<void> {
   const normalized = normalizeResultsConfig(config);
-  await runGit(['push', '-u', 'origin', branchName], {
+  await runGit(['push', '-u', normalized.remote, branchName], {
     cwd: cwd ?? normalized.path,
   });
   updateStatusFile(normalized, {
@@ -1112,33 +1310,330 @@ export async function createDraftResultsPr(params: {
 
 const DIRECT_PUSH_MAX_RETRIES = 3;
 
-async function hasUnpushedCommits(repoDir: string, upstreamRef: string): Promise<boolean> {
-  const { stdout } = await runGit(['rev-list', '--count', `${upstreamRef}..HEAD`], {
+async function hasUnpushedCommits(
+  repoDir: string,
+  upstreamRef: string,
+  branch: string,
+): Promise<boolean> {
+  const { stdout } = await runGit(['rev-list', '--count', `${upstreamRef}..refs/heads/${branch}`], {
     cwd: repoDir,
     check: false,
   });
   return Number.parseInt(stdout.trim(), 10) > 0;
 }
 
+async function countUnpushedCommits(
+  repoDir: string,
+  upstreamRef: string,
+  branch: string,
+): Promise<number> {
+  const { stdout } = await runGit(['rev-list', '--count', `${upstreamRef}..refs/heads/${branch}`], {
+    cwd: repoDir,
+    check: false,
+  });
+  const count = Number.parseInt(stdout.trim(), 10);
+  return Number.isFinite(count) ? count : 0;
+}
+
+async function assertValidResultsBranchName(repoDir: string, branch: string): Promise<void> {
+  if (
+    branch.length === 0 ||
+    branch.includes('..') ||
+    branch.startsWith('/') ||
+    branch.endsWith('/') ||
+    branch.endsWith('.lock') ||
+    [...branch].some((char) => {
+      const code = char.charCodeAt(0);
+      return code <= 31 || code === 127;
+    })
+  ) {
+    throw new Error(`Invalid results branch name: ${branch}`);
+  }
+  await runGit(['check-ref-format', '--branch', branch], { cwd: repoDir });
+}
+
+function normalizeDestinationPath(destinationPath: string): string {
+  const normalized = destinationPath.split(path.sep).join('/');
+  const segments = normalized.split('/').filter(Boolean);
+  if (
+    segments.length === 0 ||
+    normalized.startsWith('/') ||
+    segments.some((segment) => segment === '..')
+  ) {
+    throw new Error(`Invalid results destination path: ${destinationPath}`);
+  }
+  return segments.join('/');
+}
+
+async function listSourceFiles(sourceDir: string): Promise<string[]> {
+  const entries: string[] = [];
+  async function visit(dir: string): Promise<void> {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const absolutePath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await visit(absolutePath);
+      } else if (entry.isFile() || entry.isSymbolicLink()) {
+        entries.push(absolutePath);
+      }
+    }
+  }
+  await visit(sourceDir);
+  entries.sort();
+  return entries;
+}
+
+async function getExistingRunTreePaths(
+  repoDir: string,
+  ref: string | undefined,
+  destinationTreePath: string,
+): Promise<string[]> {
+  if (!ref) {
+    return [];
+  }
+  const { stdout } = await runGit(['ls-tree', '-r', '--name-only', ref, destinationTreePath], {
+    cwd: repoDir,
+    check: false,
+  });
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+async function resolveStorageBranchBase(params: {
+  readonly repoDir: string;
+  readonly normalized: StorageBranchResultsConfig;
+  readonly preferRemote?: boolean;
+}): Promise<{
+  readonly baseRef?: string;
+  readonly baseCommit?: string;
+  readonly baseTree?: string;
+  readonly localRef: string;
+  readonly localExists: boolean;
+  readonly remoteRef: string;
+  readonly remoteExists: boolean;
+}> {
+  const localRef = `refs/heads/${params.normalized.branch}`;
+  const remoteRef = `refs/remotes/${params.normalized.remote}/${params.normalized.branch}`;
+  const localExists = await gitRefExists(params.repoDir, localRef);
+  const remoteExists = await gitRefExists(params.repoDir, remoteRef);
+  const baseRef = params.preferRemote
+    ? remoteExists
+      ? remoteRef
+      : localExists
+        ? localRef
+        : undefined
+    : localExists
+      ? localRef
+      : remoteExists
+        ? remoteRef
+        : undefined;
+  const baseCommit = baseRef
+    ? (
+        await runGit(['rev-parse', `${baseRef}^{commit}`], {
+          cwd: params.repoDir,
+        })
+      ).stdout.trim()
+    : undefined;
+  const baseTree = baseRef
+    ? (
+        await runGit(['rev-parse', `${baseRef}^{tree}`], {
+          cwd: params.repoDir,
+        })
+      ).stdout.trim()
+    : undefined;
+  return { baseRef, baseCommit, baseTree, localRef, localExists, remoteRef, remoteExists };
+}
+
+async function ensureResultsBranchNotCheckedOut(
+  repoDir: string,
+  normalized: StorageBranchResultsConfig,
+): Promise<void> {
+  const currentBranch = await getCurrentBranch(repoDir);
+  if (currentBranch !== normalized.branch) {
+    return;
+  }
+  if (normalized.repo_path) {
+    throw new Error(
+      `Refusing to publish results while '${normalized.branch}' is checked out in ${repoDir}`,
+    );
+  }
+  await runGit(['checkout', '--detach'], { cwd: repoDir });
+}
+
+async function commitResultsRunWithTemporaryIndex(params: {
+  readonly normalized: StorageBranchResultsConfig;
+  readonly repoDir: string;
+  readonly sourceDir: string;
+  readonly destinationPath: string;
+  readonly commitMessage: string;
+  readonly targetRunId: string;
+  readonly preferRemoteBase?: boolean;
+}): Promise<{
+  readonly commitCreated: boolean;
+  readonly branchUpdated: boolean;
+  readonly upstreamRef?: string;
+}> {
+  const { normalized } = params;
+  await assertValidResultsBranchName(params.repoDir, normalized.branch);
+  await ensureResultsBranchNotCheckedOut(params.repoDir, normalized);
+
+  const destinationRunPath = normalizeDestinationPath(params.destinationPath);
+  const destinationTreePath = path.posix.join(RESULTS_REPO_RUNS_DIR, destinationRunPath);
+  const base = await resolveStorageBranchBase({
+    repoDir: params.repoDir,
+    normalized,
+    preferRemote: params.preferRemoteBase,
+  });
+
+  const indexRoot = await mkdtemp(path.join(os.tmpdir(), 'agentv-results-index-'));
+  const indexFile = path.join(indexRoot, 'index');
+  const indexEnv = { GIT_INDEX_FILE: indexFile };
+
+  try {
+    if (base.baseRef) {
+      await runGit(['read-tree', base.baseRef], { cwd: params.repoDir, env: indexEnv });
+    } else {
+      await runGit(['read-tree', '--empty'], { cwd: params.repoDir, env: indexEnv });
+    }
+
+    const existingPaths = await getExistingRunTreePaths(
+      params.repoDir,
+      base.baseRef,
+      destinationTreePath,
+    );
+    for (const existingPath of existingPaths) {
+      await runGit(['update-index', '--force-remove', '--', existingPath], {
+        cwd: params.repoDir,
+        env: indexEnv,
+        check: false,
+      });
+    }
+
+    const sourceFiles = await listSourceFiles(params.sourceDir);
+    for (const sourceFile of sourceFiles) {
+      const relativeFile = path.relative(params.sourceDir, sourceFile).split(path.sep).join('/');
+      const destinationFile = path.posix.join(destinationTreePath, relativeFile);
+      const fileStat = await lstat(sourceFile);
+      let mode = fileStat.mode & 0o111 ? '100755' : '100644';
+      let hashInputPath = sourceFile;
+      if (fileStat.isSymbolicLink()) {
+        mode = '120000';
+        hashInputPath = sourceFile;
+      }
+      const { stdout: blob } = await runGit(['hash-object', '-w', '--no-filters', hashInputPath], {
+        cwd: params.repoDir,
+      });
+      await runGit(
+        ['update-index', '--add', '--cacheinfo', `${mode},${blob.trim()},${destinationFile}`],
+        {
+          cwd: params.repoDir,
+          env: indexEnv,
+        },
+      );
+    }
+
+    const { stdout: newTreeStdout } = await runGit(['write-tree'], {
+      cwd: params.repoDir,
+      env: indexEnv,
+    });
+    const newTree = newTreeStdout.trim();
+    if (base.baseTree && newTree === base.baseTree) {
+      return {
+        commitCreated: false,
+        branchUpdated: false,
+        upstreamRef: base.remoteExists ? base.remoteRef : undefined,
+      };
+    }
+
+    await ensureResultsRepoCommitIdentity(params.repoDir);
+    const commitArgs = [
+      'commit-tree',
+      newTree,
+      ...(base.baseCommit ? ['-p', base.baseCommit] : []),
+      '-m',
+      params.commitMessage,
+      '-m',
+      `AgentV-Run: ${params.targetRunId}`,
+    ];
+    const { stdout: commitStdout } = await runGit(commitArgs, { cwd: params.repoDir });
+    const commitSha = commitStdout.trim();
+    await runGit(
+      [
+        'update-ref',
+        `refs/heads/${normalized.branch}`,
+        commitSha,
+        ...(base.localExists && !params.preferRemoteBase ? [base.baseCommit ?? ''] : []),
+      ].filter(Boolean),
+      { cwd: params.repoDir },
+    );
+
+    if (base.remoteExists) {
+      await runGit(['branch', '--set-upstream-to', base.remoteRef, normalized.branch], {
+        cwd: params.repoDir,
+        check: false,
+      });
+    }
+
+    return {
+      commitCreated: true,
+      branchUpdated: true,
+      upstreamRef: base.remoteExists ? base.remoteRef : undefined,
+    };
+  } finally {
+    await rm(indexRoot, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
 async function pushDirectResultsToStorageBranch(params: {
-  readonly normalized: NormalizedResultsConfig;
+  readonly normalized: StorageBranchResultsConfig;
   readonly repoDir: string;
   readonly storageBranch: string;
-  readonly upstreamRef: string;
+  readonly upstreamRef?: string;
+  readonly sourceDir: string;
+  readonly destinationPath: string;
+  readonly commitMessage: string;
+  readonly targetRunId: string;
 }): Promise<void> {
   for (let attempt = 1; attempt <= DIRECT_PUSH_MAX_RETRIES; attempt++) {
     try {
-      await runGit(['push', 'origin', `HEAD:${params.storageBranch}`], { cwd: params.repoDir });
+      await runGit(
+        [
+          'push',
+          '--porcelain',
+          params.normalized.remote,
+          `refs/heads/${params.storageBranch}:refs/heads/${params.storageBranch}`,
+        ],
+        { cwd: params.repoDir },
+      );
       updateStatusFile(params.normalized, {
         last_synced_at: new Date().toISOString(),
         last_error: undefined,
       });
+      await fetchResultsRepo(params.repoDir, params.normalized.remote).catch(() => undefined);
       return;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (attempt < DIRECT_PUSH_MAX_RETRIES && message.includes('non-fast-forward')) {
-        await fetchResultsRepo(params.repoDir);
-        await runGit(['rebase', params.upstreamRef], { cwd: params.repoDir });
+        await fetchResultsRepo(params.repoDir, params.normalized.remote);
+        const remoteRef = remoteBranchRef(params.storageBranch, params.normalized.remote);
+        const localOnlyCount = (await gitRefExists(params.repoDir, remoteRef))
+          ? await countUnpushedCommits(params.repoDir, remoteRef, params.storageBranch)
+          : 0;
+        if (localOnlyCount > 1) {
+          throw new Error(
+            `Results branch has ${localOnlyCount} local commits and remote advanced; push manually after reconciling ${params.storageBranch}`,
+          );
+        }
+        await commitResultsRunWithTemporaryIndex({
+          normalized: params.normalized,
+          repoDir: params.repoDir,
+          sourceDir: params.sourceDir,
+          destinationPath: params.destinationPath,
+          commitMessage: params.commitMessage,
+          targetRunId: params.targetRunId,
+          preferRemoteBase: true,
+        });
       } else {
         throw error;
       }
@@ -1159,47 +1654,71 @@ export async function directPushResults(params: {
 }): Promise<boolean> {
   const normalized = normalizeResultsConfig(params.config);
   const repoDir = await ensureResultsRepoClone(normalized);
-  await fetchResultsRepo(repoDir);
-  const configuredRef = await checkoutConfiguredResultsBranch(repoDir, normalized);
+  await fetchResultsRepo(repoDir, normalized.remote).catch((error) => {
+    if (normalized.require_push) {
+      throw error;
+    }
+  });
   const storageBranch = normalized.branch ?? (await resolveDefaultBranch(repoDir));
-  const upstreamRef = configuredRef ?? remoteBranchRef(storageBranch);
+  const storageConfig: StorageBranchResultsConfig = {
+    ...normalized,
+    branch: storageBranch,
+  };
   const targetRunId = buildGitRunId(params.destinationPath);
 
-  const destinationDir = path.join(
-    repoDir,
-    RESULTS_REPO_RESULTS_DIR,
-    'runs',
-    params.destinationPath,
-  );
-  await stageResultsArtifacts({
+  const result = await commitResultsRunWithTemporaryIndex({
+    normalized: storageConfig,
     repoDir,
     sourceDir: params.sourceDir,
-    destinationDir,
+    destinationPath: params.destinationPath,
+    commitMessage: params.commitMessage,
+    targetRunId,
   });
 
-  await runGit(['add', '--all'], { cwd: repoDir });
-  const { stdout: status } = await runGit(['status', '--porcelain'], {
-    cwd: repoDir,
-    check: false,
-  });
-  if (status.trim().length === 0) {
-    if (await hasUnpushedCommits(repoDir, upstreamRef)) {
-      const aheadPaths = await getAheadPaths(repoDir, upstreamRef);
-      if (!areSafeResultsRepoPaths(aheadPaths)) {
-        throw new Error('Results repo has non-results committed changes');
+  const shouldPush = normalized.auto_push || normalized.require_push;
+  if (!shouldPush) {
+    updateStatusFile(storageConfig, { last_error: undefined });
+    return result.commitCreated;
+  }
+
+  if (!result.commitCreated) {
+    const hasUnpushed = result.upstreamRef
+      ? await hasUnpushedCommits(repoDir, result.upstreamRef, storageBranch)
+      : true;
+    if (hasUnpushed) {
+      const aheadPaths = result.upstreamRef
+        ? await getAheadPaths(repoDir, result.upstreamRef, `refs/heads/${storageBranch}`)
+        : [];
+      if (result.upstreamRef && !areSafeResultsRepoPaths(aheadPaths)) {
+        const error = new Error('Results repo has non-results committed changes');
+        updateStatusFile(storageConfig, { last_error: error.message });
+        throw error;
       }
-      await pushDirectResultsToStorageBranch({ normalized, repoDir, storageBranch, upstreamRef });
+      await pushDirectResultsToStorageBranch({
+        normalized: storageConfig,
+        repoDir,
+        storageBranch,
+        upstreamRef: result.upstreamRef,
+        sourceDir: params.sourceDir,
+        destinationPath: params.destinationPath,
+        commitMessage: params.commitMessage,
+        targetRunId,
+      });
       return true;
     }
     return false;
   }
 
-  await ensureResultsRepoCommitIdentity(repoDir);
-  await runGit(['commit', '-m', params.commitMessage, '-m', `Agentv-Run: ${targetRunId}`], {
-    cwd: repoDir,
+  await pushDirectResultsToStorageBranch({
+    normalized: storageConfig,
+    repoDir,
+    storageBranch,
+    upstreamRef: result.upstreamRef,
+    sourceDir: params.sourceDir,
+    destinationPath: params.destinationPath,
+    commitMessage: params.commitMessage,
+    targetRunId,
   });
-
-  await pushDirectResultsToStorageBranch({ normalized, repoDir, storageBranch, upstreamRef });
   return true;
 }
 
@@ -1394,6 +1913,7 @@ export interface WipWorktreeHandle {
   readonly wipBranch: string;
   readonly worktreeDir: string;
   readonly cloneDir: string;
+  readonly remote: string;
   readonly cleanup: () => Promise<void>;
 }
 
@@ -1403,12 +1923,20 @@ export async function setupWipWorktree(params: {
 }): Promise<WipWorktreeHandle> {
   const normalized = normalizeResultsConfig(params.config);
   const cloneDir = await ensureResultsRepoClone(normalized);
-  await fetchResultsRepo(cloneDir);
-  const baseRef = normalized.branch
-    ? await assertConfiguredResultsBranchExists(cloneDir, normalized)
-    : remoteBranchRef(await resolveDefaultBranch(cloneDir));
+  await fetchResultsRepo(cloneDir, normalized.remote).catch((error) => {
+    if (normalized.require_push) {
+      throw error;
+    }
+  });
+  let baseRef = normalized.branch
+    ? await configuredResultsBranchRef(cloneDir, normalized)
+    : remoteBranchRef(await resolveDefaultBranch(cloneDir), normalized.remote);
+  if (!baseRef && normalized.branch) {
+    await createOrphanResultsBranch(cloneDir, normalized.branch);
+    baseRef = normalized.branch;
+  }
   if (!baseRef) {
-    throw missingConfiguredBranchError(normalized);
+    throw new Error('Could not resolve a base ref for the WIP results branch');
   }
   const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), 'agentv-wip-'));
   const worktreeDir = path.join(worktreeRoot, 'repo');
@@ -1422,6 +1950,7 @@ export async function setupWipWorktree(params: {
     wipBranch: params.wipBranch,
     worktreeDir,
     cloneDir,
+    remote: normalized.remote,
     cleanup: async () => {
       try {
         await runGit(['worktree', 'remove', '--force', worktreeDir], { cwd: cloneDir });
@@ -1469,7 +1998,7 @@ export async function pushWipCheckpoint(params: {
     ['commit', '--amend', '-m', `wip(results): checkpoint ${params.handle.wipBranch} ${timestamp}`],
     { cwd: params.handle.worktreeDir },
   );
-  await runGit(['push', '--force', 'origin', params.handle.wipBranch], {
+  await runGit(['push', '--force', params.handle.remote, params.handle.wipBranch], {
     cwd: params.handle.worktreeDir,
   });
   return true;
@@ -1481,7 +2010,7 @@ export async function deleteWipBranch(params: {
 }): Promise<void> {
   const normalized = normalizeResultsConfig(params.config);
   const cloneDir = await ensureResultsRepoClone(normalized);
-  await runGit(['push', 'origin', '--delete', params.wipBranch], { cwd: cloneDir });
+  await runGit(['push', normalized.remote, '--delete', params.wipBranch], { cwd: cloneDir });
 }
 
 export async function listGitRuns(repoDir: string, ref = 'origin/main'): Promise<GitListedRun[]> {

--- a/packages/core/src/evaluation/validation/config-validator.ts
+++ b/packages/core/src/evaluation/validation/config-validator.ts
@@ -284,7 +284,27 @@ function validateProjectResultsConfig(
     }
   }
 
-  validateGitRemoteUrl(errors, filePath, resultsRecord.repo_url, `${location}.repo_url`);
+  const hasRepoUrl = resultsRecord.repo_url !== undefined;
+  const hasRepoPath = resultsRecord.repo_path !== undefined;
+  if (hasRepoUrl && hasRepoPath) {
+    errors.push({
+      severity: 'error',
+      filePath,
+      location,
+      message: `Field '${location}' must set only one of repo_url or repo_path`,
+    });
+  } else if (hasRepoUrl) {
+    validateGitRemoteUrl(errors, filePath, resultsRecord.repo_url, `${location}.repo_url`);
+  } else if (hasRepoPath) {
+    validateRequiredString(errors, filePath, resultsRecord.repo_path, `${location}.repo_path`);
+  } else {
+    errors.push({
+      severity: 'error',
+      filePath,
+      location,
+      message: `Field '${location}' must set repo_url or repo_path`,
+    });
+  }
 
   if (
     resultsRecord.branch !== undefined &&
@@ -295,6 +315,18 @@ function validateProjectResultsConfig(
       filePath,
       location: `${location}.branch`,
       message: `Field '${location}.branch' must be a non-empty string`,
+    });
+  }
+
+  if (
+    resultsRecord.remote !== undefined &&
+    (typeof resultsRecord.remote !== 'string' || resultsRecord.remote.trim().length === 0)
+  ) {
+    errors.push({
+      severity: 'error',
+      filePath,
+      location: `${location}.remote`,
+      message: `Field '${location}.remote' must be a non-empty string`,
     });
   }
 
@@ -338,6 +370,14 @@ function validateProjectResultsConfig(
           message: `Field '${location}.sync.auto_push' must be a boolean`,
         });
       }
+      if (syncRecord.require_push !== undefined && typeof syncRecord.require_push !== 'boolean') {
+        errors.push({
+          severity: 'error',
+          filePath,
+          location: `${location}.sync.require_push`,
+          message: `Field '${location}.sync.require_push' must be a boolean`,
+        });
+      }
     }
   }
 
@@ -376,7 +416,7 @@ function validateResultsConfig(
   }
 
   const resultsRecord = rawResults as Record<string, unknown>;
-  if (resultsRecord.mode !== 'github') {
+  if (resultsRecord.mode !== undefined && resultsRecord.mode !== 'github') {
     errors.push({
       severity: 'error',
       filePath,
@@ -384,7 +424,31 @@ function validateResultsConfig(
       message: `Field '${location}.mode' must be 'github'`,
     });
   }
-  validateRequiredString(errors, filePath, resultsRecord.repo, `${location}.repo`);
+  const hasLegacyRepo = resultsRecord.repo !== undefined;
+  const hasRepoUrl = resultsRecord.repo_url !== undefined;
+  const hasRepoPath = resultsRecord.repo_path !== undefined;
+  const sourceCount = [hasLegacyRepo, hasRepoUrl, hasRepoPath].filter(Boolean).length;
+  if (sourceCount === 0) {
+    errors.push({
+      severity: 'error',
+      filePath,
+      location,
+      message: `Field '${location}' must set repo_url/repo or repo_path`,
+    });
+  } else if (sourceCount > 1) {
+    errors.push({
+      severity: 'error',
+      filePath,
+      location,
+      message: `Field '${location}' must set only one of repo_url/repo or repo_path`,
+    });
+  } else if (hasLegacyRepo) {
+    validateRequiredString(errors, filePath, resultsRecord.repo, `${location}.repo`);
+  } else if (hasRepoUrl) {
+    validateGitRemoteUrl(errors, filePath, resultsRecord.repo_url, `${location}.repo_url`);
+  } else {
+    validateRequiredString(errors, filePath, resultsRecord.repo_path, `${location}.repo_path`);
+  }
 
   if (
     resultsRecord.branch !== undefined &&
@@ -395,6 +459,18 @@ function validateResultsConfig(
       filePath,
       location: `${location}.branch`,
       message: `Field '${location}.branch' must be a non-empty string`,
+    });
+  }
+
+  if (
+    resultsRecord.remote !== undefined &&
+    (typeof resultsRecord.remote !== 'string' || resultsRecord.remote.trim().length === 0)
+  ) {
+    errors.push({
+      severity: 'error',
+      filePath,
+      location: `${location}.remote`,
+      message: `Field '${location}.remote' must be a non-empty string`,
     });
   }
 
@@ -426,6 +502,39 @@ function validateResultsConfig(
       location: `${location}.auto_push`,
       message: `Field '${location}.auto_push' must be a boolean`,
     });
+  }
+
+  if (resultsRecord.sync !== undefined) {
+    if (
+      typeof resultsRecord.sync !== 'object' ||
+      resultsRecord.sync === null ||
+      Array.isArray(resultsRecord.sync)
+    ) {
+      errors.push({
+        severity: 'error',
+        filePath,
+        location: `${location}.sync`,
+        message: `Field '${location}.sync' must be an object`,
+      });
+    } else {
+      const syncRecord = resultsRecord.sync as Record<string, unknown>;
+      if (syncRecord.auto_push !== undefined && typeof syncRecord.auto_push !== 'boolean') {
+        errors.push({
+          severity: 'error',
+          filePath,
+          location: `${location}.sync.auto_push`,
+          message: `Field '${location}.sync.auto_push' must be a boolean`,
+        });
+      }
+      if (syncRecord.require_push !== undefined && typeof syncRecord.require_push !== 'boolean') {
+        errors.push({
+          severity: 'error',
+          filePath,
+          location: `${location}.sync.require_push`,
+          message: `Field '${location}.sync.require_push' must be a boolean`,
+        });
+      }
+    }
   }
 
   if (

--- a/packages/core/src/projects.ts
+++ b/packages/core/src/projects.ts
@@ -20,11 +20,13 @@
  *       path: /home/user/projects/my-app
  *       ref: main
  *       results:
- *         repo_url: git@github.com:example/my-app-results.git
- *         branch: agentv-results
+ *         repo_path: .
+ *         branch: agentv/results/v1
+ *         remote: origin
  *         path: /srv/agentv/results/my-app
  *         sync:
  *           auto_push: true
+ *           require_push: false
  *       added_at: "2026-03-20T10:00:00Z"
  *       last_opened_at: "2026-03-30T14:00:00Z"
  *
@@ -59,11 +61,14 @@ import { getAgentvConfigDir } from './paths.js';
 
 export interface ProjectResultsSyncConfig {
   autoPush?: boolean;
+  requirePush?: boolean;
 }
 
 export interface ProjectResultsConfig {
-  repoUrl: string;
+  repoUrl?: string;
+  repoPath?: string;
   branch?: string;
+  remote?: string;
   path?: string;
   sync?: ProjectResultsSyncConfig;
   branchPrefix?: string;
@@ -97,11 +102,14 @@ export function getProjectsRegistryPath(): string {
 
 interface ProjectResultsSyncYaml {
   auto_push?: boolean;
+  require_push?: boolean;
 }
 
 interface ProjectResultsYaml {
-  repo_url: string;
+  repo_url?: string;
+  repo_path?: string;
   branch?: string;
+  remote?: string;
   path?: string;
   sync?: ProjectResultsSyncYaml;
   branch_prefix?: string;
@@ -139,16 +147,35 @@ function fromYaml(raw: unknown): ProjectEntry | null {
   }
   if (e.results && typeof e.results === 'object') {
     const r = e.results as Partial<ProjectResultsYaml>;
-    if (typeof r.repo_url === 'string' && r.repo_url.trim().length > 0) {
+    const repoUrl =
+      typeof r.repo_url === 'string' && r.repo_url.trim().length > 0
+        ? r.repo_url.trim()
+        : undefined;
+    const repoPath =
+      typeof r.repo_path === 'string' && r.repo_path.trim().length > 0
+        ? r.repo_path.trim()
+        : undefined;
+    if (repoUrl || repoPath) {
       const sync = r.sync && typeof r.sync === 'object' ? r.sync : undefined;
       entry.results = {
-        repoUrl: r.repo_url.trim(),
+        ...(repoUrl ? { repoUrl } : {}),
+        ...(repoPath ? { repoPath } : {}),
         ...(typeof r.branch === 'string' && r.branch.trim().length > 0
           ? { branch: r.branch.trim() }
           : {}),
+        ...(typeof r.remote === 'string' && r.remote.trim().length > 0
+          ? { remote: r.remote.trim() }
+          : {}),
         ...(typeof r.path === 'string' && r.path.trim().length > 0 ? { path: r.path.trim() } : {}),
-        ...(sync && typeof sync.auto_push === 'boolean'
-          ? { sync: { autoPush: sync.auto_push } }
+        ...(sync && (typeof sync.auto_push === 'boolean' || typeof sync.require_push === 'boolean')
+          ? {
+              sync: {
+                ...(typeof sync.auto_push === 'boolean' ? { autoPush: sync.auto_push } : {}),
+                ...(typeof sync.require_push === 'boolean'
+                  ? { requirePush: sync.require_push }
+                  : {}),
+              },
+            }
           : {}),
         ...(typeof r.branch_prefix === 'string' && r.branch_prefix.trim().length > 0
           ? { branchPrefix: r.branch_prefix.trim() }
@@ -171,11 +198,21 @@ function toYaml(entry: ProjectEntry): ProjectEntryYaml {
   };
   if (entry.results) {
     yaml.results = {
-      repo_url: entry.results.repoUrl,
+      ...(entry.results.repoUrl !== undefined && { repo_url: entry.results.repoUrl }),
+      ...(entry.results.repoPath !== undefined && { repo_path: entry.results.repoPath }),
       ...(entry.results.branch !== undefined && { branch: entry.results.branch }),
+      ...(entry.results.remote !== undefined && { remote: entry.results.remote }),
       ...(entry.results.path !== undefined && { path: entry.results.path }),
-      ...(entry.results.sync?.autoPush !== undefined && {
-        sync: { auto_push: entry.results.sync.autoPush },
+      ...((entry.results.sync?.autoPush !== undefined ||
+        entry.results.sync?.requirePush !== undefined) && {
+        sync: {
+          ...(entry.results.sync?.autoPush !== undefined && {
+            auto_push: entry.results.sync.autoPush,
+          }),
+          ...(entry.results.sync?.requirePush !== undefined && {
+            require_push: entry.results.sync.requirePush,
+          }),
+        },
       }),
       ...(entry.results.branchPrefix !== undefined && {
         branch_prefix: entry.results.branchPrefix,

--- a/packages/core/test/evaluation/loaders/config-loader.test.ts
+++ b/packages/core/test/evaluation/loaders/config-loader.test.ts
@@ -287,7 +287,7 @@ describe('parseResultsConfig', () => {
     });
   });
 
-  it('returns undefined when mode is missing', () => {
+  it('accepts missing mode for current results config', () => {
     const result = parseResultsConfig(
       {
         repo: 'EntityProcess/agentv-evals',
@@ -295,7 +295,36 @@ describe('parseResultsConfig', () => {
       '/tmp/.agentv/config.yaml',
     );
 
-    expect(result).toBeUndefined();
+    expect(result).toEqual({
+      mode: 'github',
+      repo: 'EntityProcess/agentv-evals',
+    });
+  });
+
+  it('parses repo_path and nested sync config', () => {
+    const result = parseResultsConfig(
+      {
+        repo_path: '.',
+        branch: 'agentv/results/v1',
+        remote: 'upstream',
+        sync: {
+          auto_push: false,
+          require_push: true,
+        },
+      },
+      '/tmp/.agentv/config.yaml',
+    );
+
+    expect(result).toEqual({
+      mode: 'github',
+      repo_path: '.',
+      branch: 'agentv/results/v1',
+      remote: 'upstream',
+      sync: {
+        auto_push: false,
+        require_push: true,
+      },
+    });
   });
 
   it('returns undefined when mode is not github', () => {
@@ -341,6 +370,18 @@ describe('parseResultsConfig', () => {
       {
         mode: 'github',
         repo: '',
+      },
+      '/tmp/.agentv/config.yaml',
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when repo_url and repo_path are both set', () => {
+    const result = parseResultsConfig(
+      {
+        repo_url: 'https://github.com/example/results.git',
+        repo_path: '.',
       },
       '/tmp/.agentv/config.yaml',
     );

--- a/packages/core/test/evaluation/results-repo.test.ts
+++ b/packages/core/test/evaluation/results-repo.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import type { ResultsConfig } from '../../src/evaluation/loaders/config-loader.js';
 import {
+  DEFAULT_RESULTS_BRANCH,
   buildWipBranchName,
   deleteWipBranch,
   directPushResults,
@@ -14,6 +15,7 @@ import {
   getResultsRepoSyncStatus,
   listGitRuns,
   materializeGitRun,
+  normalizeResultsConfig,
   pushWipCheckpoint,
   setupWipWorktree,
   syncResultsRepo,
@@ -348,6 +350,97 @@ describe('results repo write path', () => {
     rmSync(rootDir, { recursive: true, force: true });
   });
 
+  it('defaults the storage branch to agentv/results/v1', () => {
+    const normalized = normalizeResultsConfig(
+      {
+        repo_path: '.',
+        sync: { auto_push: false },
+      },
+      { baseDir: '/tmp/source-project' },
+    );
+
+    expect(DEFAULT_RESULTS_BRANCH).toBe('agentv/results/v1');
+    expect(normalized.branch).toBe('agentv/results/v1');
+    expect(normalized.repo_path).toBe('/tmp/source-project');
+    expect(normalized.auto_push).toBe(false);
+  });
+
+  it('publishes current-repo results to an auto-created branch without switching source checkout', async () => {
+    const projectDir = path.join(rootDir, 'source-project');
+    mkdirSync(projectDir, { recursive: true });
+    git('git init --initial-branch=main --quiet', projectDir);
+    git('git config user.email "test@example.com"', projectDir);
+    git('git config user.name "Test User"', projectDir);
+    writeFileSync(path.join(projectDir, 'README.md'), '# source project\n');
+    git('git add README.md && git commit --quiet -m "seed source"', projectDir);
+
+    const runTimestamp = '2026-06-17T10-00-00-000Z';
+    const runDir = path.join(
+      projectDir,
+      '.agentv',
+      'results',
+      'runs',
+      'current-repo',
+      runTimestamp,
+    );
+    writeRunArtifacts(runDir, 'current-repo', '2026-06-17T10:00:00.000Z');
+    writeFileSync(path.join(projectDir, 'UNRELATED.txt'), 'do not publish\n');
+
+    const published = await directPushResults({
+      config: {
+        repo_path: projectDir,
+        branch: DEFAULT_RESULTS_BRANCH,
+        sync: { auto_push: false },
+      },
+      sourceDir: runDir,
+      destinationPath: path.join('current-repo', runTimestamp),
+      commitMessage: 'feat(results): current-repo - 1/1 PASS (1.000)',
+    });
+
+    expect(published).toBe(true);
+    expect(git('git branch --show-current', projectDir)).toBe('main');
+    const branchFiles = git(`git ls-tree -r --name-only ${DEFAULT_RESULTS_BRANCH}`, projectDir);
+    expect(branchFiles).toContain(
+      `.agentv/results/runs/current-repo/${runTimestamp}/benchmark.json`,
+    );
+    expect(branchFiles).not.toContain('README.md');
+    expect(branchFiles).not.toContain('UNRELATED.txt');
+    expect(git('git status --short --branch', projectDir)).toContain('## main');
+  }, 20000);
+
+  it('publishes to an explicit external local repo path', async () => {
+    const projectDir = path.join(rootDir, 'project');
+    const resultsRepoDir = path.join(rootDir, 'local-results-repo');
+    mkdirSync(projectDir, { recursive: true });
+    mkdirSync(resultsRepoDir, { recursive: true });
+    git('git init --initial-branch=main --quiet', resultsRepoDir);
+    git('git config user.email "test@example.com"', resultsRepoDir);
+    git('git config user.name "Test User"', resultsRepoDir);
+    writeFileSync(path.join(resultsRepoDir, 'README.md'), '# result repo main\n');
+    git('git add README.md && git commit --quiet -m "seed results repo"', resultsRepoDir);
+
+    const runTimestamp = '2026-06-17T11-00-00-000Z';
+    const runDir = path.join(projectDir, '.agentv', 'results', 'runs', 'external', runTimestamp);
+    writeRunArtifacts(runDir, 'external', '2026-06-17T11:00:00.000Z');
+
+    const published = await directPushResults({
+      config: {
+        repo_path: resultsRepoDir,
+        branch: DEFAULT_RESULTS_BRANCH,
+        sync: { auto_push: false },
+      },
+      sourceDir: runDir,
+      destinationPath: path.join('external', runTimestamp),
+      commitMessage: 'feat(results): external - 1/1 PASS (1.000)',
+    });
+
+    expect(published).toBe(true);
+    expect(git('git branch --show-current', resultsRepoDir)).toBe('main');
+    const branchFiles = git(`git ls-tree -r --name-only ${DEFAULT_RESULTS_BRANCH}`, resultsRepoDir);
+    expect(branchFiles).toContain(`.agentv/results/runs/external/${runTimestamp}/index.jsonl`);
+    expect(branchFiles).not.toContain('README.md');
+  }, 20000);
+
   it('retries an interrupted direct push without dropping the committed run', async () => {
     const { remoteDir } = initializeRemoteRepo(rootDir);
     const cloneDir = path.join(rootDir, 'results-clone');
@@ -373,7 +466,7 @@ describe('results repo write path', () => {
         commitMessage: 'feat(results): retry - 1/1 PASS (1.000)',
       }),
     ).rejects.toThrow(/simulated interrupted push/);
-    expect(git('git rev-list --count origin/main..HEAD', cloneDir)).toBe('1');
+    expect(git('git rev-list --count origin/main..main', cloneDir)).toBe('1');
     expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir)).not.toContain(
       `.agentv/results/runs/retry/${runTimestamp}/benchmark.json`,
     );
@@ -389,16 +482,16 @@ describe('results repo write path', () => {
       }),
     ).resolves.toBe(true);
 
-    expect(git('git rev-list --count origin/main..HEAD', cloneDir)).toBe('0');
+    expect(git('git rev-list --count origin/main..main', cloneDir)).toBe('0');
     expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir)).toContain(
       `.agentv/results/runs/retry/${runTimestamp}/benchmark.json`,
     );
     expect(git(`git --git-dir "${remoteDir}" log -1 --pretty=%B main`, rootDir)).toContain(
-      `Agentv-Run: retry::${runTimestamp}`,
+      `AgentV-Run: retry::${runTimestamp}`,
     );
   }, 20000);
 
-  it('commits pushed runs into the configured clone with an Agentv-Run trailer', async () => {
+  it('commits pushed runs into the configured clone with an AgentV-Run trailer', async () => {
     const { remoteDir } = initializeRemoteRepo(rootDir);
     const cloneDir = path.join(rootDir, 'results-clone');
     const sourceDir = path.join(rootDir, 'source-run');
@@ -420,28 +513,17 @@ describe('results repo write path', () => {
 
     expect(pushed).toBe(true);
     expect(git('git rev-parse --show-toplevel', cloneDir)).toBe(cloneDir);
-    expect(git('git log -1 --pretty=%B', cloneDir)).toContain(
-      `Agentv-Run: with-skills::${runTimestamp}`,
+    expect(git('git log -1 --pretty=%B main', cloneDir)).toContain(
+      `AgentV-Run: with-skills::${runTimestamp}`,
     );
     expect(git(`git --git-dir "${remoteDir}" log -1 --pretty=%B main`, rootDir)).toContain(
-      `Agentv-Run: with-skills::${runTimestamp}`,
+      `AgentV-Run: with-skills::${runTimestamp}`,
     );
-    expect(
-      readFileSync(
-        path.join(
-          cloneDir,
-          '.agentv',
-          'results',
-          'runs',
-          'with-skills',
-          runTimestamp,
-          'index.jsonl',
-        ),
-        'utf8',
-      ),
-    ).toContain('"test_id":"alpha"');
+    expect(git('git ls-tree -r --name-only main', cloneDir)).toContain(
+      `.agentv/results/runs/with-skills/${runTimestamp}/index.jsonl`,
+    );
 
-    const runs = await listGitRuns(cloneDir, 'HEAD');
+    const runs = await listGitRuns(cloneDir, 'main');
     expect(runs).toHaveLength(1);
     expect(runs[0].run_id).toBe(`with-skills::${runTimestamp}`);
   }, 20000);
@@ -471,7 +553,7 @@ describe('results repo write path', () => {
     });
 
     expect(pushed).toBe(true);
-    expect(git('git branch --show-current', cloneDir)).toBe(storageBranch);
+    expect(git('git branch --show-current', cloneDir)).toBe('main');
     expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir)).not.toContain(
       `.agentv/results/runs/branch-storage/${runTimestamp}/benchmark.json`,
     );
@@ -480,10 +562,10 @@ describe('results repo write path', () => {
     ).toContain(`.agentv/results/runs/branch-storage/${runTimestamp}/benchmark.json`);
     expect(
       git(`git --git-dir "${remoteDir}" log -1 --pretty=%B ${storageBranch}`, rootDir),
-    ).toContain(`Agentv-Run: branch-storage::${runTimestamp}`);
+    ).toContain(`AgentV-Run: branch-storage::${runTimestamp}`);
   }, 20000);
 
-  it('fails clearly when a configured storage branch is missing', async () => {
+  it('auto-creates a missing configured storage branch', async () => {
     const { remoteDir } = initializeRemoteRepo(rootDir);
     const cloneDir = path.join(rootDir, 'results-clone');
     const sourceDir = path.join(rootDir, 'source-run');
@@ -500,7 +582,13 @@ describe('results repo write path', () => {
         destinationPath: path.join('missing-branch', '2026-06-12T11-00-00-000Z'),
         commitMessage: 'feat(results): missing branch',
       }),
-    ).rejects.toThrow(/git switch --orphan agentv-results/);
+    ).resolves.toBe(true);
+    expect(git(`git --git-dir "${remoteDir}" branch --list agentv-results`, rootDir)).toContain(
+      'agentv-results',
+    );
+    expect(
+      git(`git --git-dir "${remoteDir}" ls-tree -r --name-only agentv-results`, rootDir),
+    ).toContain('.agentv/results/runs/missing-branch/2026-06-12T11-00-00-000Z/benchmark.json');
   }, 20000);
 
   it('syncResultsRepo refreshes refs without checking out the base branch', async () => {

--- a/packages/core/test/evaluation/validation/config-validator.test.ts
+++ b/packages/core/test/evaluation/validation/config-validator.test.ts
@@ -106,6 +106,30 @@ describe('validateConfigFile', () => {
     expect(result.errors).toHaveLength(0);
   });
 
+  it('accepts branch-backed repo_path results in global project config', async () => {
+    const filePath = path.join(tempDir, 'global-config-repo-path.yaml');
+    await writeFile(
+      filePath,
+      `projects:
+  - id: agentv
+    name: AgentV
+    path: /srv/agentv
+    results:
+      repo_path: .
+      branch: agentv/results/v1
+      remote: origin
+      sync:
+        auto_push: false
+        require_push: true
+`,
+    );
+
+    const result = await validateConfigFile(filePath, { scope: 'global' });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
   it('infers AGENTV_HOME config.yaml as global even when the home dir is named .agentv', async () => {
     const fakeHome = path.join(tempDir, 'fake-user-home');
     const homeConfigDir = path.join(fakeHome, '.agentv');
@@ -168,6 +192,7 @@ describe('validateConfigFile', () => {
     results:
       repo_url: EntityProcess/results
       branch: ""
+      remote: ""
       path: repo/subdir
       sync:
         auto_push: yes
@@ -188,6 +213,7 @@ describe('validateConfigFile', () => {
         expect.objectContaining({ severity: 'error', location: 'projects[0].ref' }),
         expect.objectContaining({ severity: 'error', location: 'projects[0].results.repo_url' }),
         expect.objectContaining({ severity: 'error', location: 'projects[0].results.branch' }),
+        expect.objectContaining({ severity: 'error', location: 'projects[0].results.remote' }),
         expect.objectContaining({ severity: 'error', location: 'projects[0].results.path' }),
         expect.objectContaining({
           severity: 'error',
@@ -323,7 +349,7 @@ describe('validateConfigFile', () => {
     expect(result.errors).toHaveLength(0);
   });
 
-  it('errors on missing results.mode', async () => {
+  it('accepts top-level results without mode', async () => {
     const filePath = path.join(tempDir, 'config-results-no-mode.yaml');
     await writeFile(
       filePath,
@@ -334,10 +360,8 @@ describe('validateConfigFile', () => {
 
     const result = await validateConfigFile(filePath);
 
-    const fieldErrors = result.errors.filter(
-      (e) => e.severity === 'error' && e.location === 'results.mode',
-    );
-    expect(fieldErrors).toHaveLength(1);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
   });
 
   it('errors on old-style subdirectory path', async () => {

--- a/packages/core/test/projects.test.ts
+++ b/packages/core/test/projects.test.ts
@@ -176,6 +176,47 @@ describe('projects registry', () => {
     expect(yamlOnDisk).not.toContain('branchPrefix:');
   });
 
+  it('round-trips branch-backed current-repo results config through YAML', () => {
+    const registryPath = getProjectsRegistryPath();
+    mkdirSync(path.dirname(registryPath), { recursive: true });
+    writeFileSync(
+      registryPath,
+      `projects:
+  - id: branch-results
+    name: Branch Results
+    path: /srv/agentv/repo
+    results:
+      repo_path: .
+      branch: agentv/results/v1
+      remote: origin
+      sync:
+        auto_push: false
+        require_push: true
+    added_at: "2026-01-01T00:00:00Z"
+    last_opened_at: "2026-01-01T00:00:00Z"
+`,
+      'utf-8',
+    );
+
+    const registry = loadProjectRegistry();
+    expect(registry.projects[0].results).toEqual({
+      repoPath: '.',
+      branch: 'agentv/results/v1',
+      remote: 'origin',
+      sync: { autoPush: false, requirePush: true },
+    });
+
+    saveProjectRegistry(registry);
+    const yamlOnDisk = readFileSync(registryPath, 'utf-8');
+    expect(yamlOnDisk).toContain('repo_path: .');
+    expect(yamlOnDisk).toContain('branch: agentv/results/v1');
+    expect(yamlOnDisk).toContain('remote: origin');
+    expect(yamlOnDisk).toContain('auto_push: false');
+    expect(yamlOnDisk).toContain('require_push: true');
+    expect(yamlOnDisk).not.toContain('repoPath:');
+    expect(yamlOnDisk).not.toContain('requirePush:');
+  });
+
   it('preserves unrelated global config keys when saving projects', () => {
     const registryPath = getProjectsRegistryPath();
     mkdirSync(path.dirname(registryPath), { recursive: true });


### PR DESCRIPTION
## Summary

- Add branch-backed results config for `results.repo_path`, `results.repo_url`, `results.branch`, `results.remote`, and `results.sync.require_push` while keeping `sync.auto_push` false by default.
- Publish completed runs from canonical `.agentv/results/runs/...` into a configured Git branch through Git object/index plumbing, so `repo_path: .` never checks out `agentv/results/v1` in the source worktree.
- Auto-create missing storage branches as empty/orphan result branches, stage only `.agentv/results/**`, and preserve existing separate results repo behavior.
- Teach CLI eval flags, project registry YAML, Dashboard remote discovery/status, docs, and tests about branch-backed result storage.

## Config shape

```yaml
results:
  repo_path: .
  branch: agentv/results/v1
  remote: origin
  sync:
    auto_push: false
    require_push: false
```

`branch` defaults to `agentv/results/v1` for `repo_path` configs. Existing managed-clone configs continue to use `repo`/`repo_url`; they can opt into the same `branch`, `remote`, and `sync` fields.

## Validation

```text
bun test packages/core/test/evaluation/results-repo.test.ts packages/core/test/evaluation/loaders/config-loader.test.ts packages/core/test/projects.test.ts packages/core/test/evaluation/validation/config-validator.test.ts
159 pass, 0 fail

bun test apps/cli/test/commands/eval
117 pass, 0 fail

bun test apps/cli/test/commands/results
191 pass, 0 fail

bun test apps/dashboard/src
93 pass, 0 fail

bun test packages/core/test/evaluation/validation/config-validator.test.ts
22 pass, 0 fail

bun run lint
Checked 728 files. No fixes applied.

bun run typecheck
@agentv/core typecheck: Exited with code 0
@agentv/phoenix-adapter typecheck: Exited with code 0
agentv typecheck: Exited with code 0
```

## Functional UAT

Temp repo: `/tmp/agentv-results-branch-uat-wITm8Z/source`

Commands:

```bash
git init --initial-branch=main
git config user.email uat@example.com
git config user.name "AgentV UAT"
printf ".agentv/results/\n.agentv/cache.json\n" > .gitignore
# wrote .agentv/config.yaml with results.repo_path: . and sync.auto_push: false
# wrote .agentv/targets.yaml with a mock target
# wrote evals/uat.eval.yaml with one test
git add .gitignore .agentv/config.yaml .agentv/targets.yaml evals/uat.eval.yaml
git commit -m "test: seed branch storage uat"
AGENTV_HOME=/tmp/agentv-results-branch-uat-wITm8Z/home AGENTV_NO_UPDATE_CHECK=1 \
  bun /home/entity/projects/EntityProcess/agentv__worktrees/av-results-branch-storage/apps/cli/src/cli.ts \
  eval evals/uat.eval.yaml --dry-run --experiment branch-storage-uat --workers 1
git status --short --branch
git show-ref --verify refs/heads/agentv/results/v1
git ls-tree -r --name-only agentv/results/v1
git ls-tree -r --name-only main
```

Output evidence:

```text
Artifact directory: /tmp/agentv-results-branch-uat-wITm8Z/source/.agentv/results/runs/branch-storage-uat/2026-06-17T11-51-53-501Z
RESULT: PASS  (1/1 scored >= 80%, mean: 100%)
Results written to: /tmp/agentv-results-branch-uat-wITm8Z/source/.agentv/results/runs/branch-storage-uat/2026-06-17T11-51-53-501Z/index.jsonl
Results published locally to . (agentv/results/v1:branch-storage-uat/2026-06-17T11-51-53-501Z)

## main
97ef27fe91fe0ef2a3b266202426191139db5d0c refs/heads/agentv/results/v1
.agentv/results/runs/branch-storage-uat/2026-06-17T11-51-53-501Z/benchmark.json
.agentv/results/runs/branch-storage-uat/2026-06-17T11-51-53-501Z/index.jsonl
.agentv/results/runs/branch-storage-uat/2026-06-17T11-51-53-501Z/timing.json
.agentv/results/runs/branch-storage-uat/2026-06-17T11-51-53-501Z/transcript.jsonl
.agentv/results/runs/branch-storage-uat/2026-06-17T11-51-53-501Z/uat/uat-pass/grading.json
.agentv/results/runs/branch-storage-uat/2026-06-17T11-51-53-501Z/uat/uat-pass/input.md
.agentv/results/runs/branch-storage-uat/2026-06-17T11-51-53-501Z/uat/uat-pass/outputs/answer.md
.agentv/results/runs/branch-storage-uat/2026-06-17T11-51-53-501Z/uat/uat-pass/outputs/response.md
.agentv/results/runs/branch-storage-uat/2026-06-17T11-51-53-501Z/uat/uat-pass/outputs/trace-envelope.json
.agentv/results/runs/branch-storage-uat/2026-06-17T11-51-53-501Z/uat/uat-pass/outputs/transcript.jsonl
.agentv/results/runs/branch-storage-uat/2026-06-17T11-51-53-501Z/uat/uat-pass/task/EVAL.yaml
.agentv/results/runs/branch-storage-uat/2026-06-17T11-51-53-501Z/uat/uat-pass/task/targets.yaml
.agentv/results/runs/branch-storage-uat/2026-06-17T11-51-53-501Z/uat/uat-pass/timing.json
.agentv/config.yaml
.agentv/targets.yaml
.gitignore
evals/uat.eval.yaml
```

The UAT also checked `git branch --show-current` before and after the eval; both were `main`. The results branch tree was additionally filtered with `grep -v '^\.agentv/results/'` and produced no unexpected paths.

## Notes

The branch writer follows the local Entire CLI pattern researched during this task: write blobs/trees/commits directly, update the configured branch ref, and push an explicit `refs/heads/<branch>:refs/heads/<branch>` refspec instead of creating or switching a source worktree.

Blockers: none.
