### PR TITLE
docs(roadmap): clarify Harbor runner direction

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,6 +10,7 @@ This roadmap translates [STRATEGY.md](STRATEGY.md) into the next few product pha
 - Phoenix is the preferred shared UI for traces, experiments, and longitudinal results analysis.
 - The AgentV Dashboard stays valuable as the zero-infra local cockpit; this roadmap does not deprecate it.
 - Harbor stays an optional benchmark-grade runner boundary, not AgentV core.
+- AgentV YAML remains the authoring surface even when execution moves behind another runner; prefer a lightweight translation layer over duplicated specs.
 - Adapters, workers, and artifact projections are preferred over rebuilding adjacent platforms inside AgentV.
 
 ## Phase 1: Finish the artifact and projection foundation
@@ -33,7 +34,8 @@ This roadmap translates [STRATEGY.md](STRATEGY.md) into the next few product pha
 
 ## Phase 4: Extend outward through optional boundaries
 
-- Harbor: launch or import benchmark-grade runs through a runner boundary, then gate on imported results.
+- Harbor: move toward Harbor becoming the benchmark-grade runner behind a lightweight translation layer from AgentV YAML, while AgentV stays the authoring, gating, import, and comparison surface.
+- Harbor: in the near term, launch or import benchmark-grade runs through a runner boundary; over time, converge on Harbor as the execution layer for the suites it already owns.
 - Opik and similar systems: consume completed AgentV projection bundles as post-run adapters rather than as runtime owners.
 - Additional observability backends should reuse the same projection and export seams instead of adding new core product models.
 


### PR DESCRIPTION
## Summary

The roadmap now makes the intended Harbor end-state explicit: AgentV YAML remains the authoring surface, a thin translation layer bridges to Harbor, and Harbor can eventually become the benchmark-grade execution runner for the suites it already owns.

- keep AgentV YAML as the stable authoring surface even when execution moves behind another runner
- clarify that the near-term Harbor path is launch/import through a runner boundary, while the longer-term direction is Harbor as the execution layer for benchmark-owned suites
- preserve AgentV as the authoring, gating, import, and comparison surface rather than duplicating Harbor schema in core

## Testing

Not run (docs-only).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
