### PR TITLE
fix(copilot): trust subprocess cwd for relative path resolution in args

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,10 @@ cd ../agentv.worktrees/<type>-<short-desc>
 - Prefer named exports
 - Keep modules cohesive
 
+### Subprocess and Provider Conventions
+
+**Relative paths in CLI arg arrays:** When spawning a subprocess with an explicit `cwd`, pass user-supplied `args` through unchanged — the subprocess resolves its own relative paths against its `cwd`. Do not pre-process arg arrays with `startsWith('./')` or `!path.isAbsolute()` heuristics: they miss bare relative paths (`plugins/foo`), can corrupt flag-value pairs (`--config=./x`), and duplicate what `cwd` already does. See `docs/solutions/best-practices/trust-subprocess-cwd-for-relative-path-resolution.md`.
+
 ## Naming Convention: "Project" vs "Benchmark"
 
 These two words have distinct, non-interchangeable meanings in this codebase. Get them right when adding new symbols, docs, or example dirs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ AI agents are the primary users of AgentV—not humans reading docs. Design for 
 - `apps/cli/` - Command-line interface (published as `agentv`)
   - `src/commands/create/` - Scaffold commands (`agentv create assertion/eval`)
 - `examples/features/sdk-*` - SDK usage examples (custom assertion, programmatic API, config file)
-- `docs/solutions/` - documented solutions to past problems (bugs, conventions, best practices), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when working in documented areas.
+- `docs/learnings/` - captured learnings from bug fixes and deliberate decisions (best practices, conventions, tooling choices), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when working in documented areas.
 - `CONCEPTS.md` - shared domain vocabulary (providers, targets, and other project-specific terms). Relevant when orienting to the codebase or discussing domain concepts.
 
 ## Working Style
@@ -185,7 +185,7 @@ cd ../agentv.worktrees/<type>-<short-desc>
 
 ### Subprocess and Provider Conventions
 
-**Relative paths in CLI arg arrays:** When spawning a subprocess with an explicit `cwd`, pass user-supplied `args` through unchanged — the subprocess resolves its own relative paths against its `cwd`. Do not pre-process arg arrays with `startsWith('./')` or `!path.isAbsolute()` heuristics: they miss bare relative paths (`plugins/foo`), can corrupt flag-value pairs (`--config=./x`), and duplicate what `cwd` already does. See `docs/solutions/best-practices/trust-subprocess-cwd-for-relative-path-resolution.md`.
+**Relative paths in CLI arg arrays:** When spawning a subprocess with an explicit `cwd`, pass user-supplied `args` through unchanged — the subprocess resolves its own relative paths against its `cwd`. Do not pre-process arg arrays with `startsWith('./')` or `!path.isAbsolute()` heuristics: they miss bare relative paths (`plugins/foo`), can corrupt flag-value pairs (`--config=./x`), and duplicate what `cwd` already does. See `docs/learnings/best-practices/trust-subprocess-cwd-for-relative-path-resolution.md`.
 
 ## Naming Convention: "Project" vs "Benchmark"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,8 @@ AI agents are the primary users of AgentV—not humans reading docs. Design for 
 - `apps/cli/` - Command-line interface (published as `agentv`)
   - `src/commands/create/` - Scaffold commands (`agentv create assertion/eval`)
 - `examples/features/sdk-*` - SDK usage examples (custom assertion, programmatic API, config file)
+- `docs/solutions/` - documented solutions to past problems (bugs, conventions, best practices), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when working in documented areas.
+- `CONCEPTS.md` - shared domain vocabulary (providers, targets, and other project-specific terms). Relevant when orienting to the codebase or discussing domain concepts.
 
 ## Working Style
 

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -1,0 +1,9 @@
+# Concepts
+
+Shared domain vocabulary for this project — entities, named processes, and status concepts with project-specific meaning. Seeded with core domain vocabulary, then accretes as ce-compound and ce-compound-refresh process learnings; direct edits are fine. Glossary only, not a spec or catch-all.
+
+## Providers and Targets
+
+**Provider** — an adapter plugin that connects AgentV's evaluation engine to a specific AI system (e.g., copilot CLI, copilot SDK, Claude API, pi). Each provider implements the request/response contract: given a test case, invoke the AI system and return its output. Providers are selected per-target in eval YAML and can be extended via the provider registry.
+
+**Target** — the eval YAML declaration that activates a specific provider for an evaluation run. A target names the provider, supplies configuration (model, API keys, timeouts, passthrough args), and scopes to a subset of test cases when needed. A single eval file can declare multiple targets to compare AI systems side by side.

