### PR TITLE
fix(copilot): use api_format for custom provider wire format

### DIFF
--- a/apps/web/src/content/docs/docs/targets/coding-agents.mdx
+++ b/apps/web/src/content/docs/docs/targets/coding-agents.mdx
@@ -145,7 +145,7 @@ targets:
 | `api_key` | No | Provider API key. Prefer `${{ ENV_VAR }}` references. |
 | `bearer_token` | No | Provider bearer token. Prefer `${{ ENV_VAR }}` references. Takes precedence over `api_key` when set. |
 | `api_version` | No | Provider API version, primarily for Azure endpoints |
-| `wire_api` | No | Provider wire API format, such as `responses` |
+| `api_format` | No | Provider API format, such as `responses` |
 | `grader_target` | Yes | LLM target for evaluation |
 
 Route Copilot through an OpenAI-compatible endpoint:
@@ -157,7 +157,7 @@ targets:
     subprovider: openai
     base_url: ${{ OPENAI_ENDPOINT }}
     api_key: ${{ OPENAI_API_KEY }}
-    wire_api: ${{ COPILOT_PROVIDER_WIRE_API }}
+    api_format: responses
     grader_target: azure-base
 ```
 

--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -1565,10 +1565,15 @@ function resolveCopilotFlatProviderConfig(
       optionalEnv: true,
     },
   );
-  const wireApi = resolveOptionalString(target.wire_api, env, `${target.name} copilot wire API`, {
-    allowLiteral: true,
-    optionalEnv: true,
-  });
+  const apiFormat = resolveOptionalString(
+    target.api_format,
+    env,
+    `${target.name} copilot API format`,
+    {
+      allowLiteral: true,
+      optionalEnv: true,
+    },
+  );
 
   return {
     ...(type ? { type } : {}),
@@ -1576,7 +1581,7 @@ function resolveCopilotFlatProviderConfig(
     ...(apiKey ? { apiKey } : {}),
     ...(bearerToken ? { bearerToken } : {}),
     ...(apiVersion ? { apiVersion } : {}),
-    ...(wireApi ? { wireApi } : {}),
+    ...(apiFormat ? { wireApi: apiFormat } : {}),
   };
 }
 

--- a/packages/core/src/evaluation/providers/types.ts
+++ b/packages/core/src/evaluation/providers/types.ts
@@ -383,6 +383,7 @@ export interface TargetDefinition {
   readonly model?: string | unknown | undefined;
   readonly version?: string | unknown | undefined;
   readonly api_version?: string | unknown | undefined;
+  readonly api_format?: string | unknown | undefined;
   // Anthropic fields
   readonly variant?: string | unknown | undefined;
   readonly thinking_budget?: number | unknown | undefined;

--- a/packages/core/src/evaluation/validation/targets-validator.ts
+++ b/packages/core/src/evaluation/validation/targets-validator.ts
@@ -133,7 +133,7 @@ const COPILOT_SDK_SETTINGS = new Set([
   'api_key',
   'bearer_token',
   'api_version',
-  'wire_api',
+  'api_format',
 ]);
 
 const COPILOT_CLI_SETTINGS = new Set([
@@ -155,7 +155,7 @@ const COPILOT_CLI_SETTINGS = new Set([
   'api_key',
   'bearer_token',
   'api_version',
-  'wire_api',
+  'api_format',
 ]);
 
 const VSCODE_SETTINGS = new Set([

--- a/packages/core/test/evaluation/providers/targets.test.ts
+++ b/packages/core/test/evaluation/providers/targets.test.ts
@@ -799,7 +799,7 @@ describe('resolveTargetDefinition', () => {
         base_url: '${{ OPENAI_ENDPOINT }}',
         api_key: '${{ OPENAI_API_KEY }}',
         bearer_token: '${{ OPTIONAL_BEARER_TOKEN }}',
-        wire_api: 'responses',
+        api_format: 'responses',
         api_version: '2024-10-21',
       },
       env,
@@ -834,7 +834,7 @@ describe('resolveTargetDefinition', () => {
         subprovider: 'openai',
         base_url: '${{ OPENAI_ENDPOINT }}',
         api_key: '${{ OPENAI_API_KEY }}',
-        wire_api: 'responses',
+        api_format: 'responses',
       },
       env,
     );
@@ -922,7 +922,7 @@ describe('resolveTargetDefinition', () => {
     expect(target.config.customProvider?.apiKey).toBeUndefined();
   });
 
-  it('copilot-sdk flat config supports wire_api', () => {
+  it('copilot-sdk flat config supports api_format', () => {
     const env = {
       FOUNDRY_KEY: 'foundry-secret',
     } satisfies Record<string, string>;
@@ -935,7 +935,7 @@ describe('resolveTargetDefinition', () => {
         subprovider: 'openai',
         base_url: 'https://resource.openai.azure.com/openai/v1/',
         api_key: '${{ FOUNDRY_KEY }}',
-        wire_api: 'responses',
+        api_format: 'responses',
       },
       env,
     );

--- a/packages/core/test/evaluation/validation/targets-validator.test.ts
+++ b/packages/core/test/evaluation/validation/targets-validator.test.ts
@@ -132,13 +132,13 @@ describe('validateTargetsFile', () => {
     subprovider: openai
     base_url: \${{ OPENAI_ENDPOINT }}
     api_key: \${{ OPENAI_API_KEY }}
-    wire_api: responses
+    api_format: responses
   - name: copilot-cli-custom-provider
     provider: copilot-cli
     subprovider: openai
     base_url: \${{ OPENAI_ENDPOINT }}
     api_key: \${{ OPENAI_API_KEY }}
-    wire_api: responses
+    api_format: responses
 `,
     );
 


### PR DESCRIPTION
## Summary

Copilot custom provider config now reuses AgentV's existing `api_format` public field instead of introducing a Copilot-specific `wire_api` YAML key. The resolver still maps `api_format` to Copilot's internal `wireApi` field and `COPILOT_PROVIDER_WIRE_API` env var at the provider boundary, so the user-facing config stays aligned with existing OpenAI-style target naming.

## Config Example

```yaml
targets:
  - name: copilot-openai
    provider: copilot-cli
    subprovider: openai
    base_url: ${{ OPENAI_ENDPOINT }}
    api_key: ${{ OPENAI_API_KEY }}
    api_format: responses
```

## Tests

- `bun run typecheck`
- `bun --filter @agentv/core test test/evaluation/providers/targets.test.ts test/evaluation/validation/targets-validator.test.ts` — 70 pass, 0 fail
- `bun run verify`

## Post-Deploy Monitoring & Validation

No additional production monitoring required; this is local eval target configuration parsing. Validate by running a Copilot target with flat `api_format: responses` and confirming the resolved Copilot provider still receives `wireApi: responses` / `COPILOT_PROVIDER_WIRE_API=responses`.
