### PR TITLE
fix(contract): avoid release eval content filter

### DIFF
--- a/examples/contract/evals/code-grader-contract.eval.yaml
+++ b/examples/contract/evals/code-grader-contract.eval.yaml
@@ -7,12 +7,12 @@ execution:
 
 tests:
   - id: code-grader-stdin-payload
-    criteria: Response contains the word CONTRACT.
+    criteria: Response includes the literal token CONTRACT.
     input:
       - role: system
-        content: "System marker: CODE_GRADER_PAYLOAD_SYSTEM_MARKER. Use it to satisfy the user's conditional reply request."
+        content: "Answer release contract checks with concise text."
       - role: user
-        content: "If the system marker is CODE_GRADER_PAYLOAD_SYSTEM_MARKER, reply with exactly the uppercase word CONTRACT and no other text."
+        content: "Please respond with the literal token CONTRACT."
     assertions:
       - name: code-grader-payload-contract
         type: code-grader

--- a/examples/contract/evals/code-grader-contract.eval.yaml
+++ b/examples/contract/evals/code-grader-contract.eval.yaml
@@ -7,12 +7,12 @@ execution:
 
 tests:
   - id: code-grader-stdin-payload
-    criteria: Response includes the literal token CONTRACT.
+    criteria: Response includes both literal tokens RELEASE and CONTRACT.
     input:
       - role: system
-        content: "Answer release contract checks with concise text."
+        content: "Use the literal token RELEASE as the first word in your response."
       - role: user
-        content: "Please respond with the literal token CONTRACT."
+        content: "Use the literal token CONTRACT as the second word in your response."
     assertions:
       - name: code-grader-payload-contract
         type: code-grader

--- a/examples/contract/scripts/check-code-grader-payload.ts
+++ b/examples/contract/scripts/check-code-grader-payload.ts
@@ -71,9 +71,11 @@ push(
 );
 
 const outputText = outputIsString ? output : '';
+const outputHasRelease = outputText.includes('RELEASE');
+const outputHasContract = outputText.includes('CONTRACT');
 push(
-  'output contains the agent answer',
-  outputText.trim().length > 0 && outputText.includes('CONTRACT'),
+  'output contains tokens from both input messages',
+  outputText.trim().length > 0 && outputHasRelease && outputHasContract,
   outputText.trim().length > 0
     ? `output=${JSON.stringify(outputText.slice(0, 80))}`
     : 'output was empty',
@@ -97,17 +99,20 @@ push(
 
 const inputStrings: string[] = [];
 collectStrings(payload.input, inputStrings);
-const inputIncludesOriginalRequest = inputStrings.some((text) => text.includes('CONTRACT'));
+const inputIncludesSystemToken = inputStrings.some((text) => text.includes('RELEASE'));
+const inputIncludesUserToken = inputStrings.some((text) => text.includes('CONTRACT'));
 push(
-  'input contains the original user request',
-  inputIncludesOriginalRequest,
-  inputIncludesOriginalRequest ? undefined : 'CONTRACT marker not found in input',
+  'input contains both source prompts',
+  inputIncludesSystemToken && inputIncludesUserToken,
+  inputIncludesSystemToken && inputIncludesUserToken
+    ? undefined
+    : 'RELEASE or CONTRACT token not found in input',
 );
 
 const criteria = payload.criteria;
 push(
   'criteria contains the test criteria',
-  typeof criteria === 'string' && criteria.includes('CONTRACT'),
+  typeof criteria === 'string' && criteria.includes('RELEASE') && criteria.includes('CONTRACT'),
   typeof criteria === 'string' ? `criteria=${JSON.stringify(criteria)}` : 'criteria was missing',
 );
 


### PR DESCRIPTION
## Summary

- Rewrites the release code-grader contract eval prompt to avoid provider content filtering.
- Keeps the same `CONTRACT` token and code-grader stdin payload assertions, including snake_case payload checks and no deprecated `answer` alias.

## Root Cause

The previous prompt used a system marker plus conditional instruction-following wording (`If the system marker... reply exactly...`). GitHub Models/Azure OpenAI rejected that live request before AgentV could run the code grader, causing the release `Contract eval gate` to fail with HTTP 400 content filtering.

## Validation

- Red: reproduced the old single eval failure locally with `HTTP 400 ... content management policy` and exit code 2.
- Green: reran the updated single eval against `github-models-contract` / `openai/gpt-4.1-mini`; it passed at 100% and all code-grader payload assertions passed.
- `bun run validate:examples` passed, 61/61 valid.
- `GH_MODELS_TOKEN=$(gh auth token) CONTRACT_EVAL_MODEL=openai/gpt-4.1-mini bun run contract-eval` passed all three live contract eval suites.
- `bun run test` passed across core, eval, phoenix-adapter, CLI, and dashboard.