### PR TITLE
fix(results): flatten on-branch results layout and tolerate missing branch

### DIFF
--- a/apps/cli/src/commands/eval/wip-checkpoint.ts
+++ b/apps/cli/src/commands/eval/wip-checkpoint.ts
@@ -15,7 +15,7 @@
  * Manual recovery from a WIP branch:
  *   git clone <results-repo> /tmp/recovery
  *   cd /tmp/recovery && git checkout agentv/wip/<hostname>/<run-dir>
- *   cp -r .agentv/results/runs/<run-dir> <project>/.agentv/results/runs/
+ *   cp -r runs/<run-dir> <project>/.agentv/results/runs/
  *   agentv eval <eval-file> --output <project>/.agentv/results/runs/<run-dir> --resume
  *
  * All checkpoint operations are best-effort: failures are logged as warnings

--- a/apps/cli/src/commands/results/remote-metadata.ts
+++ b/apps/cli/src/commands/results/remote-metadata.ts
@@ -1,11 +1,11 @@
 /**
  * Mutable metadata overlays for remote result runs.
  *
- * Remote run artifacts under `.agentv/results/runs/**` are treated as immutable
- * fetched payloads. Editable fields, starting with tags, live in a small
- * sidecar tree under `.agentv/results/metadata/runs/**` inside the configured
- * results repo checkout. That keeps local edits pushable by normal Git sync
- * without rewriting the fetched run directory.
+ * Remote run artifacts under `runs/**` on the results branch are treated as
+ * immutable fetched payloads. Editable fields, starting with tags, live in a
+ * small sidecar tree under `metadata/runs/**` inside the configured results repo
+ * checkout. That keeps local edits pushable by normal Git sync without rewriting
+ * the fetched run directory.
  *
  * To add another mutable field: create a sibling helper that maps the remote
  * run manifest to the same metadata run directory, keep the on-disk keys
@@ -19,8 +19,8 @@ import path from 'node:path';
 
 import { RUN_TAGS_FILENAME, normalizeTags } from './run-tags.js';
 
-const RESULTS_RUNS_DIR = path.join('.agentv', 'results', 'runs');
-const REMOTE_METADATA_RUNS_DIR = path.join('.agentv', 'results', 'metadata', 'runs');
+const RESULTS_RUNS_DIR = 'runs';
+const REMOTE_METADATA_RUNS_DIR = path.join('metadata', 'runs');
 
 interface TagsFile {
   readonly tags: string[];

--- a/apps/cli/src/commands/results/remote.ts
+++ b/apps/cli/src/commands/results/remote.ts
@@ -458,10 +458,9 @@ export async function ensureRemoteRunAvailable(
     throw new Error(`Remote manifest path is outside the results repo clone: ${meta.path}`);
   }
 
-  const relativeRunPath = path.posix.relative(
-    '.agentv/results/runs',
-    path.posix.dirname(relativeManifestPath),
-  );
+  // On the results branch runs live flat under `runs/` (the branch namespaces
+  // results), so strip that prefix to recover <experiment>/<timestamp>.
+  const relativeRunPath = path.posix.relative('runs', path.posix.dirname(relativeManifestPath));
   await materializeGitRun(config.path, relativeRunPath, getResultsStorageRef(config));
 }
 

--- a/apps/cli/test/commands/results/remote-auto-export.test.ts
+++ b/apps/cli/test/commands/results/remote-auto-export.test.ts
@@ -148,7 +148,7 @@ describe('maybeAutoExportRunArtifacts', () => {
 
     expect(status).toBe('published');
     expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir)).toContain(
-      '.agentv/results/runs/default/run-001/index.jsonl',
+      'runs/default/run-001/index.jsonl',
     );
   }, 20_000);
 
@@ -203,10 +203,10 @@ describe('maybeAutoExportRunArtifacts', () => {
 
     expect(status).toBe('published');
     expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir)).not.toContain(
-      '.agentv/results/runs/default/run-001/index.jsonl',
+      'runs/default/run-001/index.jsonl',
     );
     expect(git('git ls-tree -r --name-only main', cloneDir)).toContain(
-      '.agentv/results/runs/default/run-001/index.jsonl',
+      'runs/default/run-001/index.jsonl',
     );
   });
 });

--- a/apps/cli/test/commands/results/remote-metadata.test.ts
+++ b/apps/cli/test/commands/results/remote-metadata.test.ts
@@ -38,14 +38,14 @@ function seedRepo(repoDir: string): string {
   git('git config user.email "test@example.com"', repoDir);
   git('git config user.name "Test User"', repoDir);
 
-  const runDir = path.join(repoDir, '.agentv', 'results', 'runs', 'default', RUN_TIMESTAMP);
+  const runDir = path.join(repoDir, 'runs', 'default', RUN_TIMESTAMP);
   mkdirSync(runDir, { recursive: true });
   writeFileSync(path.join(runDir, 'index.jsonl'), '{"test_id":"alpha","score":1}\n');
   writeFileSync(
     path.join(runDir, 'tags.json'),
     `${JSON.stringify({ tags: ['remote-baseline'], updated_at: '2026-06-06T09:00:00.000Z' }, null, 2)}\n`,
   );
-  git('git add .agentv', repoDir);
+  git('git add runs', repoDir);
   git('git commit --quiet -m "seed remote run"', repoDir);
   return path.join(runDir, 'index.jsonl');
 }
@@ -73,7 +73,7 @@ describe('remote metadata tags', () => {
     expect(state.pendingTags).toEqual(['pending', 'remote-baseline']);
     expect(state.dirty).toBe(true);
     expect(state.metadataPath).toContain(
-      path.join('.agentv', 'results', 'metadata', 'runs', 'default', RUN_TIMESTAMP, 'tags.json'),
+      path.join('metadata', 'runs', 'default', RUN_TIMESTAMP, 'tags.json'),
     );
     expect(readFileSync(artifactTagsPath, 'utf8')).toBe(originalArtifactTags);
     expect(existsSync(state.metadataPath)).toBe(true);
@@ -88,7 +88,7 @@ describe('remote metadata tags', () => {
   it('uses committed metadata overlays as the clean remote baseline', () => {
     const manifestPath = seedRepo(repoDir);
     const state = writeRemoteRunTags(repoDir, manifestPath, ['accepted']);
-    git('git add .agentv/results/metadata', repoDir);
+    git('git add metadata', repoDir);
     git('git commit --quiet -m "update tags"', repoDir);
 
     const reloaded = readRemoteRunTags(repoDir, manifestPath);
@@ -113,7 +113,7 @@ describe('remote metadata tags', () => {
   });
 
   it('rejects writes when the configured results path is not a git checkout', () => {
-    const runDir = path.join(repoDir, '.agentv', 'results', 'runs', 'default', RUN_TIMESTAMP);
+    const runDir = path.join(repoDir, 'runs', 'default', RUN_TIMESTAMP);
     mkdirSync(runDir, { recursive: true });
     const manifestPath = path.join(runDir, 'index.jsonl');
     writeFileSync(manifestPath, '{"test_id":"alpha","score":1}\n');

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -133,7 +133,7 @@ function writeRemoteRunArtifact(
     /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/,
     '$1T$2:$3:$4.$5Z',
   );
-  const runDir = path.join(cloneDir, '.agentv', 'results', 'runs', experiment, timestamp);
+  const runDir = path.join(cloneDir, 'runs', experiment, timestamp);
   mkdirSync(runDir, { recursive: true });
   const records = Array.isArray(resultRecords) ? resultRecords : [resultRecords];
   writeFileSync(path.join(runDir, 'index.jsonl'), toJsonl(...records));
@@ -173,7 +173,7 @@ function writeDirtyRemoteRunArtifact(
     /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/,
     '$1T$2:$3:$4.$5Z',
   );
-  const runDir = path.join(cloneDir, '.agentv', 'results', 'runs', experiment, timestamp);
+  const runDir = path.join(cloneDir, 'runs', experiment, timestamp);
   mkdirSync(runDir, { recursive: true });
   writeFileSync(path.join(runDir, 'index.jsonl'), toJsonl(resultRecord));
   writeFileSync(
@@ -205,16 +205,7 @@ function writeRemoteTagMetadataOverlay(
   timestamp: string,
   tags: readonly string[],
 ): string {
-  const metadataPath = path.join(
-    repoDir,
-    '.agentv',
-    'results',
-    'metadata',
-    'runs',
-    experiment,
-    timestamp,
-    'tags.json',
-  );
+  const metadataPath = path.join(repoDir, 'metadata', 'runs', experiment, timestamp, 'tags.json');
   mkdirSync(path.dirname(metadataPath), { recursive: true });
   writeFileSync(
     metadataPath,
@@ -1379,8 +1370,6 @@ describe('serve app', () => {
 
       const runManifestPath = path.join(
         cloneDir,
-        '.agentv',
-        'results',
         'runs',
         'external-sync',
         '2026-03-26T11-00-00-000Z',
@@ -1454,8 +1443,6 @@ describe('serve app', () => {
 
       const artifactTagsPath = path.join(
         cloneDir,
-        '.agentv',
-        'results',
         'runs',
         'green-uat',
         '2026-03-26T12-00-00-000Z',
@@ -1463,8 +1450,6 @@ describe('serve app', () => {
       );
       const overlayTagsPath = path.join(
         cloneDir,
-        '.agentv',
-        'results',
         'metadata',
         'runs',
         'green-uat',
@@ -1846,7 +1831,7 @@ describe('serve app', () => {
           '2026-03-26T11-00-00-000Z',
           RESULT_A,
         );
-        git('git add .agentv && git commit --quiet -m "remote result"', seedDir);
+        git('git add runs && git commit --quiet -m "remote result"', seedDir);
         git('git push --quiet origin main', seedDir);
 
         const app = createApp([], tempDir, tempDir, undefined, { studioDir });
@@ -1875,8 +1860,6 @@ describe('serve app', () => {
           existsSync(
             path.join(
               cloneDir,
-              '.agentv',
-              'results',
               'runs',
               'project-sync-pull',
               runId.replace('project-sync-pull::', ''),
@@ -1949,7 +1932,7 @@ describe('serve app', () => {
           run_count: 1,
         });
         expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, tempDir)).toContain(
-          `.agentv/results/metadata/runs/project-sync-push/${runTimestamp}/tags.json`,
+          `metadata/runs/project-sync-push/${runTimestamp}/tags.json`,
         );
       } finally {
         if (previousHome === undefined) {
@@ -2048,8 +2031,6 @@ describe('serve app', () => {
 
         const runTimestamp = '2026-03-26T13-00-00-000Z';
         const relativeMetadataPath = path.posix.join(
-          '.agentv',
-          'results',
           'metadata',
           'runs',
           'project-sync-conflict',
@@ -2057,14 +2038,14 @@ describe('serve app', () => {
           'tags.json',
         );
         writeRemoteTagMetadataOverlay(seedDir, 'project-sync-conflict', runTimestamp, ['base']);
-        git('git add .agentv && git commit --quiet -m "seed tag metadata"', seedDir);
+        git('git add metadata && git commit --quiet -m "seed tag metadata"', seedDir);
         git('git push --quiet origin main', seedDir);
         git('git pull --ff-only --quiet', cloneDir);
 
         writeRemoteTagMetadataOverlay(cloneDir, 'project-sync-conflict', runTimestamp, ['local']);
-        git('git add .agentv && git commit --quiet -m "local tag metadata"', cloneDir);
+        git('git add metadata && git commit --quiet -m "local tag metadata"', cloneDir);
         writeRemoteTagMetadataOverlay(seedDir, 'project-sync-conflict', runTimestamp, ['remote']);
-        git('git add .agentv && git commit --quiet -m "remote tag metadata"', seedDir);
+        git('git add metadata && git commit --quiet -m "remote tag metadata"', seedDir);
         git('git push --quiet origin main', seedDir);
         git('git fetch --quiet origin --prune', cloneDir);
         git('git merge origin/main || true', cloneDir);

--- a/apps/dashboard/src/lib/project-sync-status.test.ts
+++ b/apps/dashboard/src/lib/project-sync-status.test.ts
@@ -22,7 +22,7 @@ describe('getProjectSyncView', () => {
       configured: true,
       available: true,
       sync_status: 'dirty',
-      dirty_paths: ['.agentv/results/metadata/runs/demo/tags.json'],
+      dirty_paths: ['metadata/runs/demo/tags.json'],
       auto_push: false,
     });
 

--- a/docs/plans/git-native-results.md
+++ b/docs/plans/git-native-results.md
@@ -14,7 +14,7 @@ After comparing with **entireio** (single-ref + git tree as index) and **skillfu
 
 ## Core idea
 
-The configured results branch tree IS the index. `git ls-tree -r <storage-ref> -- .agentv/results/runs/` lists every run path without reading every blob. `git cat-file --batch` reads existing `benchmark.json` blobs in one subprocess call. No separate index file. No drift. Natural pruning when runs are deleted. With `--filter=blob:none` clone, individual run blobs are fetched lazily when a user opens the detail view.
+The configured results branch tree IS the index. `git ls-tree -r <storage-ref> -- runs/` lists every run path without reading every blob. `git cat-file --batch` reads existing `benchmark.json` blobs in one subprocess call. No separate index file. No drift. Natural pruning when runs are deleted. With `--filter=blob:none` clone, individual run blobs are fetched lazily when a user opens the detail view.
 
 ## Architecture
 
@@ -23,7 +23,7 @@ The configured results branch tree IS the index. `git ls-tree -r <storage-ref> -
 - `results.repo_path` points at an existing local Git checkout whose object database and refs AgentV may write to. Use `repo_path: .` to store results in a dedicated branch of the source repo without checking that branch out in the source worktree.
 - `results.repo_url` points at a remote results repository. AgentV manages a local clone at `results.path`; omit `path` to use the default AgentV data dir.
 - `results.branch` is the storage branch. `repo_path` configs default to `agentv/results/v1`.
-- Local `.agentv/results/runs/` remains the active run workspace for local Dashboard, resume, and rerun flows. Publishing copies completed run artifacts into the branch-backed store under `.agentv/results/**`.
+- Local `.agentv/results/runs/` remains the active run workspace for local Dashboard, resume, and rerun flows. Publishing copies completed run artifacts into the branch-backed store under `runs/**` (the branch name already namespaces results, so no redundant `.agentv/results/` prefix on the branch). Editable tag overlays live alongside under `metadata/runs/**`.
 
 ```yaml
 # Existing checkout, usually the eval source repo.
@@ -51,7 +51,7 @@ Every completed `agentv eval` publish is one atomic operation:
 
 1. Write artifacts into the normal local run workspace at `.agentv/results/runs/<experiment>/<timestamp>/`.
 2. Resolve the results store: either the `repo_path` checkout or the managed clone for `repo_url`.
-3. Build a commit for `.agentv/results/**` on the storage branch using git plumbing and a temporary index, so `repo_path: .` never has to check out `agentv/results/v1`.
+3. Build a commit for `runs/**` (and `metadata/**`) on the storage branch using git plumbing and a temporary index, so `repo_path: .` never has to check out `agentv/results/v1`.
 4. If `sync.auto_push` or `sync.require_push` is enabled, push the storage branch. Non-fast-forward conflicts fetch the remote branch, rebuild the single run commit on the remote base when safe, and retry.
 
 Each run is one commit. Files are unique to that run, so rebases never content-conflict.
@@ -59,14 +59,14 @@ Each run is one commit. Files are unique to that run, so rebases never content-c
 ### Reads
 
 **Listing** (replaces `listResultFilesFromRunsDir`):
-- `git ls-tree -r <storage-ref> -- .agentv/results/runs/` → filter for `benchmark.json` paths
+- `git ls-tree -r <storage-ref> -- runs/` → filter for `benchmark.json` paths
 - `git cat-file --batch` → read those blobs in one subprocess
 - Derive `run_id` from path (same logic as current `buildRunId`)
 - Sort by timestamp descending
 - Apply cursor pagination
 
 **Detail view file reads** (replaces `readFileSync(meta.path)`):
-- Committed: `git cat-file -p <storage-ref>:.agentv/results/runs/.../<file>`
+- Committed: `git cat-file -p <storage-ref>:runs/.../<file>`
 - In-progress (post-write, pre-commit): `readFileSync(<path>)` from working tree
 
 **In-progress detection**: between artifact write and commit, files exist only in the working tree. `git status --porcelain .agentv/results/` surfaces them; merge with the committed list for the Dashboard runs view.
@@ -91,7 +91,7 @@ Each run is one commit. Files are unique to that run, so rebases never content-c
 - `normalizeResultsConfig()` accepts `repo_url`/legacy `repo` or `repo_path`, but prerelease docs and config examples use `repo_url` or `repo_path`.
 - `directPushResults()` resolves the results store, builds one storage-branch commit for the completed run, and pushes when `sync.auto_push` or `sync.require_push` is enabled.
 - `commitResultsRunWithTemporaryIndex()` writes blobs into the repo object database and updates the storage branch via a temporary index. This is the normal `repo_path: .` path and avoids copying files into a checked-out results branch.
-- `listGitRuns()` uses `git ls-tree` plus `git cat-file --batch` against `.agentv/results/runs/**/benchmark.json`.
+- `listGitRuns()` uses `git ls-tree` plus `git cat-file --batch` against `runs/**/benchmark.json`. A not-yet-created storage branch (ref does not exist) returns `[]` rather than throwing, so the Dashboard's remote-results poll stays quiet before the first push.
 - `setupWipWorktree()` and `pushWipCheckpoint()` maintain recoverable in-progress branches under `agentv/wip/...`.
 
 ## Breaking changes

--- a/docs/plans/results-branch-layout.md
+++ b/docs/plans/results-branch-layout.md
@@ -1,0 +1,81 @@
+# Plan: Flatten on-branch results layout + graceful missing results-branch handling
+
+Branch: `fix/results-branch-layout` — single PR shipping both changes.
+
+## Change 1 — Flatten the on-branch results path (primary)
+
+On the results branch (default `agentv/results/v1`) the `.agentv/results/` prefix is
+redundant because the branch name already namespaces results. Flatten the **on-branch /
+results-repo-clone** layout:
+
+- `.agentv/results/runs/<exp>/<ts>/...` → `runs/<exp>/<ts>/...`
+- `.agentv/results/metadata/runs/<exp>/<ts>/tags.json` → `metadata/runs/<exp>/<ts>/tags.json`
+
+The metadata sidecar is dragged in because `remote-metadata.ts` computes overlay paths
+**relative to the on-branch runs dir** and shares the same auto-sync safe-path umbrella as
+runs. Leaving it at `.agentv/results/metadata/` would (a) break tag overlays (the relative
+manifest computation would resolve outside the runs root and throw) and (b) leave a
+half-flattened branch (`runs/` next to `.agentv/results/metadata/`). So both flatten together.
+
+### Scope guard (do NOT change)
+
+The **local working-tree run workspace** stays `.agentv/results/runs/`. That is where
+`agentv eval` writes by default and what inspect/trend/export/combine/serve read locally.
+Concretely, `resolveResultsRepoRunsDir()` keeps returning `<path>/.agentv/results/runs`
+(constant `RESULTS_REPO_RESULTS_DIR='.agentv/results'` is retained solely for that).
+
+### Files to touch
+
+- `packages/core/src/evaluation/results-repo.ts`
+  - `RESULTS_REPO_RUNS_DIR`: `${RESULTS_REPO_RESULTS_DIR}/runs` → `'runs'`.
+  - Add `RESULTS_REPO_METADATA_DIR='metadata'` and `RESULTS_REPO_TRACKED_DIRS=['runs','metadata']`.
+  - `isSafeResultsRepoPath`: accept anything under `runs/` or `metadata/` (was `.agentv/results`).
+  - The three `git add --all -- .agentv/results` sites (sync dirty-commit ×1, that same
+    block's commit `--` path, `pushWipCheckpoint`) → add the tracked dirs instead.
+  - `commitResultsRunWithTemporaryIndex`, `listGitRuns`, `materializeGitRun`, `pushWipCheckpoint`
+    all use `RESULTS_REPO_RUNS_DIR` → now `runs`.
+  - `resolveResultsRepoRunsDir`: unchanged (local workspace).
+- `apps/cli/src/commands/results/remote.ts:462`: literal `.agentv/results/runs` → `runs`.
+- `apps/cli/src/commands/results/remote-metadata.ts`:
+  - `RESULTS_RUNS_DIR` → `runs`.
+  - `REMOTE_METADATA_RUNS_DIR` → `metadata/runs`.
+
+### Breaking change
+
+Prerelease breaking change (acceptable per AGENTS.md / git-native-results.md). Existing
+branches written under `.agentv/results/runs/` (and `.agentv/results/metadata/`) will not be
+read by the new path. **No read-compat fallback** — documented as a clean breaking change to
+keep the surface minimal.
+
+## Change 2 — Treat a not-yet-created results branch as "no remote runs"
+
+`listGitRuns` runs `git ls-tree -r --name-only <ref> runs`. When `<ref>` (the configured
+results branch) does not exist yet, git exits non-zero with `fatal: Not a valid object name
+<ref>` and the Dashboard logs a full stack on every poll.
+
+Fix at the `listGitRuns` boundary (all callers benefit): wrap the `ls-tree` call, and if the
+error matches the "missing ref" predicate, return `[]`. Genuine failures still throw.
+
+Missing-ref predicate (`isMissingGitRefError`) — match (case-insensitive) on combined
+stderr+message containing any of:
+`not a valid object name`, `unknown revision or path`, `bad revision`, `does not exist`.
+
+`remote.ts` keeps its existing catch for genuine errors and its non-`config.branch` fallback;
+with the boundary fix it simply stops firing for the missing-branch case.
+
+## Tests
+
+- `packages/core/test/evaluation/results-repo.test.ts`: flip on-branch path assertions and
+  clone-working-tree run creations to `runs/`; add a case: `listGitRuns(repo, 'missing-branch')`
+  resolves to `[]` (no throw).
+- `apps/cli/test/commands/results/remote-metadata.test.ts`: seed runs at `runs/`, overlays at
+  `metadata/runs/`.
+- `apps/cli/test/commands/results/serve.test.ts`: `writeRemoteRunArtifact` /
+  `writeDirtyRemoteRunArtifact` → `runs/`; `writeRemoteTagMetadataOverlay` → `metadata/runs/`;
+  branch-content assertions updated. (Local-workspace run helpers stay `.agentv/results/runs/`.)
+
+## Verify
+
+- `bun test` in `packages/core` and `apps/cli`; typecheck + lint per repo scripts.
+- `bun run build` at root; report the built CLI path for dogfooding.
+- Manual red/green UAT.

--- a/packages/core/src/evaluation/results-repo.ts
+++ b/packages/core/src/evaluation/results-repo.ts
@@ -17,8 +17,19 @@ import { getAgentvDataDir } from '../paths.js';
 import type { ResultsConfig } from './loaders/config-loader.js';
 
 const execFileAsync = promisify(execFile);
+// Local working-tree run workspace inside the eval repo. Local commands
+// (`agentv eval` default --output, inspect/trend/export/combine/serve) read and
+// write runs here. This is NOT the on-branch layout — see resolveResultsRepoRunsDir.
 const RESULTS_REPO_RESULTS_DIR = '.agentv/results';
-const RESULTS_REPO_RUNS_DIR = `${RESULTS_REPO_RESULTS_DIR}/runs`;
+// On-branch / results-repo-clone storage layout. The results branch (e.g.
+// agentv/results/v1) already namespaces results, so runs are stored flat at
+// runs/<experiment>/<timestamp>/ and the editable tag overlays at
+// metadata/runs/<experiment>/<timestamp>/ — no redundant `.agentv/results/` prefix.
+const RESULTS_REPO_RUNS_DIR = 'runs';
+const RESULTS_REPO_METADATA_DIR = 'metadata';
+// Top-level directories AgentV owns on the results branch. The auto-sync
+// dirty-commit path stages only these so it never touches unrelated repo files.
+const RESULTS_REPO_TRACKED_DIRS = [RESULTS_REPO_RUNS_DIR, RESULTS_REPO_METADATA_DIR] as const;
 const RESULTS_REPO_COMMIT_EMAIL = 'agentv@results-repo';
 const RESULTS_REPO_COMMIT_NAME = 'AgentV Results';
 export const DEFAULT_RESULTS_BRANCH = 'agentv/results/v1';
@@ -787,7 +798,25 @@ function withActionFlags(
 }
 
 function isSafeResultsRepoPath(p: string): boolean {
-  return p === RESULTS_REPO_RESULTS_DIR || p.startsWith(`${RESULTS_REPO_RESULTS_DIR}/`);
+  return RESULTS_REPO_TRACKED_DIRS.some((dir) => p === dir || p.startsWith(`${dir}/`));
+}
+
+// git errors on a pathspec that matches nothing, so when staging AgentV's result
+// trees we only pass the ones that currently exist on disk or in the index. A run
+// commit may have no tag overlays yet (no `metadata/`), and vice versa.
+async function existingTrackedResultsDirs(repoDir: string): Promise<string[]> {
+  const targets: string[] = [];
+  for (const dir of RESULTS_REPO_TRACKED_DIRS) {
+    if (existsSync(path.join(repoDir, dir))) {
+      targets.push(dir);
+      continue;
+    }
+    const { stdout } = await runGit(['ls-files', '--', dir], { cwd: repoDir, check: false });
+    if (stdout.trim().length > 0) {
+      targets.push(dir);
+    }
+  }
+  return targets;
 }
 
 function areSafeResultsRepoPaths(paths: readonly string[]): boolean {
@@ -1038,16 +1067,11 @@ export async function syncResultsRepoForProject(config: ResultsConfig): Promise<
       }
 
       if (inspection.syncStatus === 'dirty') {
-        await runGit(['add', '--all', '--', RESULTS_REPO_RESULTS_DIR], { cwd: repoDir });
+        const trackedDirs = await existingTrackedResultsDirs(repoDir);
+        await runGit(['add', '--all', '--', ...trackedDirs], { cwd: repoDir });
         await ensureResultsRepoCommitIdentity(repoDir);
         await runGit(
-          [
-            'commit',
-            '-m',
-            'chore(results): sync local result metadata',
-            '--',
-            RESULTS_REPO_RESULTS_DIR,
-          ],
+          ['commit', '-m', 'chore(results): sync local result metadata', '--', ...trackedDirs],
           {
             cwd: repoDir,
           },
@@ -1894,7 +1918,7 @@ function parseGitBatchBlobs(output: Buffer): GitBatchBlob[] {
 //
 // Manual recovery: if a pod is lost mid-run, an operator can clone the results
 // repo, checkout `agentv/wip/<hostname>/<run-dir>`, and resume with:
-//   cp -r .agentv/results/runs/<run-dir> <local-workspace>
+//   cp -r runs/<run-dir> <local-workspace>
 //   agentv eval <eval-file> --output <local-workspace>/<run-dir> --resume
 
 export function buildWipBranchName(runDir: string): string {
@@ -1983,7 +2007,8 @@ export async function pushWipCheckpoint(params: {
     sourceDir: params.sourceDir,
     destinationDir,
   });
-  await runGit(['add', '--all', '--', RESULTS_REPO_RESULTS_DIR], {
+  const trackedDirs = await existingTrackedResultsDirs(params.handle.worktreeDir);
+  await runGit(['add', '--all', '--', ...trackedDirs], {
     cwd: params.handle.worktreeDir,
   });
   const { stdout: status } = await runGit(['status', '--porcelain'], {
@@ -2013,13 +2038,44 @@ export async function deleteWipBranch(params: {
   await runGit(['push', normalized.remote, '--delete', params.wipBranch], { cwd: cloneDir });
 }
 
-export async function listGitRuns(repoDir: string, ref = 'origin/main'): Promise<GitListedRun[]> {
-  const { stdout: treeOut } = await runGit(
-    ['ls-tree', '-r', '--name-only', ref, RESULTS_REPO_RUNS_DIR],
-    {
-      cwd: repoDir,
-    },
+// git exits non-zero with one of these messages when the requested ref/object
+// does not exist yet — e.g. a configured results branch that has never been
+// pushed. We treat that as "no remote runs" rather than a hard failure.
+function isMissingGitRefError(error: unknown): boolean {
+  const parts: string[] = [];
+  if (error && typeof error === 'object') {
+    const e = error as { stderr?: unknown; message?: unknown };
+    if (typeof e.stderr === 'string') parts.push(e.stderr);
+    if (typeof e.message === 'string') parts.push(e.message);
+  } else if (typeof error === 'string') {
+    parts.push(error);
+  }
+  const haystack = parts.join('\n').toLowerCase();
+  return (
+    haystack.includes('not a valid object name') ||
+    haystack.includes('unknown revision or path') ||
+    haystack.includes('bad revision') ||
+    haystack.includes('does not exist')
   );
+}
+
+export async function listGitRuns(repoDir: string, ref = 'origin/main'): Promise<GitListedRun[]> {
+  let treeOut: string;
+  try {
+    ({ stdout: treeOut } = await runGit(
+      ['ls-tree', '-r', '--name-only', ref, RESULTS_REPO_RUNS_DIR],
+      {
+        cwd: repoDir,
+      },
+    ));
+  } catch (error) {
+    // A not-yet-created results branch is an empty result, not an error. This
+    // keeps the Dashboard's remote-results poll quiet before the first push.
+    if (isMissingGitRefError(error)) {
+      return [];
+    }
+    throw error;
+  }
 
   const benchmarkPaths = treeOut
     .split(/\r?\n/)

--- a/packages/core/test/evaluation/results-repo.test.ts
+++ b/packages/core/test/evaluation/results-repo.test.ts
@@ -115,14 +115,7 @@ describe('listGitRuns', () => {
   });
 
   it('returns committed runs derived from benchmark.json blobs', async () => {
-    const defaultRunDir = path.join(
-      repoDir,
-      '.agentv',
-      'results',
-      'runs',
-      'default',
-      '2026-05-20T10-00-00-000Z',
-    );
+    const defaultRunDir = path.join(repoDir, 'runs', 'default', '2026-05-20T10-00-00-000Z');
     mkdirSync(defaultRunDir, { recursive: true });
     writeFileSync(
       path.join(defaultRunDir, 'benchmark.json'),
@@ -144,14 +137,7 @@ describe('listGitRuns', () => {
       ),
     );
 
-    const experimentRunDir = path.join(
-      repoDir,
-      '.agentv',
-      'results',
-      'runs',
-      'with-skills',
-      '2026-05-21T11-00-00-000Z',
-    );
+    const experimentRunDir = path.join(repoDir, 'runs', 'with-skills', '2026-05-21T11-00-00-000Z');
     mkdirSync(experimentRunDir, { recursive: true });
     writeFileSync(
       path.join(experimentRunDir, 'benchmark.json'),
@@ -178,7 +164,7 @@ describe('listGitRuns', () => {
       ),
     );
 
-    git('git add .agentv && git commit -m "seed runs"', repoDir);
+    git('git add runs && git commit -m "seed runs"', repoDir);
 
     const runs = await listGitRuns(repoDir, 'HEAD');
 
@@ -191,8 +177,8 @@ describe('listGitRuns', () => {
       experiment: 'with-skills',
       timestamp: '2026-05-21T11:00:00.000Z',
       display_name: 'remote friendly run',
-      manifest_path: '.agentv/results/runs/with-skills/2026-05-21T11-00-00-000Z/index.jsonl',
-      benchmark_path: '.agentv/results/runs/with-skills/2026-05-21T11-00-00-000Z/benchmark.json',
+      manifest_path: 'runs/with-skills/2026-05-21T11-00-00-000Z/index.jsonl',
+      benchmark_path: 'runs/with-skills/2026-05-21T11-00-00-000Z/benchmark.json',
       test_count: 3,
       pass_rate: 0.75,
       avg_score: 0,
@@ -202,7 +188,7 @@ describe('listGitRuns', () => {
       experiment: 'default',
       display_name: '2026-05-20T10-00-00-000Z',
       target: 'gpt-4o',
-      manifest_path: '.agentv/results/runs/default/2026-05-20T10-00-00-000Z/index.jsonl',
+      manifest_path: 'runs/default/2026-05-20T10-00-00-000Z/index.jsonl',
       test_count: 2,
       pass_rate: 0.5,
     });
@@ -216,15 +202,15 @@ describe('listGitRuns', () => {
     await expect(listGitRuns(repoDir, 'HEAD')).resolves.toEqual([]);
   });
 
+  it('returns an empty list when the configured ref does not exist yet', async () => {
+    writeFileSync(path.join(repoDir, 'README.md'), '# test\n');
+    git('git add README.md && git commit -m "initial"', repoDir);
+
+    await expect(listGitRuns(repoDir, 'agentv/results/v1')).resolves.toEqual([]);
+  });
+
   it('ignores inherited git hook environment variables', async () => {
-    const runDir = path.join(
-      repoDir,
-      '.agentv',
-      'results',
-      'runs',
-      'default',
-      '2026-05-20T10-00-00-000Z',
-    );
+    const runDir = path.join(repoDir, 'runs', 'default', '2026-05-20T10-00-00-000Z');
     mkdirSync(runDir, { recursive: true });
     writeFileSync(
       path.join(runDir, 'benchmark.json'),
@@ -245,7 +231,7 @@ describe('listGitRuns', () => {
         2,
       ),
     );
-    git('git add .agentv && git commit -m "seed run"', repoDir);
+    git('git add runs && git commit -m "seed run"', repoDir);
 
     const previousGitDir = process.env.GIT_DIR;
     const previousGitWorkTree = process.env.GIT_WORK_TREE;
@@ -272,14 +258,7 @@ describe('listGitRuns', () => {
   });
 
   it('materializes an entire run subtree atomically from git objects', async () => {
-    const runDir = path.join(
-      repoDir,
-      '.agentv',
-      'results',
-      'runs',
-      'with-files',
-      '2026-05-22T10-00-00-000Z',
-    );
+    const runDir = path.join(repoDir, 'runs', 'with-files', '2026-05-22T10-00-00-000Z');
     mkdirSync(path.join(runDir, 'attachments'), { recursive: true });
     writeFileSync(path.join(runDir, 'index.jsonl'), '{"test_id":"alpha"}\n');
     writeFileSync(
@@ -299,7 +278,7 @@ describe('listGitRuns', () => {
       }),
     );
     writeFileSync(path.join(runDir, 'attachments', 'response.md'), 'hello from git\n');
-    git('git add .agentv && git commit -m "seed run with files"', repoDir);
+    git('git add runs && git commit -m "seed run with files"', repoDir);
 
     rmSync(runDir, { recursive: true, force: true });
 
@@ -317,17 +296,10 @@ describe('listGitRuns', () => {
     const defaultBranch = git('git branch --show-current', repoDir);
     git('git checkout -b agentv-results', repoDir);
 
-    const runDir = path.join(
-      repoDir,
-      '.agentv',
-      'results',
-      'runs',
-      'branch-only',
-      '2026-06-12T10-00-00-000Z',
-    );
+    const runDir = path.join(repoDir, 'runs', 'branch-only', '2026-06-12T10-00-00-000Z');
     writeRunArtifacts(runDir, 'branch-only', '2026-06-12T10:00:00.000Z');
     writeFileSync(path.join(runDir, 'attachments.txt'), 'from branch\n');
-    git('git add .agentv && git commit -m "seed branch run"', repoDir);
+    git('git add runs && git commit -m "seed branch run"', repoDir);
     git(`git checkout ${defaultBranch}`, repoDir);
 
     const runs = await listGitRuns(repoDir, 'agentv-results');
@@ -400,9 +372,7 @@ describe('results repo write path', () => {
     expect(published).toBe(true);
     expect(git('git branch --show-current', projectDir)).toBe('main');
     const branchFiles = git(`git ls-tree -r --name-only ${DEFAULT_RESULTS_BRANCH}`, projectDir);
-    expect(branchFiles).toContain(
-      `.agentv/results/runs/current-repo/${runTimestamp}/benchmark.json`,
-    );
+    expect(branchFiles).toContain(`runs/current-repo/${runTimestamp}/benchmark.json`);
     expect(branchFiles).not.toContain('README.md');
     expect(branchFiles).not.toContain('UNRELATED.txt');
     expect(git('git status --short --branch', projectDir)).toContain('## main');
@@ -437,7 +407,7 @@ describe('results repo write path', () => {
     expect(published).toBe(true);
     expect(git('git branch --show-current', resultsRepoDir)).toBe('main');
     const branchFiles = git(`git ls-tree -r --name-only ${DEFAULT_RESULTS_BRANCH}`, resultsRepoDir);
-    expect(branchFiles).toContain(`.agentv/results/runs/external/${runTimestamp}/index.jsonl`);
+    expect(branchFiles).toContain(`runs/external/${runTimestamp}/index.jsonl`);
     expect(branchFiles).not.toContain('README.md');
   }, 20000);
 
@@ -468,7 +438,7 @@ describe('results repo write path', () => {
     ).rejects.toThrow(/simulated interrupted push/);
     expect(git('git rev-list --count origin/main..main', cloneDir)).toBe('1');
     expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir)).not.toContain(
-      `.agentv/results/runs/retry/${runTimestamp}/benchmark.json`,
+      `runs/retry/${runTimestamp}/benchmark.json`,
     );
 
     rmSync(hookPath, { force: true });
@@ -484,7 +454,7 @@ describe('results repo write path', () => {
 
     expect(git('git rev-list --count origin/main..main', cloneDir)).toBe('0');
     expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir)).toContain(
-      `.agentv/results/runs/retry/${runTimestamp}/benchmark.json`,
+      `runs/retry/${runTimestamp}/benchmark.json`,
     );
     expect(git(`git --git-dir "${remoteDir}" log -1 --pretty=%B main`, rootDir)).toContain(
       `AgentV-Run: retry::${runTimestamp}`,
@@ -520,7 +490,7 @@ describe('results repo write path', () => {
       `AgentV-Run: with-skills::${runTimestamp}`,
     );
     expect(git('git ls-tree -r --name-only main', cloneDir)).toContain(
-      `.agentv/results/runs/with-skills/${runTimestamp}/index.jsonl`,
+      `runs/with-skills/${runTimestamp}/index.jsonl`,
     );
 
     const runs = await listGitRuns(cloneDir, 'main');
@@ -555,11 +525,11 @@ describe('results repo write path', () => {
     expect(pushed).toBe(true);
     expect(git('git branch --show-current', cloneDir)).toBe('main');
     expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir)).not.toContain(
-      `.agentv/results/runs/branch-storage/${runTimestamp}/benchmark.json`,
+      `runs/branch-storage/${runTimestamp}/benchmark.json`,
     );
     expect(
       git(`git --git-dir "${remoteDir}" ls-tree -r --name-only ${storageBranch}`, rootDir),
-    ).toContain(`.agentv/results/runs/branch-storage/${runTimestamp}/benchmark.json`);
+    ).toContain(`runs/branch-storage/${runTimestamp}/benchmark.json`);
     expect(
       git(`git --git-dir "${remoteDir}" log -1 --pretty=%B ${storageBranch}`, rootDir),
     ).toContain(`AgentV-Run: branch-storage::${runTimestamp}`);
@@ -588,7 +558,7 @@ describe('results repo write path', () => {
     );
     expect(
       git(`git --git-dir "${remoteDir}" ls-tree -r --name-only agentv-results`, rootDir),
-    ).toContain('.agentv/results/runs/missing-branch/2026-06-12T11-00-00-000Z/benchmark.json');
+    ).toContain('runs/missing-branch/2026-06-12T11-00-00-000Z/benchmark.json');
   }, 20000);
 
   it('syncResultsRepo refreshes refs without checking out the base branch', async () => {
@@ -627,16 +597,9 @@ describe('results repo write path', () => {
       behind: 0,
     });
 
-    const localRunDir = path.join(
-      cloneDir,
-      '.agentv',
-      'results',
-      'runs',
-      'local-only',
-      '2026-05-23T10-00-00-000Z',
-    );
+    const localRunDir = path.join(cloneDir, 'runs', 'local-only', '2026-05-23T10-00-00-000Z');
     writeRunArtifacts(localRunDir, 'local-only', '2026-05-23T10:00:00.000Z');
-    git('git add .agentv && git commit --quiet -m "local result"', cloneDir);
+    git('git add runs && git commit --quiet -m "local result"', cloneDir);
 
     await expect(getResultsRepoSyncStatus(config)).resolves.toMatchObject({
       sync_status: 'ahead',
@@ -724,7 +687,7 @@ describe('results repo write path', () => {
     git('git config user.name "Test User"', cloneDir);
 
     const runTimestamp = '2026-05-24T10-00-00-000Z';
-    const runDir = path.join(cloneDir, '.agentv', 'results', 'runs', 'metadata', runTimestamp);
+    const runDir = path.join(cloneDir, 'runs', 'metadata', runTimestamp);
     writeRunArtifacts(runDir, 'metadata', '2026-05-24T10:00:00.000Z');
 
     const status = await syncResultsRepoForProject(config);
@@ -736,7 +699,7 @@ describe('results repo write path', () => {
       blocked: false,
     });
     expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir)).toContain(
-      `.agentv/results/runs/metadata/${runTimestamp}/benchmark.json`,
+      `runs/metadata/${runTimestamp}/benchmark.json`,
     );
   }, 20000);
 
@@ -774,7 +737,7 @@ describe('results repo write path', () => {
     writeFileSync(path.join(cloneDir, 'package.json'), '{"dependencies":{"agentv":"next"}}\n');
 
     const runTimestamp = '2026-05-24T11-00-00-000Z';
-    const runDir = path.join(cloneDir, '.agentv', 'results', 'runs', 'safe-run', runTimestamp);
+    const runDir = path.join(cloneDir, 'runs', 'safe-run', runTimestamp);
     writeRunArtifacts(runDir, 'safe-run', '2026-05-24T11:00:00.000Z');
 
     const status = await syncResultsRepoForProject(config);
@@ -787,7 +750,7 @@ describe('results repo write path', () => {
     });
     expect(status.dirty_paths).toEqual([]);
     expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir)).toContain(
-      `.agentv/results/runs/safe-run/${runTimestamp}/benchmark.json`,
+      `runs/safe-run/${runTimestamp}/benchmark.json`,
     );
     expect(git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir)).not.toContain(
       'package.json',
@@ -809,14 +772,7 @@ describe('results repo write path', () => {
     git('git add package.json', cloneDir);
 
     const runTimestamp = '2026-05-24T11-30-00-000Z';
-    const runDir = path.join(
-      cloneDir,
-      '.agentv',
-      'results',
-      'runs',
-      'staged-unrelated',
-      runTimestamp,
-    );
+    const runDir = path.join(cloneDir, 'runs', 'staged-unrelated', runTimestamp);
     writeRunArtifacts(runDir, 'staged-unrelated', '2026-05-24T11:30:00.000Z');
 
     const status = await syncResultsRepoForProject(config);
@@ -828,9 +784,7 @@ describe('results repo write path', () => {
       blocked: false,
     });
     const remoteFiles = git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir);
-    expect(remoteFiles).toContain(
-      `.agentv/results/runs/staged-unrelated/${runTimestamp}/benchmark.json`,
-    );
+    expect(remoteFiles).toContain(`runs/staged-unrelated/${runTimestamp}/benchmark.json`);
     expect(remoteFiles).not.toContain('package.json');
     expect(git('git status --porcelain', cloneDir)).toContain('A  package.json');
   }, 20000);
@@ -876,14 +830,7 @@ describe('results repo write path', () => {
     git('git push --quiet origin main', seedDir);
 
     const runTimestamp = '2026-05-24T12-00-00-000Z';
-    const runDir = path.join(
-      cloneDir,
-      '.agentv',
-      'results',
-      'runs',
-      'pulled-then-pushed',
-      runTimestamp,
-    );
+    const runDir = path.join(cloneDir, 'runs', 'pulled-then-pushed', runTimestamp);
     writeRunArtifacts(runDir, 'pulled-then-pushed', '2026-05-24T12:00:00.000Z');
 
     const status = await syncResultsRepoForProject(config);
@@ -897,9 +844,7 @@ describe('results repo write path', () => {
     });
     const remoteFiles = git(`git --git-dir "${remoteDir}" ls-tree -r --name-only main`, rootDir);
     expect(remoteFiles).toContain('REMOTE.md');
-    expect(remoteFiles).toContain(
-      `.agentv/results/runs/pulled-then-pushed/${runTimestamp}/benchmark.json`,
-    );
+    expect(remoteFiles).toContain(`runs/pulled-then-pushed/${runTimestamp}/benchmark.json`);
     expect(remoteFiles).not.toContain('package.json');
     expect(readFileSync(path.join(cloneDir, 'package.json'), 'utf8')).toBe(
       '{"dependencies":{"agentv":"next"}}\n',
@@ -915,16 +860,9 @@ describe('results repo write path', () => {
     git('git config user.email "test@example.com"', cloneDir);
     git('git config user.name "Test User"', cloneDir);
 
-    const runDir = path.join(
-      cloneDir,
-      '.agentv',
-      'results',
-      'runs',
-      'local-only',
-      '2026-05-25T10-00-00-000Z',
-    );
+    const runDir = path.join(cloneDir, 'runs', 'local-only', '2026-05-25T10-00-00-000Z');
     writeRunArtifacts(runDir, 'local-only', '2026-05-25T10:00:00.000Z');
-    git('git add .agentv && git commit --quiet -m "local result"', cloneDir);
+    git('git add runs && git commit --quiet -m "local result"', cloneDir);
 
     writeFileSync(path.join(seedDir, 'REMOTE.md'), 'remote update\n');
     git('git add REMOTE.md && git commit --quiet -m "remote update"', seedDir);
@@ -945,8 +883,6 @@ describe('results repo write path', () => {
     const cloneDir = path.join(rootDir, 'results-clone');
     const config = { ...createResultsConfig(remoteDir, cloneDir), auto_push: false };
     const relativeMetadataPath = path.join(
-      '.agentv',
-      'results',
       'metadata',
       'runs',
       'stale-error',
@@ -969,17 +905,17 @@ describe('results repo write path', () => {
     expect(dirtyStatus.block_reason).toContain('auto_push is disabled');
 
     git('git reset --hard --quiet', cloneDir);
-    git('git clean -fd --quiet .agentv', cloneDir);
+    git('git clean -fd --quiet metadata', cloneDir);
 
     writeTags(seedDir, ['base']);
-    git('git add .agentv && git commit --quiet -m "seed tag metadata"', seedDir);
+    git('git add metadata && git commit --quiet -m "seed tag metadata"', seedDir);
     git('git push --quiet origin main', seedDir);
     git('git pull --ff-only --quiet', cloneDir);
 
     writeTags(cloneDir, ['local']);
-    git('git add .agentv && git commit --quiet -m "local tag metadata"', cloneDir);
+    git('git add metadata && git commit --quiet -m "local tag metadata"', cloneDir);
     writeTags(seedDir, ['remote']);
-    git('git add .agentv && git commit --quiet -m "remote tag metadata"', seedDir);
+    git('git add metadata && git commit --quiet -m "remote tag metadata"', seedDir);
     git('git push --quiet origin main', seedDir);
     git('git fetch --quiet origin --prune', cloneDir);
     git('git merge origin/main || true', cloneDir);


### PR DESCRIPTION
## Summary

Git-native results storage cleanups, found while dogfooding the multi-project Dashboard with `results: { repo_path: ., branch: agentv/results/v1, sync: { auto_push: true } }`.

### 1. Flatten the on-branch results layout
On the results branch the run tree already lives under a dedicated branch (`agentv/results/v1`), so the `.agentv/results/` prefix was redundant. Runs now publish to `runs/<experiment>/<timestamp>/…` (was `.agentv/results/runs/…`), and the coupled tag/metadata sidecar to `metadata/runs/…` (was `.agentv/results/metadata/runs/…`). Branch root is now just `runs/` + `metadata/`.

- **Scope guard:** the local working-tree run workspace stays `.agentv/results/runs/` (unchanged for `agentv eval --output`, inspect/trend/export/serve, etc.). Only the on-branch / results-repo-clone storage path is flattened.
- **Prerelease breaking change:** existing branches written under `.agentv/results/runs/` are not read by the new path (no read-compat fallback; documented per the git-native-results plan).

### 2. Tolerate a missing results branch when listing
Before the first push the results branch doesn't exist, and the Dashboard's remote listing threw + logged a full `git ls-tree … fatal: Not a valid object name` stack on every poll (100+ lines observed). `listGitRuns` now detects the "unknown revision / not a valid object name" class at the boundary and returns `[]`; genuine git failures still propagate.

## Testing
- `bun --filter @agentv/core typecheck` ✅ · `bun --filter agentv typecheck` ✅ · `bun run lint` ✅
- Tests: core **1900** pass / 0 fail, CLI **621** / 0, dashboard **97** / 0 (incl. new missing-branch + flat-layout round-trip tests).
- Manual dogfood (built core, via Dashboard eval-run): published run lands flat at `runs/default/<ts>/…` (branch root tree = `runs`); listing a non-existent branch returns no runs with **zero** error-log spam; source working tree untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
