### PR TITLE
docs(sdk-dx): align eval authoring surfaces

### DIFF
--- a/apps/web/src/content/docs/docs/evaluation/eval-files.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/eval-files.mdx
@@ -7,6 +7,8 @@ sidebar:
 
 Evaluation files define the test cases, targets, and graders for an evaluation run. AgentV supports two formats: YAML and JSONL.
 
+YAML is the canonical portable model. TypeScript helpers, generated fixtures, and Python scripts should lower to the same YAML/JSONL shapes rather than inventing a separate eval contract.
+
 ## Suites
 
 An eval file is a **suite**: it binds test cases to execution context (workspace, hooks, targets, trials). Test cases can be inline or loaded from an external file via `tests: ./cases.yaml` for reuse across suites.

--- a/apps/web/src/content/docs/docs/evaluation/running-evals.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/running-evals.mdx
@@ -154,6 +154,8 @@ agentv inspect show traces/eval.otlp.json --tree
 trace counters. `--otel-file` writes standard OTLP JSON that can be imported into any
 OpenTelemetry-compatible backend.
 
+For Opik specifically, use `--otel-file` for post-run import or provide your own local backend resolver. AgentV does not currently ship a built-in `opik` backend name.
+
 ### Live OTel Export
 
 Stream traces directly to an observability backend during evaluation using `--export-otel`:

--- a/apps/web/src/content/docs/docs/evaluation/sdk.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/sdk.mdx
@@ -5,7 +5,9 @@ sidebar:
   order: 6
 ---
 
-AgentV provides two npm packages for programmatic use:
+YAML remains AgentV's canonical, portable eval format. The SDK surfaces below are for cases where you want to generate YAML-shaped definitions in code, embed eval runs inside another application, or write executable graders and prompt templates.
+
+AgentV currently provides two npm packages for programmatic use:
 
 - **`@agentv/eval`** — custom assertions and code graders
 - **`@agentv/core`** — programmatic evaluation API and typed configuration
@@ -19,6 +21,17 @@ npm install @agentv/eval
 # Programmatic API (evaluate, defineConfig)
 npm install @agentv/core
 ```
+
+## Choose a Surface
+
+Use the simplest surface that matches the job:
+
+- **YAML / JSONL first** for portable eval specs you want to run from the CLI, check into a repo, or share across TypeScript and Python workflows.
+- **`evaluate({ specFile })`** when you want library control around an existing YAML suite.
+- **Inline `evaluate({ tests })`** when the eval definition truly belongs inside application code. The programmatic API mirrors YAML, but uses current TypeScript naming such as `expectedOutput` and `assert`.
+- **`defineAssertion` / `defineCodeGrader`** when the grading logic itself must execute code.
+
+There is no separate first-party Python authoring SDK today. Python-facing workflows should either emit canonical YAML/JSONL or implement executable graders that consume the standard `snake_case` wire format.
 
 ## Custom Assertions
 
@@ -49,10 +62,11 @@ Return a `score` (0–1) instead of `pass` for graded evaluation:
 import { defineAssertion } from '@agentv/eval';
 
 export default defineAssertion(({ output, traceSummary }) => {
-  const pass = (output ?? '').length > 0 && (traceSummary?.eventCount ?? 0) <= 10;
+  const hasContent = (output ?? '').length > 0 ? 0.5 : 0;
+  const isEfficient = (traceSummary?.eventCount ?? 0) <= 10 ? 0.5 : 0;
   return {
-    pass,
-    assertions: [{ text: 'Checks content exists and is efficient', passed: pass }],
+    score: hasContent + isEfficient,
+    reasoning: 'Checks content exists and is efficient',
   };
 });
 ```
@@ -111,11 +125,11 @@ Raw grader stdin uses `snake_case` because it crosses a process boundary and may
 | `duration_ms` | `durationMs` |
 | `workspace_path` | `workspacePath` |
 
-`output` is already the final answer string in both formats. Transcript-aware code should read `messages`, `trace.messages`, or `trace.events`; answer-text graders should read `output` or the deprecated `answer` alias.
+`output` is already the final answer string in both formats. Transcript-aware code should read `messages`, `trace.messages`, or `trace.events`; answer-text graders should read `output`.
 
 ## Programmatic API
 
-Use `evaluate()` from `@agentv/core` to run evaluations as a library — no YAML needed.
+Use `evaluate()` from `@agentv/core` to run evaluations as a library. The most portable pattern is still to keep the suite in YAML and point `specFile` at it; inline tests are best when the eval is tightly coupled to application code.
 
 ### Inline Test Definitions
 
@@ -127,7 +141,8 @@ const { results, summary } = await evaluate({
     {
       id: 'greeting',
       input: 'Say hello',
-      assertions: [{ type: 'contains', value: 'Hello' }],
+      expectedOutput: 'Hello there!',
+      assert: [{ type: 'contains', value: 'Hello' }],
     },
   ],
 });
@@ -149,6 +164,8 @@ const { results, summary } = await evaluate({
 });
 ```
 
+This is the recommended bridge when you want SDK control without creating a separate code-first eval surface.
+
 ## Typed Configuration
 
 Create `agentv.config.ts` at your project root for type-safe, validated configuration using `defineConfig()` from `@agentv/core`:
@@ -169,6 +186,15 @@ export default defineConfig({
 ```
 
 The config file is auto-discovered by the CLI from your project root and validated with Zod at startup.
+
+## Observability Export
+
+AgentV's observability surface is OpenTelemetry. For post-run workflows:
+
+- Use `agentv eval ... --otel-file traces/eval.otlp.json` to write OTLP JSON you can import into systems such as Opik.
+- Use `agentv eval ... --export-otel --otel-backend <name>` for live export when a built-in or local resolver exists.
+
+AgentV does not currently ship a dedicated Opik authoring facade or built-in `opik` backend resolver. Keep the eval definition in YAML and route observability through OTLP export.
 
 ## Scaffold Commands
 

--- a/apps/web/src/content/docs/docs/graders/code-graders.mdx
+++ b/apps/web/src/content/docs/docs/graders/code-graders.mdx
@@ -18,7 +18,6 @@ Code graders receive eval context via stdin JSON and return a result via stdout.
   "input_files": [],
   "criteria": "Correctly calculates 15 + 27 = 42",
   "output": "The answer is 42.",
