### PR TITLE
chore(sdk): remove deprecated aliases and scaffold drift

### DIFF
--- a/apps/cli/src/commands/create/commands.ts
+++ b/apps/cli/src/commands/create/commands.ts
@@ -6,53 +6,27 @@ const ASSERTION_TEMPLATES: Record<string, string> = {
   default: `#!/usr/bin/env bun
 import { defineAssertion } from '@agentv/eval';
 
-/** Extract text from the last message with the given role. */
-function getMessageText(messages: Array<{ role: string; content?: unknown }>, role = 'assistant'): string {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
-    if (msg.role !== role) continue;
-    if (typeof msg.content === 'string') return msg.content;
-    if (Array.isArray(msg.content)) {
-      return msg.content.filter((b: any) => b.type === 'text').map((b: any) => b.text).join('\\n');
-    }
-  }
-  return '';
-}
-
 export default defineAssertion(({ output }) => {
   // TODO: Implement your assertion logic
-  const text = getMessageText(output ?? []);
+  const text = output ?? '';
   const pass = text.length > 0;
   return {
     pass,
-    reasoning: pass ? 'Output has content' : 'Output is empty',
+    assertions: [{ text: pass ? 'Output has content' : 'Output is empty', passed: pass }],
   };
 });
 `,
   score: `#!/usr/bin/env bun
 import { defineAssertion } from '@agentv/eval';
 
-/** Extract text from the last message with the given role. */
-function getMessageText(messages: Array<{ role: string; content?: unknown }>, role = 'assistant'): string {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
-    if (msg.role !== role) continue;
-    if (typeof msg.content === 'string') return msg.content;
-    if (Array.isArray(msg.content)) {
-      return msg.content.filter((b: any) => b.type === 'text').map((b: any) => b.text).join('\\n');
-    }
-  }
-  return '';
-}
-
 export default defineAssertion(({ output }) => {
   // TODO: Implement your scoring logic (0.0 to 1.0)
-  const text = getMessageText(output ?? []);
+  const text = output ?? '';
   const score = text.length > 0 ? 1.0 : 0.0;
   return {
     pass: score >= 0.5,
     score,
-    reasoning: \`Score: \${score}\`,
+    assertions: [{ text: 'Output has content', passed: score === 1.0 }],
   };
 });
 `,

--- a/apps/cli/src/commands/eval/commands/assert.ts
+++ b/apps/cli/src/commands/eval/commands/assert.ts
@@ -80,8 +80,6 @@ export const evalAssertCommand = command({
         question: resolvedInput,
         criteria: '',
         expected_output: [],
-        reference_answer: '',
-
         input_files: [],
         trace,
         token_usage: null,
@@ -93,10 +91,6 @@ export const evalAssertCommand = command({
         workspace_path: null,
         config: null,
         metadata: {},
-        // Text convenience accessors (new names)
-        input_text: resolvedInput,
-        output_text: resolvedOutput,
-        expected_output_text: '',
       },
       null,
       2,

--- a/apps/cli/src/commands/pipeline/grade.ts
+++ b/apps/cli/src/commands/pipeline/grade.ts
@@ -107,7 +107,6 @@ export async function runCodeGraders(
   const executeCodeGrader = async (graderConfig: Record<string, unknown>, task: GraderTask) => {
     const { testId, resultsDir, responseText, inputData } = task;
     const graderName = graderConfig.name as string;
-    const inputText = extractInputText(inputData.input);
     const messages = [{ role: 'assistant' as const, content: responseText }];
     const trace = buildTraceFromMessages({
       input: inputData.input,
@@ -133,9 +132,6 @@ export async function runCodeGraders(
       workspace_path: null,
       config: graderConfig.config ?? null,
       metadata: inputData.metadata ?? {},
-      input_text: inputText,
-      output_text: responseText,
-      expected_output_text: '',
     });
 
     try {

--- a/apps/cli/test/commands/create/assertion.test.ts
+++ b/apps/cli/test/commands/create/assertion.test.ts
@@ -23,9 +23,14 @@ describe('agentv create assertion', () => {
 
       expect(result.exitCode).toBe(0);
 
-      const content = await readFile(path.join(cwd, '.agentv', 'assertions', 'word-count.ts'), 'utf8');
+      const content = await readFile(
+        path.join(cwd, '.agentv', 'assertions', 'word-count.ts'),
+        'utf8',
+      );
       expect(content).toContain("const text = output ?? '';");
-      expect(content).toContain('assertions: [{ text: pass ? \'Output has content\' : \'Output is empty\', passed: pass }]');
+      expect(content).toContain(
+        "assertions: [{ text: pass ? 'Output has content' : 'Output is empty', passed: pass }]",
+      );
       expect(content).not.toContain('reasoning:');
       expect(content).not.toContain('getMessageText');
     } finally {

--- a/apps/cli/test/commands/create/assertion.test.ts
+++ b/apps/cli/test/commands/create/assertion.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execa } from 'execa';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '../../../../..');
+const CLI_ENTRY = path.join(projectRoot, 'apps/cli/src/cli.ts');
+
+describe('agentv create assertion', () => {
+  it('scaffolds canonical assertion output without deprecated reasoning examples', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'agentv-create-assertion-'));
+
+    try {
+      const result = await execa(
+        'bun',
+        ['--no-env-file', CLI_ENTRY, 'create', 'assertion', 'word-count'],
+        { cwd, reject: false },
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      const content = await readFile(path.join(cwd, '.agentv', 'assertions', 'word-count.ts'), 'utf8');
+      expect(content).toContain("const text = output ?? '';");
+      expect(content).toContain('assertions: [{ text: pass ? \'Output has content\' : \'Output is empty\', passed: pass }]');
+      expect(content).not.toContain('reasoning:');
+      expect(content).not.toContain('getMessageText');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/apps/cli/test/commands/eval/assert.test.ts
+++ b/apps/cli/test/commands/eval/assert.test.ts
@@ -27,9 +27,26 @@ console.log(JSON.stringify({ score: 1.0, assertions: [{ text: "always passes", p
     path.join(gradersDir, 'check-contains.ts'),
     `const input = await Bun.stdin.text();
 const payload = JSON.parse(input);
-const output = payload.output_text ?? payload.output ?? '';
+const output = payload.output ?? '';
 const score = typeof output === 'string' && output.includes('hello') ? 1.0 : 0.0;
 console.log(JSON.stringify({ score, assertions: [{ text: score ? "contains hello" : "missing hello", passed: !!score }] }));`,
+    'utf8',
+  );
+
+  await writeFile(
+    path.join(gradersDir, 'reject-legacy-fields.ts'),
+    `const input = await Bun.stdin.text();
+const payload = JSON.parse(input);
+const hasLegacyFields = [
+  "input_text",
+  "output_text",
+  "expected_output_text",
+  "reference_answer",
+].some((key) => Object.prototype.hasOwnProperty.call(payload, key));
+console.log(JSON.stringify({
+  score: hasLegacyFields ? 0 : 1,
+  assertions: [{ text: hasLegacyFields ? "legacy fields present" : "canonical fields only", passed: !hasLegacyFields }],
+}));`,
     'utf8',
   );
 
@@ -134,6 +151,32 @@ describe('agentv eval assert', () => {
         { cwd: baseDir, reject: false },
       );
       expect(result.exitCode).not.toBe(0);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it('sends only canonical wire fields to code graders', async () => {
+    const { baseDir } = await createGraderFixture();
+    try {
+      const result = await execa(
+        'bun',
+        [
+          '--no-env-file',
+          CLI_ENTRY,
+          'eval',
+          'assert',
+          'reject-legacy-fields',
+          '--agent-output',
+          'hello world',
+          '--agent-input',
+          'test',
+        ],
+        { cwd: baseDir, reject: false },
+      );
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.score).toBe(1.0);
     } finally {
       await rm(baseDir, { recursive: true, force: true });
     }

--- a/apps/web/src/content/docs/docs/evaluation/batch-cli.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/batch-cli.mdx
@@ -147,7 +147,7 @@ Each test has its own grader that validates the batch runner output. The grader 
 **Input (stdin):**
 ```json
 {
-  "output_text": "{\"id\":\"case-001\",\"decision\":\"CLEAR\",...}",
+  "output": "{\"id\":\"case-001\",\"decision\":\"CLEAR\",...}",
   "expected_output": [{"role": "assistant", "content": {"decision": "CLEAR"}}],
   "input": [...]
 }
@@ -170,7 +170,7 @@ Each test has its own grader that validates the batch runner output. The grader 
 import fs from 'node:fs';
 
 type EvalInput = {
-  output_text?: string;
+  output?: string;
   expected_output?: Array<{ role: string; content: unknown }>;
 };
 
@@ -182,7 +182,7 @@ function main() {
 
   let candidateDecision: string | undefined;
   try {
-    const parsed = JSON.parse(input.output_text ?? '');
+    const parsed = JSON.parse(input.output ?? '');
     candidateDecision = parsed.decision;
   } catch {
     candidateDecision = undefined;

--- a/apps/web/src/content/docs/docs/evaluation/sdk.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/sdk.mdx
@@ -32,9 +32,10 @@ import { defineAssertion } from '@agentv/eval';
 
 export default defineAssertion(({ output }) => {
   const wordCount = (output ?? '').trim().split(/\s+/).filter(Boolean).length;
+  const pass = wordCount >= 3;
   return {
-    pass: wordCount >= 3,
-    reasoning: `Output has ${wordCount} words`,
+    pass,
+    assertions: [{ text: `Output has ${wordCount} words`, passed: pass }],
   };
 });
 ```
@@ -47,10 +48,13 @@ Return a `score` (0–1) instead of `pass` for graded evaluation:
 // .agentv/assertions/efficiency.ts
 import { defineAssertion } from '@agentv/eval';
 
-export default defineAssertion(({ output, traceSummary }) => ({
-  pass: (output ?? '').length > 0 && (traceSummary?.eventCount ?? 0) <= 10,
-  reasoning: 'Checks content exists and is efficient',
-}));
+export default defineAssertion(({ output, traceSummary }) => {
+  const pass = (output ?? '').length > 0 && (traceSummary?.eventCount ?? 0) <= 10;
+  return {
+    pass,
+    assertions: [{ text: 'Checks content exists and is efficient', passed: pass }],
+  };
+});
 ```
 
 If only `pass` is given, score is `1` (pass) or `0` (fail).

--- a/apps/web/src/content/docs/docs/graders/code-graders.mdx
+++ b/apps/web/src/content/docs/docs/graders/code-graders.mdx
@@ -108,11 +108,11 @@ Scripts that write to stderr and exit non-zero surface as execution errors rathe
 # validators/check_answer.py
 import json, sys
 data = json.load(sys.stdin)
-output_text = data.get("output") or data.get("answer") or ""
+output = data.get("output") or data.get("answer") or ""
 
 assertions = []
 
-if "42" in output_text:
+if "42" in output:
     assertions.append({"text": "Output contains correct value (42)", "passed": True})
 else:
     assertions.append({"text": "Output does not contain expected value (42)", "passed": False})
@@ -133,11 +133,11 @@ print(json.dumps({
 import { readFileSync } from "fs";
 
 const data = JSON.parse(readFileSync("/dev/stdin", "utf-8"));
-const outputText: string = data.output ?? data.answer ?? "";
+const output: string = data.output ?? data.answer ?? "";
 
 const assertions: Array<{ text: string; passed: boolean }> = [];
 
-if (outputText.includes("42")) {
+if (output.includes("42")) {
   assertions.push({ text: "Output contains correct value (42)", passed: true });
 } else {
   assertions.push({ text: "Output does not contain expected value (42)", passed: false });
@@ -148,7 +148,6 @@ const passed = assertions.filter(a => a.passed).length;
 console.log(JSON.stringify({
   score: passed > 0 ? 1.0 : 0.0,
   assertions,
-  reasoning: `Passed ${passed} check(s)`,
 }));
 ```
 

--- a/apps/web/src/content/docs/docs/graders/code-graders.mdx
+++ b/apps/web/src/content/docs/docs/graders/code-graders.mdx
@@ -35,7 +35,7 @@ Raw grader stdin is a process-boundary wire format, so keys are `snake_case`. Ty
 | Raw stdin key | SDK field | Meaning |
 |---------------|-----------|---------|
 | `output` | `output` | Final answer / scored result as a string |
-| `answer` | `answer` | Deprecated alias for the same final answer string |
+| `answer` | `answer` | Same final answer string, exposed for ergonomic handler code |
 | `messages` | `messages` | Transcript messages for transcript-aware graders |
 | `expected_output` | `expectedOutput` | Reference answer messages |
 | `output_path` | `outputPath` | Temp file containing large final answer JSON, when used |

--- a/apps/web/src/content/docs/docs/graders/custom-assertions.mdx
+++ b/apps/web/src/content/docs/docs/graders/custom-assertions.mdx
@@ -57,7 +57,7 @@ assertions:
 
 ## Pass/Fail Pattern
 
-The simplest pattern returns `pass` (boolean) and `reasoning` (string):
+The simplest pattern returns `pass` (boolean) and an optional `assertions` array:
 
 ```typescript
 // .agentv/assertions/word-count.ts
@@ -65,9 +65,10 @@ import { defineAssertion } from '@agentv/eval';
 
 export default defineAssertion(({ output }) => {
   const wordCount = (output ?? '').trim().split(/\s+/).filter(Boolean).length;
+  const pass = wordCount >= 3;
   return {
-    pass: wordCount >= 3,
-    reasoning: `Output has ${wordCount} words`,
+    pass,
+    assertions: [{ text: `Output has ${wordCount} words`, passed: pass }],
   };
 });
 ```
@@ -106,7 +107,6 @@ The handler must return an `AssertionScore` object:
 | `pass` | `boolean` | Explicit pass/fail. If omitted, derived from `score` (>= 0.5 = pass). |
 | `score` | `number` | Numeric score between 0 and 1. Defaults to 1 if `pass=true`, 0 if `pass=false`. |
 | `assertions` | `Array<{ text: string, passed: boolean, evidence?: string }>` | Per-aspect results. Each entry describes one check with its verdict and optional evidence. |
-| `reasoning` | `string` | Human-readable explanation. |
 | `details` | `Record<string, unknown>` | Optional structured data for domain-specific metrics. |
 
 ## Context Available to Assertions
@@ -140,8 +140,9 @@ Expected output:
 ```json
 {
   "score": 1,
-  "assertions": [],
-  "reasoning": "Output has 6 words (>= 3 required)"
+  "assertions": [
+    { "text": "Output has 6 words", "passed": true }
+  ]
 }
 ```
 
@@ -201,9 +202,14 @@ export default defineAssertion(({ output }) => {
   return {
     pass,
     score: pass ? 1.0 : Math.min(wordCount / minWords, 0.9),
-    reasoning: pass
-      ? `Output has ${wordCount} words (>= ${minWords} required)`
-      : `Output has only ${wordCount} words (need >= ${minWords})`,
+    assertions: [
+      {
+        text: pass
+          ? `Output has ${wordCount} words (>= ${minWords} required)`
+          : `Output has only ${wordCount} words (need >= ${minWords})`,
+        passed: pass,
+      },
+    ],
   };
 });
 ```

--- a/apps/web/src/content/docs/docs/graders/llm-graders.mdx
+++ b/apps/web/src/content/docs/docs/graders/llm-graders.mdx
@@ -48,10 +48,10 @@ Write evaluation instructions as markdown. Template variables are interpolated:
 
 Evaluate the candidate's response to the following question:
 
-**Question:** {{input_text}}
+**Question:** {{input}}
 **Criteria:** {{criteria}}
-**Reference Answer:** {{expected_output_text}}
-**Candidate Answer:** {{output_text}}
+**Reference Answer:** {{expected_output}}
+**Candidate Answer:** {{output}}
 
 ## Scoring
 
@@ -65,13 +65,10 @@ Score the response from 0.0 to 1.0 based on:
 
 | Variable | Source |
 |----------|--------|
-| `input_text` | First user message content |
-| `output_text` | Candidate final answer text |
-| `expected_output_text` | Last expected message content |
-| `criteria` | Test `criteria` field |
 | `input` | Resolved input text |
 | `expected_output` | Reference answer text |
 | `output` | Candidate answer text |
+| `criteria` | Test `criteria` field |
 | `metadata` | Test metadata as formatted JSON |
 | `metadata_json` | Test metadata as compact JSON |
 | `rubrics` | LLM-grader rubric items as formatted JSON |
@@ -230,7 +227,7 @@ TypeScript templates receive a context object with these fields:
 |-------|------|-------------|
 | `input` | `Message[]` | Full resolved input messages |
 | `output` | `string \| null` | Candidate final answer / scored result |
-| `answer` | `string` | Deprecated alias for `output` |
+| `answer` | `string` | Same final answer string, exposed for ergonomic handler code |
 | `messages` | `Message[]` | Transcript messages from the target execution |
 | `criteria` | `string` | Test `criteria` field |
 | `expectedOutput` | `Message[]` | Full resolved expected output |
@@ -267,11 +264,8 @@ Derived strings injected into grader prompts:
 
 | Variable | Derivation |
 |----------|------------|
-| `input_text` | Content of the first `user` role entry in `input` |
-| `criteria` | Passed through from the test field |
-| `expected_output_text` | Content of the last entry in `expected_output` |
-| `output_text` | Candidate final answer text |
 | `input` | Resolved input text |
+| `criteria` | Passed through from the test field |
 | `expected_output` | Reference answer text |
 | `output` | Candidate answer text |
 | `metadata_json` | Test metadata, compact JSON |
@@ -292,7 +286,7 @@ input:    [{ role: "user", content: "What is 2+2?" }]
 expected_output: [{ role: "assistant", content: "The answer is 4" }]
 
 # Derived template variables:
-input_text:           "What is 2+2?"
-expected_output_text: "The answer is 4"
-output_text: (extracted from provider output at runtime)
+input:           "What is 2+2?"
+expected_output: "The answer is 4"
+output: (extracted from provider output at runtime)
 ```

--- a/apps/web/src/content/docs/docs/integrations/autoevals-integration.mdx
+++ b/apps/web/src/content/docs/docs/integrations/autoevals-integration.mdx
@@ -77,9 +77,9 @@ import { Factuality } from "autoevals";
 const input = JSON.parse(readFileSync("/dev/stdin", "utf-8"));
 
 const result = await Factuality({
-  input: input.input_text,
-  output: input.output_text,
-  expected: input.reference_answer,
+  input: input.input,
+  output: input.output ?? input.answer,
+  expected: input.expected_output,
 });
 
 const score = result.score ?? 0;
@@ -94,7 +94,7 @@ console.log(
 );
 ```
 
-The code grader reads the AgentV input from stdin (`input_text`, `output_text`, `expected_output_text`), maps the fields to autoevals parameters (`input`, `output`, `expected`), runs the scorer, and writes the AgentV result format (with `assertions` array) to stdout.
+The code grader reads the AgentV input from stdin (`input`, `output`, `expected_output`), maps the fields to autoevals parameters (`input`, `output`, `expected`), runs the scorer, and writes the AgentV result format (with `assertions` array) to stdout.
 
 ## Python Example
 
@@ -127,9 +127,9 @@ data = json.load(sys.stdin)
 
 grader = Faithfulness()
 result = grader(
-    input=data.get("input_text", ""),
-    output=data.get("output_text", ""),
-    expected=data.get("reference_answer", ""),
+    input=data.get("input", ""),
+    output=data.get("output") or data.get("answer", ""),
+    expected=data.get("expected_output", ""),
 )
 
 score = result.score or 0
@@ -218,9 +218,9 @@ import {
 const input = JSON.parse(readFileSync("/dev/stdin", "utf-8"));
 
 const scorerArgs = {
-  input: input.input_text,
-  output: input.output_text,
-  expected: input.reference_answer,
+  input: input.input,
+  output: input.output ?? input.answer,
+  expected: input.expected_output,
 };
 
 // Run all scorers in parallel

--- a/examples/features/basic/evals/check_python_keywords.py
+++ b/examples/features/basic/evals/check_python_keywords.py
@@ -80,7 +80,7 @@ def main():
         input_data = json.loads(sys.stdin.read())
         
         # Extract the generated output
-        output = input_data.get("output_text", "")
+        output = input_data.get("output") or input_data.get("answer", "")
         
         # Extract code from markdown if present
         code = extract_code_from_markdown(output)

--- a/examples/features/document-extraction/graders/fuzzy_match.ts
+++ b/examples/features/document-extraction/graders/fuzzy_match.ts
@@ -20,10 +20,10 @@
 import { jaroWinklerSimilarity, levenshteinSimilarity } from '../lib/fuzzy_utils';
 
 interface EvalInput {
-  output_text: string;
-  expected_output_text: string;
+  output: string;
+  expected_output: string;
   criteria: string;
-  input_text: string;
+  input: string;
 }
 
 interface AssertionEntry {
@@ -51,10 +51,10 @@ async function main(): Promise<void> {
   const input: EvalInput = JSON.parse(inputText);
 
   // Extract and normalize strings for comparison
-  const candidate = String(input.output_text || '')
+  const candidate = String(input.output || '')
     .trim()
     .toLowerCase();
-  const expected = String(input.expected_output_text || '')
+  const expected = String(input.expected_output || '')
     .trim()
     .toLowerCase();
 
@@ -77,7 +77,7 @@ async function main(): Promise<void> {
           ? `Similarity: ${(similarity * 100).toFixed(1)}% (threshold: ${SIMILARITY_THRESHOLD * 100}%)`
           : `Similarity: ${(similarity * 100).toFixed(1)}% < ${SIMILARITY_THRESHOLD * 100}% threshold`,
         passed,
-        evidence: `${ALGORITHM} similarity between "${input.output_text}" and "${input.expected_output_text}": ${(similarity * 100).toFixed(1)}%`,
+        evidence: `${ALGORITHM} similarity between "${input.output}" and "${input.expected_output}": ${(similarity * 100).toFixed(1)}%`,
       },
     ],
   };

--- a/examples/features/document-extraction/graders/header_confusion_metrics.ts
+++ b/examples/features/document-extraction/graders/header_confusion_metrics.ts
@@ -34,7 +34,7 @@ interface EvalConfig {
 }
 
 interface EvalInput {
-  output_text: string;
+  output: string;
   expected_output: Array<{ role: string; content: unknown }>;
   config: EvalConfig | null;
 }
@@ -146,7 +146,7 @@ async function main(): Promise<void> {
   // Parse candidate answer
   let candidateObj: unknown;
   try {
-    candidateObj = JSON.parse(input.output_text);
+    candidateObj = JSON.parse(input.output);
   } catch {
     console.log(
       JSON.stringify({

--- a/examples/features/document-extraction/graders/line_item_matching.ts
+++ b/examples/features/document-extraction/graders/line_item_matching.ts
@@ -34,7 +34,7 @@ interface EvalConfig {
 }
 
 interface EvalInput {
-  output_text: string;
+  output: string;
   expected_output: Array<{ role: string; content: unknown }>;
   config: EvalConfig | null;
 }
@@ -224,7 +224,7 @@ async function main(): Promise<void> {
   // Parse candidate answer
   let candidateObj: unknown;
   try {
-    candidateObj = JSON.parse(input.output_text);
+    candidateObj = JSON.parse(input.output);
   } catch {
     console.log(
       JSON.stringify({

--- a/examples/features/document-extraction/graders/multi_field_fuzzy.ts
+++ b/examples/features/document-extraction/graders/multi_field_fuzzy.ts
@@ -34,8 +34,8 @@ interface EvalConfig {
 }
 
 interface EvalInput {
-  output_text: string;
-  expected_output_text: string;
+  output: string;
+  expected_output: string;
   config: EvalConfig | null;
 }
 
@@ -86,8 +86,8 @@ async function main(): Promise<void> {
   let candidateObj: unknown;
   let referenceObj: unknown;
   try {
-    candidateObj = JSON.parse(input.output_text);
-    referenceObj = JSON.parse(input.expected_output_text);
+    candidateObj = JSON.parse(input.output);
+    referenceObj = JSON.parse(input.expected_output);
   } catch {
     console.log(
       JSON.stringify({

--- a/examples/features/eval-assert-demo/README.md
+++ b/examples/features/eval-assert-demo/README.md
@@ -67,7 +67,7 @@ When running the eval, the transpiler emits natural-language instructions for ea
 ```
 Run `agentv eval assert keyword-check --agent-output <text> --agent-input <text>` and check the result.
 This grader: Checks that the answer mentions Paris and France.
-The command returns JSON: {"score": 0-1, "reasoning": "..."}.
+The command returns JSON: {"score": 0-1, "assertions": [{"text": "...", "passed": true|false}]}.
 A score >= 0.5 means pass (exit 0); below 0.5 means fail (exit 1).
 ```
 

--- a/examples/features/rubric/evals/check_syntax.py
+++ b/examples/features/rubric/evals/check_syntax.py
@@ -13,7 +13,7 @@ def main():
             # Fallback if no input or invalid JSON
             input_data = {}
             
-        candidate_answer = input_data.get("output_text", "")
+        candidate_answer = input_data.get("output") or input_data.get("answer", "")
 
         # Extract code block if present (simple heuristic)
         if "```python" in candidate_answer:

--- a/examples/showcase/cw-incident-triage/evals/validate_output.py
+++ b/examples/showcase/cw-incident-triage/evals/validate_output.py
@@ -81,7 +81,7 @@ def main():
         sys.exit(1)
     
     # Extract candidate answer
-    candidate_answer = eval_data.get("output_text", "")
+    candidate_answer = eval_data.get("output") or eval_data.get("answer", "")
     
     # Required keys for CargoWise criticality rating
     required_keys = ["criticalityRating", "reasoning"]

--- a/examples/showcase/grader-conformance/conformance-check.ts
+++ b/examples/showcase/grader-conformance/conformance-check.ts
@@ -101,13 +101,11 @@ const maxFlipRate = Number.parseFloat(values['max-flip-rate'] ?? '0');
 function buildCodeGraderInput(fixture: Fixture): string {
   // Build a minimal CodeGraderInput in the snake_case wire format
   return JSON.stringify({
-    input_text: fixture.question,
     criteria: fixture.criteria,
-    output_text: fixture.answer,
-    expected_output_text: fixture.expected_output,
-    expected_output: [],
+    output: fixture.answer,
+    answer: fixture.answer,
+    expected_output: [{ role: 'assistant', content: fixture.expected_output }],
     input: [{ role: 'user', content: fixture.question }],
-    output: [{ role: 'assistant', content: fixture.answer }],
     input_files: [],
   });
 }

--- a/examples/showcase/psychotherapy/evals/validate_output.py
+++ b/examples/showcase/psychotherapy/evals/validate_output.py
@@ -229,7 +229,7 @@ def main():
         sys.exit(1)
     
     # Extract candidate answer - we only validate the candidate's structure
-    candidate_answer = eval_data.get("output_text", "")
+    candidate_answer = eval_data.get("output") or eval_data.get("answer", "")
     
     # Auto-detect required keys from candidate answer
     required_keys = detect_framework_keys(candidate_answer)

--- a/examples/showcase/tool-evaluation-plugins/README.md
+++ b/examples/showcase/tool-evaluation-plugins/README.md
@@ -67,7 +67,7 @@ All code graders receive a JSON object on stdin with:
 {
   "question": "User's question/task",
   "criteria": "Expected behavior description",
-  "reference_answer": "Gold standard answer (from expected_output)",
+  "expected_output": "Gold standard answer",
   "answer": "Agent's final response",
   "output": [
     {

--- a/examples/showcase/tool-evaluation-plugins/tool-eval-demo.eval.yaml
+++ b/examples/showcase/tool-evaluation-plugins/tool-eval-demo.eval.yaml
@@ -104,7 +104,7 @@ tests:
   # ==========================================
   # Example 4: Pairwise Comparison
   # Use case: Compare candidate against baseline response
-  # Requires reference_answer field
+  # Requires expected_output to supply a reference answer
   # ==========================================
   - id: pairwise-demo
 
@@ -116,7 +116,7 @@ tests:
         content: Summarize the main points of the user manual.
 
     # Reference answer for comparison (from a baseline agent)
-    # Note: reference_answer is constructed from expected_output content
+    # Note: the reference answer is derived from expected_output content
     expected_output:
       - role: assistant
         content: |-

--- a/packages/core/src/evaluation/graders/llm-grader-prompt.ts
+++ b/packages/core/src/evaluation/graders/llm-grader-prompt.ts
@@ -50,9 +50,6 @@ function buildTemplateVariables(input: {
     [TEMPLATE_VARIABLES.RUBRICS_JSON]: stringifyCompact(input.rubrics),
     [TEMPLATE_VARIABLES.FILE_CHANGES]: input.fileChanges ?? '',
     [TEMPLATE_VARIABLES.TOOL_CALLS]: input.toolCalls ?? '',
-    [TEMPLATE_VARIABLES.INPUT_TEXT]: formattedQuestion.trim(),
-    [TEMPLATE_VARIABLES.OUTPUT_TEXT]: input.candidate.trim(),
-    [TEMPLATE_VARIABLES.EXPECTED_OUTPUT_TEXT]: (input.evalCase.reference_answer ?? '').trim(),
   };
 }
 

--- a/packages/core/src/evaluation/graders/llm-grader.ts
+++ b/packages/core/src/evaluation/graders/llm-grader.ts
@@ -11,7 +11,7 @@ import type { ContentImage } from '../content.js';
 import { isContentArray } from '../content.js';
 import type { Message, Provider, ProviderResponse, ProviderTool } from '../providers/types.js';
 import { extractLastAssistantContent, isAgentProvider } from '../providers/types.js';
-import { DEPRECATED_TEMPLATE_VARIABLES, TEMPLATE_VARIABLES } from '../template-variables.js';
+import { TEMPLATE_VARIABLES } from '../template-variables.js';
 import type { TokenUsage } from '../trace.js';
 import type { AssertionEntry, JsonObject, RubricItem } from '../types.js';
 import { formatRubricOperatorGuidance, formatRubricOperatorLabel } from './rubric-operators.js';
@@ -181,10 +181,6 @@ function buildTemplateVariables(context: EvaluationContext): Record<string, stri
     [TEMPLATE_VARIABLES.RUBRICS_JSON]: stringifyCompact(rubrics),
     [TEMPLATE_VARIABLES.FILE_CHANGES]: context.fileChanges ?? '',
     [TEMPLATE_VARIABLES.TOOL_CALLS]: context.toolCalls ?? '',
-    // Deprecated aliases — same values as the primary variables above
-    [TEMPLATE_VARIABLES.INPUT_TEXT]: formattedQuestion.trim(),
-    [TEMPLATE_VARIABLES.OUTPUT_TEXT]: context.candidate.trim(),
-    [TEMPLATE_VARIABLES.EXPECTED_OUTPUT_TEXT]: (context.evalCase.reference_answer ?? '').trim(),
   };
 }
 
@@ -300,9 +296,6 @@ export class LlmGrader implements Grader {
     // Build user prompt based on custom template or default template
     const graderTemplate =
       context.graderTemplateOverride ?? this.graderTemplate ?? DEFAULT_GRADER_TEMPLATE;
-
-    // Warn once per run when custom templates use deprecated _text variable names
-    warnDeprecatedTemplateVars(graderTemplate);
 
     let userPrompt = substituteVariables(graderTemplate, variables);
 
@@ -713,7 +706,6 @@ export class LlmGrader implements Grader {
 
     const template = context.graderTemplateOverride ?? this.graderTemplate;
     if (template) {
-      warnDeprecatedTemplateVars(template);
       return substituteVariables(template, variables);
     }
 
@@ -781,7 +773,6 @@ export class LlmGrader implements Grader {
     const template = context.graderTemplateOverride ?? this.graderTemplate;
     if (template) {
       const variables = buildTemplateVariables(context);
-      warnDeprecatedTemplateVars(template);
       const customPrompt = substituteVariables(template, variables);
 
       const outputSchema =
@@ -987,7 +978,6 @@ export class LlmGrader implements Grader {
 
   private buildCustomPrompt(context: EvaluationContext): string {
     const template = context.graderTemplateOverride ?? this.graderTemplate ?? '';
-    warnDeprecatedTemplateVars(template);
     return substituteVariables(template, buildTemplateVariables(context));
   }
 
@@ -1224,34 +1214,6 @@ export function substituteVariables(template: string, variables: Record<string, 
   return template.replace(/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g, (match, varName) => {
     return variables[varName] ?? match;
   });
-}
-
-const ANSI_YELLOW = '\u001b[33m';
-const ANSI_RESET = '\u001b[0m';
-
-/** Set of templates that have already emitted a deprecation warning (one-time per template). */
-const warnedTemplateStrings = new Set<string>();
-
-/**
- * Emit a one-time stderr warning when a template uses deprecated _text variable names.
- * Skips the default template (which uses the new names and should never trigger warnings).
- */
-export function warnDeprecatedTemplateVars(template: string): void {
-  if (warnedTemplateStrings.has(template)) return;
-
-  const used: string[] = [];
-  for (const [deprecated, replacement] of DEPRECATED_TEMPLATE_VARIABLES) {
-    if (new RegExp(`\\{\\{\\s*${deprecated}\\s*\\}\\}`).test(template)) {
-      used.push(`{{ ${deprecated} }} → {{ ${replacement} }}`);
-    }
-  }
-
-  if (used.length > 0) {
-    warnedTemplateStrings.add(template);
-    console.warn(
-      `${ANSI_YELLOW}⚠ Deprecated template variables detected (they still work but will be removed in a future version):\n  ${used.join('\n  ')}\n  Update your custom grader template to use the new names.${ANSI_RESET}`,
-    );
-  }
 }
 
 export function calculateRubricScore(

--- a/packages/core/src/evaluation/template-variables.ts
+++ b/packages/core/src/evaluation/template-variables.ts
@@ -14,10 +14,6 @@
  *   - {{ file_changes }}    — file diff (if available)
  *   - {{ tool_calls }}     — formatted summary of tool calls from agent execution
  *
- * Deprecated aliases (emit a warning when used in custom templates):
- *   - {{ input_text }}           → use {{ input }}
- *   - {{ output_text }}          → use {{ output }}
- *   - {{ expected_output_text }} → use {{ expected_output }}
  */
 export const TEMPLATE_VARIABLES = {
   EXPECTED_OUTPUT: 'expected_output',
@@ -30,12 +26,6 @@ export const TEMPLATE_VARIABLES = {
   OUTPUT: 'output',
   FILE_CHANGES: 'file_changes',
   TOOL_CALLS: 'tool_calls',
-  /** @deprecated Use INPUT instead — resolves to the same text value. */
-  INPUT_TEXT: 'input_text',
-  /** @deprecated Use OUTPUT instead — resolves to the same text value. */
-  OUTPUT_TEXT: 'output_text',
-  /** @deprecated Use EXPECTED_OUTPUT instead — resolves to the same text value. */
-  EXPECTED_OUTPUT_TEXT: 'expected_output_text',
 } as const;
 
 /**
@@ -55,14 +45,4 @@ export const VALID_TEMPLATE_VARIABLES = new Set<string>(Object.values(TEMPLATE_V
 export const REQUIRED_TEMPLATE_VARIABLES = new Set<string>([
   TEMPLATE_VARIABLES.OUTPUT,
   TEMPLATE_VARIABLES.EXPECTED_OUTPUT,
-]);
-
-/**
- * Deprecated template variable names that still work but trigger a warning.
- * Maps deprecated name → replacement name.
- */
-export const DEPRECATED_TEMPLATE_VARIABLES: ReadonlyMap<string, string> = new Map([
-  [TEMPLATE_VARIABLES.INPUT_TEXT, TEMPLATE_VARIABLES.INPUT],
-  [TEMPLATE_VARIABLES.OUTPUT_TEXT, TEMPLATE_VARIABLES.OUTPUT],
-  [TEMPLATE_VARIABLES.EXPECTED_OUTPUT_TEXT, TEMPLATE_VARIABLES.EXPECTED_OUTPUT],
 ]);

--- a/packages/core/src/evaluation/validation/prompt-validator.ts
+++ b/packages/core/src/evaluation/validation/prompt-validator.ts
@@ -1,13 +1,6 @@
 import { readFile } from 'node:fs/promises';
 
-import {
-  DEPRECATED_TEMPLATE_VARIABLES,
-  TEMPLATE_VARIABLES,
-  VALID_TEMPLATE_VARIABLES,
-} from '../template-variables.js';
-
-const ANSI_YELLOW = '\u001b[33m';
-const ANSI_RESET = '\u001b[0m';
+import { TEMPLATE_VARIABLES, VALID_TEMPLATE_VARIABLES } from '../template-variables.js';
 
 /**
  * Validate custom prompt template content from a file.
@@ -41,13 +34,8 @@ export function validateTemplateVariables(content: string, source: string): void
   }
 
   // Check if template contains required variables for evaluation.
-  // Accept both new names (output, expected_output) and deprecated aliases (output_text, expected_output_text).
-  const hasCandidateAnswer =
-    foundVariables.has(TEMPLATE_VARIABLES.OUTPUT) ||
-    foundVariables.has(TEMPLATE_VARIABLES.OUTPUT_TEXT);
-  const hasExpectedOutput =
-    foundVariables.has(TEMPLATE_VARIABLES.EXPECTED_OUTPUT) ||
-    foundVariables.has(TEMPLATE_VARIABLES.EXPECTED_OUTPUT_TEXT);
+  const hasCandidateAnswer = foundVariables.has(TEMPLATE_VARIABLES.OUTPUT);
+  const hasExpectedOutput = foundVariables.has(TEMPLATE_VARIABLES.EXPECTED_OUTPUT);
   const hasRequiredFields = hasCandidateAnswer || hasExpectedOutput;
 
   // ERROR: Missing required fields - throw error to skip this evaluator/eval case
@@ -57,26 +45,13 @@ export function validateTemplateVariables(content: string, source: string): void
     );
   }
 
-  // WARNING: Deprecated variables - show warning but continue
-  const deprecatedUsed: string[] = [];
-  for (const [deprecated, replacement] of DEPRECATED_TEMPLATE_VARIABLES) {
-    if (foundVariables.has(deprecated)) {
-      deprecatedUsed.push(`{{ ${deprecated} }} → {{ ${replacement} }}`);
-    }
-  }
-  if (deprecatedUsed.length > 0) {
-    console.warn(
-      `${ANSI_YELLOW}Warning: Template at ${source} uses deprecated variable names:\n  ${deprecatedUsed.join('\n  ')}\n  These still work but will be removed in a future version.${ANSI_RESET}`,
-    );
-  }
-
   // WARNING: Invalid variables - show warning but continue
   if (invalidVariables.length > 0) {
-    const warningMessage = `${ANSI_YELLOW}Warning: Custom grader template at ${source}
+    const warningMessage = `Warning: Custom grader template at ${source}
   Contains invalid variables: ${invalidVariables.map((v) => `{{ ${v} }}`).join(', ')}
   Valid variables: ${Array.from(VALID_TEMPLATE_VARIABLES)
     .map((v) => `{{ ${v} }}`)
-    .join(', ')}${ANSI_RESET}`;
+    .join(', ')}`;
 
     console.warn(warningMessage);
   }

--- a/packages/core/test/evaluation/evaluators_variables.test.ts
+++ b/packages/core/test/evaluation/evaluators_variables.test.ts
@@ -155,45 +155,6 @@ Candidate: {{output}}
     expect(prompt).toContain('Candidate: Apple revenue increased.');
   });
 
-  it('deprecated _text aliases still resolve correctly', async () => {
-    const formattedQuestion = 'What is 2+2?';
-    const customPrompt = `
-Question: {{input_text}}
-Reference: {{expected_output_text}}
-Candidate: {{output_text}}
-`;
-
-    const graderProvider = new CapturingProvider({
-      text: JSON.stringify({
-        score: 0.9,
-        assertions: [{ text: 'OK', passed: true }],
-      }),
-    });
-
-    const evaluator = new LlmGrader({
-      resolveGraderProvider: async () => graderProvider,
-      graderTemplate: customPrompt,
-    });
-
-    await evaluator.evaluate({
-      evalCase: { ...baseTestCase, evaluator: 'llm-grader' },
-      candidate: 'Four',
-      target: baseTarget,
-      provider: graderProvider,
-      attempt: 0,
-      promptInputs: { question: formattedQuestion },
-      now: new Date(),
-    });
-
-    const request = graderProvider.lastRequest;
-    expect(request).toBeDefined();
-
-    // Deprecated aliases resolve to the same text values as the primary variables
-    expect(request?.question).toContain(`Question: ${formattedQuestion}`);
-    expect(request?.question).toContain('Reference: Reference Answer Text');
-    expect(request?.question).toContain('Candidate: Four');
-  });
-
   it('does not substitute if no variables are present', async () => {
     const customPrompt = 'Fixed prompt without variables';
     const promptQuestion = 'Summarize the latest logs without markers.';

--- a/packages/core/test/evaluation/graders/prompt-resolution.test.ts
+++ b/packages/core/test/evaluation/graders/prompt-resolution.test.ts
@@ -41,12 +41,9 @@ describe('containsTemplateVariables', () => {
     ).toBe(true);
   });
 
-  it('returns true for deprecated {{output_text}} variable', () => {
-    expect(containsTemplateVariables('Grade the {{output_text}}')).toBe(true);
-  });
-
-  it('returns true for deprecated {{input_text}} variable', () => {
-    expect(containsTemplateVariables('Evaluate {{input_text}}')).toBe(true);
+  it('returns false for removed deprecated _text variables', () => {
+    expect(containsTemplateVariables('Grade the {{output_text}}')).toBe(false);
+    expect(containsTemplateVariables('Evaluate {{input_text}}')).toBe(false);
   });
 
   it('returns true with whitespace in braces', () => {

--- a/packages/core/test/evaluation/validation/prompt-validator.test.ts
+++ b/packages/core/test/evaluation/validation/prompt-validator.test.ts
@@ -13,14 +13,16 @@ describe('validateTemplateVariables', () => {
     ).not.toThrow();
   });
 
-  it('passes when template contains deprecated {{ output_text }}', () => {
-    expect(() => validateTemplateVariables('Score: {{ output_text }}', 'test.txt')).not.toThrow();
+  it('rejects removed deprecated {{ output_text }}', () => {
+    expect(() => validateTemplateVariables('Score: {{ output_text }}', 'test.txt')).toThrow(
+      'Missing required fields',
+    );
   });
 
-  it('passes when template contains deprecated {{ expected_output_text }}', () => {
+  it('rejects removed deprecated {{ expected_output_text }}', () => {
     expect(() =>
       validateTemplateVariables('Reference: {{ expected_output_text }}', 'test.txt'),
-    ).not.toThrow();
+    ).toThrow('Missing required fields');
   });
 
   it('throws when no required or deprecated variables are present', () => {

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -16,10 +16,13 @@ npm install @agentv/eval
 #!/usr/bin/env bun
 import { defineAssertion } from '@agentv/eval';
 
-export default defineAssertion(({ answer }) => ({
-  pass: answer.toLowerCase().includes('hello'),
-  reasoning: 'Checks for greeting',
-}));
+export default defineAssertion(({ output }) => {
+  const hasGreeting = (output ?? '').toLowerCase().includes('hello');
+  return {
+    pass: hasGreeting,
+    assertions: [{ text: 'Checks for greeting', passed: hasGreeting }],
+  };
+});
 ```
 
 Assertions support `pass: boolean` for simple checks and `score: number` (0-1) for granular scoring.

--- a/skills-data/agentv-eval-writer/SKILL.md
+++ b/skills-data/agentv-eval-writer/SKILL.md
@@ -356,7 +356,7 @@ Configure via `assertions` array. Multiple graders produce a weighted average sc
   cwd: ./scripts          # optional working directory
   target: {}              # optional: enable LLM target proxy (max_calls: 50)
 ```
-Contract: stdin JSON -> stdout JSON `{score, assertions: [{text, passed, evidence?}], reasoning}`
+Contract: stdin JSON -> stdout JSON `{score, assertions: [{text, passed, evidence?}], details?}`
 Raw stdin uses snake_case and includes: `criteria`, `input`, `expected_output`, `output` (final answer string), `answer` (deprecated alias), `messages`, `trace`, `trace_summary`, `token_usage`, `cost_usd`, `duration_ms`, `start_time`, `end_time`, `file_changes`, `workspace_path`, `config`
 SDK handlers receive the same payload in camelCase: `expectedOutput`, `traceSummary`, `tokenUsage`, `costUsd`, `durationMs`, `startTime`, `endTime`, `fileChanges`, `workspacePath`.
 When a workspace is configured, `workspace_path` is the absolute path to the workspace dir (also available as `AGENTV_WORKSPACE_PATH` env var). Use this for functional grading (e.g., running `npm test` in the workspace).
@@ -575,10 +575,13 @@ Use `@agentv/eval` to build custom graders in TypeScript/JavaScript:
 #!/usr/bin/env bun
 import { defineAssertion } from '@agentv/eval';
 
-export default defineAssertion(({ answer, trace }) => ({
-  pass: answer.length > 0 && (trace?.eventCount ?? 0) <= 10,
-  reasoning: 'Checks content exists and is efficient',
-}));
+export default defineAssertion(({ output, traceSummary }) => {
+  const pass = (output ?? '').length > 0 && (traceSummary?.eventCount ?? 0) <= 10;
+  return {
+    pass,
+    assertions: [{ text: 'Checks content exists and is efficient', passed: pass }],
+  };
+});
 ```
 
 Assertions support both `pass: boolean` and `score: number` (0-1). If only `pass` is given, score is 1 (pass) or 0 (fail).
@@ -588,10 +591,11 @@ Assertions support both `pass: boolean` and `score: number` (0-1). If only `pass
 #!/usr/bin/env bun
 import { defineCodeGrader } from '@agentv/eval';
 
-export default defineCodeGrader(({ trace, answer }) => ({
-  score: trace?.eventCount <= 5 ? 1.0 : 0.5,
+export default defineCodeGrader(({ output, traceSummary }) => ({
+  score: (output ?? '').length > 0 && (traceSummary?.eventCount ?? 0) <= 5 ? 1.0 : 0.5,
   assertions: [
-    { text: 'Efficient tool usage', passed: (trace?.eventCount ?? 0) <= 5 },
+    { text: 'Output is not empty', passed: (output ?? '').length > 0 },
+    { text: 'Efficient tool usage', passed: (traceSummary?.eventCount ?? 0) <= 5 },
   ],
 }));
 ```

--- a/skills-data/agentv-eval-writer/SKILL.md
+++ b/skills-data/agentv-eval-writer/SKILL.md
@@ -372,7 +372,7 @@ See docs at https://agentv.dev/graders/code-graders/
   config:                       # passed to prompt templates as context.config
     strictness: high
 ```
-Variables: `{{question}}`, `{{criteria}}`, `{{answer}}`, `{{reference_answer}}`, `{{input}}`, `{{expected_output}}`, `{{output}}`, `{{file_changes}}`
+Variables: `{{criteria}}`, `{{answer}}`, `{{input}}`, `{{expected_output}}`, `{{output}}`, `{{file_changes}}`
 - Markdown templates: use `{{variable}}` syntax
 - TypeScript templates: use `definePromptTemplate(fn)` from `@agentv/eval`, receives context object with all variables + `config`
 - Use `target:` to run different `llm-grader` graders against different named LLM targets in the same eval (useful for grader panels / ensembles)

--- a/skills-data/agentv-eval-writer/references/custom-evaluators.md
+++ b/skills-data/agentv-eval-writer/references/custom-evaluators.md
@@ -44,12 +44,11 @@
   "assertions": [
     { "text": "passed check", "passed": true },
     { "text": "failed check", "passed": false }
-  ],
-  "reasoning": "explanation"
+  ]
 }
 ```
 
-`score` (0.0-1.0) required. `assertions`, `reasoning` optional.
+`score` (0.0-1.0) required. `assertions` and `details` optional.
 
 ## SDK Functions
 
@@ -72,7 +71,7 @@ import { defineCodeGrader, createTargetClient, definePromptTemplate } from '@age
 import json, sys
 
 def evaluate(data: dict) -> dict:
-    candidate = data.get("answer", "")
+    candidate = data.get("output") or data.get("answer") or ""
     assertions = []
     for kw in ["async", "await"]:
         assertions.append({"text": f"Keyword '{kw}'", "passed": kw in candidate})
@@ -97,9 +96,9 @@ if __name__ == "__main__":
 import { defineCodeGrader } from '@agentv/eval';
 
 export default defineCodeGrader(({ output, criteria }) => {
-  const answer = output ?? '';
+  const candidate = output ?? '';
   const assertions: Array<{ text: string; passed: boolean }> = [];
-  if (answer.includes(criteria)) {
+  if (candidate.includes(criteria)) {
     assertions.push({ text: 'Matches expected outcome', passed: true });
   } else {
     assertions.push({ text: 'Does not match expected outcome', passed: false });


### PR DESCRIPTION
## Summary
- remove deprecated `_text` / `reference_answer` alias plumbing from CLI and core grader prompt validation
- align `agentv create assertion` scaffolds, SDK docs, package README, and eval-writer skill/reference docs with the canonical `assertions[]` contract
- add CLI regression coverage for canonical wire payloads and assertion scaffold output

## Verification
- `bun run build`
- `bun test apps/cli/test/commands/eval/assert.test.ts apps/cli/test/commands/create/assertion.test.ts`
- `bun test packages/core/test/evaluation/validation/prompt-validator.test.ts packages/core/test/evaluation/graders/prompt-resolution.test.ts`

## Red/Green Evidence
- Red on `origin/main`: `apps/cli/src/commands/create/commands.ts` scaffolded `defineAssertion` examples with `reasoning` and treated `output` as a message array via `getMessageText(output ?? [])`.
- Green on this branch: `bun --no-env-file apps/cli/src/cli.ts create assertion sample --template score` now generates a scaffold that reads `const text = output ?? ''` and returns `assertions: [{ text: 'Output has content', passed: score === 1.0 }]`.
- Red on `origin/main`: deprecated prompt variables such as `{{ output_text }}` were still recognized by validation / prompt-resolution tests.
- Green on this branch: `prompt-validator.test.ts` and `prompt-resolution.test.ts` assert those legacy variables are rejected / not detected.

## Remaining Intentional Aliases
- `assertions[]` remains the canonical result/grader output contract and is unchanged.
- `answer` remains available in SDK handler context and docs where it is an ergonomic in-process alias for `output`; this bead only removes true deprecated surface aliases (`input_text`, `output_text`, `expected_output_text`, `reference_answer`) and stale reasoning-based scaffolds.
- YAML `assertions` is intentionally unchanged; `assert` convergence is tracked separately in av-bv4.10.
