### PR TITLE
docs(strategy): define repo-native product boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,11 @@ AI agents are the primary users of AgentV—not humans reading docs. Design for 
 - `apps/cli/` - Command-line interface (published as `agentv`)
   - `src/commands/create/` - Scaffold commands (`agentv create assertion/eval`)
 - `examples/features/sdk-*` - SDK usage examples (custom assertion, programmatic API, config file)
-- `docs/learnings/` - captured learnings from bug fixes and deliberate decisions (best practices, conventions, tooling choices), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when working in documented areas.
+- `STRATEGY.md` - product boundary and priorities. Relevant when proposing features, integrations, or roadmap direction.
+- `docs/adr/` - decision records for product and architecture boundaries, especially what AgentV core owns versus adapters, runtimes, and adjacent tools.
+- `docs/plans/` - design and implementation plans. Useful supporting evidence; prefer `STRATEGY.md` and ADRs when a plan's old execution details differ from the current product direction.
+- `docs/learnings/` - primary learning store for this repo (it does not use `docs/solutions/`). Captured learnings from bug fixes and deliberate decisions, organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when working in documented areas.
+- `apps/web/src/content/docs/` - public product and CLI docs. Useful when checking current user-facing contracts, tool boundaries, and integration guidance.
 - `CONCEPTS.md` - shared domain vocabulary (providers, targets, and other project-specific terms). Relevant when orienting to the codebase or discussing domain concepts.
 
 ## Working Style

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,14 @@ This is a TypeScript monorepo for AgentV - an AI agent evaluation framework.
 
 ## High-Level Goals
 
-AgentV aims to provide a robust, declarative framework for evaluating AI agents.
-- **Declarative Definitions**: Define tasks, expected outcomes, and rubrics in simple YAML files.
-- **Structured Evaluation**: Use "Rubric as Object" (Google ADK style) for deterministic, type-safe grading.
-- **Multi-Objective Scoring**: Measure correctness, latency, cost, and safety in a single run.
-- **Optimization Ready**: Designed to support future automated hyperparameter tuning and candidate generation.
+See [STRATEGY.md](STRATEGY.md) for the durable product boundary.
+
+AgentV aims to be the repo-native, workspace-native evaluation framework for AI agents.
+- **Repo-native evals**: Define evals that run against real repos, multi-repo workspaces, setup scripts, and existing harnesses.
+- **Zero-infra local to CI**: Keep the default path lightweight so the same eval contract works on a laptop and in CI.
+- **Portable run artifacts**: Treat run bundles, traces, and summaries as the source of truth for comparison, gating, and export.
+- **Adapter boundaries**: Integrate with Phoenix, Harbor, Opik, and provider-specific systems through narrow adapters instead of absorbing their concepts into core.
+- **AI-native extensibility**: Keep the core small and composable so engineers and coding agents can extend it with plugins, wrappers, and harness-specific glue.
 
 ## Design Principles
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AgentV
 
