### PR TITLE
fix(skill-trigger): case-insensitive read tool name and support input.path key

### DIFF
--- a/packages/core/src/evaluation/graders/skill-trigger.ts
+++ b/packages/core/src/evaluation/graders/skill-trigger.ts
@@ -7,8 +7,8 @@
  *
  * Detection logic:
  *   - Scans ALL tool calls (not just the first) for skill invocation evidence.
- *   - Skill tool: checks `tool === 'Skill'` and `input.skill` contains the skill name.
- *   - Read tool: checks `tool === 'Read'` and `input.file_path` contains a skills/ path.
+ *   - Skill tool: checks `tool` (case-insensitive) === 'skill' and `input.skill` contains the skill name.
+ *   - Read tool: checks `tool` (case-insensitive) === 'read' and `input.file_path` or `input.path` contains a skills/ path.
  *   - Fallback: checks tool output for skill file path references.
  *   - Supports negative cases via should_trigger: false.
  *
@@ -44,15 +44,15 @@ export class SkillTriggerGrader implements Grader {
       const toolName = toolCall.tool ?? '';
       const input = (toolCall.input ?? {}) as Record<string, unknown>;
 
-      if (toolName === 'Skill') {
+      if (toolName.toLowerCase() === 'skill') {
         const skillArg = String(input.skill ?? '');
         if (skillArg.includes(skillName)) {
           triggered = true;
           evidence = `Skill tool invoked with skill="${skillArg}"`;
           break;
         }
-      } else if (toolName === 'Read') {
-        const filePath = String(input.file_path ?? '');
+      } else if (toolName.toLowerCase() === 'read') {
+        const filePath = String(input.file_path ?? input.path ?? '');
         if (filePath.includes(`skills/${skillName}/`)) {
           triggered = true;
           evidence = `Read tool loaded skill file: ${filePath}`;

--- a/packages/core/test/evaluation/graders/skill-trigger.test.ts
+++ b/packages/core/test/evaluation/graders/skill-trigger.test.ts
@@ -331,5 +331,47 @@ describe('SkillTriggerGrader', () => {
       const result = evaluator.evaluate(context);
       expect(result.verdict).toBe('pass');
     });
+
+    it('should detect lowercase "read" tool with input.path (pi-sdk style)', () => {
+      const evaluator = new SkillTriggerGrader(makeConfig());
+      const context = makeContext({
+        output: [
+          {
+            role: 'assistant',
+            content: '',
+            toolCalls: [
+              {
+                tool: 'read',
+                input: { path: '/home/user/.agents/skills/csv-analyzer/SKILL.md' },
+              },
+            ],
+          },
+        ],
+      });
+      const result = evaluator.evaluate(context);
+      expect(result.verdict).toBe('pass');
+      expect(result.score).toBe(1);
+    });
+
+    it('should detect uppercase "Read" with input.file_path (Claude Code style)', () => {
+      const evaluator = new SkillTriggerGrader(makeConfig());
+      const context = makeContext({
+        output: [
+          {
+            role: 'assistant',
+            content: '',
+            toolCalls: [
+              {
+                tool: 'Read',
+                input: { file_path: '.agents/skills/csv-analyzer/SKILL.md' },
+              },
+            ],
+          },
+        ],
+      });
+      const result = evaluator.evaluate(context);
+      expect(result.verdict).toBe('pass');
+      expect(result.score).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Fixes #1433: `SkillTriggerGrader` now matches `Skill` and `Read` tool names case-insensitively (`.toLowerCase()`), so agents using lowercase tool names (pi-coding-agent / pi-sdk) are detected correctly
- Falls back to `input.path` when `input.file_path` is absent, covering pi-sdk's `Read` tool input schema

## Changes

**`packages/core/src/evaluation/graders/skill-trigger.ts`**
- `toolName === 'Skill'` → `toolName.toLowerCase() === 'skill'`
- `toolName === 'Read'` → `toolName.toLowerCase() === 'read'`
- `input.file_path ?? ''` → `input.file_path ?? input.path ?? ''`

**`packages/core/test/evaluation/graders/skill-trigger.test.ts`**
- Added: lowercase `"read"` tool with `input.path` (pi-sdk style) → should trigger
- Added: uppercase `"Read"` with `input.file_path` (Claude Code style) → existing behaviour preserved

## Test plan

- [ ] Existing tests in `skill-trigger.test.ts` still pass (no regressions)
- [ ] New test: lowercase `read` + `input.path` → `pass`
- [ ] New test: uppercase `Read` + `input.file_path` → `pass`

🤖 Generated with [Claude Code](https://claude.com/claude-code)