--- a/docs/learnings/best-practices/trust-subprocess-cwd-for-relative-path-resolution.md
+++ b/docs/learnings/best-practices/trust-subprocess-cwd-for-relative-path-resolution.md
@@ -111,4 +111,4 @@ targets:
 ## Related
 
 - `packages/core/src/evaluation/providers/copilot-sdk.ts` — `getOrCreateClient()` where `cwd` and `cliArgs` are set
-- PR #1402 — introduced args support for the copilot-sdk provider; removed the startsWith pre-processing in a follow-up fix
+- PR #1402 — introduced args support for the copilot-sdk provider; removed the startsWith pre-processing in a follow-up (PR #1412)

--- a/docs/solutions/best-practices/trust-subprocess-cwd-for-relative-path-resolution.md
+++ b/docs/solutions/best-practices/trust-subprocess-cwd-for-relative-path-resolution.md
@@ -1,0 +1,114 @@
+---
+title: "Trust subprocess cwd for relative path resolution in CLI arg arrays"
+module: copilot-sdk provider
+date: 2026-06-18
+problem_type: best_practice
+component: tooling
+severity: low
+tags:
+  - subprocess
+  - cwd
+  - relative-paths
+  - cli-args
+  - copilot-sdk
+  - path-resolution
+applies_when:
+  - Spawning a subprocess that accepts CLI args including file/directory paths
+  - Tempted to pre-resolve relative paths in args before passing them to a child process
+  - "Using startsWith or !isAbsolute heuristics to detect path arguments in CLI arg strings"
+---
+
+# Trust subprocess cwd for relative path resolution in CLI arg arrays
+
+## Context
+
+When adding `args` passthrough support to the `copilot-sdk` provider target (`packages/core/src/evaluation/providers/copilot-sdk.ts`), an initial implementation attempted to pre-resolve relative paths in user-supplied CLI arg arrays before handing them to the subprocess client:
+
+```typescript
+clientOptions.cliArgs = this.config.args.map((arg) =>
+  arg.startsWith('./') || arg.startsWith('../') ? path.resolve(resolvedCwd, arg) : arg,
+);
+```
+
+The intent was to ensure that relative paths like `./plugins/my-plugin` would resolve from the eval workspace directory. However, the subprocess was already being given `clientOptions.cwd = resolvedCwd`, so the subprocess inherits the eval workspace as its working directory and resolves paths itself — making the pre-processing redundant and fragile.
+
+## Guidance
+
+When a subprocess is spawned with an explicit `cwd` set to the eval workspace, **do not pre-process user-supplied CLI arg arrays to resolve relative paths**. Set `cwd` correctly and pass args through unchanged. The subprocess resolves its own relative path arguments against its own working directory.
+
+```typescript
+// Correct: set cwd once, pass args through unchanged
+const resolvedCwd = evalCwd ?? process.cwd();
+clientOptions.cwd = resolvedCwd;
+
+if (this.config.args && this.config.args.length > 0) {
+  // Pass args through unchanged; the subprocess resolves relative paths against cwd above.
+  clientOptions.cliArgs = [...this.config.args];
+}
+```
+
+## Why This Matters
+
+The `startsWith('./') || startsWith('../')` heuristic has three concrete failure modes:
+
+**1. Misses bare relative paths.** A path like `plugins/foo` or `extensions/bar` does not start with `./` or `../` but is still relative and would be silently skipped, leaving it unresolved.
+
+**2. `!path.isAbsolute()` overcorrects.** Switching to the inverse check would wrongly call `path.resolve()` on non-path arguments — flag strings like `--model=gpt-4o`, bare string values, `--config=./settings.json` passed as a single token.
+
+**3. CLI arg arrays are heterogeneous.** A real args array mixes flags (`--verbose`), string values (`gpt-4o`), single-token flag-value pairs (`--config=./settings.json`), and positional path arguments — all interleaved. There is no safe, general heuristic to identify which elements are file paths without full knowledge of the target CLI's interface. Only the subprocess itself has that knowledge, and it applies it correctly when given the right `cwd`.
+
+Pre-processing also violates the single-responsibility principle: `cwd` is already doing the job. Two sources of truth diverge.
+
+## When to Apply
+
+- Any provider target that spawns a CLI subprocess (e.g., `copilot-sdk`, any future CLI-backed provider) and accepts user-supplied `args` from eval YAML.
+- Whenever you find yourself writing `arg.startsWith('./')` or `!path.isAbsolute(arg)` inside a `.map()` over a CLI arg array — stop and check whether setting `cwd` on the subprocess is sufficient instead.
+- When adding passthrough `args` support to a new provider: set `cwd` first, then pass args through unchanged.
+
+## Examples
+
+**Before (fragile — do not use):**
+
+```typescript
+const resolvedCwd = evalCwd ?? process.cwd();
+clientOptions.cwd = resolvedCwd;
+
+if (this.config.args && this.config.args.length > 0) {
+  clientOptions.cliArgs = this.config.args.map((arg) =>
+    arg.startsWith('./') || arg.startsWith('../')
+      ? path.resolve(resolvedCwd, arg)
+      : arg,
+  );
+}
+```
+
+Problems: misses `plugins/foo`, fails on `--flag=./value` single-token forms, duplicates what `cwd` already accomplishes.
+
+**After (correct):**
+
+```typescript
+const resolvedCwd = evalCwd ?? process.cwd();
+clientOptions.cwd = resolvedCwd;
+
+if (this.config.args && this.config.args.length > 0) {
+  // Pass args through unchanged; subprocess resolves relative paths via cwd above.
+  clientOptions.cliArgs = [...this.config.args];
+}
+```
+
+**Eval YAML that works correctly with the after pattern:**
+
+```yaml
+targets:
+  - id: copilot-with-plugin
+    provider: copilot-sdk
+    args:
+      - --extensions
+      - ./plugins/my-extension     # resolved by the CLI against its cwd (the eval workspace)
+      - plugins/another-extension  # bare relative path — also resolved correctly by the subprocess
+```
+
+## Related
+
+- `packages/core/src/evaluation/providers/copilot-sdk.ts` — `getOrCreateClient()` where `cwd` and `cliArgs` are set
+- PR #1402 — introduced args support for the copilot-sdk provider; removed the startsWith pre-processing in a follow-up fix