-**Evaluate AI agents from the terminal. No server. No signup.**
+**Evaluate AI agents against real repos from the terminal. No server. No signup.**
 
 ```bash
 npm install -g agentv
@@ -33,6 +33,8 @@ agentv eval evals/math.yaml
 ## Why AgentV?
 
 - **Local-first** — runs on your machine, no cloud accounts or API keys for eval infrastructure
+- **Repo-backed workspaces** — reuse real repos, setup scripts, and existing harnesses instead of rebuilding synthetic tasks
+- **Portable artifacts** — results, traces, and reports are saved in a durable format other tools can consume
 - **Version-controlled** — evals, judges, and results all live in Git
 - **Hybrid graders** — deterministic code checks + LLM-based subjective scoring
 - **CI/CD native** — exit codes, JSONL output, threshold flags for pipeline gating

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,44 @@
+# AgentV Roadmap
+
+Last updated: 2026-06-19
+
+This roadmap translates [STRATEGY.md](STRATEGY.md) into the next few product phases. It is intentionally short: the goal is to keep priorities and boundaries visible without turning the roadmap into a plan dump.
+
+## Guardrails
+
+- AgentV remains the repo-native, workspace-native runner, grader, and artifact source of truth.
+- Phoenix is the preferred shared UI for traces, experiments, and longitudinal results analysis.
+- The AgentV Dashboard stays valuable as the zero-infra local cockpit; this roadmap does not deprecate it.
+- Harbor stays an optional benchmark-grade runner boundary, not AgentV core.
+- Adapters, workers, and artifact projections are preferred over rebuilding adjacent platforms inside AgentV.
+
+## Phase 1: Finish the artifact and projection foundation
+
+- Keep the canonical handoff surface centered on completed run bundles, `index.jsonl`, grading/timing artifacts, and execution-trace sidecars.
+- Finish the vendor-neutral projection/export seams that let completed runs be re-read, compared, exported, and attached to adapters without vendor-specific logic in core.
+- Keep OTLP/OpenInference mapping generic and reusable before building backend-specific upload or import paths.
+
+## Phase 2: Make Phoenix the shared UI over AgentV-native execution
+
+- Add a Phoenix-triggered AgentV worker/runner contract so Phoenix can request or attach to real AgentV runs without owning workspace lifecycle, target execution, or grader semantics.
+- Project completed AgentV run bundles and execution traces into Phoenix through adapter workers that preserve AgentV IDs, score provenance, and links back to local artifacts.
+- Keep missing worker/config/trace state explicit: failures should surface as execution or import errors, not as silent evaluator passes.
+
+## Phase 3: Strengthen the local cockpit and the product boundary
+
+- Keep the AgentV Dashboard focused on quick local inspection, comparison, and zero-infra review.
+- Add lightweight handoff points between local AgentV artifacts and Phoenix when a shared UI exists.
+- Clarify the split across docs, CLI help, Dashboard copy, and skills so users know when to stay local and when to attach Phoenix.
+- Docs hygiene follow-up: split large AI-facing guidance such as `AGENTS.md` into linked instruction files if that makes the boundary easier to maintain.
+
+## Phase 4: Extend outward through optional boundaries
+
+- Harbor: launch or import benchmark-grade runs through a runner boundary, then gate on imported results.
+- Opik and similar systems: consume completed AgentV projection bundles as post-run adapters rather than as runtime owners.
+- Additional observability backends should reuse the same projection and export seams instead of adding new core product models.
+
+## Not On This Roadmap
+
+- Rebuilding Phoenix, Opik, Langfuse, or similar products inside AgentV.
+- Turning AgentV into a hosted experiment platform, benchmark catalog, or generic dashboard platform.
+- Deleting the local Dashboard in favor of Phoenix.

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -7,7 +7,7 @@ last_updated: 2026-06-19
 
 ## Target problem
 
-Teams evaluating coding agents and other tool-using workflows need results from the real repositories, fixtures, and harnesses their agents already touch, but most eval tools either flatten that work into generic benchmark runners or ask teams to move execution and results into a separate platform. That makes it hard to reproduce failures, compare targets fairly, and keep evaluation evidence close to the code and workflow it came from.
+Teams evaluating coding agents and other tool-using workflows need results from the real repositories, fixtures, and harnesses their agents already touch, but that work often gets split away from the actual workspace and development loop it came from. That makes it hard to reproduce failures, compare targets fairly, and keep evaluation evidence close to the code and workflow it came from.
 
 ## Our approach
 
@@ -15,7 +15,7 @@ AgentV stays repo-native and workspace-native: it runs or imports evaluations ar
 
 ## Who it's for
 
-**Primary:** AI platform engineers and agent builders working in real repositories - They're hiring AgentV to evaluate real agent workflows, compare targets, and gate changes using the same workspaces, fixtures, and result artifacts their teams already rely on.
+**Primary:** AI platform engineers and agent builders working in real repositories. They're hiring AgentV to evaluate real agent workflows, compare targets, and gate changes using the same workspaces, fixtures, and result artifacts their teams already rely on.
 
 ## Key metrics
 

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -1,0 +1,57 @@
+---
+name: AgentV
+last_updated: 2026-06-19
+---
+
+# AgentV Strategy
+
+## Target problem
+
+Teams evaluating coding agents and other tool-using workflows need results from the real repositories, fixtures, and harnesses their agents already touch, but most eval tools either flatten that work into generic benchmark runners or ask teams to move execution and results into a separate platform. That makes it hard to reproduce failures, compare targets fairly, and keep evaluation evidence close to the code and workflow it came from.
+
+## Our approach
+
+AgentV stays repo-native and workspace-native: it runs or imports evaluations around the user's existing harness, writes portable run artifacts, and keeps core primitives focused on execution, grading, routing, and results storage. It integrates outward through clear adapter boundaries so teams can use Phoenix for experiment and trace UI, Harbor for benchmark-grade execution, and post-run/export adapters for adjacent systems without AgentV trying to own every layer.
+
+## Who it's for
+
+**Primary:** AI platform engineers and agent builders working in real repositories - They're hiring AgentV to evaluate real agent workflows, compare targets, and gate changes using the same workspaces, fixtures, and result artifacts their teams already rely on.
+
+## Key metrics
+
+- **Repo-native eval success** - Share of dogfood and example eval flows that run against real workspaces, hooks, repo materialization, or imported artifacts without extra infrastructure; measured by CI and manual UAT on canonical suites.
+- **Time to inspect a run** - Time from completed `agentv eval` to usable local review, compare, or report output from the canonical run bundle; measured through CLI and Dashboard/report workflows.
+- **Artifact portability coverage** - Share of integrations and follow-on workflows that consume `index.jsonl`, `benchmark.json`, trace sidecars, or imported run bundles instead of bespoke stores; measured by adapter smoke tests, docs, and example coverage.
+- **Git-backed results reliability** - Success rate for publish, sync, resume, and WIP checkpoint flows across local branches and dedicated results repos; measured by integration tests and manual end-to-end verification.
+
+## Tracks
+
+### Workspace-native evaluation
+
+Make real repository workflows first-class: repo acquisition, hooks, pooled workspaces, replay/import paths, and reuse of existing harnesses.
+
+_Why it serves the approach:_ This keeps AgentV attached to the actual work the agent is being judged on instead of collapsing it into a synthetic runner.
+
+### Portable run artifacts
+
+Keep the run bundle, trace sidecars, and git-backed results model as the canonical exchange surface for inspection, sharing, and automation.
+
+_Why it serves the approach:_ Portable artifacts let local runs, CI, static reports, and downstream adapters all share one source of truth.
+
+### Adapter-led integrations
+
+Add Phoenix, Harbor, Opik, Langfuse, and similar systems through narrow adapter, runner, or export boundaries rather than copying their product models into core.
+
+_Why it serves the approach:_ This expands AgentV's reach without turning it into a hosted observability stack, benchmark platform, or integration kitchen sink.
+
+### Evaluation primitives for real agent workflows
+
+Strengthen provider routing, grader composition, trace and trajectory scoring, and CI gates around coding-agent and tool-using workflows.
+
+_Why it serves the approach:_ The product wins when the core primitives make real agent evaluation easier to compose, not when it accumulates adjacent platform features.
+
+## Not working on
+
+- Rebuilding Phoenix, Opik, Langfuse, or similar experiment and trace UIs inside AgentV.
+- Owning Harbor's benchmark packaging, verifier images, or suite-specific runtime contracts inside AgentV core.
+- Expanding AgentV into a generic benchmark catalog or a general-purpose dashboard platform when repo-native evals, static artifacts, and adapters already cover the job.

--- a/docs/plans/2026-06-10-remote-results-cli-contract.md
+++ b/docs/plans/2026-06-10-remote-results-cli-contract.md
@@ -6,7 +6,7 @@ AgentV should not add `agentv results remote status` or `agentv results remote s
 
 The production contract is:
 
