### PR TITLE
fix(release): publish scoped packages as public

### DIFF
--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -23,7 +23,7 @@ if (requestedTag !== undefined && requestedTag !== 'next') {
 }
 
 const npmTag = requestedTag ?? 'latest';
-const tagArgs = ['--tag', npmTag];
+const publishArgs = ['--tag', npmTag, '--access', 'public'];
 
 const PACKAGES = ['packages/core', 'packages/sdk', 'packages/eval', 'apps/cli'];
 
@@ -116,7 +116,7 @@ async function main() {
       if (publishedVersion === version) {
         console.log(`   ✓ ${name}@${version} is already published`);
       } else {
-        await $`npm publish ${tagArgs}`.cwd(pkg).env({ ...process.env, ALLOW_PUBLISH: '1' });
+        await $`npm publish ${publishArgs}`.cwd(pkg).env({ ...process.env, ALLOW_PUBLISH: '1' });
       }
 
       await ensureDistTag(name, version);


### PR DESCRIPTION
## Summary
- pass `--access public` for npm publishes
- keeps the existing idempotent publish behavior while allowing first publish of new scoped packages

## Why
The `Publish` workflow run 27806345794 created `v4.41.2-next.1`, published `@agentv/core@4.41.2-next.1`, then failed on the first publish of `@agentv/sdk@4.41.2-next.1` with:

```
npm error Can't generate provenance for new or private package, you must set `access` to public.
```

## Verification
- `bunx biome check scripts/publish.ts`
- `bun scripts/publish.ts invalid-tag` exits before publish and confirms script parses