--- a/packages/core/src/evaluation/providers/copilot-sdk.ts
+++ b/packages/core/src/evaluation/providers/copilot-sdk.ts
@@ -327,9 +327,8 @@ export class CopilotSdkProvider implements Provider {
       clientOptions.cwd = resolvedCwd;
 
       if (this.config.args && this.config.args.length > 0) {
-        clientOptions.cliArgs = this.config.args.map((arg) =>
-          arg.startsWith('./') || arg.startsWith('../') ? path.resolve(resolvedCwd, arg) : arg,
-        );
+        // Pass args through unchanged; the subprocess resolves relative paths against clientOptions.cwd above.
+        clientOptions.cliArgs = [...this.config.args];
       }
       if (this.config.githubToken) {
         clientOptions.githubToken = this.config.githubToken;

--- a/packages/core/test/evaluation/providers/copilot-sdk.test.ts
+++ b/packages/core/test/evaluation/providers/copilot-sdk.test.ts
@@ -185,7 +185,7 @@ describe('CopilotSdkProvider', () => {
     expect(constructorArgs.cliArgs).toEqual(['--verbose', 'enabled']);
   });
 
-  it('resolves relative args paths against eval cwd', async () => {
+  it('passes args through unchanged and sets cwd so the subprocess resolves relative paths itself', async () => {
     const session = createMockSession({
       events: [{ type: 'assistant.message', data: { content: 'response' } }],
     });
@@ -207,12 +207,13 @@ describe('CopilotSdkProvider', () => {
     await provider.invoke({ question: 'Test', cwd: fixturesRoot });
 
     const constructorArgs = CopilotClientMock.mock.calls[0][0];
+    // cwd is set so the subprocess resolves relative paths itself — args are NOT pre-resolved
     expect(constructorArgs.cwd).toBe(path.resolve(fixturesRoot));
     expect(constructorArgs.cliArgs).toEqual([
       '--plugin-dir',
-      path.resolve(fixturesRoot, './plugins'),
+      './plugins',
       '--shared-dir',
-      path.resolve(fixturesRoot, '../shared'),
+      '../shared',
       '--mode',
       'agent',
     ]);


### PR DESCRIPTION
## Summary

- Removes the `startsWith('./') || startsWith('../')` heuristic from `copilot-sdk`'s `cliArgs` assignment — `clientOptions.cwd` is already set to the eval workspace, so the subprocess resolves relative paths itself
- Updates the test to assert the new pass-through behavior (and explain via comment why args aren't pre-resolved)
- Adds `docs/solutions/best-practices/` with a captured learning on this antipattern
- Adds a "Subprocess Conventions" note to the TypeScript Guidelines section of AGENTS.md

## Why the heuristic was wrong

The `startsWith` check had three failure modes:
1. **Missed bare relative paths** — `plugins/foo` (no `./`) silently passed through unresolved
2. **`!path.isAbsolute()` overcorrects** — would wrongly resolve `--flag=./value` single-token forms
3. **CLI arg arrays are heterogeneous** — flags, values, and paths are interleaved; only the subprocess knows the CLI interface

Since `clientOptions.cwd = resolvedCwd` is already set, the subprocess handles resolution correctly.

## Test plan

- [x] `bun test packages/core/test/evaluation/providers/copilot-sdk.test.ts` — 24 pass
- [x] `bun run verify` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)