### PR TITLE
docs(sdk): update public guidance for sdk migration

### DIFF
--- a/apps/web/src/content/docs/docs/evaluation/sdk.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/sdk.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 6
 ---
 
-YAML remains AgentV's canonical, portable eval format. The SDK surfaces below are for cases where you want to generate YAML-shaped definitions in code, embed eval runs inside another application, or write executable graders and prompt templates.
+YAML remains AgentV's canonical, portable eval format. The SDK surfaces below are for cases where you want to generate YAML-shaped definitions in code, embed eval runs inside another application, or write executable graders and prompt templates. For authoring helpers, `@agentv/sdk` is AgentV's public lightweight SDK package.
 
 AgentV currently provides two npm packages for programmatic use:
 
@@ -15,12 +15,27 @@ AgentV currently provides two npm packages for programmatic use:
 ## Installation
 
 ```bash
-# Assertion SDK (defineAssertion, defineCodeGrader)
+# Lightweight SDK (defineEval, graders, defineAssertion, defineCodeGrader)
 npm install @agentv/sdk
 
 # Programmatic API (evaluate, defineConfig)
 npm install @agentv/core
 ```
+
+## Migrating from `@agentv/eval`
+
+Use `@agentv/sdk` for all new TypeScript SDK code:
+
+```bash
+npm uninstall @agentv/eval
+npm install @agentv/sdk
+```
+
+```typescript
+import { defineCodeGrader } from '@agentv/sdk';
+```
+
+The general policy is hard convergence for same-week or unreleased surface names: use the correct package, field, or wire name instead of carrying aliases. The package rename is the exception because `@agentv/eval` was already published. It remains a temporary deprecated compatibility package that re-exports `@agentv/sdk` for existing consumers, but it should not appear in new docs, examples, scaffolds, or skills except as migration guidance.
 
 ## Choose a Surface
 
@@ -33,6 +48,41 @@ Use the simplest surface that matches the job:
 - **`defineAssertion` / `defineCodeGrader`** when the grading logic itself must execute code.
 
 There is no separate first-party Python authoring SDK today. Python-facing workflows should either emit canonical YAML/JSONL or implement executable graders that consume the standard `snake_case` wire format.
+
+For example, the repo-local helper in `examples/features/sdk-python/` can build YAML-shaped cases while keeping `assertions` as the durable contract:
+
+```python
+from agentv_py.evals import EvalDefinition, JsonlCase, write_eval_yaml, write_jsonl
+
+
+def rag_faithfulness():
+    return {
+        "name": "rag-faithfulness",
+        "type": "llm-grader",
+        "target": "grader-target",
+        "prompt": "Grade whether the answer is supported by the retrieved context.",
+    }
+
+
+write_jsonl(
+    "evals/dataset.jsonl",
+    [
+        JsonlCase(
+            id="grounded-answer",
+            input=[{"role": "user", "content": "Answer using the retrieved context."}],
+            expected_output=[{"role": "assistant", "content": "The answer cites the source material."}],
+            extra={"assertions": [rag_faithfulness()]},
+        )
+    ],
+)
+
+write_eval_yaml(
+    "evals/dataset.eval.yaml",
+    EvalDefinition(name="rag-suite", tests="./dataset.jsonl"),
+)
+```
+
+This is example-local/repo-local guidance, not a promise of a published Python package.
 
 ## YAML-Aligned `.eval.ts` Authoring
 
