### PR TITLE
docs(evals): clarify grader wire format

### DIFF
--- a/apps/web/src/content/docs/docs/evaluation/sdk.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/sdk.mdx
@@ -30,8 +30,8 @@ Use `defineAssertion` from `@agentv/eval` to create reusable assertion types. Pl
 // .agentv/assertions/word-count.ts
 import { defineAssertion } from '@agentv/eval';
 
-export default defineAssertion(({ outputText }) => {
-  const wordCount = outputText.trim().split(/\s+/).length;
+export default defineAssertion(({ output }) => {
+  const wordCount = (output ?? '').trim().split(/\s+/).filter(Boolean).length;
   return {
     pass: wordCount >= 3,
     reasoning: `Output has ${wordCount} words`,
@@ -47,8 +47,8 @@ Return a `score` (0–1) instead of `pass` for graded evaluation:
 // .agentv/assertions/efficiency.ts
 import { defineAssertion } from '@agentv/eval';
 
-export default defineAssertion(({ outputText, trace }) => ({
-  pass: outputText.length > 0 && (trace?.eventCount ?? 0) <= 10,
+export default defineAssertion(({ output, traceSummary }) => ({
+  pass: (output ?? '').length > 0 && (traceSummary?.eventCount ?? 0) <= 10,
   reasoning: 'Checks content exists and is efficient',
 }));
 ```
@@ -80,10 +80,11 @@ Use `defineCodeGrader` from `@agentv/eval` for full control over scoring with an
 ```typescript
 import { defineCodeGrader } from '@agentv/eval';
 
-export default defineCodeGrader(({ trace, outputText }) => ({
-  score: trace?.eventCount <= 5 ? 1.0 : 0.5,
+export default defineCodeGrader(({ output, traceSummary }) => ({
+  score: (output ?? '').length > 0 && (traceSummary?.eventCount ?? 0) <= 5 ? 1.0 : 0.5,
   assertions: [
-    { text: 'Efficient tool usage', passed: (trace?.eventCount ?? 0) <= 5 },
+    { text: 'Answer is not empty', passed: (output ?? '').length > 0 },
+    { text: 'Efficient tool usage', passed: (traceSummary?.eventCount ?? 0) <= 5 },
   ],
 }));
 ```
@@ -91,6 +92,22 @@ export default defineCodeGrader(({ trace, outputText }) => ({
 `defineCodeGrader` graders are referenced in YAML with `type: code-grader` and `command: [bun, run, grader.ts]`. `defineAssertion` uses convention-based discovery instead — just place in `.agentv/assertions/` and reference by name.
 
 For detailed patterns, input/output contracts, and language-agnostic examples, see [Code Graders](/docs/graders/code-graders/).
+
+## Wire Format vs SDK Format
+
+Raw grader stdin uses `snake_case` because it crosses a process boundary and may be consumed by Python, shell, jq, or external dashboards. The `@agentv/eval` SDK converts that payload to idiomatic TypeScript `camelCase` before calling your handler.
+
+| Raw stdin | SDK handler field |
+|-----------|-------------------|
+| `expected_output` | `expectedOutput` |
+| `output_path` | `outputPath` |
+| `trace_summary` | `traceSummary` |
+| `token_usage` | `tokenUsage` |
+| `cost_usd` | `costUsd` |
+| `duration_ms` | `durationMs` |
+| `workspace_path` | `workspacePath` |
+
+`output` is already the final answer string in both formats. Transcript-aware code should read `messages`, `trace.messages`, or `trace.events`; answer-text graders should read `output` or the deprecated `answer` alias.
 
 ## Programmatic API
 

--- a/apps/web/src/content/docs/docs/graders/code-graders.mdx
+++ b/apps/web/src/content/docs/docs/graders/code-graders.mdx
@@ -11,15 +11,41 @@ Code graders are scripts that evaluate agent responses deterministically. Write 
 
 Code graders receive eval context via stdin JSON and return a result via stdout.
 
-**Input (stdin):**
+**Input (stdin, raw wire format):**
 ```json
 {
-  "input": "What is 15 + 27?",
+  "input": [{ "role": "user", "content": "What is 15 + 27?" }],
+  "input_files": [],
   "criteria": "Correctly calculates 15 + 27 = 42",
   "output": "The answer is 42.",
-  "expected_output": "42"
+  "answer": "The answer is 42.",
+  "expected_output": [{ "role": "assistant", "content": "42" }],
+  "messages": [{ "role": "assistant", "content": "The answer is 42." }],
+  "trace_summary": {
+    "event_count": 1,
+    "tool_calls": {},
+    "error_count": 0,
+    "llm_call_count": 1
+  }
 }
 ```
+
+Raw grader stdin is a process-boundary wire format, so keys are `snake_case`. TypeScript and JavaScript graders that use `@agentv/eval` receive the same payload converted to `camelCase`.
+
+| Raw stdin key | SDK field | Meaning |
+|---------------|-----------|---------|
+| `output` | `output` | Final answer / scored result as a string |
+| `answer` | `answer` | Deprecated alias for the same final answer string |
+| `messages` | `messages` | Transcript messages for transcript-aware graders |
+| `expected_output` | `expectedOutput` | Reference answer messages |
+| `output_path` | `outputPath` | Temp file containing large final answer JSON, when used |
+| `trace_summary` | `traceSummary` | Lightweight metrics summary |
+| `token_usage` | `tokenUsage` | Token usage metrics |
+| `cost_usd` | `costUsd` | Estimated cost in USD |
+| `duration_ms` | `durationMs` | Total execution duration |
+| `workspace_path` | `workspacePath` | Temp workspace path, when configured |
+
+Do not treat `output` as a message array. Use `output` / `answer` for answer-text checks, and use `messages`, `trace.messages`, or `trace.events` only when the grader intentionally evaluates transcript or tool behavior.
 
 ### JSON output (full protocol)
 
@@ -82,7 +108,7 @@ Scripts that write to stderr and exit non-zero surface as execution errors rathe
 # validators/check_answer.py
 import json, sys
 data = json.load(sys.stdin)
-output_text = data.get("output", "")
+output_text = data.get("output") or data.get("answer") or ""
 
 assertions = []
 
@@ -107,7 +133,7 @@ print(json.dumps({
 import { readFileSync } from "fs";
 
 const data = JSON.parse(readFileSync("/dev/stdin", "utf-8"));
-const outputText: string = data.output ?? "";
+const outputText: string = data.output ?? data.answer ?? "";
 
 const assertions: Array<{ text: string; passed: boolean }> = [];
 
@@ -144,7 +170,7 @@ The `@agentv/eval` package provides a declarative API with automatic stdin/stdou
 import { defineCodeGrader } from '@agentv/eval';
 
 export default defineCodeGrader(({ output, criteria }) => {
-  const outputText = output?.[0]?.content ?? '';
+  const outputText = output ?? '';
   const assertions: Array<{ text: string; passed: boolean }> = [];
 
   if (outputText.includes(criteria)) {
@@ -161,7 +187,7 @@ export default defineCodeGrader(({ output, criteria }) => {
 });
 ```
 
-**SDK exports:** `defineCodeGrader`, `Message`, `ToolCall`, `TraceSummary`, `CodeGraderInput`, `CodeGraderResult`
+**SDK exports:** `defineCodeGrader`, `Message`, `ToolCall`, `Trace`, `TraceSummary`, `CodeGraderInput`, `CodeGraderResult`
 
 ## Target Access
 
@@ -189,8 +215,11 @@ Use `createTargetClient` from the SDK:
 import { createTargetClient, defineCodeGrader } from '@agentv/eval';
 
 export default defineCodeGrader(async ({ input, output }) => {
-  const inputText = input?.[0]?.content ?? '';
-  const outputText = output?.[0]?.content ?? '';
+  const inputText = input
+    .filter((message) => message.role === 'user')
+    .map((message) => typeof message.content === 'string' ? message.content : '')
+    .join('\n');
+  const outputText = output ?? '';
   const target = createTargetClient();
   if (!target) return { score: 0, assertions: [{ text: 'Target not configured', passed: false }] };
 
@@ -215,15 +244,19 @@ Use `target.invokeBatch(requests)` for multiple calls in parallel.
 
 ## Advanced Input Fields
 
-Beyond the basic text fields (`input`, `output`, `expected_output`, `criteria`), code graders receive additional structured context:
+Beyond the basic fields (`input`, `output`, `expected_output`, `criteria`), code graders receive additional structured context:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `input` | `string \| Message[]` | Input text or full resolved input message array |
-| `output` | `string \| Message[]` | Agent output text or full execution trace with tool calls |
-| `expected_output` | `string \| Message[]` | Expected output text or expected agent behavior including tool calls |
+| `input` | `Message[]` | Full resolved input message array |
+| `output` | `string \| null` | Final answer / scored result only |
+| `answer` | `string` | Deprecated alias for `output` |
+| `messages` | `Message[]` | Transcript messages from the target execution |
+| `expected_output` | `Message[]` | Expected/reference output messages |
+| `output_path` | `string` | Temp file containing large final answer JSON, when `output` is omitted |
 | `input_files` | `string[]` | Paths to input files referenced in the eval |
-| `trace` | `TraceSummary` | Lightweight execution metrics (tool calls, errors) |
+| `trace` | `Trace` | Full execution trace with messages, events, metrics, and provenance |
+| `trace_summary` | `TraceSummary` | Lightweight execution metrics summary |
 | `token_usage` | `{input, output}` | Token consumption |
 | `cost_usd` | `number` | Estimated cost in USD |
 | `duration_ms` | `number` | Total execution duration |
@@ -232,13 +265,12 @@ Beyond the basic text fields (`input`, `output`, `expected_output`, `criteria`),
 | `file_changes` | `string \| null` | Unified diff of workspace file changes (populated when `workspace` is configured; includes files at workspace root, changes inside nested repos, and Copilot session-state artifacts) |
 | `workspace_path` | `string \| null` | Absolute path to the temp workspace directory (populated when `workspace` is configured) |
 
-### trace structure
+### trace_summary structure
 
 ```json
 {
   "event_count": 5,
-  "tool_names": ["fetch", "search"],
-  "tool_calls_by_name": { "search": 2, "fetch": 1 },
+  "tool_calls": { "search": 2, "fetch": 1 },
   "error_count": 0,
   "llm_call_count": 2
 }
@@ -247,12 +279,11 @@ Beyond the basic text fields (`input`, `output`, `expected_output`, `criteria`),
 | Field | Type | Description |
 |-------|------|-------------|
 | `event_count` | `number` | Total tool invocations |
-| `tool_names` | `string[]` | Unique tool names used |
-| `tool_calls_by_name` | `Record<string, number>` | Count per tool |
+| `tool_calls` | `Record<string, number>` | Count per tool |
 | `error_count` | `number` | Failed tool calls |
 | `llm_call_count` | `number` | Number of LLM calls (assistant messages) |
 
-Use `expected_output` for retrieval context in RAG evals (tool calls with outputs) and `output` for the actual agent execution trace from live runs.
+Use `expected_output` for reference answers and `output` for the actual final answer from live runs. Use `messages` or `trace` when you need tool calls, intermediate messages, or replay/provenance data.
 
 ## Workspace Access
 
@@ -363,5 +394,5 @@ This is the same interface that agent-orchestrated evals use — the EVAL.yaml t
 Pipe JSON directly to the grader script for full control:
 
 ```bash
-echo '{"input":"What is 2+2?","criteria":"4","output":"4","expected_output":"4"}' | python validators/check_answer.py
+echo '{"input":[{"role":"user","content":"What is 2+2?"}],"input_files":[],"criteria":"4","output":"4","expected_output":[{"role":"assistant","content":"4"}]}' | python validators/check_answer.py
 ```

--- a/apps/web/src/content/docs/docs/graders/custom-assertions.mdx
+++ b/apps/web/src/content/docs/docs/graders/custom-assertions.mdx
@@ -63,8 +63,8 @@ The simplest pattern returns `pass` (boolean) and `reasoning` (string):
 // .agentv/assertions/word-count.ts
 import { defineAssertion } from '@agentv/eval';
 
-export default defineAssertion(({ outputText }) => {
-  const wordCount = outputText.trim().split(/\s+/).length;
+export default defineAssertion(({ output }) => {
+  const wordCount = (output ?? '').trim().split(/\s+/).filter(Boolean).length;
   return {
     pass: wordCount >= 3,
     reasoning: `Output has ${wordCount} words`,
@@ -82,9 +82,9 @@ Return a `score` (0 to 1) for granular evaluation instead of binary pass/fail:
 // .agentv/assertions/efficiency.ts
 import { defineAssertion } from '@agentv/eval';
 
-export default defineAssertion(({ outputText, trace }) => {
-  const hasContent = outputText.length > 0 ? 0.5 : 0;
-  const isEfficient = (trace?.eventCount ?? 0) <= 5 ? 0.5 : 0;
+export default defineAssertion(({ output, traceSummary }) => {
+  const hasContent = (output ?? '').length > 0 ? 0.5 : 0;
+  const isEfficient = (traceSummary?.eventCount ?? 0) <= 5 ? 0.5 : 0;
   return {
     score: hasContent + isEfficient,
     assertions: [
@@ -115,21 +115,23 @@ The handler receives an `AssertionContext` with the same fields as a code grader
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `inputText` | `string` | First user message content as string |
-| `outputText` | `string` | Last assistant message content as string |
-| `expectedOutputText` | `string` | Expected output content as string |
-| `criteria` | `string` | Evaluation criteria from the test case |
-| `trace` | `TraceSummary` | Execution metrics (tool calls, tokens, duration, cost) |
 | `input` | `Message[]` | Full resolved input messages |
+| `output` | `string \| null` | Final answer / scored result only |
+| `answer` | `string` | Deprecated alias for `output` |
+| `messages` | `Message[]` | Transcript messages from the target execution |
 | `expectedOutput` | `Message[]` | Expected output messages |
-| `output` | `Message[]` | Actual agent output messages |
+| `criteria` | `string` | Evaluation criteria from the test case |
+| `trace` | `Trace` | Full execution trace with messages, events, metrics, and provenance |
+| `traceSummary` | `TraceSummary` | Lightweight execution metrics summary |
+
+The raw stdin payload uses `snake_case` keys such as `expected_output`, `trace_summary`, and `workspace_path`. `defineAssertion()` converts them to SDK `camelCase` fields such as `expectedOutput`, `traceSummary`, and `workspacePath`.
 
 ## Testing Custom Assertions
 
 Test assertions locally by piping JSON to stdin:
 
 ```bash
-echo '{"input_text":"Say hello","criteria":"Multi-word greeting","output_text":"Hello there, nice to meet you!","expected_output_text":""}' \
+echo '{"input":[{"role":"user","content":"Say hello"}],"input_files":[],"criteria":"Multi-word greeting","output":"Hello there, nice to meet you!","expected_output":[]}' \
   | bun run .agentv/assertions/word-count.ts
 ```
 
@@ -191,8 +193,8 @@ my-project/
 #!/usr/bin/env bun
 import { defineAssertion } from '@agentv/eval';
 
-export default defineAssertion(({ outputText }) => {
-  const wordCount = outputText.trim().split(/\s+/).length;
+export default defineAssertion(({ output }) => {
+  const wordCount = (output ?? '').trim().split(/\s+/).filter(Boolean).length;
   const minWords = 3;
   const pass = wordCount >= minWords;
 

--- a/apps/web/src/content/docs/docs/graders/llm-graders.mdx
+++ b/apps/web/src/content/docs/docs/graders/llm-graders.mdx
@@ -66,7 +66,7 @@ Score the response from 0.0 to 1.0 based on:
 | Variable | Source |
 |----------|--------|
 | `input_text` | First user message content |
-| `output_text` | Last candidate response content |
+| `output_text` | Candidate final answer text |
 | `expected_output_text` | Last expected message content |
 | `criteria` | Test `criteria` field |
 | `input` | Resolved input text |
@@ -133,18 +133,28 @@ For dynamic prompt generation, use the `definePromptTemplate` function from `@ag
 #!/usr/bin/env bun
 import { definePromptTemplate } from '@agentv/eval';
 
+function textFromMessages(messages: Array<{ content?: unknown }>): string {
+  return messages
+    .map((message) => typeof message.content === 'string' ? message.content : '')
+    .filter(Boolean)
+    .join('\n');
+}
+
 export default definePromptTemplate((ctx) => {
   const rubric = ctx.config?.rubric as string | undefined;
+  const question = textFromMessages(ctx.input.filter((message) => message.role === 'user'));
+  const referenceAnswer = textFromMessages(ctx.expectedOutput);
+  const candidateAnswer = ctx.output ?? ctx.answer ?? '';
 
   return `You are evaluating an AI assistant's response.
 
 ## Question
-${ctx.inputText}
+${question}
 
 ## Candidate Answer
-${ctx.outputText}
+${candidateAnswer}
 
-${ctx.expectedOutputText ? `## Reference Answer\n${ctx.expectedOutputText}` : ''}
+${referenceAnswer ? `## Reference Answer\n${referenceAnswer}` : ''}
 
 ${rubric ? `## Evaluation Criteria\n${rubric}` : ''}
 
@@ -218,15 +228,18 @@ TypeScript templates receive a context object with these fields:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `inputText` | `string` | First user message content |
-| `outputText` | `string` | Last entry in `output` |
-| `expectedOutputText` | `string` | Last entry in `expected_output` |
+| `input` | `Message[]` | Full resolved input messages |
+| `output` | `string \| null` | Candidate final answer / scored result |
+| `answer` | `string` | Deprecated alias for `output` |
+| `messages` | `Message[]` | Transcript messages from the target execution |
 | `criteria` | `string` | Test `criteria` field |
 | `expectedOutput` | `Message[]` | Full resolved expected output |
-| `output` | `Message[]` | Full provider output messages |
-| `trace` | `TraceSummary` | Execution metrics summary |
+| `trace` | `Trace` | Full execution trace with messages, events, metrics, and provenance |
+| `traceSummary` | `TraceSummary` | Lightweight execution metrics summary |
 | `metadata` | `object` | Test metadata after suite defaults are merged |
 | `config` | `object` | Custom config from YAML |
+
+The raw prompt-template stdin uses `snake_case` keys such as `expected_output`, `trace_summary`, and `token_usage`. `definePromptTemplate()` converts them to SDK `camelCase` fields before calling your handler.
 
 ## Template Variable Derivation
 
@@ -257,7 +270,7 @@ Derived strings injected into grader prompts:
 | `input_text` | Content of the first `user` role entry in `input` |
 | `criteria` | Passed through from the test field |
 | `expected_output_text` | Content of the last entry in `expected_output` |
-| `output_text` | Content of the last entry in `output` |
+| `output_text` | Candidate final answer text |
 | `input` | Resolved input text |
 | `expected_output` | Reference answer text |
 | `output` | Candidate answer text |

--- a/examples/README.md
+++ b/examples/README.md
@@ -108,8 +108,8 @@ Then write type-safe code graders:
 #!/usr/bin/env bun
 import { defineCodeGrader } from '@agentv/eval';
 
-export default defineCodeGrader(({ answer, criteria }) => ({
-  score: answer.includes('expected') ? 1.0 : 0.0,
-  assertions: [{ text: 'Found expected content', passed: answer.includes('expected') }],
+export default defineCodeGrader(({ output }) => ({
+  score: (output ?? '').includes('expected') ? 1.0 : 0.0,
+  assertions: [{ text: 'Found expected content', passed: (output ?? '').includes('expected') }],
 }));
 ```

--- a/examples/features/code-grader-sdk/README.md
+++ b/examples/features/code-grader-sdk/README.md
@@ -27,12 +27,11 @@ Test the SDK-based code grader directly with a mock payload:
 cd examples/features/code-grader-sdk
 cat << 'EOF' | bun run scripts/verify-attachments.ts
 {
-  "question": "Please echo this request",
   "criteria": "The CLI echoes the prompt and lists attachment names.",
-  "expected_output": [{"role": "assistant", "content": "Attachments detected (2): example.txt, python.instructions.md."}],
-  "answer": "Attachments detected (2): example.txt, python.instructions.md.",
+  "input": [{"role": "user", "content": "Please echo this request"}],
   "input_files": ["evals/python.instructions.md", "evals/example.txt"],
-  "input": []
+  "expected_output": [{"role": "assistant", "content": "Attachments detected (2): example.txt, python.instructions.md."}],
+  "output": "Attachments detected (2): example.txt, python.instructions.md."
 }
 EOF
 ```
@@ -59,8 +58,8 @@ The `defineCodeGrader` helper:
 ```typescript
 import { defineCodeGrader } from '@agentv/eval';
 
-export default defineCodeGrader(({ answer, criteria }) => ({
-  score: answer.includes(criteria) ? 1.0 : 0.0,
-  assertions: [{ text: 'Check passed', passed: answer.includes(criteria) }],
+export default defineCodeGrader(({ output, criteria }) => ({
+  score: (output ?? '').includes(criteria) ? 1.0 : 0.0,
+  assertions: [{ text: 'Check passed', passed: (output ?? '').includes(criteria) }],
 }));
 ```

--- a/examples/features/code-grader-sdk/scripts/verify-attachments.ts
+++ b/examples/features/code-grader-sdk/scripts/verify-attachments.ts
@@ -12,27 +12,8 @@ function fileName(path: string): string {
   return parts[parts.length - 1] ?? path;
 }
 
-function getMessageText(
-  messages: readonly { role: string; content?: unknown }[],
-  role = 'assistant',
-): string {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
-    if (msg.role === role) {
-      if (typeof msg.content === 'string') return msg.content;
-      if (Array.isArray(msg.content)) {
-        return msg.content
-          .filter((b: { type?: string }) => b.type === 'text')
-          .map((b: { text?: string }) => b.text)
-          .join('\n');
-      }
-    }
-  }
-  return '';
-}
-
 export default defineCodeGrader(({ expectedOutput, output, inputFiles }) => {
-  const outputText = getMessageText(output ?? []);
+  const outputText = output ?? '';
   const assertions: Array<{ text: string; passed: boolean }> = [];
 
   // Check if candidate matches expected message
@@ -58,5 +39,9 @@ export default defineCodeGrader(({ expectedOutput, output, inputFiles }) => {
     }
   }
 
-  return { assertions };
+  const passed = assertions.filter((assertion) => assertion.passed).length;
+  return {
+    score: assertions.length > 0 ? passed / assertions.length : 0,
+    assertions,
+  };
 });

--- a/examples/features/prompt-template-sdk/README.md
+++ b/examples/features/prompt-template-sdk/README.md
@@ -16,11 +16,18 @@ Instead of static text files with `{{variable}}` placeholders, you can use TypeS
 ```typescript
 import { definePromptTemplate } from '@agentv/eval';
 
-export default definePromptTemplate((ctx) => `
-  Question: ${ctx.question}
-  Answer: ${ctx.answer}
+function textFromMessages(messages) {
+  return messages
+    .map((message) => typeof message.content === 'string' ? message.content : '')
+    .filter(Boolean)
+    .join('\n');
+}
 
-  ${ctx.referenceAnswer ? `Reference: ${ctx.referenceAnswer}` : ''}
+export default definePromptTemplate((ctx) => `
+  Question: ${textFromMessages(ctx.input.filter((message) => message.role === 'user'))}
+  Answer: ${ctx.output ?? ctx.answer ?? ''}
+
+  ${ctx.expectedOutput.length > 0 ? `Reference: ${textFromMessages(ctx.expectedOutput)}` : ''}
 `);
 ```
 
@@ -28,15 +35,15 @@ The template receives evaluation context via stdin (JSON) and outputs the prompt
 
 ## Available Context Fields
 
-- `question` - The test question
-- `answer` - The agent's response being evaluated
-- `referenceAnswer` - Optional reference answer
-- `criteria` - Optional criteria / expected outcome
-- `expectedOutput` - Optional expected output messages
-- `output` - Optional output messages from agent
-- `inputFiles` - Paths to input files
 - `input` - Input messages to agent
-- `trace` - Optional trace summary with tool usage metrics
+- `output` - The agent's final answer being evaluated
+- `answer` - Deprecated alias for `output`
+- `expectedOutput` - Optional expected output messages
+- `criteria` - Optional criteria / expected outcome
+- `messages` - Transcript messages from the target execution
+- `inputFiles` - Paths to input files
+- `trace` - Optional full trace with transcript and events
+- `traceSummary` - Optional trace summary with tool usage metrics
 - `config` - Optional pass-through config from YAML
 
 ## Running

--- a/examples/features/prompt-template-sdk/bun.lock
+++ b/examples/features/prompt-template-sdk/bun.lock
@@ -1,0 +1,17 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "agentv-example-prompt-template-sdk",
+      "dependencies": {
+        "@agentv/eval": "file:../../../packages/eval",
+      },
+    },
+  },
+  "packages": {
+    "@agentv/eval": ["@agentv/eval@file:../../../packages/eval", { "dependencies": { "zod": "^3.23.8" } }],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+  }
+}

--- a/examples/features/prompt-template-sdk/package.json
+++ b/examples/features/prompt-template-sdk/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "agentv-example-prompt-template-sdk",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@agentv/eval": "file:../../../packages/eval"
+  }
+}

--- a/examples/features/prompt-template-sdk/prompts/custom-evaluator.ts
+++ b/examples/features/prompt-template-sdk/prompts/custom-evaluator.ts
@@ -28,7 +28,7 @@ function getMessageText(
 
 export default definePromptTemplate((ctx) => {
   const inputText = getMessageText(ctx.input, 'user');
-  const outputText = getMessageText(ctx.output ?? []);
+  const outputText = ctx.output ?? ctx.answer ?? '';
   const expectedOutputText = getMessageText(ctx.expectedOutput);
 
   // Access typed config from YAML

--- a/examples/features/sdk-custom-assertion/.agentv/assertions/word-count.ts
+++ b/examples/features/sdk-custom-assertion/.agentv/assertions/word-count.ts
@@ -1,28 +1,9 @@
 #!/usr/bin/env bun
 import { defineAssertion } from '@agentv/eval';
 
-function getMessageText(
-  messages: readonly { role: string; content?: unknown }[],
-  role = 'assistant',
-): string {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
-    if (msg.role === role) {
-      if (typeof msg.content === 'string') return msg.content;
-      if (Array.isArray(msg.content)) {
-        return msg.content
-          .filter((b: { type?: string }) => b.type === 'text')
-          .map((b: { text?: string }) => b.text)
-          .join('\n');
-      }
-    }
-  }
-  return '';
-}
-
 export default defineAssertion(({ output }) => {
-  const outputText = getMessageText(output ?? []);
-  const wordCount = outputText.trim().split(/\s+/).length;
+  const outputText = output ?? '';
+  const wordCount = outputText.trim().split(/\s+/).filter(Boolean).length;
   const minWords = 3;
   const pass = wordCount >= minWords;
 

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -30,9 +30,12 @@ Assertions support `pass: boolean` for simple checks and `score: number` (0-1) f
 #!/usr/bin/env bun
 import { defineCodeGrader } from '@agentv/eval';
 
-export default defineCodeGrader(({ answer, trace }) => ({
-  score: answer.length > 0 ? 1.0 : 0.0,
-  assertions: [{ text: 'Output received', passed: answer.length > 0 }],
+export default defineCodeGrader(({ output, traceSummary }) => ({
+  score: (output ?? '').length > 0 ? 1.0 : 0.0,
+  assertions: [
+    { text: 'Output received', passed: (output ?? '').length > 0 },
+    { text: 'Trace summary available', passed: traceSummary !== null },
+  ],
 }));
 ```
 

--- a/packages/eval/src/index.ts
+++ b/packages/eval/src/index.ts
@@ -9,9 +9,10 @@
  * import { defineAssertion } from '@agentv/eval';
  *
  * export default defineAssertion(({ output, criteria }) => {
+ *   const answer = output ?? '';
  *   return {
- *     pass: output.includes('hello'),
- *     assertions: [{ text: 'Checks greeting', passed: output.includes('hello') }],
+ *     pass: answer.includes('hello'),
+ *     assertions: [{ text: 'Checks greeting', passed: answer.includes('hello') }],
  *   };
  * }));
  * ```
@@ -21,10 +22,13 @@
  * #!/usr/bin/env bun
  * import { defineCodeGrader } from '@agentv/eval';
  *
- * export default defineCodeGrader(({ trace, output }) => {
+ * export default defineCodeGrader(({ output, traceSummary }) => {
  *   return {
- *     score: trace?.eventCount <= 5 ? 1.0 : 0.5,
- *     assertions: [{ text: 'Efficient tool usage', passed: trace?.eventCount <= 5 }],
+ *     score: (output ?? '').length > 0 && (traceSummary?.eventCount ?? 0) <= 5 ? 1.0 : 0.5,
+ *     assertions: [
+ *       { text: 'Answer is not empty', passed: (output ?? '').length > 0 },
+ *       { text: 'Efficient tool usage', passed: (traceSummary?.eventCount ?? 0) <= 5 },
+ *     ],
  *   };
  * }));
  * ```
@@ -212,8 +216,11 @@ export function defineCodeGrader(handler: CodeGraderHandler): void {
  * import { definePromptTemplate } from '@agentv/eval';
  *
  * export default definePromptTemplate((ctx) => {
- *   const question = ctx.input.map(m => String(m.content ?? '')).join('\n');
- *   const answer = ctx.output?.map(m => String(m.content ?? '')).join('\n') ?? '';
+ *   const question = ctx.input
+ *     .filter((message) => message.role === 'user')
+ *     .map((message) => typeof message.content === 'string' ? message.content : '')
+ *     .join('\n');
+ *   const answer = ctx.output ?? ctx.answer ?? '';
  *   return `Question: ${question}\nAnswer: ${answer}`;
  * });
  * ```
@@ -245,7 +252,7 @@ export function definePromptTemplate(handler: PromptTemplateHandler): void {
  * import { defineAssertion } from '@agentv/eval';
  *
  * export default defineAssertion(({ output }) => {
- *   const text = output?.map(m => String(m.content ?? '')).join(' ') ?? '';
+ *   const text = output ?? '';
  *   return {
  *     pass: text.toLowerCase().includes('hello'),
  *     assertions: [{ text: 'Checks for greeting', passed: text.toLowerCase().includes('hello') }],
@@ -257,10 +264,10 @@ export function definePromptTemplate(handler: PromptTemplateHandler): void {
  * ```typescript
  * import { defineAssertion } from '@agentv/eval';
  *
- * export default defineAssertion(({ output, trace }) => {
- *   const text = output?.map(m => String(m.content ?? '')).join(' ') ?? '';
+ * export default defineAssertion(({ output, traceSummary }) => {
+ *   const text = output ?? '';
  *   const hasContent = text.length > 0 ? 0.5 : 0;
- *   const isEfficient = (trace?.eventCount ?? 0) <= 5 ? 0.5 : 0;
+ *   const isEfficient = (traceSummary?.eventCount ?? 0) <= 5 ? 0.5 : 0;
  *   return {
  *     score: hasContent + isEfficient,
  *     assertions: [

--- a/packages/eval/src/prompt-template.ts
+++ b/packages/eval/src/prompt-template.ts
@@ -69,11 +69,13 @@ export async function runPromptTemplate(handler: PromptTemplateHandler): Promise
  * @example
  * ```typescript
  * import { definePromptTemplate, type CodeGraderInput } from '@agentv/eval';
- * import { getTextContent } from '@agentv/core';
  *
  * export default definePromptTemplate((ctx: CodeGraderInput) => {
- *   const question = ctx.input.map(m => getTextContent(m.content)).join('\n');
- *   const answer = ctx.output?.map(m => getTextContent(m.content)).join('\n') ?? '';
+ *   const question = ctx.input
+ *     .filter((message) => message.role === 'user')
+ *     .map((message) => typeof message.content === 'string' ? message.content : '')
+ *     .join('\n');
+ *   const answer = ctx.output ?? ctx.answer ?? '';
  *   return `Question: ${question}\nAnswer: ${answer}`;
  * });
  * ```

--- a/packages/eval/src/target-client.ts
+++ b/packages/eval/src/target-client.ts
@@ -106,8 +106,12 @@ export class TargetInvocationError extends Error {
  * ```typescript
  * import { createTargetClient, defineCodeGrader } from '@agentv/eval';
  *
- * export default defineCodeGrader(async ({ question, criteria }) => {
+ * export default defineCodeGrader(async ({ input, criteria, output }) => {
  *   const target = createTargetClient();
+ *   const question = input
+ *     .filter((message) => message.role === 'user')
+ *     .map((message) => typeof message.content === 'string' ? message.content : '')
+ *     .join('\n');
  *
  *   if (!target) {
  *     // Target not available - no target config on this evaluator
@@ -115,7 +119,7 @@ export class TargetInvocationError extends Error {
  *   }
  *
  *   const response = await target.invoke({
- *     question: `Is this answer correct? Question: ${question}, Expected: ${criteria}`,
+ *     question: `Is this answer correct? Question: ${question}, Expected: ${criteria}, Answer: ${output ?? ''}`,
  *     systemPrompt: 'You are an expert grader. Respond with JSON: { "correct": true/false }'
  *   });
  *

--- a/skills-data/agentv-eval-writer/SKILL.md
+++ b/skills-data/agentv-eval-writer/SKILL.md
@@ -357,7 +357,8 @@ Configure via `assertions` array. Multiple graders produce a weighted average sc
   target: {}              # optional: enable LLM target proxy (max_calls: 50)
 ```
 Contract: stdin JSON -> stdout JSON `{score, assertions: [{text, passed, evidence?}], reasoning}`
-Input includes: `question`, `criteria`, `answer`, `reference_answer`, `output`, `trace`, `token_usage`, `cost_usd`, `duration_ms`, `start_time`, `end_time`, `file_changes`, `workspace_path`, `config`
+Raw stdin uses snake_case and includes: `criteria`, `input`, `expected_output`, `output` (final answer string), `answer` (deprecated alias), `messages`, `trace`, `trace_summary`, `token_usage`, `cost_usd`, `duration_ms`, `start_time`, `end_time`, `file_changes`, `workspace_path`, `config`
+SDK handlers receive the same payload in camelCase: `expectedOutput`, `traceSummary`, `tokenUsage`, `costUsd`, `durationMs`, `startTime`, `endTime`, `fileChanges`, `workspacePath`.
 When a workspace is configured, `workspace_path` is the absolute path to the workspace dir (also available as `AGENTV_WORKSPACE_PATH` env var). Use this for functional grading (e.g., running `npm test` in the workspace).
 See docs at https://agentv.dev/graders/code-graders/
 

--- a/skills-data/agentv-eval-writer/references/custom-evaluators.md
+++ b/skills-data/agentv-eval-writer/references/custom-evaluators.md
@@ -6,15 +6,23 @@
 
 ```json
 {
-  "question": "string",
   "criteria": "string",
-  "reference_answer": "string",
-  "answer": "string",
   "input_files": ["path"],
   "input": [{"role": "user", "content": "..."}],
   "expected_output": [{"role": "assistant", "content": "..."}],
-  "output": [{"role": "assistant", "content": "..."}],
+  "output": "final answer text",
+  "answer": "deprecated alias for output",
+  "messages": [{"role": "assistant", "content": "final answer text"}],
   "trace": {
+    "schema_version": "agentv.trace.v1",
+    "event_count": 5,
+    "tool_calls": {"fetch": 1},
+    "error_count": 0,
+    "llm_call_count": 2,
+    "messages": [],
+    "events": []
+  },
+  "trace_summary": {
     "event_count": 5,
     "tool_calls": {"fetch": 1},
     "error_count": 0,
@@ -54,7 +62,8 @@ import { defineCodeGrader, createTargetClient, definePromptTemplate } from '@age
   - `.invoke({question, systemPrompt})` - Single LLM call
   - `.invokeBatch(requests)` - Batch LLM calls
 - `definePromptTemplate(fn)` - Wraps prompt generation function
-  - Context fields: `question`, `answer`, `referenceAnswer`, `criteria`, `expectedOutput`, `output`, `config`, `trace`, `tokenUsage`, `costUsd`, `durationMs`, `startTime`, `endTime`
+  - Raw stdin uses `snake_case`; SDK handlers receive `camelCase`
+  - Context fields: `input`, `expectedOutput`, `output`, `answer`, `messages`, `criteria`, `config`, `trace`, `traceSummary`, `tokenUsage`, `costUsd`, `durationMs`, `startTime`, `endTime`
 
 ## Python Example
 
@@ -87,7 +96,8 @@ if __name__ == "__main__":
 #!/usr/bin/env bun
 import { defineCodeGrader } from '@agentv/eval';
 
-export default defineCodeGrader(({ answer, criteria }) => {
+export default defineCodeGrader(({ output, criteria }) => {
+  const answer = output ?? '';
   const assertions: Array<{ text: string; passed: boolean }> = [];
   if (answer.includes(criteria)) {
     assertions.push({ text: 'Matches expected outcome', passed: true });
@@ -108,12 +118,11 @@ Derived from test fields (users never author these directly):
 
 | Variable | Source |
 |----------|--------|
-| `question` | First user message in `input` |
 | `criteria` | Test `criteria` field |
-| `reference_answer` | Last entry in `expected_output` |
-| `answer` | Last entry in `output` (runtime) |
 | `input` | Full resolved input array (JSON) |
 | `expected_output` | Full resolved expected array (JSON) |
-| `output` | Full provider output array (JSON) |
+| `output` | Final answer / scored result string |
+| `answer` | Deprecated alias for `output` |
+| `messages` | Transcript messages from target execution |
 
 Markdown templates use `{{variable}}` syntax. TypeScript templates receive context object.


### PR DESCRIPTION
## Summary
- Document raw grader stdin as snake_case wire format and @agentv/eval handler fields as camelCase SDK format
- Update code-grader, custom assertion, prompt-template, SDK, and agentv-eval-writer examples for the 4.38 final-answer output contract
- Fix canonical SDK examples to use output as the final answer string, add prompt-template-sdk package metadata, and smoke-test the examples

## Verification
- bun --filter @agentv/eval typecheck
- bun --filter @agentv/eval test
- bun --filter @agentv/eval build
- bun run lint
- git diff --check
- Smoke: code-grader-sdk verify-attachments with final-answer output string
- Smoke: sdk-custom-assertion word-count with final-answer output string
- Smoke: prompt-template-sdk custom-evaluator with final-answer output string