-  "answer": "The answer is 42.",
   "expected_output": [{ "role": "assistant", "content": "42" }],
   "messages": [{ "role": "assistant", "content": "The answer is 42." }],
   "trace_summary": {
@@ -45,7 +44,7 @@ Raw grader stdin is a process-boundary wire format, so keys are `snake_case`. Ty
 | `duration_ms` | `durationMs` | Total execution duration |
 | `workspace_path` | `workspacePath` | Temp workspace path, when configured |
 
-Do not treat `output` as a message array. Use `output` / `answer` for answer-text checks, and use `messages`, `trace.messages`, or `trace.events` only when the grader intentionally evaluates transcript or tool behavior.
+Do not treat `output` as a message array. Use `output` for answer-text checks, and use `messages`, `trace.messages`, or `trace.events` only when the grader intentionally evaluates transcript or tool behavior.
 
 ### JSON output (full protocol)
 
@@ -249,7 +248,6 @@ Beyond the basic fields (`input`, `output`, `expected_output`, `criteria`), code
 |-------|------|-------------|
 | `input` | `Message[]` | Full resolved input message array |
 | `output` | `string \| null` | Final answer / scored result only |
-| `answer` | `string` | Deprecated alias for `output` |
 | `messages` | `Message[]` | Transcript messages from the target execution |
 | `expected_output` | `Message[]` | Expected/reference output messages |
 | `output_path` | `string` | Temp file containing large final answer JSON, when `output` is omitted |

--- a/apps/web/src/content/docs/docs/graders/custom-assertions.mdx
+++ b/apps/web/src/content/docs/docs/graders/custom-assertions.mdx
@@ -42,7 +42,7 @@ The filename (without extension) becomes the assertion type name:
 
 Supported file extensions: `.ts`, `.js`, `.mts`, `.mjs`.
 
-Custom assertion types cannot override built-in types (`contains`, `equals`, `is_json`, etc.). If a filename matches a built-in, it is silently skipped.
+Custom assertion types cannot override built-in types (`contains`, `equals`, `is-json`, etc.). If a filename matches a built-in, it is silently skipped.
 
 ### Using in YAML
 
@@ -117,7 +117,6 @@ The handler receives an `AssertionContext` with the same fields as a code grader
 |-------|------|-------------|
 | `input` | `Message[]` | Full resolved input messages |
 | `output` | `string \| null` | Final answer / scored result only |
-| `answer` | `string` | Deprecated alias for `output` |
 | `messages` | `Message[]` | Transcript messages from the target execution |
 | `expectedOutput` | `Message[]` | Expected output messages |
 | `criteria` | `string` | Evaluation criteria from the test case |

--- a/apps/web/src/content/docs/docs/graders/llm-graders.mdx
+++ b/apps/web/src/content/docs/docs/graders/llm-graders.mdx
@@ -65,10 +65,10 @@ Score the response from 0.0 to 1.0 based on:
 
 | Variable | Source |
 |----------|--------|
+| `criteria` | Test `criteria` field |
 | `input` | Resolved input text |
 | `expected_output` | Reference answer text |
 | `output` | Candidate answer text |
-| `criteria` | Test `criteria` field |
 | `metadata` | Test metadata as formatted JSON |
 | `metadata_json` | Test metadata as compact JSON |
 | `rubrics` | LLM-grader rubric items as formatted JSON |
@@ -76,7 +76,7 @@ Score the response from 0.0 to 1.0 based on:
 | `file_changes` | Unified diff of workspace file changes (populated when `workspace` is configured) |
 | `tool_calls` | Formatted summary of tool calls from agent execution (tool name + key inputs per call) |
 
-Use `prompt: file://path/to/prompt.md` to reuse a markdown prompt file. Bare `prompt: "..."` strings are treated as inline prompt text, not file paths.
+Use `prompt: ./path/to/prompt.md` for the common relative-path case. Use `prompt: file://path/to/prompt.md` only when you need to force file-reference resolution explicitly.
 
 Structured task input belongs in `input`. If `input` is a message whose `content` is a JSON object, `{{input}}` renders that object as formatted JSON for the grader prompt; no separate grader-only input field is required. Use `metadata` for provenance or suite-level source fields, and `rubrics_json` for rubric arrays.
 
@@ -141,7 +141,7 @@ export default definePromptTemplate((ctx) => {
   const rubric = ctx.config?.rubric as string | undefined;
   const question = textFromMessages(ctx.input.filter((message) => message.role === 'user'));
   const referenceAnswer = textFromMessages(ctx.expectedOutput);
-  const candidateAnswer = ctx.output ?? ctx.answer ?? '';
+  const candidateAnswer = ctx.output ?? '';
 
   return `You are evaluating an AI assistant's response.
 
@@ -246,8 +246,8 @@ Template variables are derived internally through three layers:
 
 What users write in YAML or JSONL:
 
-- `input` or `input` -- two syntaxes for the same data. `input: "What is 2+2?"` expands to `[{ role: "user", content: "What is 2+2?" }]`. If both are present, `input` takes precedence.
-- `expected_output` or `expected_output` -- two syntaxes for the same data. `expected_output: "4"` expands to `[{ role: "assistant", content: "4" }]`. If both are present, `expected_output` takes precedence.
+- `input` may be a shorthand string or a full message array. `input: "What is 2+2?"` expands to `[{ role: "user", content: "What is 2+2?" }]`.
+- `expected_output` may be a shorthand string or a full message array. `expected_output: "4"` expands to `[{ role: "assistant", content: "4" }]`.
 
 ### 2. Resolved Layer
 
@@ -264,8 +264,8 @@ Derived strings injected into grader prompts:
 
 | Variable | Derivation |
 |----------|------------|
-| `input` | Resolved input text |
 | `criteria` | Passed through from the test field |
+| `input` | Resolved input text |
 | `expected_output` | Reference answer text |
 | `output` | Candidate answer text |
 | `metadata_json` | Test metadata, compact JSON |
@@ -288,5 +288,5 @@ expected_output: [{ role: "assistant", content: "The answer is 4" }]
 # Derived template variables:
 input:           "What is 2+2?"
 expected_output: "The answer is 4"
-output: (extracted from provider output at runtime)
+output:          (extracted from provider output at runtime)
 ```

--- a/apps/web/src/content/docs/docs/guides/skill-improvement-workflow.mdx
+++ b/apps/web/src/content/docs/docs/guides/skill-improvement-workflow.mdx
@@ -79,7 +79,7 @@ Start with `evals.json` for quick iteration. It's the simplest format and works 
 }
 ```
 
-For assisted authoring, use the `agentv-eval-builder` skill — it knows the full eval file schema and can generate test cases from descriptions.
+For assisted authoring, use the `agentv-eval-writer` skill — it knows the current eval file schema and can generate test cases from descriptions.
 
 :::tip
 Start with 5–10 focused test cases. You can always add more as you discover edge cases during the review step.

--- a/apps/web/src/content/docs/docs/integrations/autoevals-integration.mdx
+++ b/apps/web/src/content/docs/docs/integrations/autoevals-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Autoevals Integration
-description: Use Braintrust's open-source autoevals scorers (Factuality, Faithfulness, etc.) as code_grader graders in AgentV.
+description: Use Braintrust's open-source autoevals scorers (Factuality, Faithfulness, etc.) as code-grader graders in AgentV.
 sidebar:
   order: 3
 ---
@@ -13,7 +13,7 @@ sidebar:
 
 - Works standalone — no Braintrust platform account required
 - Uses any OpenAI-compatible endpoint for LLM-based scorers
-- Integrates with AgentV via `code_grader` grader type: wrap any autoevals scorer in a command that reads stdin and writes the AgentV grader result to stdout
+- Integrates with AgentV via the `code-grader` type: wrap any autoevals scorer in a command that reads stdin and writes the AgentV grader result to stdout
 
 ## Installation
 
@@ -50,7 +50,7 @@ All LLM-based scorers return a `score` (0–1) and `metadata.rationale` explaini
 
 ## TypeScript Example
 
-Use the `Factuality` scorer as an AgentV `code_grader` to verify answer correctness.
+Use the `Factuality` scorer as an AgentV `code-grader` to verify answer correctness.
 
 **EVAL.yaml:**
 
@@ -75,11 +75,18 @@ import { readFileSync } from "fs";
 import { Factuality } from "autoevals";
 
 const input = JSON.parse(readFileSync("/dev/stdin", "utf-8"));
+const prompt = input.input
+  ?.filter((message) => message.role === "user")
+  ?.map((message) => typeof message.content === "string" ? message.content : "")
+  ?.join("\n") ?? "";
+const expected = input.expected_output
+  ?.map((message) => typeof message.content === "string" ? message.content : "")
+  ?.join("\n") ?? "";
 
 const result = await Factuality({
-  input: input.input,
-  output: input.output ?? input.answer,
-  expected: input.expected_output,
+  input: prompt,
+  output: input.output ?? "",
+  expected,
 });
 
 const score = result.score ?? 0;
@@ -94,7 +101,7 @@ console.log(
 );
 ```
 
-The code grader reads the AgentV input from stdin (`input`, `output`, `expected_output`), maps the fields to autoevals parameters (`input`, `output`, `expected`), runs the scorer, and writes the AgentV result format (with `assertions` array) to stdout.
+The code grader reads the canonical AgentV stdin payload (`input`, `expected_output`, `output`), maps those fields to autoevals parameters (`input`, `output`, `expected`), runs the scorer, and writes the AgentV result format (with `assertions` array) to stdout.
 
 ## Python Example
 
@@ -124,12 +131,22 @@ import sys
 from autoevals import Faithfulness
 
 data = json.load(sys.stdin)
+prompt = "\n".join(
+    message.get("content", "")
+    for message in data.get("input", [])
+    if message.get("role") == "user" and isinstance(message.get("content"), str)
+)
+expected = "\n".join(
+    message.get("content", "")
+    for message in data.get("expected_output", [])
+    if isinstance(message.get("content"), str)
+)
 
 grader = Faithfulness()
 result = grader(
-    input=data.get("input", ""),
-    output=data.get("output") or data.get("answer", ""),
-    expected=data.get("expected_output", ""),
+    input=prompt,
+    output=data.get("output", ""),
+    expected=expected,
 )
 
 score = result.score or 0
@@ -216,11 +233,18 @@ import {
 } from "autoevals";
 
 const input = JSON.parse(readFileSync("/dev/stdin", "utf-8"));
+const prompt = input.input
+  ?.filter((message) => message.role === "user")
+  ?.map((message) => typeof message.content === "string" ? message.content : "")
+  ?.join("\n") ?? "";
+const expected = input.expected_output
+  ?.map((message) => typeof message.content === "string" ? message.content : "")
+  ?.join("\n") ?? "";
 
 const scorerArgs = {
-  input: input.input,
-  output: input.output ?? input.answer,
-  expected: input.expected_output,
+  input: prompt,
+  output: input.output ?? "",
+  expected,
 };
 
 // Run all scorers in parallel

--- a/evals/self/skills/fixtures/agentv-eval-writer-full.txt
+++ b/evals/self/skills/fixtures/agentv-eval-writer-full.txt
@@ -14,6 +14,10 @@ description: >-
 
 Comprehensive docs: https://agentv.dev
 
+## Authoring Principle
+
+Treat YAML as the canonical portable model. Prefer authoring `.eval.yaml` / `EVAL.yaml` first, then use TypeScript helpers, Python scripts, or executable graders only when they lower to the same fields or when the evaluation logic must actually run code.
+
 ## Evaluation Types
 
 AgentV evaluations measure **execution quality** — whether your agent or skill produces correct output when invoked.
@@ -113,19 +117,18 @@ tests:
 |-------|----------|-------------|
 | `id` | yes | Unique identifier |
 | `criteria` | yes | What the response should accomplish |
-| `input` / `input` | yes | Input to the agent |
-| `expected_output` / `expected_output` | no | Gold-standard reference answer |
+| `input` | yes | Input to the agent (string shorthand or full message array) |
+| `expected_output` | no | Gold-standard reference answer (string shorthand or full message array) |
 | `assertions` | no | Graders: deterministic checks, rubrics, and LLM/code graders |
-| `rubrics` | no | **Deprecated** — use `assertions: [{type: rubrics, criteria: [...]}]` instead |
 | `execution` | no | Per-case execution overrides |
 | `workspace` | no | Per-case workspace config (overrides suite-level) |
 | `metadata` | no | Arbitrary key-value pairs passed to setup/teardown scripts |
 | `conversation_id` | no | Thread grouping |
 
-**Shorthand aliases:**
+**Shorthand forms:**
 - `input` (string) expands to `[{role: "user", content: "..."}]`
 - `expected_output` (string/object) expands to `[{role: "assistant", content: ...}]`
-- Canonical `input` / `expected_output` take precedence when both present
+- Use these canonical field names on disk; keep the wire format `snake_case`
 
 **Message format:** `{role, content}` where role is `system`, `user`, `assistant`, or `tool`
 **Content types:** inline text, `{type: "file", value: "./path.md"}`
@@ -348,7 +351,7 @@ See https://agentv.dev/targets/configuration/#repository-lifecycle
 
 Configure via `assertions` array. Multiple graders produce a weighted average score.
 
-### code_grader
+### code-grader
 ```yaml
 - name: format_check
   type: code-grader
@@ -357,11 +360,12 @@ Configure via `assertions` array. Multiple graders produce a weighted average sc
   target: {}              # optional: enable LLM target proxy (max_calls: 50)
 ```
 Contract: stdin JSON -> stdout JSON `{score, assertions: [{text, passed, evidence?}], reasoning}`
-Input includes: `question`, `criteria`, `answer`, `reference_answer`, `output`, `trace`, `token_usage`, `cost_usd`, `duration_ms`, `start_time`, `end_time`, `file_changes`, `workspace_path`, `config`
+Raw stdin uses snake_case and includes: `criteria`, `input`, `expected_output`, `output` (final answer string), `messages`, `trace`, `trace_summary`, `token_usage`, `cost_usd`, `duration_ms`, `start_time`, `end_time`, `file_changes`, `workspace_path`, `config`
+SDK handlers receive the same payload in camelCase: `expectedOutput`, `traceSummary`, `tokenUsage`, `costUsd`, `durationMs`, `startTime`, `endTime`, `fileChanges`, `workspacePath`.
 When a workspace is configured, `workspace_path` is the absolute path to the workspace dir (also available as `AGENTV_WORKSPACE_PATH` env var). Use this for functional grading (e.g., running `npm test` in the workspace).
 See docs at https://agentv.dev/graders/code-graders/
 
-### llm_grader
+### llm-grader
 ```yaml
 - name: quality
   type: llm-grader
@@ -371,7 +375,7 @@ See docs at https://agentv.dev/graders/code-graders/
   config:                       # passed to prompt templates as context.config
     strictness: high
 ```
-Variables: `{{question}}`, `{{criteria}}`, `{{answer}}`, `{{reference_answer}}`, `{{input}}`, `{{expected_output}}`, `{{output}}`, `{{file_changes}}`
+Variables: `{{criteria}}`, `{{input}}`, `{{expected_output}}`, `{{output}}`, `{{metadata}}`, `{{metadata_json}}`, `{{rubrics}}`, `{{rubrics_json}}`, `{{file_changes}}`, `{{tool_calls}}`
 - Markdown templates: use `{{variable}}` syntax
 - TypeScript templates: use `definePromptTemplate(fn)` from `@agentv/eval`, receives context object with all variables + `config`
 - Use `target:` to run different `llm-grader` graders against different named LLM targets in the same eval (useful for grader panels / ensembles)
@@ -498,8 +502,6 @@ Binary check: is the output valid JSON?
 LLM-judged structured evaluation with weighted criteria. Criteria items support `id`, `outcome`, `weight`, and `required` fields.
 Use optional `operator: correctness` for positive support checks or `operator: contradiction` for guard criteria where omission is acceptable but incompatible claims fail.
 
-### rubrics (inline, deprecated)
-Top-level `rubrics:` field is deprecated. Use `type: rubrics` under `assertions` instead.
 See `references/rubric-grader.md` for score-range mode and scoring formula.
 
 ## Execution Error Tolerance
@@ -574,10 +576,13 @@ Use `@agentv/eval` to build custom graders in TypeScript/JavaScript:
 #!/usr/bin/env bun
 import { defineAssertion } from '@agentv/eval';
 
-export default defineAssertion(({ answer, trace }) => ({
-  pass: answer.length > 0 && (trace?.eventCount ?? 0) <= 10,
-  reasoning: 'Checks content exists and is efficient',
-}));
+export default defineAssertion(({ output, trace }) => {
+  const finalOutput = output ?? '';
+  return {
+    pass: finalOutput.length > 0 && (trace?.eventCount ?? 0) <= 10,
+    reasoning: 'Checks content exists and is efficient',
+  };
+});
 ```
 
 Assertions support both `pass: boolean` and `score: number` (0-1). If only `pass` is given, score is 1 (pass) or 0 (fail).
@@ -587,12 +592,16 @@ Assertions support both `pass: boolean` and `score: number` (0-1). If only `pass
 #!/usr/bin/env bun
 import { defineCodeGrader } from '@agentv/eval';
 
-export default defineCodeGrader(({ trace, answer }) => ({
-  score: trace?.eventCount <= 5 ? 1.0 : 0.5,
-  assertions: [
-    { text: 'Efficient tool usage', passed: (trace?.eventCount ?? 0) <= 5 },
-  ],
-}));
+export default defineCodeGrader(({ output, trace }) => {
+  const finalOutput = output ?? '';
+  return {
+    score: finalOutput.length > 0 && (trace?.eventCount ?? 0) <= 5 ? 1.0 : 0.5,
+    assertions: [
+      { text: 'Output is not empty', passed: finalOutput.length > 0 },
+      { text: 'Efficient tool usage', passed: (trace?.eventCount ?? 0) <= 5 },
+    ],
+  };
+});
 ```
 
 Both are used via `type: code-grader` in YAML with `command: [bun, run, grader.ts]`.
@@ -610,7 +619,7 @@ No `command:` needed in YAML — just use `type: <filename>`.
 
 ## Programmatic API
 
-Use `evaluate()` from `@agentv/core` to run evals as a library:
+Use `evaluate()` from `@agentv/core` to run evals as a library when you need application-level control. Keep YAML as the default portable surface; use `specFile` to point at existing evals and inline `tests` only when the definition belongs in code.
 
 ```typescript
 import { evaluate } from '@agentv/core';
@@ -620,7 +629,8 @@ const { results, summary } = await evaluate({
     {
       id: 'greeting',
       input: 'Say hello',
-      assertions: [{ type: 'contains', value: 'hello' }],
+      expectedOutput: 'Hello there!',
+      assert: [{ type: 'contains', value: 'hello' }],
     },
   ],
   target: { provider: 'mock_agent' },
@@ -628,7 +638,13 @@ const { results, summary } = await evaluate({
 console.log(`${summary.passed}/${summary.total} passed`);
 ```
 
-Supports inline tests (no YAML) or file-based via `specFile`.
+Programmatic API notes:
+
+- Inline programmatic tests use `assert`, not `assertions`.
+- Use camelCase in TypeScript (`expectedOutput`, `beforeAll`, `budgetUsd`).
+- When bridging from Python, generate canonical YAML/JSONL or call the CLI; there is no separate first-party Python authoring SDK.
+
+Supports inline tests or file-based usage via `specFile`.
 
 ## defineConfig
 
@@ -684,6 +700,15 @@ Review workflow: run evals → inspect results (`agentv inspect show`) → write
 
 Full guide: https://agentv.dev/guides/human-review/
 
+## Observability Export
+
+AgentV exports observability data via OpenTelemetry:
+
+- `agentv eval <file.yaml> --otel-file traces/eval.otlp.json` writes a post-run OTLP JSON file that external systems such as Opik can ingest.
+- `agentv eval <file.yaml> --export-otel --otel-backend <name>` streams live traces when a built-in or local resolver exists.
+
+Do not invent a separate Opik-specific eval surface. Keep the eval definition in YAML and route observability through OTLP export.
+
 ## Schemas
 
 - Eval file: `references/eval-schema.json`
@@ -704,192 +729,6 @@ cat $(agentv skills path agentv-eval-writer)/references/eval-schema.json
 ```
 
 Use `--full` to retrieve every file in the skill at once.
-
---- references/config-schema.json ---
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "AgentV Config Schema",
-  "description": "Schema for .agentv/config.yaml configuration files",
-  "type": "object",
-  "properties": {
-    "$schema": {
-      "type": "string",
-      "description": "Schema identifier",
-      "enum": ["agentv-config-v2"]
-    },
-    "required_version": {
-      "type": "string",
-      "description": "Minimum AgentV version required to run this project's evals. Uses semver range syntax (e.g., '>=2.11.0', '^2.11.0'). When the installed version is below the range, AgentV warns and prompts to update.",
-      "examples": [">=2.11.0", "^2.12.0", ">=2.11.0 <3.0.0"]
-    },
-    "eval_patterns": {
-      "type": "array",
-      "description": "Glob patterns for discovering eval files during interactive mode (`agentv eval` with no args). Defaults to ['**/evals/**/dataset*.yaml', '**/evals/**/eval.yaml'] if not specified.",
-      "items": {
-        "type": "string",
-        "description": "Glob pattern (e.g., '**/evals/**/dataset*.yaml', '**/evals/**/eval.yaml')"
-      },
-      "examples": [["**/evals/**/dataset*.yaml", "**/evals/**/eval.yaml"], ["**/evals/**/*.yaml"]]
-    },
-    "execution": {
-      "type": "object",
-      "description": "Default execution options. CLI flags take precedence over these values.",
-      "properties": {
-        "verbose": {
-          "type": "boolean",
-          "description": "Enable verbose logging (equivalent to --verbose)",
-          "default": false
-        },
-        "keep_workspaces": {
-          "type": "boolean",
-          "description": "Always keep temp workspaces after eval (equivalent to --keep-workspaces)",
-          "default": false
-        },
-        "otel_file": {
-          "type": "string",
-          "description": "Write OTLP JSON trace to this path (equivalent to --otel-file). Supports {timestamp} placeholder.",
-          "examples": [".agentv/results/otel-{timestamp}.json"]
-        }
-      },
-      "additionalProperties": false
-    },
-    "hooks": {
-      "type": "object",
-      "description": "Lifecycle hooks that run at specific points during agentv execution.",
-      "properties": {
-        "before_session": {
-          "type": "string",
-          "description": "Shell command to run once at agentv startup, before any command executes. stdout is parsed for env var exports (KEY=value or export KEY=\"value\") and injected into process.env. Keys already set in the environment are not overwritten. stderr is forwarded to the user. Non-zero exit aborts with an error.",
-          "examples": ["bun scripts/load-secrets.ts", "eval $(aws ssm get-parameters-by-path ...)"]
-        }
-      },
-      "additionalProperties": false
-    }
-  },
-  "required": ["$schema"],
-  "additionalProperties": false
-}
-
---- references/custom-evaluators.md ---
-# Custom Graders
-
-## Wire Format
-
-### Input (stdin JSON)
-
-```json
-{
-  "question": "string",
-  "criteria": "string",
-  "reference_answer": "string",
-  "answer": "string",
-  "input_files": ["path"],
-  "input": [{"role": "user", "content": "..."}],
-  "expected_output": [{"role": "assistant", "content": "..."}],
-  "output": [{"role": "assistant", "content": "..."}],
-  "trace": {
-    "event_count": 5,
-    "tool_calls": {"fetch": 1},
-    "error_count": 0,
-    "llm_call_count": 2
-  },
-  "token_usage": {"input": 1000, "output": 500},
-  "cost_usd": 0.0015,
-  "duration_ms": 3500,
-  "start_time": "2026-02-13T10:00:00.000Z",
-  "end_time": "2026-02-13T10:00:03.500Z"
-}
-```
-
-### Output (stdout JSON)
-
-```json
-{
-  "score": 0.85,
-  "assertions": [
-    { "text": "passed check", "passed": true },
-    { "text": "failed check", "passed": false }
-  ],
-  "reasoning": "explanation"
-}
-```
-
-`score` (0.0-1.0) required. `assertions`, `reasoning` optional.
-
-## SDK Functions
-
-```typescript
-import { defineCodeGrader, createTargetClient, definePromptTemplate } from '@agentv/eval';
-```
-
-- `defineCodeGrader(fn)` - Wraps evaluation function with stdin/stdout handling
-- `createTargetClient()` - Returns LLM proxy client (when `target: {}` configured)
-  - `.invoke({question, systemPrompt})` - Single LLM call
-  - `.invokeBatch(requests)` - Batch LLM calls
-- `definePromptTemplate(fn)` - Wraps prompt generation function
-  - Context fields: `question`, `answer`, `referenceAnswer`, `criteria`, `expectedOutput`, `output`, `config`, `trace`, `tokenUsage`, `costUsd`, `durationMs`, `startTime`, `endTime`
-
-## Python Example
-
-```python
-#!/usr/bin/env python3
-import json, sys
-
-def evaluate(data: dict) -> dict:
-    candidate = data.get("answer", "")
-    assertions = []
-    for kw in ["async", "await"]:
-        assertions.append({"text": f"Keyword '{kw}'", "passed": kw in candidate})
-    passed = sum(1 for a in assertions if a["passed"])
-    return {
-        "score": passed / max(len(assertions), 1),
-        "assertions": assertions,
-    }
-
-if __name__ == "__main__":
-    try:
-        print(json.dumps(evaluate(json.loads(sys.stdin.read()))))
-    except Exception as e:
-        print(json.dumps({"score": 0, "assertions": [{"text": str(e), "passed": False}]}))
-        sys.exit(1)
-```
-
-## TypeScript Example
-
-```typescript
-#!/usr/bin/env bun
-import { defineCodeGrader } from '@agentv/eval';
-
-export default defineCodeGrader(({ answer, criteria }) => {
-  const assertions: Array<{ text: string; passed: boolean }> = [];
-  if (answer.includes(criteria)) {
-    assertions.push({ text: 'Matches expected outcome', passed: true });
-  } else {
-    assertions.push({ text: 'Does not match expected outcome', passed: false });
-  }
-  const passed = assertions.filter(a => a.passed).length;
-  return {
-    score: passed / Math.max(assertions.length, 1),
-    assertions,
-  };
-});
-```
-
-## Template Variables
-
-Derived from test fields (users never author these directly):
-
-| Variable | Source |
-|----------|--------|
-| `question` | First user message in `input` |
-| `criteria` | Test `criteria` field |
-| `reference_answer` | Last entry in `expected_output` |
-| `answer` | Last entry in `output` (runtime) |
-| `input` | Full resolved input array (JSON) |
-| `expected_output` | Full resolved expected array (JSON) |
-| `output` | Full provider output array (JSON) |
-
-Markdown templates use `{{variable}}` syntax. TypeScript templates receive context object.
 
 --- references/eval-schema.json ---
 {
@@ -18191,3 +18030,196 @@ Ranges must be integers 0-10, non-overlapping, covering all values 0-10.
 | `fail` | score < 0.8 OR any gating criterion failed |
 
 Gating: checklist uses `required: true`, score-range uses `min_score: N` (0–1 scale).
+
+--- references/config-schema.json ---
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AgentV Config Schema",
+  "description": "Schema for .agentv/config.yaml configuration files",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Schema identifier",
+      "enum": ["agentv-config-v2"]
+    },
+    "required_version": {
+      "type": "string",
+      "description": "Minimum AgentV version required to run this project's evals. Uses semver range syntax (e.g., '>=2.11.0', '^2.11.0'). When the installed version is below the range, AgentV warns and prompts to update.",
+      "examples": [">=2.11.0", "^2.12.0", ">=2.11.0 <3.0.0"]
+    },
+    "eval_patterns": {
+      "type": "array",
+      "description": "Glob patterns for discovering eval files during interactive mode (`agentv eval` with no args). Defaults to ['**/evals/**/dataset*.yaml', '**/evals/**/eval.yaml'] if not specified.",
+      "items": {
+        "type": "string",
+        "description": "Glob pattern (e.g., '**/evals/**/dataset*.yaml', '**/evals/**/eval.yaml')"
+      },
+      "examples": [["**/evals/**/dataset*.yaml", "**/evals/**/eval.yaml"], ["**/evals/**/*.yaml"]]
+    },
+    "execution": {
+      "type": "object",
+      "description": "Default execution options. CLI flags take precedence over these values.",
+      "properties": {
+        "verbose": {
+          "type": "boolean",
+          "description": "Enable verbose logging (equivalent to --verbose)",
+          "default": false
+        },
+        "keep_workspaces": {
+          "type": "boolean",
+          "description": "Always keep temp workspaces after eval (equivalent to --keep-workspaces)",
+          "default": false
+        },
+        "otel_file": {
+          "type": "string",
+          "description": "Write OTLP JSON trace to this path (equivalent to --otel-file). Supports {timestamp} placeholder.",
+          "examples": [".agentv/results/otel-{timestamp}.json"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "hooks": {
+      "type": "object",
+      "description": "Lifecycle hooks that run at specific points during agentv execution.",
+      "properties": {
+        "before_session": {
+          "type": "string",
+          "description": "Shell command to run once at agentv startup, before any command executes. stdout is parsed for env var exports (KEY=value or export KEY=\"value\") and injected into process.env. Keys already set in the environment are not overwritten. stderr is forwarded to the user. Non-zero exit aborts with an error.",
+          "examples": ["bun scripts/load-secrets.ts", "eval $(aws ssm get-parameters-by-path ...)"]
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": ["$schema"],
+  "additionalProperties": false
+}
+
+--- references/custom-evaluators.md ---
+# Custom Graders
+
+## Wire Format
+
+### Input (stdin JSON)
+
+```json
+{
+  "criteria": "string",
+  "input_files": ["path"],
+  "input": [{"role": "user", "content": "..."}],
+  "expected_output": [{"role": "assistant", "content": "..."}],
+  "output": "final answer text",
+  "messages": [{"role": "assistant", "content": "final answer text"}],
+  "trace": {
+    "schema_version": "agentv.trace.v1",
+    "event_count": 5,
+    "tool_calls": {"fetch": 1},
+    "error_count": 0,
+    "llm_call_count": 2,
+    "messages": [],
+    "events": []
+  },
+  "trace_summary": {
+    "event_count": 5,
+    "tool_calls": {"fetch": 1},
+    "error_count": 0,
+    "llm_call_count": 2
+  },
+  "token_usage": {"input": 1000, "output": 500},
+  "cost_usd": 0.0015,
+  "duration_ms": 3500,
+  "start_time": "2026-02-13T10:00:00.000Z",
+  "end_time": "2026-02-13T10:00:03.500Z"
+}
+```
+
+### Output (stdout JSON)
+
+```json
+{
+  "score": 0.85,
+  "assertions": [
+    { "text": "passed check", "passed": true },
+    { "text": "failed check", "passed": false }
+  ],
+  "reasoning": "explanation"
+}
+```
+
+`score` (0.0-1.0) required. `assertions`, `reasoning` optional.
+
+## SDK Functions
+
+```typescript
+import { defineCodeGrader, createTargetClient, definePromptTemplate } from '@agentv/eval';
+```
+
+- `defineCodeGrader(fn)` - Wraps evaluation function with stdin/stdout handling
+- `createTargetClient()` - Returns LLM proxy client (when `target: {}` configured)
+  - `.invoke({question, systemPrompt})` - Single LLM call
+  - `.invokeBatch(requests)` - Batch LLM calls
+- `definePromptTemplate(fn)` - Wraps prompt generation function
+  - Raw stdin uses `snake_case`; SDK handlers receive `camelCase`
+  - Context fields: `input`, `expectedOutput`, `output`, `messages`, `criteria`, `config`, `trace`, `traceSummary`, `tokenUsage`, `costUsd`, `durationMs`, `startTime`, `endTime`
+
+## Python Example
+
+```python
+#!/usr/bin/env python3
+import json, sys
+
+def evaluate(data: dict) -> dict:
+    candidate = data.get("output", "")
+    assertions = []
+    for kw in ["async", "await"]:
+        assertions.append({"text": f"Keyword '{kw}'", "passed": kw in candidate})
+    passed = sum(1 for a in assertions if a["passed"])
+    return {
+        "score": passed / max(len(assertions), 1),
+        "assertions": assertions,
+    }
+
+if __name__ == "__main__":
+    try:
+        print(json.dumps(evaluate(json.loads(sys.stdin.read()))))
+    except Exception as e:
+        print(json.dumps({"score": 0, "assertions": [{"text": str(e), "passed": False}]}))
+        sys.exit(1)
+```
+
+## TypeScript Example
+
+```typescript
+#!/usr/bin/env bun
+import { defineCodeGrader } from '@agentv/eval';
+
+export default defineCodeGrader(({ output, criteria }) => {
+  const answer = output ?? '';
+  const assertions: Array<{ text: string; passed: boolean }> = [];
+  if (answer.includes(criteria)) {
+    assertions.push({ text: 'Matches expected outcome', passed: true });
+  } else {
+    assertions.push({ text: 'Does not match expected outcome', passed: false });
+  }
+  const passed = assertions.filter(a => a.passed).length;
+  return {
+    score: passed / Math.max(assertions.length, 1),
+    assertions,
+  };
+});
+```
+
+## Template Variables
+
+Derived from test fields (users never author these directly):
+
+| Variable | Source |
+|----------|--------|
+| `criteria` | Test `criteria` field |
+| `input` | Full resolved input array (JSON) |
+| `expected_output` | Full resolved expected array (JSON) |
+| `output` | Final answer / scored result string |
+| `messages` | Transcript messages from target execution |
+
+Markdown templates use `{{variable}}` syntax. TypeScript templates receive context object.

--- a/evals/self/skills/fixtures/agentv-eval-writer.txt
+++ b/evals/self/skills/fixtures/agentv-eval-writer.txt
@@ -14,6 +14,10 @@ description: >-
 
 Comprehensive docs: https://agentv.dev
 
+## Authoring Principle
+
+Treat YAML as the canonical portable model. Prefer authoring `.eval.yaml` / `EVAL.yaml` first, then use TypeScript helpers, Python scripts, or executable graders only when they lower to the same fields or when the evaluation logic must actually run code.
+
 ## Evaluation Types
 
 AgentV evaluations measure **execution quality** — whether your agent or skill produces correct output when invoked.
@@ -113,19 +117,18 @@ tests:
 |-------|----------|-------------|
 | `id` | yes | Unique identifier |
 | `criteria` | yes | What the response should accomplish |
-| `input` / `input` | yes | Input to the agent |
-| `expected_output` / `expected_output` | no | Gold-standard reference answer |
+| `input` | yes | Input to the agent (string shorthand or full message array) |
+| `expected_output` | no | Gold-standard reference answer (string shorthand or full message array) |
 | `assertions` | no | Graders: deterministic checks, rubrics, and LLM/code graders |
-| `rubrics` | no | **Deprecated** — use `assertions: [{type: rubrics, criteria: [...]}]` instead |
 | `execution` | no | Per-case execution overrides |
 | `workspace` | no | Per-case workspace config (overrides suite-level) |
 | `metadata` | no | Arbitrary key-value pairs passed to setup/teardown scripts |
 | `conversation_id` | no | Thread grouping |
 
-**Shorthand aliases:**
+**Shorthand forms:**
 - `input` (string) expands to `[{role: "user", content: "..."}]`
 - `expected_output` (string/object) expands to `[{role: "assistant", content: ...}]`
-- Canonical `input` / `expected_output` take precedence when both present
+- Use these canonical field names on disk; keep the wire format `snake_case`
 
 **Message format:** `{role, content}` where role is `system`, `user`, `assistant`, or `tool`
 **Content types:** inline text, `{type: "file", value: "./path.md"}`
@@ -348,7 +351,7 @@ See https://agentv.dev/targets/configuration/#repository-lifecycle
 
 Configure via `assertions` array. Multiple graders produce a weighted average score.
 
-### code_grader
+### code-grader
 ```yaml
 - name: format_check
   type: code-grader
@@ -357,11 +360,12 @@ Configure via `assertions` array. Multiple graders produce a weighted average sc
   target: {}              # optional: enable LLM target proxy (max_calls: 50)
 ```
 Contract: stdin JSON -> stdout JSON `{score, assertions: [{text, passed, evidence?}], reasoning}`
-Input includes: `question`, `criteria`, `answer`, `reference_answer`, `output`, `trace`, `token_usage`, `cost_usd`, `duration_ms`, `start_time`, `end_time`, `file_changes`, `workspace_path`, `config`
+Raw stdin uses snake_case and includes: `criteria`, `input`, `expected_output`, `output` (final answer string), `messages`, `trace`, `trace_summary`, `token_usage`, `cost_usd`, `duration_ms`, `start_time`, `end_time`, `file_changes`, `workspace_path`, `config`
+SDK handlers receive the same payload in camelCase: `expectedOutput`, `traceSummary`, `tokenUsage`, `costUsd`, `durationMs`, `startTime`, `endTime`, `fileChanges`, `workspacePath`.
 When a workspace is configured, `workspace_path` is the absolute path to the workspace dir (also available as `AGENTV_WORKSPACE_PATH` env var). Use this for functional grading (e.g., running `npm test` in the workspace).
 See docs at https://agentv.dev/graders/code-graders/
 
-### llm_grader
+### llm-grader
 ```yaml
 - name: quality
   type: llm-grader
@@ -371,7 +375,7 @@ See docs at https://agentv.dev/graders/code-graders/
   config:                       # passed to prompt templates as context.config
     strictness: high
 ```
-Variables: `{{question}}`, `{{criteria}}`, `{{answer}}`, `{{reference_answer}}`, `{{input}}`, `{{expected_output}}`, `{{output}}`, `{{file_changes}}`
+Variables: `{{criteria}}`, `{{input}}`, `{{expected_output}}`, `{{output}}`, `{{metadata}}`, `{{metadata_json}}`, `{{rubrics}}`, `{{rubrics_json}}`, `{{file_changes}}`, `{{tool_calls}}`
 - Markdown templates: use `{{variable}}` syntax
 - TypeScript templates: use `definePromptTemplate(fn)` from `@agentv/eval`, receives context object with all variables + `config`
 - Use `target:` to run different `llm-grader` graders against different named LLM targets in the same eval (useful for grader panels / ensembles)
@@ -498,8 +502,6 @@ Binary check: is the output valid JSON?
 LLM-judged structured evaluation with weighted criteria. Criteria items support `id`, `outcome`, `weight`, and `required` fields.
 Use optional `operator: correctness` for positive support checks or `operator: contradiction` for guard criteria where omission is acceptable but incompatible claims fail.
 
-### rubrics (inline, deprecated)
-Top-level `rubrics:` field is deprecated. Use `type: rubrics` under `assertions` instead.
 See `references/rubric-grader.md` for score-range mode and scoring formula.
 
 ## Execution Error Tolerance
@@ -574,10 +576,13 @@ Use `@agentv/eval` to build custom graders in TypeScript/JavaScript:
 #!/usr/bin/env bun
 import { defineAssertion } from '@agentv/eval';
 
-export default defineAssertion(({ answer, trace }) => ({
-  pass: answer.length > 0 && (trace?.eventCount ?? 0) <= 10,
-  reasoning: 'Checks content exists and is efficient',
-}));
+export default defineAssertion(({ output, trace }) => {
+  const finalOutput = output ?? '';
+  return {
+    pass: finalOutput.length > 0 && (trace?.eventCount ?? 0) <= 10,
+    reasoning: 'Checks content exists and is efficient',
+  };
+});
 ```
 
 Assertions support both `pass: boolean` and `score: number` (0-1). If only `pass` is given, score is 1 (pass) or 0 (fail).
@@ -587,12 +592,16 @@ Assertions support both `pass: boolean` and `score: number` (0-1). If only `pass
 #!/usr/bin/env bun
 import { defineCodeGrader } from '@agentv/eval';
 
-export default defineCodeGrader(({ trace, answer }) => ({
-  score: trace?.eventCount <= 5 ? 1.0 : 0.5,
-  assertions: [
-    { text: 'Efficient tool usage', passed: (trace?.eventCount ?? 0) <= 5 },
-  ],
-}));
+export default defineCodeGrader(({ output, trace }) => {
+  const finalOutput = output ?? '';
+  return {
+    score: finalOutput.length > 0 && (trace?.eventCount ?? 0) <= 5 ? 1.0 : 0.5,
+    assertions: [
+      { text: 'Output is not empty', passed: finalOutput.length > 0 },
+      { text: 'Efficient tool usage', passed: (trace?.eventCount ?? 0) <= 5 },
+    ],
+  };
+});
 ```
 
 Both are used via `type: code-grader` in YAML with `command: [bun, run, grader.ts]`.
@@ -610,7 +619,7 @@ No `command:` needed in YAML — just use `type: <filename>`.
 
 ## Programmatic API
 
-Use `evaluate()` from `@agentv/core` to run evals as a library:
+Use `evaluate()` from `@agentv/core` to run evals as a library when you need application-level control. Keep YAML as the default portable surface; use `specFile` to point at existing evals and inline `tests` only when the definition belongs in code.
 
 ```typescript
 import { evaluate } from '@agentv/core';
@@ -620,7 +629,8 @@ const { results, summary } = await evaluate({
     {
       id: 'greeting',
       input: 'Say hello',
-      assertions: [{ type: 'contains', value: 'hello' }],
+      expectedOutput: 'Hello there!',
+      assert: [{ type: 'contains', value: 'hello' }],
     },
   ],
   target: { provider: 'mock_agent' },
@@ -628,7 +638,13 @@ const { results, summary } = await evaluate({
 console.log(`${summary.passed}/${summary.total} passed`);
 ```
 
-Supports inline tests (no YAML) or file-based via `specFile`.
+Programmatic API notes:
+
+- Inline programmatic tests use `assert`, not `assertions`.
+- Use camelCase in TypeScript (`expectedOutput`, `beforeAll`, `budgetUsd`).
+- When bridging from Python, generate canonical YAML/JSONL or call the CLI; there is no separate first-party Python authoring SDK.
+
+Supports inline tests or file-based usage via `specFile`.
 
 ## defineConfig
 
@@ -683,6 +699,15 @@ Use `evaluator_overrides` for workspace evaluations to annotate specific grader 
 Review workflow: run evals → inspect results (`agentv inspect show`) → write feedback → tune prompts/graders → re-run.
 
 Full guide: https://agentv.dev/guides/human-review/
+
+## Observability Export
+
+AgentV exports observability data via OpenTelemetry:
+
+- `agentv eval <file.yaml> --otel-file traces/eval.otlp.json` writes a post-run OTLP JSON file that external systems such as Opik can ingest.
+- `agentv eval <file.yaml> --export-otel --otel-backend <name>` streams live traces when a built-in or local resolver exists.
+
+Do not invent a separate Opik-specific eval surface. Keep the eval definition in YAML and route observability through OTLP export.
 
 ## Schemas
 

--- a/examples/features/code-grader-sdk/README.md
+++ b/examples/features/code-grader-sdk/README.md
@@ -1,10 +1,10 @@
 # Code Grader SDK Helper
 
-Demonstrates how a TypeScript code_grader grader can use `defineCodeGrader` from `@agentv/eval` for a declarative, zero-boilerplate approach.
+Demonstrates how a TypeScript `code-grader` can use `defineCodeGrader` from `@agentv/eval` for a declarative, low-boilerplate approach while still consuming the canonical AgentV wire format.
 
 ## Files
 
-- `evals/dataset.eval.yaml`: Example test that uses a code_grader grader.
+- `evals/dataset.eval.yaml`: Example test that uses a `code-grader`.
 - `scripts/verify-attachments.ts`: Code grader script using `defineCodeGrader`.
 - `evals/example.txt`, `evals/python.instructions.md`: Attachment fixtures.
 

--- a/examples/features/sdk-programmatic-api-advanced/README.md
+++ b/examples/features/sdk-programmatic-api-advanced/README.md
@@ -1,6 +1,6 @@
 # SDK Programmatic API — Advanced
 
-Demonstrates the advanced programmatic API features added in [#1115](https://github.com/anthropics/agentv/issues/1115):
+Demonstrates the advanced programmatic API features that extend the same YAML-shaped evaluation model:
 
 - **`beforeAll`** — run setup commands before the suite starts
 - **`budgetUsd`** — cap total LLM spend

--- a/examples/features/sdk-programmatic-api/README.md
+++ b/examples/features/sdk-programmatic-api/README.md
@@ -1,11 +1,11 @@
 # SDK Example: Programmatic API
 
-Demonstrates using `evaluate()` from `@agentv/core` to run evaluations as a library — no YAML needed.
+Demonstrates using `evaluate()` from `@agentv/core` to run evaluations as a library when the eval definition belongs in TypeScript. The config mirrors the canonical YAML surface, but uses programmatic names such as `expectedOutput` and `assert`.
 
 ## What It Does
 
 1. Imports `evaluate()` from `@agentv/core`
-2. Defines tests inline with assertions
+2. Defines tests inline with `assert`
 3. Runs the evaluation and prints summary statistics
 4. Writes canonical AgentV run artifacts under `.agentv/results/runs/...`
 
@@ -23,7 +23,7 @@ bun run evaluate.ts
 ## Key Patterns
 
 - **`evaluate()`** — use AgentV as a library, not just a CLI
-- **Inline tests** — define tests in TypeScript, no YAML needed
-- **Config mirrors YAML** — same `assert`, `target` structure
+- **Inline tests** — define YAML-shaped tests directly in TypeScript
+- **Config mirrors YAML** — same evaluation model, with programmatic `assert` and camelCase fields
 - **Typed results** — `EvalRunResult` with summary statistics
 - **Canonical artifacts** — opt into the same `index.jsonl` / `benchmark.json` workspace layout as `agentv eval`

--- a/examples/features/sdk-programmatic-api/evaluate.ts
+++ b/examples/features/sdk-programmatic-api/evaluate.ts
@@ -2,7 +2,7 @@
  * Programmatic API Example
  *
  * Uses evaluate() from @agentv/core to run evaluations as a library.
- * No YAML needed — tests defined inline with full type safety.
+ * The inline config mirrors the canonical YAML surface with TypeScript-friendly names.
  *
  * Run: bun run evaluate.ts
  * (Uses 'default' target from .agentv/targets.yaml and .env credentials)

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -1,6 +1,6 @@
 # @agentv/eval
 
-Evaluation SDK for AgentV - build custom graders with zero boilerplate.
+Evaluation SDK for AgentV - build custom graders and prompt templates around the canonical AgentV eval model.
 
 ## Installation
 
@@ -16,13 +16,10 @@ npm install @agentv/eval
 #!/usr/bin/env bun
 import { defineAssertion } from '@agentv/eval';
 
-export default defineAssertion(({ output }) => {
-  const hasGreeting = (output ?? '').toLowerCase().includes('hello');
-  return {
-    pass: hasGreeting,
-    assertions: [{ text: 'Checks for greeting', passed: hasGreeting }],
-  };
-});
+export default defineAssertion(({ output }) => ({
+  pass: (output ?? '').toLowerCase().includes('hello'),
+  reasoning: 'Checks for greeting',
+}));
 ```
 
 Assertions support `pass: boolean` for simple checks and `score: number` (0-1) for granular scoring.
@@ -63,7 +60,7 @@ For complete documentation including:
 - Execution metrics usage
 - Best practices
 
-See the [Custom Graders Guide](../../apps/web/src/content/docs/docs/graders/custom-graders.mdx) or run AgentV's `/agentv-eval-builder` skill.
+See the docs site guides under `apps/web/src/content/docs/docs/graders/` or run `agentv skills get agentv-eval-writer`.
 
 ## Repository
 

--- a/skills-data/agentv-eval-writer/SKILL.md
+++ b/skills-data/agentv-eval-writer/SKILL.md
@@ -14,6 +14,10 @@ description: >-
 
 Comprehensive docs: https://agentv.dev
 
+## Authoring Principle
+
+Treat YAML as the canonical portable model. Prefer authoring `.eval.yaml` / `EVAL.yaml` first, then use TypeScript helpers, Python scripts, or executable graders only when they lower to the same fields or when the evaluation logic must actually run code.
+
 ## Evaluation Types
 
 AgentV evaluations measure **execution quality** — whether your agent or skill produces correct output when invoked.
@@ -113,19 +117,18 @@ tests:
 |-------|----------|-------------|
 | `id` | yes | Unique identifier |
 | `criteria` | yes | What the response should accomplish |
-| `input` / `input` | yes | Input to the agent |
-| `expected_output` / `expected_output` | no | Gold-standard reference answer |
+| `input` | yes | Input to the agent (string shorthand or full message array) |
+| `expected_output` | no | Gold-standard reference answer (string shorthand or full message array) |
 | `assertions` | no | Graders: deterministic checks, rubrics, and LLM/code graders |
-| `rubrics` | no | **Deprecated** — use `assertions: [{type: rubrics, criteria: [...]}]` instead |
 | `execution` | no | Per-case execution overrides |
 | `workspace` | no | Per-case workspace config (overrides suite-level) |
 | `metadata` | no | Arbitrary key-value pairs passed to setup/teardown scripts |
 | `conversation_id` | no | Thread grouping |
 
-**Shorthand aliases:**
+**Shorthand forms:**
 - `input` (string) expands to `[{role: "user", content: "..."}]`
 - `expected_output` (string/object) expands to `[{role: "assistant", content: ...}]`
-- Canonical `input` / `expected_output` take precedence when both present
+- Use these canonical field names on disk; keep the wire format `snake_case`
 
 **Message format:** `{role, content}` where role is `system`, `user`, `assistant`, or `tool`
 **Content types:** inline text, `{type: "file", value: "./path.md"}`
@@ -348,7 +351,7 @@ See https://agentv.dev/targets/configuration/#repository-lifecycle
 
 Configure via `assertions` array. Multiple graders produce a weighted average score.
 
-### code_grader
+### code-grader
 ```yaml
 - name: format_check
   type: code-grader
@@ -356,13 +359,13 @@ Configure via `assertions` array. Multiple graders produce a weighted average sc
   cwd: ./scripts          # optional working directory
   target: {}              # optional: enable LLM target proxy (max_calls: 50)
 ```
-Contract: stdin JSON -> stdout JSON `{score, assertions: [{text, passed, evidence?}], details?}`
-Raw stdin uses snake_case and includes: `criteria`, `input`, `expected_output`, `output` (final answer string), `answer` (deprecated alias), `messages`, `trace`, `trace_summary`, `token_usage`, `cost_usd`, `duration_ms`, `start_time`, `end_time`, `file_changes`, `workspace_path`, `config`
+Contract: stdin JSON -> stdout JSON `{score, assertions: [{text, passed, evidence?}], reasoning}`
+Raw stdin uses snake_case and includes: `criteria`, `input`, `expected_output`, `output` (final answer string), `messages`, `trace`, `trace_summary`, `token_usage`, `cost_usd`, `duration_ms`, `start_time`, `end_time`, `file_changes`, `workspace_path`, `config`
 SDK handlers receive the same payload in camelCase: `expectedOutput`, `traceSummary`, `tokenUsage`, `costUsd`, `durationMs`, `startTime`, `endTime`, `fileChanges`, `workspacePath`.
 When a workspace is configured, `workspace_path` is the absolute path to the workspace dir (also available as `AGENTV_WORKSPACE_PATH` env var). Use this for functional grading (e.g., running `npm test` in the workspace).
 See docs at https://agentv.dev/graders/code-graders/
 
-### llm_grader
+### llm-grader
 ```yaml
 - name: quality
   type: llm-grader
@@ -372,7 +375,7 @@ See docs at https://agentv.dev/graders/code-graders/
   config:                       # passed to prompt templates as context.config
     strictness: high
 ```
-Variables: `{{criteria}}`, `{{answer}}`, `{{input}}`, `{{expected_output}}`, `{{output}}`, `{{file_changes}}`
+Variables: `{{criteria}}`, `{{input}}`, `{{expected_output}}`, `{{output}}`, `{{metadata}}`, `{{metadata_json}}`, `{{rubrics}}`, `{{rubrics_json}}`, `{{file_changes}}`, `{{tool_calls}}`
 - Markdown templates: use `{{variable}}` syntax
 - TypeScript templates: use `definePromptTemplate(fn)` from `@agentv/eval`, receives context object with all variables + `config`
 - Use `target:` to run different `llm-grader` graders against different named LLM targets in the same eval (useful for grader panels / ensembles)
@@ -499,8 +502,6 @@ Binary check: is the output valid JSON?
 LLM-judged structured evaluation with weighted criteria. Criteria items support `id`, `outcome`, `weight`, and `required` fields.
 Use optional `operator: correctness` for positive support checks or `operator: contradiction` for guard criteria where omission is acceptable but incompatible claims fail.
 
-### rubrics (inline, deprecated)
-Top-level `rubrics:` field is deprecated. Use `type: rubrics` under `assertions` instead.
 See `references/rubric-grader.md` for score-range mode and scoring formula.
 
 ## Execution Error Tolerance
@@ -575,11 +576,11 @@ Use `@agentv/eval` to build custom graders in TypeScript/JavaScript:
 #!/usr/bin/env bun
 import { defineAssertion } from '@agentv/eval';
 
-export default defineAssertion(({ output, traceSummary }) => {
-  const pass = (output ?? '').length > 0 && (traceSummary?.eventCount ?? 0) <= 10;
+export default defineAssertion(({ output, trace }) => {
+  const finalOutput = output ?? '';
   return {
-    pass,
-    assertions: [{ text: 'Checks content exists and is efficient', passed: pass }],
+    pass: finalOutput.length > 0 && (trace?.eventCount ?? 0) <= 10,
+    reasoning: 'Checks content exists and is efficient',
   };
 });
 ```
@@ -591,13 +592,16 @@ Assertions support both `pass: boolean` and `score: number` (0-1). If only `pass
 #!/usr/bin/env bun
 import { defineCodeGrader } from '@agentv/eval';
 
-export default defineCodeGrader(({ output, traceSummary }) => ({
-  score: (output ?? '').length > 0 && (traceSummary?.eventCount ?? 0) <= 5 ? 1.0 : 0.5,
-  assertions: [
-    { text: 'Output is not empty', passed: (output ?? '').length > 0 },
-    { text: 'Efficient tool usage', passed: (traceSummary?.eventCount ?? 0) <= 5 },
-  ],
-}));
+export default defineCodeGrader(({ output, trace }) => {
+  const finalOutput = output ?? '';
+  return {
+    score: finalOutput.length > 0 && (trace?.eventCount ?? 0) <= 5 ? 1.0 : 0.5,
+    assertions: [
+      { text: 'Output is not empty', passed: finalOutput.length > 0 },
+      { text: 'Efficient tool usage', passed: (trace?.eventCount ?? 0) <= 5 },
+    ],
+  };
+});
 ```
 
 Both are used via `type: code-grader` in YAML with `command: [bun, run, grader.ts]`.
@@ -615,7 +619,7 @@ No `command:` needed in YAML — just use `type: <filename>`.
 
 ## Programmatic API
 
-Use `evaluate()` from `@agentv/core` to run evals as a library:
+Use `evaluate()` from `@agentv/core` to run evals as a library when you need application-level control. Keep YAML as the default portable surface; use `specFile` to point at existing evals and inline `tests` only when the definition belongs in code.
 
 ```typescript
 import { evaluate } from '@agentv/core';
@@ -625,7 +629,8 @@ const { results, summary } = await evaluate({
     {
       id: 'greeting',
       input: 'Say hello',
-      assertions: [{ type: 'contains', value: 'hello' }],
+      expectedOutput: 'Hello there!',
+      assert: [{ type: 'contains', value: 'hello' }],
     },
   ],
   target: { provider: 'mock_agent' },
@@ -633,7 +638,13 @@ const { results, summary } = await evaluate({
 console.log(`${summary.passed}/${summary.total} passed`);
 ```
 
-Supports inline tests (no YAML) or file-based via `specFile`.
+Programmatic API notes:
+
+- Inline programmatic tests use `assert`, not `assertions`.
+- Use camelCase in TypeScript (`expectedOutput`, `beforeAll`, `budgetUsd`).
+- When bridging from Python, generate canonical YAML/JSONL or call the CLI; there is no separate first-party Python authoring SDK.
+
+Supports inline tests or file-based usage via `specFile`.
 
 ## defineConfig
 
@@ -688,6 +699,15 @@ Use `evaluator_overrides` for workspace evaluations to annotate specific grader 
 Review workflow: run evals → inspect results (`agentv inspect show`) → write feedback → tune prompts/graders → re-run.
 
 Full guide: https://agentv.dev/guides/human-review/
+
+## Observability Export
+
+AgentV exports observability data via OpenTelemetry:
+
+- `agentv eval <file.yaml> --otel-file traces/eval.otlp.json` writes a post-run OTLP JSON file that external systems such as Opik can ingest.
+- `agentv eval <file.yaml> --export-otel --otel-backend <name>` streams live traces when a built-in or local resolver exists.
+
+Do not invent a separate Opik-specific eval surface. Keep the eval definition in YAML and route observability through OTLP export.
 
 ## Schemas
 

--- a/skills-data/agentv-eval-writer/references/custom-evaluators.md
+++ b/skills-data/agentv-eval-writer/references/custom-evaluators.md
@@ -11,7 +11,6 @@
   "input": [{"role": "user", "content": "..."}],
   "expected_output": [{"role": "assistant", "content": "..."}],
   "output": "final answer text",
-  "answer": "deprecated alias for output",
   "messages": [{"role": "assistant", "content": "final answer text"}],
   "trace": {
     "schema_version": "agentv.trace.v1",
@@ -62,7 +61,7 @@ import { defineCodeGrader, createTargetClient, definePromptTemplate } from '@age
   - `.invokeBatch(requests)` - Batch LLM calls
 - `definePromptTemplate(fn)` - Wraps prompt generation function
   - Raw stdin uses `snake_case`; SDK handlers receive `camelCase`
-  - Context fields: `input`, `expectedOutput`, `output`, `answer`, `messages`, `criteria`, `config`, `trace`, `traceSummary`, `tokenUsage`, `costUsd`, `durationMs`, `startTime`, `endTime`
+  - Context fields: `input`, `expectedOutput`, `output`, `messages`, `criteria`, `config`, `trace`, `traceSummary`, `tokenUsage`, `costUsd`, `durationMs`, `startTime`, `endTime`
 
 ## Python Example
 
@@ -71,7 +70,7 @@ import { defineCodeGrader, createTargetClient, definePromptTemplate } from '@age
 import json, sys
 
 def evaluate(data: dict) -> dict:
-    candidate = data.get("output") or data.get("answer") or ""
+    candidate = data.get("output", "")
     assertions = []
     for kw in ["async", "await"]:
         assertions.append({"text": f"Keyword '{kw}'", "passed": kw in candidate})
@@ -121,7 +120,6 @@ Derived from test fields (users never author these directly):
 | `input` | Full resolved input array (JSON) |
 | `expected_output` | Full resolved expected array (JSON) |
 | `output` | Final answer / scored result string |
-| `answer` | Deprecated alias for `output` |
 | `messages` | Transcript messages from target execution |
 
 Markdown templates use `{{variable}}` syntax. TypeScript templates receive context object.


### PR DESCRIPTION
## Summary
- make the SDK and eval authoring docs explicitly YAML-first and correct the current programmatic API shape (`assert`, camelCase)
- remove deprecated `_text` / `reference_answer` examples from the main authoring, grader, and autoevals guidance
- update the bundled `agentv-eval-writer` skill plus regenerated fixtures to match the shipped surfaces and OTLP/Opik export guidance

## Validation
- `bun install`
- `bun run build`
- `bun run validate:examples`
- `bun apps/cli/dist/cli.js skills get agentv-eval-writer`
- `bun apps/cli/dist/cli.js skills get agentv-eval-writer --full`

## Notes
- No new SDK package or Braintrust facade was added.
- Opik is documented via OTLP export, not as a built-in backend.