@@ -105,6 +155,55 @@ export default defineEval({
 ```
 
 The catalog covers `contains`, `equals`/`exact`, `regex`, `is-json`/`json`, `rubrics`, `llm-grader`, and `code-grader`. CamelCase SDK options such as `minScore`, `maxSteps`, and rubric `scoreRanges` lower to `min_score`, `max_steps`, and `score_ranges` when AgentV loads or serializes the suite.
+
+## AgentV-Native Helper Factories
+
+If you are coming from Braintrust `scores` or DeepEval metrics, keep the reusable logic AgentV-native: write helper factories that return `graders.*` configs, then let `defineEval()` lower them to ordinary `assertions`.
+
+```typescript
+import { defineEval, graders } from '@agentv/sdk';
+
+function ragFaithfulness() {
+  return graders.llmGrader({
+    name: 'rag-faithfulness',
+    target: 'grader-target',
+    prompt: [
+      'Grade whether the answer is supported by the retrieved context.',
+      'Use the input and expected_output fields as grounding evidence.',
+    ].join('\n'),
+  });
+}
+
+export default defineEval({
+  name: 'rag-suite',
+  tests: [
+    {
+      id: 'grounded-answer',
+      input: 'Answer the question using the retrieved context.',
+      expectedOutput: 'The answer cites the source material.',
+      assertions: [
+        graders.contains('source', { name: 'mentions-source' }),
+        ragFaithfulness(),
+      ],
+    },
+  ],
+});
+```
+
+The helper above serializes to the same shape you could write by hand:
+
+```yaml
+assertions:
+  - name: mentions-source
+    type: contains
+    value: source
+  - name: rag-faithfulness
+    type: llm-grader
+    target: grader-target
+    prompt: |-
+      Grade whether the answer is supported by the retrieved context.
+      Use the input and expected_output fields as grounding evidence.
+```
 
 ## Custom Assertions
 

--- a/examples/features/eval-assert-demo/.agentv/graders/keyword-check.ts
+++ b/examples/features/eval-assert-demo/.agentv/graders/keyword-check.ts
@@ -1,27 +1,8 @@
 #!/usr/bin/env bun
-import { defineCodeGrader } from '@agentv/eval';
-
-function getMessageText(
-  messages: readonly { role: string; content?: unknown }[],
-  role = 'assistant',
-): string {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
-    if (msg.role === role) {
-      if (typeof msg.content === 'string') return msg.content;
-      if (Array.isArray(msg.content)) {
-        return msg.content
-          .filter((b: { type?: string }) => b.type === 'text')
-          .map((b: { text?: string }) => b.text)
-          .join('\n');
-      }
-    }
-  }
-  return '';
-}
+import { defineCodeGrader } from '@agentv/sdk';
 
 export default defineCodeGrader(({ output }) => {
-  const outputText = getMessageText(output ?? []);
+  const outputText = output ?? '';
   const lower = outputText.toLowerCase();
   const assertions: Array<{ text: string; passed: boolean }> = [];
 
@@ -37,5 +18,6 @@ export default defineCodeGrader(({ output }) => {
     assertions.push({ text: 'Answer does not mention France', passed: false });
   }
 
-  return { assertions };
+  const passed = assertions.filter((assertion) => assertion.passed).length;
+  return { score: passed / assertions.length, assertions };
 });

--- a/examples/features/eval-assert-demo/.agentv/graders/length-check.ts
+++ b/examples/features/eval-assert-demo/.agentv/graders/length-check.ts
@@ -1,27 +1,8 @@
 #!/usr/bin/env bun
-import { defineCodeGrader } from '@agentv/eval';
-
-function getMessageText(
-  messages: readonly { role: string; content?: unknown }[],
-  role = 'assistant',
-): string {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
-    if (msg.role === role) {
-      if (typeof msg.content === 'string') return msg.content;
-      if (Array.isArray(msg.content)) {
-        return msg.content
-          .filter((b: { type?: string }) => b.type === 'text')
-          .map((b: { text?: string }) => b.text)
-          .join('\n');
-      }
-    }
-  }
-  return '';
-}
+import { defineCodeGrader } from '@agentv/sdk';
 
 export default defineCodeGrader(({ output }) => {
-  const outputText = getMessageText(output ?? []);
+  const outputText = output ?? '';
   const wordCount = outputText.split(/\s+/).filter(Boolean).length;
   const assertions: Array<{ text: string; passed: boolean }> = [];
 
@@ -37,5 +18,6 @@ export default defineCodeGrader(({ output }) => {
     assertions.push({ text: `Answer has ${wordCount} words (> 50, too verbose)`, passed: false });
   }
 
-  return { assertions };
+  const passed = assertions.filter((assertion) => assertion.passed).length;
+  return { score: passed / assertions.length, assertions };
 });

--- a/examples/features/sdk-custom-assertion/.agentv/assertions/word-count.ts
+++ b/examples/features/sdk-custom-assertion/.agentv/assertions/word-count.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { defineAssertion } from '@agentv/eval';
+import { defineAssertion } from '@agentv/sdk';
 
 export default defineAssertion(({ output }) => {
   const outputText = output ?? '';

--- a/examples/features/sdk-eval-authoring/README.md
+++ b/examples/features/sdk-eval-authoring/README.md
@@ -5,8 +5,9 @@ Demonstrates authoring a `.eval.ts` suite with `defineEval()` from `@agentv/sdk`
 ## What It Shows
 
 1. `defineEval()` brands a TypeScript suite for the `.eval.ts` loader.
-2. CamelCase authoring fields such as `inputFiles`, `expectedOutput`, `beforeAll`, and `beforeEach` lower to the canonical YAML/runtime keys.
-3. The suite still runs through the standard CLI and YAML parser path instead of a separate SDK runner.
+2. The `graders` helper catalog returns ordinary `assertions` entries.
+3. CamelCase authoring fields such as `inputFiles`, `expectedOutput`, `beforeAll`, and `beforeEach` lower to the canonical YAML/runtime keys.
+4. The suite still runs through the standard CLI and YAML parser path instead of a separate SDK runner.
 
 ## Files
 

--- a/examples/features/sdk-eval-authoring/evals/greeting.eval.ts
+++ b/examples/features/sdk-eval-authoring/evals/greeting.eval.ts
@@ -1,4 +1,4 @@
-import { defineEval } from '@agentv/sdk';
+import { defineEval, graders } from '@agentv/sdk';
 
 export default defineEval({
   name: 'sdk-eval-authoring',
@@ -20,7 +20,10 @@ export default defineEval({
       input: 'Use the attached notes and say hello.',
       inputFiles: ['../fixtures/per-test-note.md'],
       expectedOutput: 'Hello from the mock target',
-      assertions: [{ type: 'contains', value: 'Hello' }],
+      assertions: [
+        graders.contains('Hello', { name: 'mentions-hello' }),
+        graders.regex(/mock target/i, { name: 'mentions-mock-target' }),
+      ],
       workspace: {
         hooks: {
           beforeEach: {

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,12 +1,27 @@
 # @agentv/sdk
 
-Evaluation SDK for AgentV - build YAML-aligned eval suites, custom graders, and prompt templates around the canonical AgentV eval model.
+Public lightweight SDK for AgentV - build YAML-aligned eval suites, custom graders, and prompt templates around the canonical AgentV eval model.
 
 ## Installation
 
 ```bash
 npm install @agentv/sdk
 ```
+
+## Migrating from `@agentv/eval`
+
+Use `@agentv/sdk` for new code:
+
+```bash
+npm uninstall @agentv/eval
+npm install @agentv/sdk
+```
+
+```typescript
+import { defineCodeGrader } from '@agentv/sdk';
+```
+
+`@agentv/eval` remains only as a temporary deprecated compatibility package that re-exports this SDK for existing consumers. New docs, examples, scaffolds, and skills should not import from it.
 
 ## Quick Start
 
@@ -96,6 +111,33 @@ export default defineEval({
 ```
 
 The helpers return ordinary `assertions` entries such as `type: contains`, `type: llm-grader`, and `type: code-grader`. CamelCase SDK options such as `minScore` and `maxSteps` lower to canonical YAML keys such as `min_score` and `max_steps`.
+
+If you are coming from Braintrust `scores` or DeepEval metrics, model reusable checks as small AgentV-native helper factories that return these grader configs. They still lower to the same YAML/runtime contract:
+
+```typescript
+import { defineEval, graders } from '@agentv/sdk';
+
+function ragFaithfulness() {
+  return graders.llmGrader({
+    name: 'rag-faithfulness',
+    target: 'grader-target',
+    prompt: 'Grade whether the answer is supported by the provided context.',
+  });
+}
+
+export default defineEval({
+  name: 'rag-suite',
+  tests: [
+    {
+      id: 'grounded-answer',
+      input: 'Answer using the retrieved context.',
+      assertions: [ragFaithfulness()],
+    },
+  ],
+});
+```
+
+Python workflows should emit canonical YAML/JSONL or implement code graders over the stdin/stdout contract. The repo-local helper under `examples/features/sdk-python/` is an example, not a promised published Python package.
 
 ## Exports
 

--- a/skills-data/agentv-bench/references/environment-adaptation.md
+++ b/skills-data/agentv-bench/references/environment-adaptation.md
@@ -30,10 +30,11 @@ to any platform with skill-discovery mechanisms. All listed providers support sk
 
 The built-in `skill-trigger` grader covers Claude, Copilot, Pi, Codex and VS Code out
 of the box. For providers with different tool-call formats, write a code-grader that inspects
-the agent's tool call trace.
+the agent's transcript messages or tool call trace.
 
-A code-grader receives the full evaluation context including the agent's output messages and
-tool calls. You can inspect these to determine whether the skill was invoked:
+A code-grader receives the full evaluation context including the final `output` string,
+transcript `messages`, and structured `trace`. Inspect `messages` or `trace.events` for
+tool calls; reserve `output` for final-answer text checks.
 
 ```yaml
 # Example: code-grader for Codex skill-trigger detection
@@ -42,27 +43,32 @@ tests:
     input: "Analyze this CSV file"
     assertions:
       - type: code-grader
-        path: ./judges/codex-skill-trigger.ts
+        command: [bun, run, ./judges/codex-skill-trigger.ts]
 ```
 
 ```typescript
 // judges/codex-skill-trigger.ts
 import { defineCodeGrader } from '@agentv/sdk';
 
-export default defineCodeGrader(({ output }) => {
+export default defineCodeGrader(({ messages }) => {
   const skillName = 'csv-analyzer';
-  const toolCalls = (output ?? []).flatMap((msg) => msg.toolCalls ?? []);
+  const toolCalls = messages.flatMap((msg) => msg.toolCalls ?? []);
   const firstTool = toolCalls[0];
 
   if (!firstTool) {
-    return { score: 0, reason: 'No tool calls recorded' };
+    return { score: 0, assertions: [{ text: 'No tool calls recorded', passed: false }] };
   }
 
   // Codex reads skill files via shell commands
   if (firstTool.tool === 'command_execution') {
     const cmd = String(firstTool.input ?? '');
     if (cmd.includes(skillName)) {
-      return { score: 1, reason: `Skill "${skillName}" triggered via command: ${cmd}` };
+      return {
+        score: 1,
+        assertions: [
+          { text: `Skill "${skillName}" triggered via command`, passed: true, evidence: cmd },
+        ],
+      };
     }
   }
 
@@ -70,11 +76,23 @@ export default defineCodeGrader(({ output }) => {
   if (firstTool.tool === 'file_change') {
     const path = String((firstTool.input as Record<string, unknown>)?.path ?? '');
     if (path.includes(skillName)) {
-      return { score: 1, reason: `Skill file accessed: ${path}` };
+      return {
+        score: 1,
+        assertions: [{ text: 'Skill file accessed', passed: true, evidence: path }],
+      };
     }
   }
 
-  return { score: 0, reason: `First tool was "${firstTool.tool}" — not a skill invocation for "${skillName}"` };
+  return {
+    score: 0,
+    assertions: [
+      {
+        text: `First tool was not a skill invocation for "${skillName}"`,
+        passed: false,
+        evidence: firstTool.tool,
+      },
+    ],
+  };
 });
 ```
 

--- a/skills-data/agentv-bench/references/eval-yaml-spec.md
+++ b/skills-data/agentv-bench/references/eval-yaml-spec.md
@@ -219,7 +219,7 @@ Each line in the results JSONL file is an `EvaluationResult` object. In JSONL, f
 - `test_id` (string)
 - `score` (number, 0.0-1.0, weighted average of all assertion scores)
 - `assertions` (array of `{text, passed, evidence?}`)
-- `output` (Message[]) — agent output messages
+- `output` (string) — final answer/scored result; transcript evidence is available through captured trace/messages when present
 - `execution_status` (string: `ok` | `quality_failure` | `execution_error`)
 
 ### Optional fields

--- a/skills-data/agentv-eval-writer/SKILL.md
+++ b/skills-data/agentv-eval-writer/SKILL.md
@@ -18,6 +18,8 @@ Comprehensive docs: https://agentv.dev
 
 Treat YAML as the canonical portable model. Prefer authoring `.eval.yaml` / `EVAL.yaml` first, then use TypeScript helpers, Python scripts, or executable graders only when they lower to the same fields or when the evaluation logic must actually run code.
 
+Use `@agentv/sdk` for TypeScript helper imports. Do not use `@agentv/eval` for new evals, examples, scaffolds, or skill guidance; it is only a deprecated compatibility shim for existing consumers during migration.
+
 ## Evaluation Types
 
 AgentV evaluations measure **execution quality** — whether your agent or skill produces correct output when invoked.
@@ -567,9 +569,47 @@ agentv validate <file.yaml>
 
 **Replay targets:** Add `provider: replay`, `fixtures: <jsonl>`, and `source_target: <live target name>` in `.agentv/targets.yaml`. Optional `suite`, `eval_path`, and `variant` tighten lookup. The eval YAML and graders stay unchanged; replay only substitutes recorded target output, and graders run fresh.
 
-## Code Judge SDK
+## TypeScript SDK Helpers
 
-Use `@agentv/sdk` to build custom graders in TypeScript/JavaScript:
+Use `@agentv/sdk` as the public lightweight SDK package for TypeScript/JavaScript helpers. SDK helpers must stay AgentV-native and lower to YAML/runtime contracts rather than introducing a second eval vocabulary.
+
+### YAML-aligned eval authoring
+```typescript
+import { defineEval, graders } from '@agentv/sdk';
+
+export default defineEval({
+  name: 'helper-suite',
+  execution: { targets: ['default'] },
+  tests: [
+    {
+      id: 'json-answer',
+      input: 'Return a JSON answer with a status field.',
+      assertions: [
+        graders.json({ name: 'valid-json', required: true }),
+        graders.regex(/"status"\s*:/, { name: 'status-key' }),
+      ],
+    },
+  ],
+});
+```
+
+The `graders` catalog returns ordinary `assertions` entries such as `type: is-json`, `type: regex`, `type: llm-grader`, and `type: code-grader`. `defineEval()` lowers camelCase TypeScript fields such as `expectedOutput`, `inputFiles`, and `maxSteps` to canonical snake_case YAML/runtime keys.
+
+If adapting Braintrust `scores` or DeepEval metrics, write small AgentV helper factories that return `graders.*` configs:
+
+```typescript
+import { graders } from '@agentv/sdk';
+
+export function ragFaithfulness() {
+  return graders.llmGrader({
+    name: 'rag-faithfulness',
+    target: 'grader-target',
+    prompt: 'Grade whether the answer is supported by the retrieved context.',
+  });
+}
+```
+
+Use the helper in `assertions: [ragFaithfulness()]`; do not create new YAML terms like `scores`.
 
 ### defineAssertion (recommended for custom checks)
 ```typescript
@@ -604,7 +644,7 @@ export default defineCodeGrader(({ output, trace }) => {
 });
 ```
 
-Both are used via `type: code-grader` in YAML with `command: [bun, run, grader.ts]`.
+`defineAssertion()` files go in `.agentv/assertions/` and are referenced by filename as `type: <name>`. `defineCodeGrader()` scripts are referenced in YAML with `type: code-grader` and `command: [bun, run, grader.ts]`.
 
 ### Convention-Based Discovery
 

--- a/skills-data/agentv-eval-writer/references/custom-evaluators.md
+++ b/skills-data/agentv-eval-writer/references/custom-evaluators.md
@@ -49,13 +49,21 @@
 
 `score` (0.0-1.0) required. `assertions` and `details` optional.
 
-## SDK Functions
+## TypeScript SDK Functions
 
 ```typescript
-import { defineCodeGrader, createTargetClient, definePromptTemplate } from '@agentv/sdk';
+import {
+  createTargetClient,
+  defineCodeGrader,
+  defineEval,
+  definePromptTemplate,
+  graders,
+} from '@agentv/sdk';
 ```
 
 - `defineCodeGrader(fn)` - Wraps evaluation function with stdin/stdout handling
+- `defineEval(definition)` - Defines a YAML-aligned `.eval.ts` suite
+- `graders` - Helper catalog that returns ordinary AgentV `assertions` entries
 - `createTargetClient()` - Returns LLM proxy client (when `target: {}` configured)
   - `.invoke({question, systemPrompt})` - Single LLM call
   - `.invokeBatch(requests)` - Batch LLM calls
@@ -63,7 +71,50 @@ import { defineCodeGrader, createTargetClient, definePromptTemplate } from '@age
   - Raw stdin uses `snake_case`; SDK handlers receive `camelCase`
   - Context fields: `input`, `expectedOutput`, `output`, `messages`, `criteria`, `config`, `trace`, `traceSummary`, `tokenUsage`, `costUsd`, `durationMs`, `startTime`, `endTime`
 
-For Python, the repo-local helper example in `examples/features/sdk-python/` keeps canonical `snake_case` fields and rejects deprecated wire aliases like `output_text`, `input_text`, and `reference_answer`. It is not a separate Python runner; generated evals still run through the AgentV CLI.
+For Python, the repo-local helper example in `examples/features/sdk-python/` keeps canonical `snake_case` fields and rejects deprecated wire aliases like `output_text`, `input_text`, and `reference_answer`. It is not a separate Python runner or a promised published package; generated evals still run through the AgentV CLI.
+
+## YAML-Aligned Helper Example
+
+Use helper factories for reusable Braintrust/DeepEval-inspired checks, but keep the result as AgentV `assertions`:
+
+```typescript
+import { defineEval, graders } from '@agentv/sdk';
+
+function ragFaithfulness() {
+  return graders.llmGrader({
+    name: 'rag-faithfulness',
+    target: 'grader-target',
+    prompt: 'Grade whether the answer is supported by the retrieved context.',
+  });
+}
+
+export default defineEval({
+  name: 'rag-suite',
+  tests: [
+    {
+      id: 'grounded-answer',
+      input: 'Answer using the retrieved context.',
+      assertions: [
+        graders.contains('source', { name: 'mentions-source' }),
+        ragFaithfulness(),
+      ],
+    },
+  ],
+});
+```
+
+The helper lowers to ordinary YAML:
+
+```yaml
+assertions:
+  - name: mentions-source
+    type: contains
+    value: source
+  - name: rag-faithfulness
+    type: llm-grader
+    target: grader-target
+    prompt: Grade whether the answer is supported by the retrieved context.
+```
 
 ## Python Example
 

--- a/skills-data/agentv-eval-writer/references/python-helpers.md
+++ b/skills-data/agentv-eval-writer/references/python-helpers.md
@@ -1,6 +1,6 @@
 # Repo-Local Python Helpers
 
-AgentV's Python authoring surface is currently a repo-local helper example under `examples/features/sdk-python/`.
+AgentV's Python authoring surface is currently a repo-local helper example under `examples/features/sdk-python/`. It is not a promised published Python package.
 
 Use it when the user wants Python-based custom graders or wants to emit AgentV YAML/JSONL from Python without introducing a Python-native runner.
 
@@ -10,6 +10,7 @@ Use it when the user wants Python-based custom graders or wants to emit AgentV Y
 - Do not accept deprecated wire aliases like `output_text`, `input_text`, or `reference_answer`.
 - Keep Python eval authoring YAML-shaped. Mirror `execution`, `tests`, `assertions`, `expected_output`, and related AgentV keys directly.
 - Run evals through the AgentV CLI, not through a separate Python runtime.
+- If adapting Braintrust or DeepEval patterns, write Python functions that return ordinary AgentV assertion dictionaries rather than new terms like `scores`.
 
 ## Available helpers
 
@@ -44,4 +45,33 @@ def evaluate(context):
 
 if __name__ == "__main__":
     define_code_grader(evaluate)
+```
+
+## YAML helper example
+
+```python
+from agentv_py.evals import EvalDefinition, JsonlCase, write_eval_yaml, write_jsonl
+
+
+def rag_faithfulness():
+    return {
+        "name": "rag-faithfulness",
+        "type": "llm-grader",
+        "target": "grader-target",
+        "prompt": "Grade whether the answer is supported by the retrieved context.",
+    }
+
+
+write_jsonl(
+    "evals/dataset.jsonl",
+    [
+        JsonlCase(
+            id="grounded-answer",
+            input=[{"role": "user", "content": "Answer using context."}],
+            expected_output=[{"role": "assistant", "content": "Answer cites context."}],
+            extra={"assertions": [rag_faithfulness()]},
+        )
+    ],
+)
+write_eval_yaml("evals/dataset.eval.yaml", EvalDefinition(name="rag-suite", tests="./dataset.jsonl"))
 ```


### PR DESCRIPTION
## Summary

AgentV guidance now treats `@agentv/sdk` as the lightweight public SDK package, with `@agentv/eval` documented only as a temporary deprecated compatibility shim for existing consumers. This closes the public-docs and AI-facing guidance side of Bead `av-bv4.15`.

The docs, SDK README, examples, and bundled skills now show YAML-aligned helper patterns using `defineEval()` and the `graders` catalog, plus repo-local Python helper examples that emit canonical AgentV YAML/JSONL without promising a published Python package. The stale demo imports now use `@agentv/sdk`, and the eval-assert demo graders read `output` as the final answer string and return explicit scores.

## Validation

- `bun run validate:examples` — 62 valid, 0 invalid
- `bun --filter @agentv/web build`
- `bun apps/cli/src/cli.ts validate evals/agentv-dev/skills/*.eval.yaml`
- `bun test apps/cli/test/unit/skills.test.ts`
- `bun apps/cli/src/cli.ts skills get agentv-eval-writer --ref custom-evaluators > /tmp/agentv-eval-writer-custom-evaluators.md`
- `bun --filter @agentv/core build`
- `bun --filter @agentv/sdk build`
- `bun --filter @agentv/sdk test`
- `bun apps/cli/src/cli.ts eval examples/features/sdk-eval-authoring/evals/greeting.eval.ts`
- Manual stdin checks for `examples/features/eval-assert-demo/.agentv/graders/{keyword-check,length-check}.ts`
- `bun run lint`
- Focused greps for stale primary `@agentv/eval` guidance; remaining hits are compatibility package code, build/test package references, ADR, or explicit migration/deprecation notes
- Docs link check: CI uses `lychee-action`; local `lychee` binary is not installed in this worktree, so the PR CI link job remains the authoritative link check

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because this is docs, examples, and skill guidance only. Watch the PR docs build/link CI jobs and any SDK migration feedback on the PR for 48 hours. Healthy signal: docs build/link checks pass and no reviewer finds stale primary `@agentv/eval` guidance. Failure signal: link checker failures or stale package guidance; mitigation is a follow-up docs patch before marking the PR ready.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5 Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
