### PR TITLE
docs(agents): split root guide into linked index

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -1,0 +1,139 @@
+# Technical Conventions
+
+This file expands [AGENTS.md](../AGENTS.md) for code-level rules, naming contracts, wire formats, grader-type rules, and toolchain expectations.
+
+## Toolchain
+
+- Language: TypeScript 5.x targeting ES2022
+- Runtime and package manager: Bun
+- Monorepo: Bun workspaces
+- Bundler: tsup
+- Linter and formatter: Biome
+- Testing: Vitest
+- LLM framework: Vercel AI SDK
+- Validation: Zod
+
+## TypeScript Guidelines
+
+- Target ES2022 with Node 20+.
+- Prefer type inference over explicit types when the result stays clear.
+- Use `async` and `await` for async operations.
+- Prefer named exports.
+- Keep modules cohesive.
+
+## Subprocess and Provider Conventions
+
+When spawning a subprocess with an explicit `cwd`, pass user-supplied `args` through unchanged. The subprocess resolves its own relative paths against its `cwd`.
+
+- Do not rewrite arg arrays with `startsWith('./')` or `!path.isAbsolute()` heuristics.
+- Those heuristics miss bare relative paths such as `plugins/foo`, can corrupt flag-value pairs such as `--config=./x`, and duplicate behavior the subprocess already handles.
+- See `docs/learnings/best-practices/trust-subprocess-cwd-for-relative-path-resolution.md`.
+
+## Naming: Project vs Benchmark
+
+These terms are distinct and not interchangeable.
+
+- Project: the top-level container Dashboard organizes around, backed by a registered workspace directory with `.agentv/`, run artifacts, traces, and experiments. The registry lives in `~/.agentv/projects.yaml` and is modeled by `ProjectEntry` and `ProjectRegistry` in `packages/core/src/projects.ts`.
+- Benchmark: a curated eval suite designed to measure something specific, in the academic ML sense. Example directories using this meaning are correctly named and should not be renamed.
+
+The legacy `~/.agentv/benchmarks.yaml` file is auto-migrated to `projects.yaml` by `migrateLegacyBenchmarksFile()`. The unrelated per-run `benchmark.json` artifact is a third, separate concept and should keep that name.
+
+Rule of thumb:
+
+- If it holds runs, traces, or experiments, it is a project.
+- If it is a curated set of eval cases used to measure capability, it is a benchmark.
+
+## Wire Format Convention
+
+Everything that crosses a process boundary uses `snake_case`. Internal TypeScript uses `camelCase`. Translate only at the boundary.
+
+Snake-case surfaces:
+
+- YAML files on disk such as `*.eval.yaml`, `agentv.config.yaml`, `projects.yaml`, and `dashboard/config.yaml`
+- JSONL result files such as `test_id`, `token_usage`, and `duration_ms`
+- Artifact-writer output such as `pass_rate`, `tests_run`, and `total_tool_calls`
+- HTTP response bodies from `agentv serve` or Dashboard
+- CLI JSON output
+- Anything consumed by non-TypeScript tooling
+
+Camel-case surfaces:
+
+- TypeScript source
+- Internal in-memory shapes passed between TypeScript modules
+
+Translate in one place:
+
+```typescript
+interface ProjectEntryYaml {
+  id: string;
+  name: string;
+  path: string;
+  added_at: string;
+  last_opened_at: string;
+}
+
+interface ProjectEntry {
+  id: string;
+  name: string;
+  path: string;
+  addedAt: string;
+  lastOpenedAt: string;
+}
+
+function fromYaml(entry: ProjectEntryYaml): ProjectEntry {
+  return {
+    id: entry.id,
+    name: entry.name,
+    path: entry.path,
+    addedAt: entry.added_at,
+    lastOpenedAt: entry.last_opened_at,
+  };
+}
+
+function toYaml(entry: ProjectEntry): ProjectEntryYaml {
+  return {
+    id: entry.id,
+    name: entry.name,
+    path: entry.path,
+    added_at: entry.addedAt,
+    last_opened_at: entry.lastOpenedAt,
+  };
+}
+```
+
+Anti-patterns:
+
+- `writeFileSync(path, stringifyYaml(tsObject))`
+- TypeScript response interfaces with `testId` instead of `test_id`
+- Accepting both `testId` and `test_id` on new inputs "for back-compat" when nothing has shipped
+
+If you spot a camelCase key already on disk or in a response, treat it as a bug and migrate it in the same PR that touches that path. `parseJsonlResults()` in `artifact-writer.ts` and `fromYaml` or `toYaml` in `packages/core/src/projects.ts` are the models to follow.
+
+## Grader Type System
+
+Grader types use kebab-case everywhere.
+
+- YAML config: `type: llm-grader`, `type: is-json`, `type: execution-metrics`
+- Internal TypeScript: `EvaluatorKind = 'llm-grader' | 'is-json' | ...`
+- Output `scores[].type`: `"llm-grader"`, `"is-json"`
+- Registry keys: `registry.register('llm-grader', ...)`
+
+Source of truth: `EVALUATOR_KIND_VALUES` in `packages/core/src/evaluation/types.ts`.
+
+Backward compatibility:
+
+- Snake_case is accepted in YAML by `normalizeGraderType()` in `grader-parser.ts`, for example `llm_judge` -> `llm-grader`.
+- Single-word types such as `contains`, `equals`, `regex`, `latency`, and `cost` are unchanged.
+
+Two type definitions exist and must stay in sync:
+
+- `EvaluatorKind` in `packages/core/src/evaluation/types.ts`
+- `AssertionType` in `packages/eval/src/assertion.ts`
+
+## Python Scripts
+
+When running Python scripts, always use:
+
+```bash
+uv run <script.py>
+```

--- a/.agents/product-boundary.md
+++ b/.agents/product-boundary.md
@@ -1,0 +1,109 @@
+# Product Boundary
+
+This file expands the summary in [AGENTS.md](../AGENTS.md). Read it when proposing features, changing core abstractions, or deciding whether something belongs in core, a plugin, or docs.
+
+## Direction Sources
+
+- Durable product boundary: [STRATEGY.md](../STRATEGY.md)
+- Current phases and priorities: [ROADMAP.md](../ROADMAP.md)
+- Architecture decisions: [docs/adr/](../docs/adr/)
+- Shared vocabulary: [CONCEPTS.md](../CONCEPTS.md)
+
+## High-Level Goals
+
+AgentV aims to be the repo-native, workspace-native evaluation framework for AI agents.
+
+- Repo-native evals: define evals that run against real repos, multi-repo workspaces, setup scripts, and existing harnesses.
+- Zero-infra local to CI: keep the default path lightweight so the same eval contract works on a laptop and in CI.
+- Portable run artifacts: treat run bundles, traces, and summaries as the source of truth for comparison, gating, and export.
+- Adapter boundaries: integrate with Phoenix, Harbor, Opik, and provider-specific systems through narrow adapters instead of absorbing their concepts into core.
+- AI-native extensibility: keep the core small and composable so engineers and coding agents can extend it with plugins, wrappers, and harness-specific glue.
+
+## Design Principles
+
+### 1. Lightweight Core, Plugin Extensibility
+
+AgentV's core should remain minimal. Complex or domain-specific logic belongs in plugins, not built-in features.
+
+Prefer these extension points before adding a built-in:
+
+- `code-grader` scripts for custom evaluation logic
+- `llm-grader` graders with custom prompt files for domain-specific LLM grading
+- CLI wrappers that consume AgentV JSON or JSONL output for post-processing such as aggregation, comparison, or reporting
+
+Ask: can this be achieved with existing primitives plus a plugin or wrapper? If yes, it should not be a built-in. That includes niche config overrides for existing graders.
+
+### 2. Built-ins for Primitives Only
+
+Built-in graders should provide universal primitives that users compose. A primitive is:
+
+- Stateless and deterministic
+- Single-purpose
+- Not trivially composable from existing primitives
+- Needed by most users
+
+If a feature serves a niche use case or adds conditional logic, move it to a plugin.
+
+### 3. Maximize Feature Surface Through Composition
+
+Aim for the maximum feature surface with the minimum primitives.
+
+Before proposing a new feature, enumerate which existing primitives could achieve the same outcome when composed.
+
+- Oracle validation is a `cli` provider target that runs a reference solution through the same evaluators.
+- Snapshot MCP for benchmarks is frozen data in the workspace template plus `before_all` and `after_all` hooks.
+- Harness variant comparison is target hooks with different `before_each` setup scripts.
+- Skill evaluation is `tool-trajectory` plus `execution-metrics` plus `rubric` composed via `composite`.
+
+If existing primitives cover the need, document the pattern instead of building a new feature. New primitives are justified only when composition is impossible, not merely undocumented.
+
+### 4. Align with Industry Standards
+
+Before adding features, research how peer frameworks solve the problem. Prefer the lowest common denominator that covers most use cases. Novel features without industry precedent need strong justification and should usually start as plugins.
+
+### 5. YAGNI - You Aren't Gonna Need It
+
+Do not build features until there is a concrete need. Start with the simplest version that satisfies current demand.
+
+YAGNI also applies to how you satisfy a real request:
+
+1. Audit existing primitives before adding new ones. Search for existing functions, endpoints, and config shapes first.
+2. Treat issue language as a hint, not a spec. Strip out implementation nouns and restate the acceptance criteria in simpler terms.
+3. Prefer data or config changes over new mechanisms when both satisfy the request.
+4. Stop when scope doubles. If the implementation surface grows beyond the original estimate, re-plan instead of pushing through.
+5. If you are about to add a second mode, a two-layer precedence rule, or an invariant between optional fields, stop and re-check whether the simpler model already exists.
+
+If you spot current overengineering while doing other work, call it out. Open a focused tracking issue such as `cleanup: simplify X` instead of widening the current PR unless the user explicitly asks for the cleanup now.
+
+### 6. Non-Breaking Extensions
+
+New fields should be optional. Existing configurations must continue working unchanged.
+
+Same-week or unreleased surfaces can be hard-deprecated. If a field, artifact name, CLI flag, or behavior was introduced in the current calendar week and has not shipped to real external consumers, prefer converging hard to the correct contract instead of carrying aliases or compatibility readers. This matters most for wire-format names: correct them to the snake_case v1 shape before release.
+
+### 7. AI-First Design
+
+AI agents are primary users of AgentV. Design for AI comprehension and composability.
+
+Prefer skills over rigid commands:
+
+- Use skills to teach AI how to create evals instead of locking everything into step-by-step command recipes.
+- Skills should cover most use cases; rigid commands trade off AI intelligence.
+- Prescribe exact steps only when there is an established best practice.
+
+Keep primitives intuitive:
+
+- Expose simple, single-purpose primitives that AI can combine flexibly.
+- Avoid monolithic commands that do multiple things.
+- Keep SDK internals intuitive enough for AI to modify when needed.
+
+Keep source and docs self-describing:
+
+- File headers should explain what the file does, how it works, and how to extend it.
+- Do not reference external projects, PRs, or issues in code comments; make the module standalone.
+- Prefer data-driven patterns over conditional chains.
+- Delete dead code and speculative infrastructure.
+- When a module has an extension point, include a short recipe for how to extend it.
+- When behavior changes, update the header to match.
+
+This applies to skills, repo structure, documentation, SDK design, and source code.