-- `agentv eval` and `agentv pipeline bench` may auto-export newly created runs to the configured results repository when `auto_push: true`.
+- `agentv eval` and `agentv pipeline bench` may auto-export newly created runs to the configured results repository when `sync.auto_push: true`.
 - `agentv results` remains a local-result workspace command family: combine, delete, export, report, summary, failures, show, and validate.
 - Manual remote status and sync are Dashboard/API capabilities:
   - `GET /api/remote/status`

--- a/docs/plans/git-native-results-goal.md
+++ b/docs/plans/git-native-results-goal.md
@@ -3,6 +3,8 @@
 ## Objective
 Implement the git-native results storage architecture and land PR #1261 as a clean, tested, manually verified change.
 
+> Historical note: this file captured the execution goal for PR #1261. The current git-native results contract lives in [`docs/plans/git-native-results.md`](git-native-results.md); if any implementation detail below differs, treat that design doc as the source of truth.
+
 ## Success Criteria
 - All implementation passes completed per design doc
 - Full test suite green (unit + integration + existing 1782 core + 553 CLI tests)
@@ -14,8 +16,8 @@ Implement the git-native results storage architecture and land PR #1261 as a cle
 - Worktree: `agentv.worktrees/git-native-results/`
 - Branch: `feat/git-native-results`
 
-## Key Decisions Confirmed
-- Dedicated results repo model → write directly to `main` of results repo (no separate branch needed)
+## Key Decisions Confirmed During Execution
+- Historical planning assumption: dedicated results repos would write directly to `main`; the shipped storage-branch contract is documented in `docs/plans/git-native-results.md`
 - Use raw `git` subprocess (not go-git) for ls-tree / cat-file path
 - Follow exact order in design doc
 


### PR DESCRIPTION
## Summary

Future product decisions now have a single repo-native boundary to anchor on, so AgentV stays focused on real-workspace evaluation instead of drifting into a general dashboard or benchmark-platform surface.

- add a root `STRATEGY.md` that defines the target problem, approach, tracks, and non-goals around Phoenix, Harbor, and post-run adapters
- point `AGENTS.md` and `README.md` at that boundary so contributors and coding agents see the intended product shape immediately
- correct two results-planning docs so future work follows the shipped git-backed results contract instead of stale assumptions

## Testing

Not run (docs-only).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
