### PR TITLE
fix(dashboard): replace source filter with per-run remote indicator

### DIFF
--- a/apps/cli/src/commands/results/remote.ts
+++ b/apps/cli/src/commands/results/remote.ts
@@ -80,6 +80,14 @@ export type RunSource = 'local' | 'remote';
 export interface SourcedResultFileMeta extends ResultFileMeta {
   readonly source: RunSource;
   readonly raw_filename: string;
+  /**
+   * True when this run is present on the configured remote results branch.
+   * A run synced to the remote keeps `source: 'local'` (the local copy is
+   * preferred for reads) but still records `on_remote: true`, so the Dashboard
+   * can show a per-run "on remote" indicator instead of an exclusive
+   * local/remote filter. This is the flag the run-count summary derives from.
+   */
+  readonly on_remote: boolean;
 }
 
 export interface RemoteEvalSummary {
@@ -342,9 +350,19 @@ function dedupeSyncedRunCopies(runs: SourcedResultFileMeta[]): SourcedResultFile
 
   for (const run of runs) {
     const existing = byRunId.get(run.raw_filename);
-    if (!existing || (existing.source === 'remote' && run.source === 'local')) {
+    if (!existing) {
       byRunId.set(run.raw_filename, run);
+      continue;
     }
+    // A run can appear once locally and once on the remote branch. Keep the
+    // local copy (it is materialized on disk and readable), but remember that
+    // the run is also present remotely so the per-run "on remote" indicator
+    // and the summary count stay accurate for synced runs.
+    const preferred = existing.source === 'remote' && run.source === 'local' ? run : existing;
+    byRunId.set(run.raw_filename, {
+      ...preferred,
+      on_remote: existing.on_remote || run.on_remote,
+    });
   }
 
   return [...byRunId.values()];
@@ -361,6 +379,7 @@ export async function listMergedResultFiles(
         ...meta,
         source: 'local' as const,
         raw_filename: meta.filename,
+        on_remote: false,
       }) satisfies SourcedResultFileMeta,
   );
 
@@ -381,6 +400,7 @@ export async function listMergedResultFiles(
         filename: encodeRemoteRunId(r.run_id),
         raw_filename: r.run_id,
         source: 'remote' as const,
+        on_remote: true,
         path: path.join(config.path, r.manifest_path),
         displayName: r.display_name,
         timestamp: r.timestamp,
@@ -401,6 +421,7 @@ export async function listMergedResultFiles(
               filename: encodeRemoteRunId(meta.filename),
               raw_filename: meta.filename,
               source: 'remote' as const,
+              on_remote: true,
             }) satisfies SourcedResultFileMeta,
         );
       }
@@ -413,6 +434,7 @@ export async function listMergedResultFiles(
           filename: encodeRemoteRunId(meta.filename),
           raw_filename: meta.filename,
           source: 'remote' as const,
+          on_remote: true,
         }) satisfies SourcedResultFileMeta,
     );
   }