--- a/.agents/publish.md
+++ b/.agents/publish.md
@@ -6,7 +6,7 @@ This file expands [AGENTS.md](../AGENTS.md) for version bumps, contract gates, a
 
 - Git commit history is the changelog.
 - Use the GitHub Actions publish workflow in [`.github/workflows/publish.yml`](../.github/workflows/publish.yml).
-- There is no separate GitHub Actions release workflow anymore. The publish workflow now prepares the version and tag, creates the GitHub Release, and publishes the npm packages.
+- There is no separate GitHub Actions release-prep workflow anymore. The publish workflow now prepares the version and tag, creates the GitHub Release, and publishes the npm packages.
 - Do not publish manually from a local machine.
 
 ## Publish Workflow Channels

--- a/.agents/publish.md
+++ b/.agents/publish.md
@@ -1,0 +1,37 @@
+# Publish and Versioning
+
+This file expands [AGENTS.md](../AGENTS.md) for version bumps, contract gates, and npm publishing.
+
+## Source of Truth
+
+- Git commit history is the changelog.
+- Use the GitHub Actions publish workflow in [`.github/workflows/publish.yml`](../.github/workflows/publish.yml).
+- There is no separate GitHub Actions release workflow anymore. The publish workflow now prepares the version and tag, creates the GitHub Release, and publishes the npm packages.
+- Do not publish manually from a local machine.
+
+## Publish Workflow Channels
+
+The publish workflow accepts these channels:
+
+- `next`: bump to the next prerelease such as `x.y.z-next.N`, commit, tag, create the GitHub Release, and publish to npm `next`
+- `finalize`: finalize the latest or specified prerelease tag, strip the `-next.N` suffix, create the stable tag and release, and publish to npm `latest`
+- `stable`: bump straight to a stable release, tag it, create the GitHub Release, and publish to npm `latest`
+- `existing`: publish an existing tag or ref without creating a new version bump first
+
+Contract gates:
+
+- `finalize` and `stable` run the live contract eval gate before version and tag work.
+- `existing` also runs the contract gate when it is publishing a stable release to `latest`.
+
+## Local Scripts
+
+- `bun scripts/release.ts` performs the version-bump and tagging logic that the publish workflow calls.
+- It is acceptable to run that script locally for non-publishing tasks such as inspecting version state.
+- Do not run `bun run publish` or `bun run publish:next` locally. npm publishing uses OIDC trusted publishing and only works in GitHub Actions.
+
+## Published Packages
+
+- `packages/core/` publishes as `@agentv/core`
+- `apps/cli/` publishes as `agentv`
+- The CLI bundles workspace dependencies via tsup with `noExternal: ["@agentv/core"]`
+- Install with `bun install -g agentv` or `npm install -g agentv`

--- a/.agents/verification.md
+++ b/.agents/verification.md
@@ -1,0 +1,152 @@
+# Verification
+
+This file expands [AGENTS.md](../AGENTS.md) for testing, manual UAT, CLI and browser verification, grader validation, and completion gates.
+
+## CI Gates
+
+- GitHub Actions is the authoritative merge gate.
+- The `CI` workflow runs build, typecheck, lint, tests, marketplace checks, docs link checks, and eval schema validation on pushes to `main`, pull requests to `main`, and manual dispatches.
+- Run the same core checks locally when you need fast feedback:
+
+```bash
+bun run verify
+bun run validate:examples
+```
+
+- Task tracker sync is operator-supplied. If the prompt provides an external tracker sync or flush command, run it exactly as instructed and keep exported tracker state out of AgentV commits unless explicitly requested.
+- NTM hooks are optional local coordination tooling. Do not commit generated hook files or local `.ntm/config.toml`.
+- If an existing checkout has NTM or prek hooks installed, restore Git's default hook path:
+
+```bash
+git config --unset core.hooksPath
+```
+
+## Functional Testing the CLI
+
+- Never use `agentv` directly for functional testing. It may resolve to a globally installed version.
+- Preferred: `bun apps/cli/src/cli.ts <args>`. This always runs the current CLI source.
+- Exception: changes inside `packages/core/` require `bun run build` first because the CLI imports `@agentv/core` from compiled `dist/`.
+- `bun apps/cli/dist/cli.js <args>` also works, but only after `bun run build`, and it can go stale.
+- `bun agentv <args>` runs the locally built version and also requires a build.
+- Prefer running from source during development. Rebuild after pulling changes that touch `packages/core/`.
+
+## Browser E2E for Docs and Dashboard
+
+- Use `agent-browser` for visual verification of docs-site and Dashboard changes.
+- Always use `--session <name>` so browser instances stay isolated.
+- Never use `--headed`; there is no display server.
+- Rebuild `apps/dashboard/dist/` before Dashboard UAT, even if you only changed backend or docs code:
+
+```bash
+cd apps/dashboard && bun run build
+```
+
+- Running `agentv dashboard` from source reloads the CLI and backend routes, but the Dashboard web UI is served from the static `apps/dashboard/dist/` bundle. If you skip the rebuild, you can silently test stale UI code.
+
+If `agent-browser --session <name> open <url>` hangs with EAGAIN on ARM64, pre-start Chrome and connect with CDP:
+
+```bash
+nohup chromium --headless=new --remote-debugging-port=9222 \
+  --no-first-run --disable-background-networking --disable-default-apps \
+  --disable-sync --ozone-platform=headless --window-size=1280,720 \
+  --user-data-dir=/tmp/ab-chrome > /tmp/chrome.log 2>&1 &
+curl -s http://localhost:9222/json/version
+
+agent-browser --cdp 9222 open <url>
+agent-browser --cdp 9222 screenshot output.png
+```
+
+## Agent Provider Eval Concurrency
+
+- When running evals against agent-provider targets such as `claude`, `claude-sdk`, `codex`, `copilot`, `copilot-sdk`, `pi`, or `pi-cli`, limit concurrency to 3 targets at a time.
+- These providers spawn heavyweight subprocesses and can exhaust system resources if you run too many in parallel.
+
+```bash
+bun apps/cli/src/cli.ts eval my.EVAL.yaml --target claude &
+bun apps/cli/src/cli.ts eval my.EVAL.yaml --target codex &
+wait
+bun apps/cli/src/cli.ts eval my.EVAL.yaml --target copilot &
+bun apps/cli/src/cli.ts eval my.EVAL.yaml --target pi &
+wait
+```
+
+- This limit does not apply to lightweight LLM-only targets such as `azure`, `openai`, `gemini`, or `openrouter`.
+
+## Writing Tests
+
+- Only test new or changed behavior.
+- Protect stable core contracts such as data formats, scoring semantics, routing, persistence, provider contracts, and CLI or API outcomes users depend on.
+- One test per distinct behavior.
+- Skip tests for obvious one-line behavior unless it is a regression risk.
+- Prefer regression tests over broad happy-path matrices.
+- When end-user behavior matters but churns often, prefer updating the public docs in `apps/web/src/content/docs/` over locking temporary behavior into brittle tests.
+- Tests are executable contracts. If the contract changes, update the tests to match the new promise.
+
+## Verifying Grader Changes
+
+Unit tests alone are not enough for grader changes.
+
+1. If you are in a git worktree, copy `.env` into the worktree root before claiming E2E or grader verification:
+
+```bash
+cp /path/to/main/.env .env
+```
+
+```powershell
+Copy-Item D:/path/to/main/.env .env
+```
+
+2. Run a real eval with a real example file:
+
+```bash
+bun apps/cli/src/cli.ts eval examples/features/rubric/evals/dataset.eval.yaml --test-id <test-id>
+```
+
+3. Inspect the results JSONL and verify:
+
+- the correct grader type ran by checking `scores[].type`
+- scores are calculated as expected
+- the `assertions` array reflects the evaluation logic
+
+4. Update baseline files if output format changes. Baselines live next to eval YAML files as `*.baseline.jsonl`.
+5. `--dry-run` returns schema-valid mock responses, but the scores are not meaningful. Use it only for plumbing and harness checks.
+
+## Checking Grader Score Ranges
+
+Use `scripts/check-grader-scores.ts` as a post-processor after an eval run.
+
+Workflow:
+
+```bash
+bun apps/cli/src/cli.ts eval examples/path/to/suite.eval.yaml --target azure \
+  --output examples/path/to/suite.run
+
+bun scripts/check-grader-scores.ts
+```
+
+- The script auto-discovers `examples/**/*.grader-scores.yaml`, finds the sibling `*.results.jsonl`, and exits non-zero if any score is out of range.
+- To add checks for a new eval, create `<eval-stem>.grader-scores.yaml` next to the eval YAML, add the `(test_id, grader, range)` entries you care about, then run the eval and the checker.
+- `grader` must match a `scores[].name` value in the JSONL output. `range.min` and `range.max` default to `0` and `1` if omitted.
+
+## Completion Checklist
+
+Before marking a branch ready for review:
+
+1. Preflight: if in a git worktree, ensure `.env` exists in the worktree root.
+
+```bash
+cp "$(git worktree list --porcelain | head -1 | sed 's/worktree //')/.env" .env
+```
+
+2. Run unit tests with `bun run test`.
+3. Blocking manual red and green UAT:
+
+- Red: run the scenario on `main` or the pre-change state and confirm the bug or missing feature is observable.
+- Green: run the identical scenario on your branch and confirm the fix or feature works from the end user's perspective.
+- Document both red and green evidence in the PR description or comments.
+
+4. Verify no regressions in adjacent areas.
+5. For scoring, threshold, or grader changes, run at least one real eval with a live provider and verify the output JSONL.
+6. For Dashboard config, scoring-display, or dashboard API changes, use `agent-browser` to verify the UI still renders and behaves correctly.
+7. If operator instructions require private visual evidence, save screenshots there and include the resulting paths or commits in the handoff.
+8. Mark the PR ready only after the checklist is complete and the red or green evidence is attached.