--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -599,6 +599,7 @@ async function handleRuns(c: C, { searchDir, agentvDir, projectId }: DataContext
         execution_error_count: executionErrorCount,
         size_bytes: m.sizeBytes,
         source: m.source,
+        on_remote: m.on_remote,
         ...(target && { target }),
         ...(experiment && { experiment }),
         ...tagFields,

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -942,11 +942,15 @@ describe('serve app', () => {
       const res = await app.request('/api/runs');
 
       expect(res.status).toBe(200);
-      const data = (await res.json()) as { runs: Array<{ filename: string; source: string }> };
+      const data = (await res.json()) as {
+        runs: Array<{ filename: string; source: string; on_remote: boolean }>;
+      };
       expect(data.runs).toHaveLength(1);
+      // A local-only run (no remote configured) is not on the remote branch.
       expect(data.runs[0]).toMatchObject({
         filename,
         source: 'local',
+        on_remote: false,
       });
     });
 
@@ -1103,12 +1107,15 @@ describe('serve app', () => {
 
         expect(res.status).toBe(200);
         const data = (await res.json()) as {
-          runs: Array<{ filename: string; source: string }>;
+          runs: Array<{ filename: string; source: string; on_remote: boolean }>;
         };
         expect(data.runs).toHaveLength(1);
+        // A run only present on the remote branch (no local copy) reports
+        // on_remote: true so it still shows with the on-remote indicator.
         expect(data.runs[0]).toMatchObject({
           filename: 'remote::2026-03-26T10-00-00-000Z',
           source: 'remote',
+          on_remote: true,
         });
       } finally {
         if (previousHome === undefined) {
@@ -1291,12 +1298,17 @@ describe('serve app', () => {
       const listRes = await app.request('/api/runs');
       expect(listRes.status).toBe(200);
       const listData = (await listRes.json()) as {
-        runs: Array<{ filename: string; source: string }>;
+        runs: Array<{ filename: string; source: string; on_remote: boolean }>;
       };
       expect(listData.runs).toHaveLength(1);
+      // A run present both locally and on the remote branch dedupes to a single
+      // row that prefers the local copy but still reports on_remote: true — this
+      // is the per-run flag the Dashboard's "on remote" indicator/count derive
+      // from, so synced runs are no longer hidden.
       expect(listData.runs[0]).toMatchObject({
         filename: runId,
         source: 'local',
+        on_remote: true,
       });
     }, 15000);
 

--- a/apps/dashboard/src/components/RunList.tsx
+++ b/apps/dashboard/src/components/RunList.tsx
@@ -2,8 +2,9 @@
  * Sortable run table component.
  *
  * Displays all available runs with a pass/fail status dot, human-readable name,
- * source badge, date, quality test count, execution-error count, and coloured pass-rate pill.
- * Clicking a row navigates to the run detail view.
+ * a per-run "on remote" indicator (whether the run is backed up to the
+ * configured results branch), date, quality test count, execution-error count,
+ * and coloured pass-rate pill. Clicking a row navigates to the run detail view.
  *
  * On phone-width viewports the rows collapse to dense cards so right-side table
  * data stays visible without touch-scroll hunting. Tablet and desktop keep the
@@ -49,6 +50,8 @@ interface RunListProps {
   isFetchingNextPage?: boolean;
   onLoadMore?: () => void;
   enableCombine?: boolean;
+  /** Configured remote results branch, used for the per-run "on remote" tooltip. */
+  remoteBranch?: string;
 }
 
 interface RunActionFeedback {
@@ -127,6 +130,7 @@ export function RunList({
   isFetchingNextPage = false,
   onLoadMore,
   enableCombine = false,
+  remoteBranch,
 }: RunListProps) {
   const { data: config } = useStudioConfig(projectId);
   const queryClient = useQueryClient();
@@ -433,7 +437,7 @@ export function RunList({
                     </p>
                   ) : null}
                   <div className="mt-2 flex flex-wrap items-center gap-2">
-                    <SourceBadge source={run.source} />
+                    <RemoteIndicator onRemote={run.on_remote === true} branch={remoteBranch} />
                     {metadataDirty ? <PendingSyncBadge /> : null}
                     <span className="text-xs text-gray-500" title={ts.full}>
                       {ts.date}
@@ -458,8 +462,8 @@ export function RunList({
                 <MobileRunMetric label="Errors" valueClassName="text-amber-300">
                   {errors > 0 ? errors : <span className="text-gray-600">0</span>}
                 </MobileRunMetric>
-                <MobileRunMetric label="Source" valueClassName="text-gray-400">
-                  {run.source === 'remote' ? 'Remote' : 'Local'}
+                <MobileRunMetric label="Remote" valueClassName="text-gray-400">
+                  {run.on_remote === true ? 'On remote' : 'Local only'}
                 </MobileRunMetric>
               </dl>
             </article>
@@ -482,7 +486,7 @@ export function RunList({
               {enableCombine && <th className="w-10 px-4 py-3" />}
               <th className="w-8 px-4 py-3" />
               <th className="w-[22rem] px-4 py-3 font-medium text-gray-400">Run</th>
-              <th className="px-4 py-3 font-medium text-gray-400">Source</th>
+              <th className="px-4 py-3 font-medium text-gray-400">Remote</th>
               <th className="px-4 py-3 text-right font-medium text-gray-400">Passed</th>
               <th className="px-4 py-3 text-right font-medium text-gray-400">Failures</th>
               <th className="px-4 py-3 text-right font-medium text-gray-400">Errors</th>
@@ -555,9 +559,9 @@ export function RunList({
                     </div>
                   </td>
 
-                  {/* Source */}
+                  {/* Remote presence */}
                   <td className="px-4 py-3">
-                    <SourceBadge source={run.source} />
+                    <RemoteIndicator onRemote={run.on_remote === true} branch={remoteBranch} />
                   </td>
 
                   {/* Passed / Failed / Total */}
@@ -636,17 +640,68 @@ function RunNameLink({
   );
 }
 
-function SourceBadge({ source }: { source: RunMeta['source'] }) {
+/**
+ * Per-run indicator for whether the run is backed up to the configured remote
+ * results branch. Derived from the same `on_remote` flag that the
+ * "N of M runs on remote" summary counts, so the badge and the count agree.
+ */
+function RemoteIndicator({ onRemote, branch }: { onRemote: boolean; branch?: string }) {
+  if (onRemote) {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-md border border-cyan-900/60 bg-cyan-950/20 px-2 py-0.5 text-xs font-medium text-cyan-300"
+        title={branch ? `On ${branch}` : 'On the remote results branch'}
+        aria-label={branch ? `On remote branch ${branch}` : 'On the remote results branch'}
+      >
+        <CloudCheckIcon />
+        Synced
+      </span>
+    );
+  }
   return (
     <span
-      className={`inline-flex rounded-md border px-2 py-0.5 text-xs font-medium ${
-        source === 'remote'
-          ? 'border-cyan-900/60 bg-cyan-950/20 text-cyan-300'
-          : 'border-gray-800 bg-gray-900/70 text-gray-400'
-      }`}
+      className="inline-flex items-center gap-1 rounded-md border border-gray-800 bg-gray-900/70 px-2 py-0.5 text-xs font-medium text-gray-500"
+      title="Local only — not pushed"
+      aria-label="Local only — not pushed"
     >
-      {source === 'remote' ? 'Remote' : 'Local'}
+      <CloudOutlineIcon />
+      Local only
     </span>
+  );
+}
+
+function CloudCheckIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className="h-3.5 w-3.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M7 18a4 4 0 0 1-.5-7.97A5 5 0 0 1 16 9a3.5 3.5 0 0 1 1 6.86" />
+      <path d="m9 14 2 2 4-4" />
+    </svg>
+  );
+}
+
+function CloudOutlineIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className="h-3.5 w-3.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M7 18a4 4 0 0 1-.5-7.97A5 5 0 0 1 16 9a3.5 3.5 0 0 1 1 6.86" />
+    </svg>
   );
 }
 

--- a/apps/dashboard/src/components/RunSourceToolbar.tsx
+++ b/apps/dashboard/src/components/RunSourceToolbar.tsx
@@ -5,26 +5,23 @@ import {
 } from '~/lib/project-sync-status';
 import type { RemoteStatusResponse } from '~/lib/types';
 
-export type RunSourceFilter = 'all' | 'local' | 'remote';
-
 interface RunSourceToolbarProps {
-  filter: RunSourceFilter;
-  onFilterChange: (filter: RunSourceFilter) => void;
   remoteStatus?: RemoteStatusResponse;
   syncInFlight?: boolean;
   onSync?: () => void;
   projectName?: string;
   syncFeedback?: { kind: 'success' | 'warning' | 'error'; message: string } | null;
+  /** Pre-formatted "N of M runs on remote (branch)" summary derived from the listed runs. */
+  onRemoteSummary?: string;
 }
 
 export function RunSourceToolbar({
-  filter,
-  onFilterChange,
   remoteStatus,
   syncInFlight,
   onSync,
   projectName,
   syncFeedback,
+  onRemoteSummary,
 }: RunSourceToolbarProps) {
   const remoteConfigured = remoteStatus?.configured === true;
   const syncView = getProjectSyncView(remoteStatus, syncInFlight);
@@ -44,32 +41,16 @@ export function RunSourceToolbar({
         : 'border-red-900/60 bg-red-950/20 text-red-300';
   const dirtyPathCount = remoteStatus?.dirty_paths?.length ?? 0;
   const conflictedPathCount = remoteStatus?.conflicted_paths?.length ?? 0;
-  const remoteStatusItems = buildRemoteStatusItems(remoteStatus, projectName);
+  const remoteStatusItems = buildRemoteStatusItems(remoteStatus, projectName, onRemoteSummary);
 
   return (
     <div className="flex flex-col gap-3 rounded-lg border border-gray-800 bg-gray-900/40 p-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex flex-wrap items-center gap-2">
-          {(['all', 'local', 'remote'] as const).map((value) => {
-            const dimmed = value === 'remote' && !remoteConfigured;
-            return (
-              <button
-                key={value}
-                type="button"
-                onClick={() => onFilterChange(value)}
-                title={dimmed ? 'Remote results are not configured' : undefined}
-                className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
-                  filter === value
-                    ? 'bg-cyan-500/20 text-cyan-300'
-                    : dimmed
-                      ? 'bg-gray-800 text-gray-600'
-                      : 'bg-gray-800 text-gray-400 hover:text-gray-200'
-                }`}
-              >
-                {value === 'all' ? 'All Sources' : value === 'local' ? 'Local Only' : 'Remote Only'}
-              </button>
-            );
-          })}
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-gray-200">Recent Runs</p>
+          {remoteConfigured && onRemoteSummary ? (
+            <p className="mt-0.5 text-xs text-gray-500">{onRemoteSummary}</p>
+          ) : null}
         </div>
 
         {remoteConfigured ? (
@@ -122,14 +103,14 @@ export function RunSourceToolbar({
             </div>
           ) : null}
         </div>
-      ) : filter === 'all' ? (
+      ) : (
         <p className="text-sm text-gray-500">
           Remote results are not configured. Add{' '}
           <code className="rounded bg-gray-800 px-1 text-gray-400">results</code> to{' '}
           <code className="rounded bg-gray-800 px-1 text-gray-400">.agentv/config.yaml</code> to
           enable.
         </p>
-      ) : null}
+      )}
 
       {syncFeedback ? (
         <div

--- a/apps/dashboard/src/lib/project-sync-status.test.ts
+++ b/apps/dashboard/src/lib/project-sync-status.test.ts
@@ -4,6 +4,7 @@ import {
   buildProjectSyncErrorFeedback,
   buildProjectSyncFeedback,
   buildRemoteStatusItems,
+  formatOnRemoteSummary,
   formatRemoteRunCount,
   getProjectSyncView,
   shouldPollRemoteStatus,
@@ -159,6 +160,19 @@ describe('formatRemoteRunCount', () => {
   });
 });
 
+describe('formatOnRemoteSummary', () => {
+  it('summarizes how many listed runs are backed up to the branch', () => {
+    expect(formatOnRemoteSummary(2, 3, 'agentv/results/v1')).toBe(
+      '2 of 3 runs on remote (agentv/results/v1)',
+    );
+  });
+
+  it('handles a single run and a missing branch', () => {
+    expect(formatOnRemoteSummary(1, 1)).toBe('1 of 1 run on remote');
+    expect(formatOnRemoteSummary(0, 0)).toBe('0 of 0 runs on remote');
+  });
+});
+
 describe('buildRemoteStatusItems', () => {
   it('includes WTG-like repo, remote run count, and last sync time', () => {
     const items = buildRemoteStatusItems({
@@ -172,6 +186,23 @@ describe('buildRemoteStatusItems', () => {
     expect(items).toContain('1 remote run');
     expect(items).toContain('Repo: WiseTechGlobal/WTG.AI.Prompts.EvalResults');
     expect(items.some((item) => item.startsWith('Last synced '))).toBe(true);
+  });
+
+  it('prefers the on-remote summary over the raw remote run count when provided', () => {
+    const items = buildRemoteStatusItems(
+      {
+        configured: true,
+        available: true,
+        repo: 'WiseTechGlobal/WTG.AI.Prompts.EvalResults',
+        run_count: 5,
+        last_synced_at: '2026-06-06T13:00:00.000Z',
+      },
+      undefined,
+      '2 of 3 runs on remote (agentv/results/v1)',
+    );
+
+    expect(items).toContain('2 of 3 runs on remote (agentv/results/v1)');
+    expect(items).not.toContain('5 remote runs');
   });
 });
 

--- a/apps/dashboard/src/lib/project-sync-status.ts
+++ b/apps/dashboard/src/lib/project-sync-status.ts
@@ -47,9 +47,24 @@ export function formatRemoteRunCount(count?: number): string {
   return `${count} remote run${count === 1 ? '' : 's'}`;
 }
 
+/**
+ * Summarizes how many of the listed runs are backed up to the remote results
+ * branch. Both counts derive from the same per-run `on_remote` flag that drives
+ * the row indicators, so the summary can never disagree with the badged rows.
+ */
+export function formatOnRemoteSummary(
+  onRemoteCount: number,
+  totalCount: number,
+  branch?: string,
+): string {
+  const branchSuffix = branch ? ` (${branch})` : '';
+  return `${onRemoteCount} of ${totalCount} run${totalCount === 1 ? '' : 's'} on remote${branchSuffix}`;
+}
+
 export function buildRemoteStatusItems(
   status: RemoteStatusResponse | undefined,
   projectName?: string,
+  onRemoteSummary?: string,
 ): string[] {
   if (status?.configured !== true) {
     return [];
@@ -57,7 +72,7 @@ export function buildRemoteStatusItems(
 
   return [
     projectName ? `Project: ${projectName}` : undefined,
-    formatRemoteRunCount(status.run_count),
+    onRemoteSummary ?? formatRemoteRunCount(status.run_count),
     formatLastSynced(status.last_synced_at),
     status.repo ? `Repo: ${status.repo}` : undefined,
   ].filter((item): item is string => item !== undefined);

--- a/apps/dashboard/src/lib/run-dedupe.test.ts
+++ b/apps/dashboard/src/lib/run-dedupe.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'bun:test';
 import { dedupeSyncedRuns } from './run-dedupe';
 import type { RunMeta } from './types';
 
-function run(filename: string, source: RunMeta['source']): RunMeta {
+function run(filename: string, source: RunMeta['source'], onRemote = source === 'remote'): RunMeta {
   return {
     filename,
     display_name: filename,
@@ -14,6 +14,7 @@ function run(filename: string, source: RunMeta['source']): RunMeta {
     avg_score: 1,
     size_bytes: 1024,
     source,
+    on_remote: onRemote,
   };
 }
 
@@ -29,5 +30,28 @@ describe('dedupeSyncedRuns', () => {
       '2026-05-28T08-21-09-063Z',
       'remote::2026-05-27T08-21-09-063Z',
     ]);
+  });
+
+  it('keeps the local copy but preserves remote presence for synced runs', () => {
+    const runs = [
+      run('remote::2026-05-28T08-21-09-063Z', 'remote', true),
+      run('2026-05-28T08-21-09-063Z', 'local', false),
+    ];
+
+    const deduped = dedupeSyncedRuns(runs);
+    expect(deduped).toHaveLength(1);
+    // Local copy wins (readable on disk) but on_remote stays true so the
+    // indicator and the "on remote" count agree for synced runs.
+    expect(deduped[0]).toMatchObject({
+      filename: '2026-05-28T08-21-09-063Z',
+      source: 'local',
+      on_remote: true,
+    });
+  });
+
+  it('leaves a local-only run flagged as not on remote', () => {
+    const deduped = dedupeSyncedRuns([run('2026-05-28T08-21-09-063Z', 'local', false)]);
+    expect(deduped).toHaveLength(1);
+    expect(deduped[0].on_remote).toBe(false);
   });
 });

--- a/apps/dashboard/src/lib/run-dedupe.ts
+++ b/apps/dashboard/src/lib/run-dedupe.ts
@@ -14,9 +14,18 @@ export function dedupeSyncedRuns(runs: readonly RunMeta[]): RunMeta[] {
   for (const run of runs) {
     const key = canonicalRunId(run.filename);
     const existing = byRunId.get(key);
-    if (!existing || (existing.source === 'remote' && run.source === 'local')) {
+    if (!existing) {
       byRunId.set(key, run);
+      continue;
     }
+    // Keep the local copy (it is readable from disk) but preserve remote
+    // presence so the per-run indicator and "on remote" count stay accurate
+    // for runs that exist both locally and on the results branch.
+    const preferred = existing.source === 'remote' && run.source === 'local' ? run : existing;
+    byRunId.set(key, {
+      ...preferred,
+      on_remote: existing.on_remote === true || run.on_remote === true,
+    });
   }
 
   return [...byRunId.values()];

--- a/apps/dashboard/src/lib/types.ts
+++ b/apps/dashboard/src/lib/types.ts
@@ -18,6 +18,13 @@ export interface RunMeta {
   target?: string;
   experiment?: string;
   source: 'local' | 'remote';
+  /**
+   * True when this run is present on the configured remote results branch.
+   * Drives the per-run "Remote" indicator and the "N of M runs on remote"
+   * summary. A run synced to the remote keeps `source: 'local'` but reports
+   * `on_remote: true`, so the indicator and the count always agree.
+   */
+  on_remote?: boolean;
   project_id?: string;
   project_name?: string;
   /** Optional user-assigned tags from the run's sidecar tags.json. */

--- a/apps/dashboard/src/routes/index.tsx
+++ b/apps/dashboard/src/routes/index.tsx
@@ -16,7 +16,7 @@ import { ExperimentsTab } from '~/components/ExperimentsTab';
 import { ProjectCard } from '~/components/ProjectCard';
 import { RunEvalModal } from '~/components/RunEvalModal';
 import { RunList } from '~/components/RunList';
-import { type RunSourceFilter, RunSourceToolbar } from '~/components/RunSourceToolbar';
+import { RunSourceToolbar } from '~/components/RunSourceToolbar';
 import { TargetsTab } from '~/components/TargetsTab';
 import {
   remoteStatusOptions,
@@ -35,7 +35,11 @@ import {
   resolveIndexRoute,
   resolveInitialProjectRedirect,
 } from '~/lib/navigation';
-import { buildProjectSyncErrorFeedback, buildProjectSyncFeedback } from '~/lib/project-sync-status';
+import {
+  buildProjectSyncErrorFeedback,
+  buildProjectSyncFeedback,
+  formatOnRemoteSummary,
+} from '~/lib/project-sync-status';
 import { dedupeSyncedRuns } from '~/lib/run-dedupe';
 import type { ProjectListResponse, ProjectSummary, RunMeta } from '~/lib/types';
 type TabId = StudioTabId;
@@ -227,7 +231,6 @@ function SingleProjectHome() {
   const { data: remoteStatus } = useRemoteStatus();
   const { data: config } = useStudioConfig();
   const [showRunEval, setShowRunEval] = useState(false);
-  const [sourceFilter, setSourceFilter] = useState<RunSourceFilter>('all');
   const [syncInFlight, setSyncInFlight] = useState(false);
   const [syncFeedback, setSyncFeedback] = useState<{
     kind: 'success' | 'warning' | 'error';
@@ -236,10 +239,12 @@ function SingleProjectHome() {
   const isReadOnly = config?.read_only === true;
 
   const activeTab: TabId = tabs.some((t) => t.id === tab) ? (tab as TabId) : 'runs';
-  const filteredRuns =
-    sourceFilter === 'all'
-      ? dedupeSyncedRuns(data?.runs ?? [])
-      : (data?.runs ?? []).filter((run) => run.source === sourceFilter);
+  const runs = dedupeSyncedRuns(data?.runs ?? []);
+  const onRemoteCount = runs.filter((run) => run.on_remote === true).length;
+  const onRemoteSummary =
+    remoteStatus?.configured === true
+      ? formatOnRemoteSummary(onRemoteCount, runs.length, remoteStatus.branch)
+      : undefined;
 
   async function handleSyncRemote() {
     setSyncInFlight(true);
@@ -317,16 +322,15 @@ function SingleProjectHome() {
       {/* Tab content */}
       {activeTab === 'runs' && (
         <RunsTabContent
-          runs={filteredRuns}
+          runs={runs}
           isLoading={isLoading}
           error={error}
-          sourceFilter={sourceFilter}
-          onSourceFilterChange={setSourceFilter}
           remoteStatus={remoteStatus}
           syncInFlight={syncInFlight}
           syncFeedback={syncFeedback}
           onSyncRemote={handleSyncRemote}
           projectName={config?.project_name}
+          onRemoteSummary={onRemoteSummary}
           hasNextPage={hasNextPage}
           isFetchingNextPage={isFetchingNextPage}
           onLoadMore={() => void fetchNextPage()}
@@ -359,13 +363,12 @@ function RunsTabContent({
   runs,
   isLoading,
   error,
-  sourceFilter,
-  onSourceFilterChange,
   remoteStatus,
   syncInFlight,
   syncFeedback,
   onSyncRemote,
   projectName,
+  onRemoteSummary,
   hasNextPage,
   isFetchingNextPage,
   onLoadMore,
@@ -374,13 +377,12 @@ function RunsTabContent({
   runs: RunMeta[];
   isLoading: boolean;
   error: Error | null;
-  sourceFilter: RunSourceFilter;
-  onSourceFilterChange: (filter: RunSourceFilter) => void;
   remoteStatus: ReturnType<typeof useRemoteStatus>['data'];
   syncInFlight: boolean;
   syncFeedback: { kind: 'success' | 'warning' | 'error'; message: string } | null;
   onSyncRemote: () => void;
   projectName?: string;
+  onRemoteSummary?: string;
   hasNextPage: boolean | undefined;
   isFetchingNextPage: boolean;
   onLoadMore: () => void;
@@ -402,48 +404,20 @@ function RunsTabContent({
     <div className="space-y-4">
       <ActiveRunsSection />
       <RunSourceToolbar
-        filter={sourceFilter}
-        onFilterChange={onSourceFilterChange}
         remoteStatus={remoteStatus}
         syncInFlight={syncInFlight}
         onSync={onSyncRemote}
         projectName={projectName}
         syncFeedback={syncFeedback}
+        onRemoteSummary={onRemoteSummary}
       />
       <RunList
         runs={runs}
         enableCombine={!readOnly}
+        remoteBranch={remoteStatus?.branch}
         hasNextPage={hasNextPage}
         isFetchingNextPage={isFetchingNextPage}
         onLoadMore={onLoadMore}
-        emptyMessage={
-          sourceFilter === 'remote' ? (
-            remoteStatus?.configured ? (
-              <>
-                <p className="text-lg text-gray-400">No remote runs found.</p>
-                <p className="mt-2 text-sm text-gray-500">
-                  Sync remote results or run an eval with{' '}
-                  <code className="rounded bg-gray-800 px-2 py-1 text-cyan-400">
-                    sync.auto_push: true
-                  </code>{' '}
-                  in your config.
-                </p>
-              </>
-            ) : (
-              <>
-                <p className="text-lg text-gray-400">Remote results are not configured.</p>
-                <p className="mt-2 text-sm text-gray-500">
-                  Add <code className="rounded bg-gray-800 px-2 py-1 text-cyan-400">results</code>{' '}
-                  to{' '}
-                  <code className="rounded bg-gray-800 px-2 py-1 text-cyan-400">
-                    .agentv/config.yaml
-                  </code>{' '}
-                  to enable remote result syncing.
-                </p>
-              </>
-            )
-          ) : undefined
-        }
       />
     </div>
   );

--- a/apps/dashboard/src/routes/projects/$projectId.tsx
+++ b/apps/dashboard/src/routes/projects/$projectId.tsx
@@ -12,7 +12,7 @@ import { AnalyticsTab } from '~/components/AnalyticsTab';
 import { ExperimentsTab } from '~/components/ExperimentsTab';
 import { RunEvalModal } from '~/components/RunEvalModal';
 import { RunList } from '~/components/RunList';
-import { type RunSourceFilter, RunSourceToolbar } from '~/components/RunSourceToolbar';
+import { RunSourceToolbar } from '~/components/RunSourceToolbar';
 import { TargetsTab } from '~/components/TargetsTab';
 import {
   projectCompareOptions,
@@ -25,7 +25,11 @@ import {
   useStudioConfig,
 } from '~/lib/api';
 import { resolveProjectDisplayName } from '~/lib/project-display-name';
-import { buildProjectSyncErrorFeedback, buildProjectSyncFeedback } from '~/lib/project-sync-status';
+import {
+  buildProjectSyncErrorFeedback,
+  buildProjectSyncFeedback,
+  formatOnRemoteSummary,
+} from '~/lib/project-sync-status';
 import { dedupeSyncedRuns } from '~/lib/run-dedupe';
 
 type TabId = 'runs' | 'experiments' | 'analytics' | 'targets';
@@ -131,7 +135,6 @@ function ProjectRunsTab({
     useInfiniteProjectRunList(projectId);
   const { data: activeRunsData } = useEvalRuns(projectId);
   const { data: remoteStatus } = useRemoteStatus(projectId);
-  const [sourceFilter, setSourceFilter] = useState<RunSourceFilter>('all');
   const [syncInFlight, setSyncInFlight] = useState(false);
   const [syncFeedback, setSyncFeedback] = useState<{
     kind: 'success' | 'warning' | 'error';
@@ -141,10 +144,12 @@ function ProjectRunsTab({
     (run) => run.status === 'starting' || run.status === 'running',
   );
 
-  const filteredRuns =
-    sourceFilter === 'all'
-      ? dedupeSyncedRuns(data?.runs ?? [])
-      : (data?.runs ?? []).filter((run) => run.source === sourceFilter);
+  const runs = dedupeSyncedRuns(data?.runs ?? []);
+  const onRemoteCount = runs.filter((run) => run.on_remote === true).length;
+  const onRemoteSummary =
+    remoteStatus?.configured === true
+      ? formatOnRemoteSummary(onRemoteCount, runs.length, remoteStatus.branch)
+      : undefined;
 
   async function handleSyncRemote() {
     setSyncInFlight(true);
@@ -230,18 +235,18 @@ function ProjectRunsTab({
         </div>
       )}
       <RunSourceToolbar
-        filter={sourceFilter}
-        onFilterChange={setSourceFilter}
         remoteStatus={remoteStatus}
         syncInFlight={syncInFlight}
         onSync={handleSyncRemote}
         projectName={projectName}
         syncFeedback={syncFeedback}
+        onRemoteSummary={onRemoteSummary}
       />
       <RunList
-        runs={filteredRuns}
+        runs={runs}
         projectId={projectId}
         enableCombine={!readOnly}
+        remoteBranch={remoteStatus?.branch}
         hasNextPage={hasNextPage}
         isFetchingNextPage={isFetchingNextPage}
         onLoadMore={() => void fetchNextPage()}


### PR DESCRIPTION
## Summary

Replaces the Dashboard's three-way **All Sources / Local Only / Remote Only** source filter with a single per-run **Remote** indicator, fixing a confusing inconsistency: with results pushed to the branch, the header said "N remote runs · in sync" but clicking **Remote Only** showed "No evaluation runs found."

**Root cause:** runs present both locally and on the results branch were deduped to a single `source: 'local'` row, so the `source === 'remote'` filter showed nothing — while the header count came from `getRemoteResultsStatus.run_count` (git runs on the branch). List and count came from different data and disagreed.

**Fix:** carry a per-run `on_remote: boolean` (wire `snake_case`) that drives **both** the row badge and the summary count, so they always agree. Replace the filter toggle with one unified, deduped list.

## UX (approved design)
- Per-row **Remote** indicator: cyan "Synced" cloud-check (tooltip "On remote branch `<branch>`") vs muted hollow-cloud "Local only — not pushed".
- Header summary: **"N of M runs on remote (`<branch>`)"**.
- Removed: the All/Local/Remote toggle and the remote-only empty state.
- Kept: sync state (Clean / Last synced / in sync), **Sync Project** button, delete/combine selection (remote runs stay read-only), pagination, live in-progress spinners.

## Testing
- `bun run build` ✅ · typecheck ✅ · dashboard `tsc -b` ✅ · lint (751 files) ✅
- CLI results tests **200** pass / 0 fail; dashboard **102** pass / 0 fail (new: synced→`on_remote:true`, local-only→false, remote-only→true, dedupe-OR, summary count).
- Manual dogfood (built CLI, via Dashboard): summary "2 of 34 runs on remote (agentv/results/v1)"; the 2 Synced-badged rows equal the summary count; local-only rows muted; no source toggle; combine/delete + pagination intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