--- a/.agents/workflow.md
+++ b/.agents/workflow.md
@@ -1,0 +1,129 @@
+# Workflow
+
+This file expands [AGENTS.md](../AGENTS.md) for day-to-day repo work: tracker handling, worktrees, planning, execution, git workflow, PR flow, and documentation update expectations.
+
+## Tracker and Repo Safety
+
+- Treat task-tracking instructions as operator-supplied context. If the prompt provides an external tracker database, path, or environment variable, use that exact tracker for assignment, status, dependencies, handoff notes, decomposition, and resumability.
+- If no external tracker is supplied, work from the user's prompt and the current branch or PR. Do not create, sync, stage, or commit repo-local tracker state unless the user explicitly requests it.
+- Keep private launcher names, local paths, session aliases, dispatch policy, and operator workspace details outside this public repository.
+- GitHub remains the PR, CI, review, and merge surface. Use GitHub Issues or Projects for external collaboration only when the user or operator explicitly asks for that workflow.
+- Do not add repo-local tracker directories, tracker JSONL exports, dispatch logs, cross-repo research records, or operator decision records to AgentV commits unless the user explicitly asks for repository-local tracker artifacts.
+- The only repo-local Beads files intentionally tracked are `.beads/config.yaml`, `.beads/metadata.json`, and `.beads/.gitignore`. Never commit the embedded Dolt database, JSONL exports, backups, locks, logs, or runtime state.
+- Do not commit project-local coordination config files. The safe Beads defaults above are the exception.
+- Do not use `git stash` on shared checkouts. Inspect `git status`, stage only your files, use a dedicated worktree, or ask before moving uncommitted changes.
+
+## Worktree Setup
+
+- Start every repo change with `git fetch origin` and `git status --short --branch`.
+- Prefer the primary checkout for small, bounded work only when local `main` is current with `origin/main` or can be fast-forwarded cleanly, the change is narrow, and the paths you need are not dirty or owned by another worker in the supplied tracker.
+- When working in the primary checkout, stage explicit paths only. Do not commit another agent's files, project-local coordination config, generated evidence, or unrelated tracker or doc state.
+- Use a dedicated git worktree based on the latest `origin/main` for non-trivial, risky, cross-cutting, long-running, or parallel implementation, or whenever the primary checkout is stale or dirty in paths you need.
+- Before starting implementation in a dedicated worktree, verify its `HEAD` is based on the current `origin/main` commit.
+
+Manual setup:
+
+```bash
+git fetch origin
+git worktree add ../agentv.worktrees/<type>-<short-desc> -b <type>/<issue-or-topic>-<short-desc> origin/main
+cd ../agentv.worktrees/<type>-<short-desc>
+```
+
+- Use the sibling `../agentv.worktrees/` directory for all AgentV worktrees. Do not create new AgentV worktrees inside the repository root.
+- After creating a manual worktree, run:
+
+```bash
+bun install
+cp "$(git worktree list --porcelain | head -1 | sed 's/worktree //')/.env" .env
+```
+
+- Both steps are required before running builds, tests, or evals in the worktree.
+- If you discover you are on a stale base or have uncoordinated dirty files, stop and fix that before changing code.
+- Whenever you `git checkout`, `gh pr checkout`, `git pull`, or otherwise switch to a ref that may have changed `package.json` or `bun.lock`, run `bun install` before building or testing.
+
+## Planning and Execution
+
+- Use plan mode or an explicit task list for non-trivial work, roughly five or more steps or anything with architectural decisions.
+- If something goes sideways, stop and re-plan instead of pushing a broken approach.
+- For non-trivial changes, pause and ask whether there is a more elegant solution before diving in.
+- Check in with the user before implementation on ambiguous tasks.
+- Prefer automation: execute the requested work without extra confirmation unless blocked by missing information, safety concerns, or an irreversible action the user has not approved.
+- For complex problems, keep this worker focused on its assigned scope and create or claim additional tracker items when the supplied tracker supports that workflow.
+- When you spot a bug, fix it. Only ask when there is genuine ambiguity about intent.
+- Every change should be as simple as possible. Import existing code and fix root causes directly.
+- Provide high-level progress updates at natural milestones. If scope changes, communicate it and adjust the plan.
+
+## Review and Documentation Expectations
+
+- Before declaring a repo change complete or opening or finalizing a PR, complete manual E2E verification first, then run a final review pass when warranted. If E2E fails, fix that before spending time on review.
+- When making functionality changes, update the human docs in `apps/web/src/content/docs/`.
+- If the change affects YAML schema, grader types, or CLI commands, update `plugins/agentv-dev/skills/agentv-eval-builder/` as the AI-focused reference card.
+- Update `examples/` when example code, scripts, or eval YAML files exercise the changed functionality.
+- Keep `README.md` minimal and link out to agentv.dev for full human-facing docs.
+
+## Git and PR Workflow
+
+Commit convention:
+
+- Follow conventional commits: `type(scope): description`
+- Common types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+
+Issue and tracker workflow:
+
+- Use the operator-supplied tracker, when present, for live ownership and GitHub for external collaboration.
+- Do not duplicate claim state in a second live tracker.
+- Push focused commits to the assigned branch and open or update the PR requested by the tracker item or user.
+- A branch, pushed commit, or draft PR is not done for ordinary scoped work.
+- Mark tracker items complete only after the scoped work is complete, verified, merged to `main` through a PR, and documented with verification evidence.
+- If the work intentionally remains on an ongoing branch, open a draft PR and record the branch name, PR URL, worktree path, current head commit, and remaining scope in the parent tracker item. Keep the child item open or in progress until the PR is merged or explicitly superseded.
+- If a commit is a self-contained unit of completed, verified work, push it directly to its assigned remote branch instead of leaving it local for handoff. This does not override the rule against pushing directly to `main`.
+
+GitHub issue flow:
+
+```bash
+gh issue view <number> --repo EntityProcess/agentv --json number,title,state,projectItems,assignees,url
+git fetch origin
+git worktree add ../agentv.worktrees/<branch-name> -b <type>/<issue-number>-<short-description> origin/main
+cd ../agentv.worktrees/<branch-name>
+bun install
+cp "$(git worktree list --porcelain | head -1 | sed 's/worktree //')/.env" .env
+```
+
+After the first meaningful commit, push and open a draft PR unless the user directs a different PR lifecycle:
+
+```bash
+git push -u origin <branch-name>
+gh pr create --draft --title "<type>(scope): description" --body "Closes #<issue-number>"
+```
+
+- Complete E2E verification before marking a PR ready for review.
+- Never push directly to `main`; always use branches and PRs.
+- GitHub Issues and Projects are external collaboration surfaces, not a substitute for operator-supplied tracker state unless explicitly directed.
+- `bug` marks defects. Issues without `bug` are non-bug work by default.
+- `core`, `wui`, and `tui` are area labels.
+- Keep issue bodies focused on objective, design latitude, acceptance signals, non-goals, and related links.
+- Do not put priority metadata in issue bodies.
+
+Pull requests and merges:
+
+- Always use squash merge when merging PRs to `main`.
+
+```bash
+gh pr merge <PR_NUMBER> --squash --delete-branch
+gh pr merge <PR_NUMBER> --squash --auto
+```
+
+- Do not use regular merge or rebase merge; they create noisy history with intermediate commits.
+- Once a PR is squash-merged, do not keep pushing follow-up commits from that branch. Start a fresh branch from updated `main`.
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b fix/<short-description>
+```
+
+## Plans in Branches
+
+- Design documents and implementation plans belong in `docs/plans/` inside the worktree so they are visible on the feature branch and in the draft PR.
+- When working in a worktree, use paths relative to the worktree root such as `docs/plans/plan.md`. Do not prefix paths with the worktree directory itself.
+- Plans are temporary working materials. Before merging the PR, delete the plan file and incorporate any user-relevant details into the official documentation.

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,6 @@ examples/**/*.results.jsonl
 agent-orchestrator.yaml
 
 # Agent configuration and activity logs
-.agents/*
-!.agents/*.md
 .claude/
 .codex/
 .factory/

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,8 @@ examples/**/*.results.jsonl
 agent-orchestrator.yaml
 
 # Agent configuration and activity logs
-.agents/
+.agents/*
+!.agents/*.md
 .claude/
 .codex/
 .factory/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,593 +1,66 @@
-# AgentV Repository Guidelines
+# AgentV Agent Guide
 
-This is a TypeScript monorepo for AgentV - an AI agent evaluation framework.
+This file is the root index for repo-facing agent instructions. Read the linked `.agents/*.md` guide for the kind of work you are doing, and read [STRATEGY.md](STRATEGY.md) plus [ROADMAP.md](ROADMAP.md) before making product-boundary calls.
 
-## High-Level Goals
-
-See [STRATEGY.md](STRATEGY.md) for the durable product boundary.
+## Product Direction
 
 AgentV aims to be the repo-native, workspace-native evaluation framework for AI agents.
-- **Repo-native evals**: Define evals that run against real repos, multi-repo workspaces, setup scripts, and existing harnesses.
-- **Zero-infra local to CI**: Keep the default path lightweight so the same eval contract works on a laptop and in CI.
-- **Portable run artifacts**: Treat run bundles, traces, and summaries as the source of truth for comparison, gating, and export.
-- **Adapter boundaries**: Integrate with Phoenix, Harbor, Opik, and provider-specific systems through narrow adapters instead of absorbing their concepts into core.
-- **AI-native extensibility**: Keep the core small and composable so engineers and coding agents can extend it with plugins, wrappers, and harness-specific glue.
 
-## Design Principles
-
-These principles guide all feature decisions. **Follow these when proposing or implementing changes.**
-
-### 1. Lightweight Core, Plugin Extensibility
-AgentV's core should remain minimal. Complex or domain-specific logic belongs in plugins, not built-in features.
-
-**Extension points (prefer these over adding built-ins):**
-- `code-grader` scripts for custom evaluation logic
-- `llm-grader` graders with custom prompt files for domain-specific LLM grading
-- CLI wrappers that consume AgentV's JSON/JSONL output for post-processing (aggregation, comparison, reporting)
-
-**Ask yourself:** "Can this be achieved with existing primitives + a plugin or wrapper?" If yes, it should not be a built-in. This includes adding config overrides to existing graders — if a niche provider needs custom tool-name matching, that's a code-grader, not a new config field.
-
-### 2. Built-ins for Primitives Only
-Built-in graders provide **universal primitives** that users compose. A primitive is:
-- Stateless and deterministic
-- Has a single, clear responsibility
-- Cannot be trivially composed from other primitives
-- Needed by the majority of users
-
-If a feature serves a niche use case or adds conditional logic, it belongs in a plugin.
-
-### 3. Maximize Feature Surface Through Composition
-The goal is to achieve the **maximum feature surface with the minimum primitives** due to high reusability. Before proposing a new feature, enumerate which existing primitives could achieve the same outcome when composed:
-
-- **Oracle validation** is not a feature — it's a `cli` provider target that runs a reference solution through the same evaluators.
-- **Snapshot MCP for benchmarks** is not a feature — it's frozen data in the workspace template + `before_all`/`after_all` hooks to start/stop the server.
-- **Harness variant comparison** is not a feature — it's target hooks with different `before_each` setup scripts.
-- **Skill evaluation** is not a feature — it's `tool-trajectory` + `execution-metrics` + `rubric` composed via `composite`.
-
-**If existing primitives cover it, document the pattern instead of building a feature.** New primitives are justified only when the composition is impossible, not merely when it's undocumented.
-
-### 4. Align with Industry Standards
-Before adding features, research how peer frameworks solve the problem. Prefer the **lowest common denominator** that covers most use cases. Novel features without industry precedent require strong justification and should default to plugin implementation.
-
-### 5. YAGNI — You Aren't Gonna Need It
-Don't build features until there's a concrete need. Before adding a new capability, ask: "Is there real demand for this today, or am I anticipating future needs?" Numeric thresholds, extra tracking fields, and configurable knobs should be omitted until users actually request them. Start with the simplest version (e.g., boolean over numeric range) and extend later if needed.
-
-**YAGNI applies to *how* you meet a real request, not just *whether* to meet it.** The common failure mode is not "I built X and nobody wanted it." It's "someone asked for X and I built a bigger X than they asked for." Guard against that with these habits:
-
-1. **Audit existing primitives before adding new ones.** When an issue asks for capability Y, the first question is not "how do I build Y?" — it's **"what does the codebase already do that addresses Y?"** Grep for existing functions, endpoints, and config shapes. Many requests are satisfied by a behavior that already exists and just needs to be surfaced, configured, or exercised differently.
-2. **Treat issue language as a hint, not a spec.** Issues describe problems *and* implementations. "We need a discovery root" is one implementation of "we need the registry to update live." When an issue lists multiple acceptable approaches (or its acceptance criteria don't actually require the implementation it names), pick the one with the least code surface. Summarize the acceptance criteria in your own words, strip out implementation nouns ("discovery root," "watcher," "registry reload"), then match them against existing primitives before designing anything new.
-3. **Prefer data/config changes over new mechanisms.** If the observable effect is "this list should be editable at runtime," prefer "re-read the file per request" over "add a watcher + a new field + a precedence rule + a new endpoint." Config-driven beats code-driven when both are sufficient.
-4. **Stop when scope doubles.** If an implementation's surface area grows more than ~2× the starting estimate (extra types, extra endpoints, extra invariants), that's a red flag to re-plan, not a sign to push through. Pause and ask: "What would the smallest possible version look like? Does the issue actually require more than that?"
-5. **If you are about to add a second mode, two-layer precedence, or an invariant between two optional fields, stop.** `source: manual | discovered`, "pinned wins over discovered," `excluded_paths` filtering the discovered set — every one of these is a sign that you're in complexity territory that a simpler data model would have avoided.
-
-**Call out existing overengineering.** If, while working on a task, you notice a *current* feature in the repo that looks overengineered relative to what it's used for (multiple modes, optional precedence rules, dead-looking extensibility scaffolding), flag it — don't silently fix it. Open a tracking issue titled "cleanup: simplify X" that lists: the observable behavior today, the simpler model that would cover it, and the migration notes. Link to the code. Do not widen your current PR to absorb the cleanup unless the user asks.
-
-### 6. Non-Breaking Extensions
-New fields should be optional. Existing configurations must continue working unchanged.
-
-Same-week or unreleased surfaces can be hard-deprecated. If a field, artifact name, CLI flag, or behavior was introduced in the current calendar week and has not shipped to real external consumers, prefer converging hard to the correct contract instead of carrying aliases, mirrors, or compatibility readers. This is especially important for wire-format names: fix them to the snake_case v1 shape before release. Do not apply this shortcut to established files, flags, config fields, or known consumers; those still need an explicit compatibility, migration, and versioning plan.
-
-### 7. AI-First Design
-AI agents are the primary users of AgentV—not humans reading docs. Design for AI comprehension and composability.
-
-**Skills over rigid commands:**
-- Use Claude Code skills (or agent skill standards) to teach AI *how* to create evals, not step-by-step CLI instructions
-- Skills should cover most use cases; rigid commands trade off AI intelligence
-- Only prescribe exact steps where there's an established best practice
-
-**Intuitive primitives:**
-- Expose simple, single-purpose primitives that AI can combine flexibly
-- Avoid monolithic commands that do multiple things
-- SDK internals should be intuitive enough for AI to modify when needed
-
-**Self-documenting code:**
-- File headers should explain what the file does, how it works, and how to extend it — no need to read other files to understand this one
-- Don't reference external projects, PRs, or issues in code comments; make everything standalone
-- Prefer data-driven patterns (static mappings, config tables) over conditional chains — AI can extend a mapping by adding an entry, but has to trace logic to extend an if/else tree
-- No dead code or speculative infrastructure; if it's unused, delete it
-- When a module has an extension point, include a short recipe in the header (e.g., "To add a new provider: 1. Create a matcher, 2. Add it to the mapping")
-- When changing a module's behavior, update its file header to match. Stale headers are worse than no headers.
-
-**Scope:** Applies to skills, repo structure, documentation, SDK design, and source code — anything AI might need to reason about or extend.
-
-## Tech Stack & Tools
-- **Language:** TypeScript 5.x targeting ES2022
-- **Runtime:** Bun (use `bun` for all package and script operations)
-- **Monorepo:** Bun workspaces
-- **Bundler:** tsup (TypeScript bundler)
-- **Linter/Formatter:** Biome
-- **Testing:** Vitest
-- **LLM Framework:** Vercel AI SDK
-- **Validation:** Zod
-
-## Project Structure
-- `packages/core/` - Evaluation engine, providers, grading
-  - `src/evaluation/registry/` - Extensible grader registry (EvaluatorRegistry, assertion discovery)
-  - `src/evaluation/providers/provider-registry.ts` - Provider plugin registry
-  - `src/evaluation/evaluate.ts` - `evaluate()` programmatic API
-  - `src/evaluation/config.ts` - `defineConfig()` for typed agentv.config.ts
-- `packages/eval/` - Lightweight assertion SDK (`defineAssertion`, `defineCodeGrader`)
-- `apps/cli/` - Command-line interface (published as `agentv`)
-  - `src/commands/create/` - Scaffold commands (`agentv create assertion/eval`)
-- `examples/features/sdk-*` - SDK usage examples (custom assertion, programmatic API, config file)
-- `STRATEGY.md` - product boundary and priorities. Relevant when proposing features, integrations, or roadmap direction.
-- `docs/adr/` - decision records for product and architecture boundaries, especially what AgentV core owns versus adapters, runtimes, and adjacent tools.
-- `docs/plans/` - design and implementation plans. Useful supporting evidence; prefer `STRATEGY.md` and ADRs when a plan's old execution details differ from the current product direction.
-- `docs/learnings/` - primary learning store for this repo (it does not use `docs/solutions/`). Captured learnings from bug fixes and deliberate decisions, organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when working in documented areas.
-- `apps/web/src/content/docs/` - public product and CLI docs. Useful when checking current user-facing contracts, tool boundaries, and integration guidance.
-- `CONCEPTS.md` - shared domain vocabulary (providers, targets, and other project-specific terms). Relevant when orienting to the codebase or discussing domain concepts.
-
-## Working Style
-
-### Task Tracking and Orchestration
-- Treat task tracking instructions as operator-supplied context. If the operator prompt provides an external tracker database, path, or environment variable, use that exact tracker for assignment, status, dependencies, handoff notes, decomposition, and resumability.
-- If no external tracker is supplied, work from the user's prompt and the current branch/PR. Do not create, sync, stage, or commit repo-local task tracker state unless the user explicitly requests it.
-- Keep private launcher names, local paths, session aliases, dispatch policy, and operator workspace details outside this public repository.
-- GitHub remains the PR, CI, review, and merge surface. Use GitHub Issues or Projects for external collaboration only when the user or operator prompt asks for that workflow.
-
-### Tracker Ownership
-- External tracker state belongs to the operator-provided tracker, not this repository.
-- Do not add repo-local tracker directories, tracker JSONL exports, dispatch logs, cross-repo research records, or operator decision records to AgentV commits unless the user explicitly asks for repository-local tracker artifacts. The only repo-local Beads files intentionally tracked are safe team defaults: `.beads/config.yaml`, `.beads/metadata.json`, and `.beads/.gitignore`; never commit the embedded Dolt database, JSONL exports, backups, locks, logs, or runtime state.
-- If external research discovers AgentV implementation work, capture the public code/docs change in a focused branch/PR and keep private research or orchestration records outside this repository.
-- When an external tracker is supplied, keep it updated with user-visible decisions, verification evidence, blockers, and handoff state. Run sync or flush commands only against that supplied tracker and keep exported tracker state out of AgentV commits unless explicitly requested.
-- Do not use `git stash` on shared checkouts. Other agents may be editing the same worktree, and stashing can hide or replay their changes in the wrong branch. If you need to isolate work, inspect `git status`, stage only your files, use a dedicated worktree, or ask before moving uncommitted changes. If a stash is genuinely unavoidable, immediately record it in the supplied tracker or orchestrator handoff with the stash name, affected paths, reason, and recovery plan.
-
-### Coordination and Shared Checkouts
-- Use the operator-supplied tracker for ownership, handoff notes, blockers, and evidence.
-- If the operator provides a separate coordination or reservation system, keep its server URLs, startup commands, bearer tokens, and project keys outside this public repository.
-- Do not commit project-local coordination config files; they may contain bearer tokens and are ignored by `.gitignore`. The safe Beads team-default files listed above are the exception and exist so fresh clones can discover the AgentV Beads Dolt remote.
-
-### Worktree Setup
-- Start every repo change by running `git fetch origin` and inspecting `git status --short --branch`.
-- Prefer the primary checkout for small, bounded work when all of these are true: local `main` is current with `origin/main` or can be fast-forwarded cleanly; the change is narrow (docs-only, a small single-file fix, or a focused review follow-up); and the intended paths are not dirty or owned by another worker in the supplied tracker.
-- When working in the primary checkout, stage explicit paths only. Do not commit another agent's files, project-local coordination config, generated evidence, or unrelated tracker/doc state. Reconcile external tracker state in the supplied tracker, not by staging repo-local artifacts.
-- Use a dedicated git worktree based on the latest `origin/main` for non-trivial, risky, cross-cutting, long-running, or parallel implementation, or whenever the primary checkout is stale/dirty in paths you need.
-- Before starting implementation in a dedicated worktree, verify its `HEAD` is based on the current `origin/main` commit. Do not implement from a stale local `main` or from a branch created off an outdated base.
-- Manual setup:
-```bash
-git fetch origin
-git worktree add ../agentv.worktrees/<type>-<short-desc> -b <type>/<issue-or-topic>-<short-desc> origin/main
-cd ../agentv.worktrees/<type>-<short-desc>
-```
-- If you discover you are on a stale base or have uncoordinated dirty files, stop and fix that before changing code.
-
-### Planning
-- Use plan mode for any non-trivial task (5+ steps or architectural decisions).
-- If something goes sideways, STOP and re-plan immediately — don't keep pushing a broken approach.
-- For non-trivial changes, pause and ask: "Is there a more elegant solution?" before diving in.
-- Check in with the user before starting implementation on ambiguous tasks.
-- Prefer automation: execute the requested work without extra confirmation unless blocked by missing information, safety concerns, or an irreversible/destructive action the user has not approved.
-
-### Worker and Review Strategy
-- For complex problems, keep this worker focused on its assigned scope and create or claim additional tracker items when an operator-supplied tracker supports that workflow.
-- Before declaring a repo change complete or opening/finalizing a PR, complete manual e2e verification first (see E2E Checklist), **then** run a final review pass when warranted. E2E must pass before review — if e2e fails, fix the issue before investing time in review. The user may explicitly skip the review step.
-
-### Autonomous Bug Fixes
-- When you spot a bug, just fix it. Don't ask for hand-holding.
-- Point at logs, errors, failing tests — then resolve them.
-- Only ask when there's genuine ambiguity about intent.
-- Fix failing CI tests without being told.
-
-### Simplicity
-- Every change should be as simple as possible. Import existing code; don't reinvent.
-- Find root causes and fix them directly. No shotgun debugging.
-
-### Progress Updates
-- Provide high-level status updates at natural milestones.
-- When scope changes mid-task, communicate the shift and adjust the plan.
-- Use parallel tool calls when applicable, especially for independent reads, checks, and validation steps.
-
-### PR & Commit Titles
-- Prefer conventional commit style for branch-facing titles: `type(scope): summary`.
-- Use the repository's normal types where they fit, such as `feat`, `fix`, `chore`, `refactor`, `docs`, and `test`.
-- Use the most relevant module or product area as `scope`, such as `dashboard`, `cli`, `results`, or `evals`.
-- Do not prefix PR titles with `[codex]` unless the user explicitly requests it.
-
-## TypeScript Guidelines
-- Target ES2022 with Node 20+
-- Prefer type inference over explicit types
-- Use `async/await` for async operations
-- Prefer named exports
-- Keep modules cohesive
-
-### Subprocess and Provider Conventions
-
-**Relative paths in CLI arg arrays:** When spawning a subprocess with an explicit `cwd`, pass user-supplied `args` through unchanged — the subprocess resolves its own relative paths against its `cwd`. Do not pre-process arg arrays with `startsWith('./')` or `!path.isAbsolute()` heuristics: they miss bare relative paths (`plugins/foo`), can corrupt flag-value pairs (`--config=./x`), and duplicate what `cwd` already does. See `docs/learnings/best-practices/trust-subprocess-cwd-for-relative-path-resolution.md`.
-
-## Naming Convention: "Project" vs "Benchmark"
-
-These two words have distinct, non-interchangeable meanings in this codebase. Get them right when adding new symbols, docs, or example dirs:
-
-- **Project** — the top-level container Dashboard organises around: a registered workspace directory (`.agentv/` + run artifacts + traces + experiments). Lives in `~/.agentv/projects.yaml`. Modelled by `ProjectEntry` / `ProjectRegistry` in `packages/core/src/projects.ts`. Matches the terminology used by Phoenix, Langfuse, Braintrust, W&B Weave, and LangSmith.
-- **Benchmark** — a curated *eval suite* designed to measure something specific (academic ML sense: MMLU, HumanEval, SWE-bench). Example dirs use this sense: `examples/showcase/multi-model-benchmark/`, `examples/showcase/offline-grader-benchmark/`, `examples/features/benchmark-tooling/`. Do not rename these — they are correctly named.
-
-The legacy registry file `~/.agentv/benchmarks.yaml` is auto-migrated to `projects.yaml` on first load by `migrateLegacyBenchmarksFile()`. The unrelated per-run `benchmark.json` artifact (Agent Skills compatibility output) is a third, separate concept — also keep that name.
-
-When in doubt: if the thing holds runs / traces / experiments, it's a **project**. If it's a curated set of eval cases meant to measure capability, it's a **benchmark**.
-
-## Wire Format Convention
-
-**Everything that crosses a process boundary uses `snake_case` keys. Internal TypeScript uses `camelCase`. Translate at the boundary — never in the middle.**
-
-The rule is blanket: if the key is going to disk, to a user's editor, into a JSON response, or onto a CLI, it's snake_case. There is no "well this file is internal-ish" carve-out. If in doubt, snake_case.
-
-### snake_case surfaces
-- All YAML files on disk: `*.eval.yaml`, `agentv.config.yaml`, `projects.yaml`, `dashboard/config.yaml`, any future YAML we add.
-- JSONL result files (`test_id`, `token_usage`, `duration_ms`).
-- Artifact-writer output (`pass_rate`, `tests_run`, `total_tool_calls`).
-- HTTP response bodies from `agentv serve` / Dashboard (`added_at`, `pass_rate`, `project_id`).
-- CLI JSON output (`agentv results summary`, `results failures`, `results show`).
-- Anything consumed by non-TS tooling (Python, jq pipelines, external dashboards).
-
-### camelCase surfaces
-- TypeScript source: all variables, parameters, fields, type members.
-- Internal in-memory shapes passed between TS modules.
-
-### Translate only at the boundary
-Define a second interface for the wire shape and convert in one place — don't smear snake_case through TS internals.
-
-```typescript
-// Wire shape — snake_case, matches what hits disk / the network
-interface ProjectEntryYaml {
-  id: string;
-  name: string;
-  path: string;
-  added_at: string;
-  last_opened_at: string;
-}
-
-// Internal shape — camelCase, what every TS call site sees
-interface ProjectEntry {
-  id: string;
-  name: string;
-  path: string;
-  addedAt: string;
-  lastOpenedAt: string;
-}
-
-function fromYaml(e: ProjectEntryYaml): ProjectEntry {
-  return { id: e.id, name: e.name, path: e.path, addedAt: e.added_at, lastOpenedAt: e.last_opened_at };
-}
-
-function toYaml(e: ProjectEntry): ProjectEntryYaml {
-  return { id: e.id, name: e.name, path: e.path, added_at: e.addedAt, last_opened_at: e.lastOpenedAt };
-}
-```
-
-Yes, this is two interfaces and two functions per entity. That's the price of keeping TS idiomatic while staying faithful to the wire contract. Don't skip it — dumping TS objects directly to YAML leaks `addedAt`-style camelCase onto disk and breaks jq/Python consumers.
-
-### Anti-patterns
-- `writeFileSync(path, stringifyYaml(tsObject))` — dumps TS field names verbatim. Wrong.
-- `interface Foo { testId: string; ... }` for a JSON response body — `test_id`, always.
-- Accepting both `testId` and `test_id` on input "for back-compat" when nothing is shipped yet. Just snake_case.
-
-### Existing divergences
-If you spot a camelCase key already on disk or in a response (e.g. a legacy endpoint), treat it as a bug: migrate it to snake_case in the same PR where you touch that code path. Don't grandfather it in.
-
-**Reading back:** `parseJsonlResults()` in `artifact-writer.ts` converts snake_case → camelCase when reading JSONL into TypeScript. `fromYaml` / `toYaml` in `packages/core/src/projects.ts` is the model for YAML boundaries.
-
-**Why:** Aligns with skill-creator (claude-plugins-official) and broader Python/JSON ecosystem conventions where snake_case is the standard wire format.
-
-## Testing & Verification
-
-### CI Gates
-
-GitHub Actions is the authoritative merge gate. The `CI` workflow runs build, typecheck, lint, tests, marketplace checks, docs link checks, and eval schema validation on pushes to `main`, pull requests to `main`, and manual dispatches.
-
-Run the same core checks locally when you need fast feedback:
-```bash
-bun run verify
-bun run validate:examples
-```
-
-Task tracker sync is operator-supplied. If the prompt provides an external tracker sync or flush command, run it exactly as instructed and keep exported tracker state out of AgentV commits unless explicitly requested. Hooks must not silently mutate or stash shared worktrees.
-
-NTM hooks are optional local coordination tooling. Do not commit generated task-tracker hook files or local `.ntm/config.toml`; they embed machine-specific paths and can bypass the repo's normal Git behavior when installed via `core.hooksPath`.
-
-If an existing checkout has NTM or prek hooks installed, restore Git's default hook path:
-```bash
-git config --unset core.hooksPath
-```
-
-### Functional Testing (CLI)
-
-When functionally testing changes to the AgentV CLI, **NEVER** use `agentv` directly as it may run the globally installed version (bun or npm). Instead:
-
-- **From TypeScript source (preferred):** `bun apps/cli/src/cli.ts <args>` — always runs current CLI code, no build step needed. **Exception:** changes inside `packages/core/` require `bun run build` first, because the CLI imports `@agentv/core` from its compiled `dist/`, not from TypeScript source.
-- **From built dist:** `bun apps/cli/dist/cli.js <args>` — requires `bun run build` first, can be stale
-- **From repository root:** `bun agentv <args>` — runs the locally built version (also requires build)
-
-**Prefer running from source** (`src/cli.ts`) during development. The dist build can silently serve stale code if you forget to rebuild after changes. After pulling changes that touch `packages/core/`, always run `bun run build` before CLI testing.
-
-**Dashboard frontend exception — rebuild `apps/dashboard/dist/` before UAT.** Running `agentv dashboard` from source (`bun apps/cli/src/cli.ts dashboard ...`) only reloads the CLI and backend routes from source. The Dashboard web UI (React/Tailwind bundle) is served as static assets from `apps/dashboard/dist/`, which is build output and does **not** recompile on change. After pulling the latest `main`, and before any Dashboard E2E/UAT, rebuild the frontend bundle even if you did not personally edit Dashboard source:
-
-```bash
-cd apps/dashboard && bun run build
-```
-
-Skipping this step silently serves the previous bundle, so you'll see the old UI even though the source tree and backend API are current. This has burned at least one post-merge UAT; always rebuild before screenshotting or driving Dashboard with `agent-browser`.
-
-### Browser E2E Testing (Docs and Dashboard)
-
-Use `agent-browser` for visual verification of docs site and Dashboard changes. Environment-specific rules:
-
-- **Always use `--session <name>`** — isolates browser instances; close with `agent-browser --session <name> close` when done
-- **Never use `--headed`** — no display server available; headless (default) works correctly
-
-**Troubleshooting: `--session` hangs with EAGAIN on ARM64**
-
-If `agent-browser --session <name> open <url>` consistently fails with "Resource temporarily unavailable" or times out, Chrome is taking longer to start than the client's retry window. Workaround: pre-start Chrome manually and use `--cdp`:
-
-```bash
-nohup chromium --headless=new --remote-debugging-port=9222 \
-  --no-first-run --disable-background-networking --disable-default-apps \
-  --disable-sync --ozone-platform=headless --window-size=1280,720 \
-  --user-data-dir=/tmp/ab-chrome > /tmp/chrome.log 2>&1 &
-curl -s http://localhost:9222/json/version  # verify ready
-
-agent-browser --cdp 9222 open <url>
-agent-browser --cdp 9222 screenshot output.png
-```
-
-### Agent Provider Eval Concurrency
-
-When running evals against agent provider targets (claude, claude-sdk, codex, copilot, copilot-sdk, pi, pi-cli), **limit concurrency to 3 targets at a time**. Each agent provider spawns heavyweight subprocesses (CLI binaries, SDK sessions) that consume significant memory and CPU. Running more than 3 in parallel can exhaust system resources.
-
-```bash
-# Good: batch targets in groups of 2-3
-bun apps/cli/src/cli.ts eval my.EVAL.yaml --target claude &
-bun apps/cli/src/cli.ts eval my.EVAL.yaml --target codex &
-wait
-bun apps/cli/src/cli.ts eval my.EVAL.yaml --target copilot &
-bun apps/cli/src/cli.ts eval my.EVAL.yaml --target pi &
-wait
-```
-
-This does not apply to lightweight LLM-only targets (azure, openai, gemini, openrouter) which can run with higher concurrency.
-
-### Writing Tests
-
-Tests should be lean and focused on what matters. Follow these principles:
-
-- **Only test new or changed behavior.** Don't write tests for existing behavior that's already covered by the 1600+ core tests. If you fix a bug, test the fix and its edge cases — not the surrounding module.
-- **Protect stable core contracts, not every new detail.** Tests should primarily prevent regressions in existing core behavior: data formats, scoring semantics, routing, persistence, provider contracts, and CLI/API outcomes users depend on. Experimental features, early UI flows, and behavior expected to churn do not need detailed test matrices until the contract stabilizes.
-- **One test per distinct behavior.** Don't write separate tests for trivially different inputs that exercise the same code path.
-- **No tests for obvious code.** If a function returns `undefined` for missing input and that's a one-line null check, you don't need a test for it unless it's a regression risk.
-- **Regression tests > comprehensive tests.** A test that would have caught the bug is worth more than five tests that exercise happy paths.
-- **Document churny end-user behavior instead of over-testing it.** When behavior matters to users but changes frequently, prefer updating the Astro docs in `apps/web/src/content/docs/` over locking presentation details, migration variants, or temporary workflows into brittle tests.
-- **Tests are executable contracts.** When a module's behavioral contract changes, the tests must reflect the new contract — not just the happy path. If you change what a function promises, update its tests to assert the new promise.
-
-### Verifying Grader Changes
-
-Unit tests alone are insufficient for grader changes. After implementing or modifying graders:
-
-1. **Copy `.env` to the worktree** if running in a git worktree (e2e tests need environment variables):
-   ```bash
-   cp /path/to/main/.env .env
-   ```
-   ```powershell
-   Copy-Item D:/path/to/main/.env .env
-   ```
-   Do not claim e2e or grader verification results unless this preflight has passed.
-
-2. **Run an actual eval** with a real example file:
-   ```bash
-   bun apps/cli/src/cli.ts eval examples/features/rubric/evals/dataset.eval.yaml --test-id <test-id>
-   ```
-
-3. **Inspect the results JSONL** to verify:
-   - The correct grader type is invoked (check `scores[].type`)
-   - Scores are calculated as expected
-   - Assertions array reflects the evaluation logic (each entry has `text`, `passed`, optional `evidence`)
-
-4. **Update baseline files** if output format changes (e.g., type name renames). Baseline files live alongside eval YAML files as `*.baseline.jsonl` and contain expected `scores[].type` values. There are 30+ baseline files across `examples/`.
-
-5. **Note:** `--dry-run` returns schema-valid mock responses for both agent output and grader evaluation (score=1, empty assertions/checks). Built-in LLM graders run without parse errors but scores are meaningless. Use it for end-to-end harness testing including grader plumbing.
-
-### Checking Grader Score Ranges (manual e2e)
-
-`scripts/check-grader-scores.ts` is a post-processor that asserts each grader's score on each test case falls within an expected range. Run it manually after an eval to catch grader regressions (false positives / false negatives) before merging.
-
-**Workflow:**
-```bash
-# 1. Run the eval, writing results to a sibling *.results.jsonl file
-bun apps/cli/src/cli.ts eval examples/path/to/suite.eval.yaml --target azure \
-  --output examples/path/to/suite.run
-
-# 2. Assert all expected score ranges pass
-bun scripts/check-grader-scores.ts
-```
-
-The script auto-discovers `examples/**/*.grader-scores.yaml`, locates the sibling `*.results.jsonl` (same stem), and exits non-zero if any score is out of range.
-
-**To add score checks for a new eval:**
-1. Create `<eval-stem>.grader-scores.yaml` next to the eval YAML.
-2. Add entries for each `(test_id, grader, range)` you care about — `grader` must match a `scores[].name` value in the JSONL output, and `range.min`/`range.max` default to 0/1 if omitted.
-3. Run the eval with `--output <eval-stem>.run`, then run the script.
-
-See `examples/red-team/archetypes/coding-agent/suites/screenshot-pii-upload.grader-scores.yaml` for a concrete example.
-
-### Completing Work — E2E Checklist
-
-Before marking any branch as ready for review, complete this checklist:
-
-1. **Preflight:** If in a git worktree, ensure `.env` exists in the worktree root.
-   ```bash
-   cp "$(git worktree list --porcelain | head -1 | sed 's/worktree //')/.env" .env
-   ```
-   Without this, any eval run or LLM-dependent test will fail with missing API key errors.
-
-2. **Run unit tests**: `bun run test` — all must pass.
-
-3. **⚠️ BLOCKING: Manual red/green UAT — must complete before steps 4-5:**
-   Unit tests passing is NOT sufficient. Every change must be manually verified from the end user's perspective. Do NOT skip this step or proceed to step 4 until red/green evidence is documented.
-
-   - **Red (before your changes):** Run the scenario on `main` (or the code state before your changes). Confirm the bug or missing feature is observable from the CLI / user-facing output. Capture the output.
-   - **Green (with your changes):** Run the identical scenario with your branch. Confirm the fix or feature works correctly from the end user's perspective. Capture the output.
-   - **Document both** red and green results in the PR description or comments so reviewers can see the before/after evidence.
-
-   For grader changes, this means running a real eval (not `--dry-run`) and inspecting the output JSONL. For CLI/UX changes, this means running the CLI command and verifying the console output.
-
-4. **Verify no regressions** in areas adjacent to your changes (e.g., if you changed grader parsing, run an eval that exercises different grader types).
-
-5. **Live eval verification**: For changes affecting scoring, thresholds, or grader behavior, run at least one real eval with a live provider (not `--dry-run`) and verify the output JSONL has correct scores, verdicts, and execution status.
-
-6. **Dashboard UX verification**: For changes affecting config, scoring display, or dashboard API, use `agent-browser` to verify the Dashboard UI still renders and functions correctly (settings page loads, pass/fail indicators are correct, config saves work).
-
-7. **Save visual evidence when required by operator instructions:** If local or operator-provided instructions specify a private evidence repository or asset location, save Dashboard/docs/browser E2E screenshots there and include the resulting paths/commit in the handoff.
-
-8. **Mark PR as ready** only after steps 1-7 have been completed AND red/green UAT evidence is included in the PR.
-
-## Documentation Updates
-
-When making changes to functionality:
-
-1. **Docs site** (`apps/web/src/content/docs/`): Update human-readable documentation on agentv.dev. This is the comprehensive reference.
-
-2. **Skill files** (`plugins/agentv-dev/skills/agentv-eval-builder/`): Update the AI-focused reference card if the change affects YAML schema, grader types, or CLI commands. Keep concise — link to docs site for details.
-
-3. **Examples** (`examples/`): Update any example code, scripts, or eval YAML files that exercise the changed functionality. Examples are both documentation and integration tests.
-
-4. **README.md**: Keep minimal. Links point to agentv.dev.
-
-## Grader Type System
-
-Grader types use **kebab-case** everywhere (matching promptfoo convention):
-
-- **YAML config:** `type: llm-grader`, `type: is-json`, `type: execution-metrics`
-- **Internal TypeScript:** `EvaluatorKind = 'llm-grader' | 'is-json' | ...`
-- **Output `scores[].type`:** `"llm-grader"`, `"is-json"`
-- **Registry keys:** `registry.register('llm-grader', ...)`
-
-**Source of truth:** `EVALUATOR_KIND_VALUES` array in `packages/core/src/evaluation/types.ts`
-
-**Backward compatibility:** Snake_case is accepted in YAML (`llm_judge` → `llm-grader`) via `normalizeGraderType()` in `grader-parser.ts`. Single-word types (`contains`, `equals`, `regex`, `latency`, `cost`) have no separator and are unchanged.
-
-**Two type definitions exist:**
-- `EvaluatorKind` in `packages/core/src/evaluation/types.ts` — internal, canonical
-- `AssertionType` in `packages/eval/src/assertion.ts` — SDK-facing, must stay in sync
-
-## Git Workflow
-
-### Commit Convention
-
-Follow conventional commits: `type(scope): description`
-
-Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
-
-### Issue Workflow
-
-Use the operator-supplied tracker, when present, for live ownership and GitHub for external collaboration. Do not duplicate claim state in a separate live tracker. Push focused commits to the assigned branch and open/update the PR requested by the tracker item or user. A branch, pushed commit, or draft PR is not done for ordinary scoped work. Mark tracker items complete only after the scoped work is complete, verified, merged to `main` through a PR, and documented with verification evidence.
-
-Exception: if the tracker item is part of an epic/worktree continuation and the work intentionally remains on an ongoing branch, open a draft PR and record the branch name, PR URL, worktree path, current head commit, and remaining scope in the parent tracker item. In that case, keep the child/task item open or in progress rather than closing it as completed until the PR is merged or the parent explicitly supersedes it.
-
-If a commit is a self-contained unit of completed, verified work, push it directly to its assigned remote branch instead of leaving it local for handoff. This applies to feature branches and artifact/documentation branches. For private asset repositories, follow the relevant operator-provided instructions. It does not override the rule against pushing directly to `main` in this repository.
-
-When working from a GitHub issue instead of an operator-supplied tracker item, use GitHub project state to avoid duplicate work before branching:
-
-```bash
-gh issue view <number> --repo EntityProcess/agentv --json number,title,state,projectItems,assignees,url
-git fetch origin
-git worktree add ../agentv.worktrees/<branch-name> -b <type>/<issue-number>-<short-description> origin/main
-cd ../agentv.worktrees/<branch-name>
-bun install
-cp "$(git worktree list --porcelain | head -1 | sed 's/worktree //')/.env" .env
-```
-
-After the first meaningful commit, push and open a draft PR unless the user directs a different PR lifecycle:
-
-```bash
-git push -u origin <branch-name>
-gh pr create --draft --title "<type>(scope): description" --body "Closes #<issue-number>"
-```
-
-Complete E2E verification before marking a PR ready for review. Never push directly to `main`; always use branches and PRs.
-
-### Tracker Conventions
-
-- GitHub Issues + Projects are external collaboration surfaces, not a substitute for operator-supplied tracker state unless explicitly directed.
-- `bug` marks defects.
-- Issues without `bug` are non-bug work by default.
-- `core`, `wui`, and `tui` are area labels.
-- Keep issue bodies focused on the handoff contract: objective, design latitude, acceptance signals, non-goals, and related links.
-- Do not put priority metadata in issue bodies.
-
-### Pull Requests
-
-**Always use squash merge** when merging PRs to main. This keeps the commit history clean with one commit per feature/fix.
-
-```bash
-# Using GitHub CLI to squash merge a PR
-gh pr merge <PR_NUMBER> --squash --delete-branch
-
-# Or with auto-merge enabled
-gh pr merge <PR_NUMBER> --squash --auto
-```
-
-Do NOT use regular merge or rebase merge, as these create noisy commit history with intermediate commits.
-
-### After Squash Merge
-
-Once a PR is squash-merged, its source branch diverges from main. **Do NOT** try to push additional commits from that branch—you will get merge conflicts.
-
-For follow-up fixes:
-```bash
-git checkout main
-git pull origin main
-git checkout -b fix/<short-description>
-# Apply fixes on the fresh branch
-```
-
-### Plans and Worktrees
-
-#### Plans
-
-Design documents and implementation plans are stored in `docs/plans/` inside the worktree (not the main repo). Save plans to the worktree so they are committed on the feature branch and visible in the draft PR.
-
-**Path warning:** When working in a worktree, use paths relative to the worktree root (e.g., `docs/plans/plan.md`). Do NOT prefix with the worktree directory from the main repo (e.g., `agentv.worktrees/feat/xxx/docs/plans/plan.md`) — this creates accidental nested directories inside the worktree.
-
-Plans are temporary working materials. **Before merging the PR**, delete the plan file and incorporate any user-relevant details into the official documentation.
-
-#### Git Worktrees
-
-Use the sibling `../agentv.worktrees/` directory for all AgentV worktrees. This overrides any generic skill or default preference for `.worktrees/` or `worktrees/` inside the repository. Do not create new AgentV worktrees inside the repository root.
-
-After creating a manual worktree, always run setup:
-```bash
-bun install                                    # worktrees do NOT share node_modules
-cp "$(git worktree list --porcelain | head -1 | sed 's/worktree //')/.env" .env    # required for e2e tests and LLM operations
-```
-Both steps are required before running builds, tests, or evals in the worktree.
-
-### After Checking Out an Existing Branch or PR
-
-Whenever you `git checkout`, `gh pr checkout`, `git pull`, or otherwise switch to a ref that may have changed `package.json` / `bun.lock`, run `bun install` before building or testing. If dependencies are stale, CI/local checks can fail with errors like `Cannot find module 'recharts'` even though the source change is unrelated. `bun install` is cheap when already up-to-date, so run it by default after any ref switch.
-
-## Version Management
-
-This project uses a simple release script for version bumping. The git commit history serves as the changelog.
-
-### Releasing a new version
-
-Use the **GitHub Actions workflows** — do not publish manually from a local machine.
-
-**Standard flow (pre-release → stable):**
-1. Run the [Release workflow](https://github.com/EntityProcess/agentv/actions/workflows/release.yml) with `channel=next` (and desired bump: patch/minor/major). This bumps the version to `x.y.z-next.1`, commits, tags, and pushes.
-2. The [Publish workflow](https://github.com/EntityProcess/agentv/actions/workflows/publish.yml) triggers automatically and publishes to npm `next`.
-3. Run the [Release workflow](https://github.com/EntityProcess/agentv/actions/workflows/release.yml) with `channel=finalize`. This finalizes the latest prerelease tag by default (or a specific `prerelease_tag` if provided), strips the `-next.N` suffix (e.g. `4.12.0-next.1` → `4.12.0`), commits, and tags that prerelease lineage.
-4. The Publish workflow triggers automatically and publishes to npm `latest`.
-
-**Direct stable release (skip pre-release):**
-1. Run the Release workflow with `channel=stable` (and bump).
-2. Publish workflow auto-publishes to npm `latest`.
-
-The release script (`bun scripts/release.ts`) is what the Release workflow calls; it can also be run locally for non-publishing tasks (e.g. inspecting version state), but **do not run `bun run publish` or `bun run publish:next` locally** — npm publish uses OIDC trusted publishing which only works in GitHub Actions.
-
-## Package Publishing
-- Core package (`packages/core/`) - Core evaluation engine and grading logic (published as `@agentv/core`)
-- CLI package (`apps/cli/`) is published as `agentv` on npm
-- Uses tsup with `noExternal: ["@agentv/core"]` to bundle workspace dependencies
-- Install command: `bun install -g agentv` (preferred) or `npm install -g agentv`
-
-## Python Scripts
-When running Python scripts, always use: `uv run <script.py>`
+- Repo-native evals: run against real repos, multi-repo workspaces, setup scripts, and existing harnesses.
+- Zero-infra local to CI: keep the default path lightweight so the same eval contract works on a laptop and in CI.
+- Portable run artifacts: treat run bundles, traces, and summaries as the source of truth for comparison, gating, and export.
+- Adapter boundaries: integrate with Phoenix, Harbor, Opik, and provider-specific systems through narrow adapters instead of absorbing their concepts into core.
+- AI-native extensibility: keep the core small and composable so engineers and coding agents can extend it with plugins, wrappers, and harness-specific glue.
+
+Design guardrails:
+
+- Prefer core primitives plus plugins or wrappers over new built-ins.
+- Document composition patterns before inventing a new feature.
+- Match industry-standard lowest-common-denominator contracts when possible.
+- Apply YAGNI aggressively and solve the current request with the smallest surface that works.
+- Keep extensions non-breaking unless a same-week unreleased surface should be hard-corrected.
+- Design for AI comprehension with self-describing modules, clear extension points, and no dead scaffolding.
+
+Read the full rationale and examples in [.agents/product-boundary.md](.agents/product-boundary.md).
+
+## Always-Read Rules
+
+- Start every repo change with `git fetch origin` and `git status --short --branch`.
+- Use `bun` for package and script operations.
+- Use the operator-supplied tracker when present. Do not commit tracker runtime state, local coordination config, or other machine-local artifacts.
+- Do not use `git stash` on shared checkouts. Stage explicit paths only, and never push directly to `main`.
+- Prefer the primary checkout only for small, clean, bounded work. Use a dedicated worktree from the latest `origin/main` for non-trivial, risky, long-running, or parallel changes.
+- Non-trivial work needs a plan or task list. If the implementation surface starts to balloon, stop and re-plan.
+- Manual red/green UAT is blocking before a branch is ready for review. GitHub Actions is the authoritative merge gate.
+- Wire formats are `snake_case`; internal TypeScript is `camelCase`. Translate only at the boundary.
+- In AgentV, a `project` holds runs, traces, and experiments; a `benchmark` is a curated eval suite. Do not collapse those terms.
+
+## Repo Map
+
+- `packages/core/`: evaluation engine, providers, grading, project registry, and the programmatic API.
+- `packages/eval/`: lightweight assertion SDK such as `defineAssertion` and `defineCodeGrader`.
+- `apps/cli/`: published CLI surface for `agentv`.
+- `apps/web/src/content/docs/`: public product and CLI docs on agentv.dev.
+- `examples/`: examples that double as reference material and integration coverage.
+- `docs/adr/`: durable product and architecture boundary decisions.
+- `docs/plans/`: implementation plans and temporary design artifacts.
+- `docs/learnings/`: primary learning store for captured fixes and decisions.
+- `CONCEPTS.md`: shared domain vocabulary.
+
+## Routing
+
+Read the relevant guide before specialized work:
+
+- [.agents/product-boundary.md](.agents/product-boundary.md): full goals, design principles, AI-first guidance, and how to decide core vs plugin vs docs.
+- [.agents/workflow.md](.agents/workflow.md): tracker handling, worktrees, planning, execution, git workflow, PR flow, and documentation update expectations.
+- [.agents/verification.md](.agents/verification.md): CI gates, CLI and browser E2E, grader verification, concurrency limits, and the completion checklist.
+- [.agents/conventions.md](.agents/conventions.md): TypeScript and Bun conventions, subprocess rules, naming contracts, wire formats, grader type rules, and Python script usage.
+- [.agents/publish.md](.agents/publish.md): versioning, publish workflow, contract gates, and published package surfaces.
+
+Common entry points:
+
+- Product or architecture decisions: start with [STRATEGY.md](STRATEGY.md), [ROADMAP.md](ROADMAP.md), and [.agents/product-boundary.md](.agents/product-boundary.md).
+- Tracker, worktree, or PR flow questions: read [.agents/workflow.md](.agents/workflow.md).
+- Dashboard, docs, CLI UX, or grader verification work: read [.agents/verification.md](.agents/verification.md).
+- Wire-format, naming, or grader-type changes: read [.agents/conventions.md](.agents/conventions.md).
+- Version bumps or npm publishing: read [.agents/publish.md](.agents/publish.md).


### PR DESCRIPTION
## Summary

- split the long root `AGENTS.md` into a short routing index plus tracked `.agents/*.md` guidance files
- keep detailed product boundary, workflow, verification, conventions, and publish guidance discoverable from the root file
- update `.gitignore` so committed `.agents/*.md` docs are tracked while scratch files remain ignored

## Tracking

Bead: `av-57v`

## Verification

- `git rebase origin/main`
- `git diff --check origin/main...HEAD`
- `wc -l AGENTS.md` -> 66 lines

Docs-only; build/test not run.
