### PR TITLE
feat(export): add stable projection identity

### DIFF
--- a/apps/cli/src/commands/eval/artifact-writer.ts
+++ b/apps/cli/src/commands/eval/artifact-writer.ts
@@ -6,6 +6,7 @@ import {
   type BenchmarkArtifact,
   type EvalTest,
   type EvaluationResult,
+  type ExportDuplicatePolicy,
   type GradingArtifact,
   type IndexArtifactEntry,
   RESULT_INDEX_FILENAME,
@@ -201,6 +202,8 @@ export async function writePerTestArtifacts(
   outputDir: string,
   options?: {
     experiment?: string;
+    runId?: string;
+    duplicatePolicy?: ExportDuplicatePolicy;
     cwd?: string;
     repoRoot?: string;
     sourceTests?: readonly EvalTest[];
@@ -209,6 +212,8 @@ export async function writePerTestArtifacts(
 ): Promise<void> {
   await writeCorePerTestArtifacts(results, outputDir, {
     experiment: options?.experiment,
+    runId: options?.runId,
+    duplicatePolicy: options?.duplicatePolicy,
     sourceTests: options?.sourceTests,
     additionalArtifacts: createTaskBundleArtifactsWriter(options),
   });
@@ -221,6 +226,8 @@ export async function writeArtifactsFromResults(
     evalFile?: string;
     experiment?: string;
     plannedTestCount?: number;
+    runId?: string;
+    duplicatePolicy?: ExportDuplicatePolicy;
     cwd?: string;
     repoRoot?: string;
     sourceTests?: readonly EvalTest[];
@@ -236,6 +243,8 @@ export async function writeArtifactsFromResults(
     evalFile: options?.evalFile,
     experiment: options?.experiment,
     plannedTestCount: options?.plannedTestCount,
+    runId: options?.runId,
+    duplicatePolicy: options?.duplicatePolicy,
     sourceTests: options?.sourceTests,
     additionalArtifacts: createTaskBundleArtifactsWriter(options),
   });

--- a/apps/cli/src/commands/results/export.ts
+++ b/apps/cli/src/commands/results/export.ts
@@ -23,9 +23,9 @@
 
 import path from 'node:path';
 
-import { command, option, optional, positional, string } from 'cmd-ts';
+import { command, oneOf, option, optional, positional, string } from 'cmd-ts';
 
-import type { EvaluationResult } from '@agentv/core';
+import type { EvaluationResult, ExportDuplicatePolicy } from '@agentv/core';
 
 import { parseJsonlResults, writeArtifactsFromResults } from '../eval/artifact-writer.js';
 import { RESULT_INDEX_FILENAME } from '../eval/result-layout.js';
@@ -37,6 +37,7 @@ export async function exportResults(
   sourceFile: string,
   content: string,
   outputDir: string,
+  options?: { duplicatePolicy?: ExportDuplicatePolicy },
 ): Promise<void> {
   const results = parseJsonlResults(content);
 
@@ -46,6 +47,8 @@ export async function exportResults(
 
   await writeArtifactsFromResults(results, outputDir, {
     evalFile: sourceFile,
+    runId: deriveExportRunId(sourceFile),
+    duplicatePolicy: options?.duplicatePolicy ?? 'update',
   });
 }
 
@@ -71,6 +74,13 @@ export function deriveOutputDir(cwd: string, sourceFile: string): string {
     return path.join(cwd, '.agentv', 'results', 'export', parentDir.slice(5));
   }
   return path.join(cwd, '.agentv', 'results', 'export', parentDir);
+}
+
+export function deriveExportRunId(sourceFile: string): string {
+  if (path.basename(sourceFile) === RESULT_INDEX_FILENAME) {
+    return path.basename(path.dirname(sourceFile));
+  }
+  return path.basename(sourceFile, path.extname(sourceFile));
 }
 
 export async function loadExportSource(
@@ -106,9 +116,16 @@ export const resultsExportCommand = command({
       short: 'd',
       description: 'Working directory (default: current directory)',
     }),
+    duplicatePolicy: option({
+      type: optional(oneOf(['skip', 'update', 'error'])),
+      long: 'duplicate-policy',
+      description:
+        'How to handle duplicate projection identities in the output: update (default), skip, or error',
+    }),
   },
-  handler: async ({ source, out, dir }) => {
+  handler: async ({ source, out, dir, duplicatePolicy }) => {
     const cwd = dir ?? process.cwd();
+    const policy = (duplicatePolicy ?? 'update') as ExportDuplicatePolicy;
 
     try {
       const { sourceFile, results } = await loadExportSource(source, cwd);
@@ -121,6 +138,8 @@ export const resultsExportCommand = command({
 
       await writeArtifactsFromResults(results, outputDir, {
         evalFile: sourceFile,
+        runId: deriveExportRunId(sourceFile),
+        duplicatePolicy: policy,
       });
 
       // Report exported test IDs

--- a/apps/cli/test/commands/results/export.test.ts
+++ b/apps/cli/test/commands/results/export.test.ts
@@ -10,6 +10,7 @@ import type {
   TimingArtifact,
 } from '../../../src/commands/eval/artifact-writer.js';
 import {
+  deriveExportRunId,
   deriveOutputDir,
   exportResults,
   loadExportSource,
@@ -104,6 +105,18 @@ function artifactDir(outputDir: string, record: { suite?: string; test_id?: stri
   return path.join(outputDir, ...(record.suite ? [record.suite] : []), testId);
 }
 
+function readIndex(outputDir: string): IndexArtifactEntry[] {
+  return readFileSync(path.join(outputDir, 'index.jsonl'), 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as IndexArtifactEntry);
+}
+
+function readAnswer(outputDir: string, record: { suite?: string; test_id?: string }): string {
+  return readFileSync(path.join(artifactDir(outputDir, record), 'outputs', 'answer.md'), 'utf8');
+}
+
 describe('results export', () => {
   let tempDir: string;
 
@@ -162,6 +175,15 @@ describe('results export', () => {
     );
   });
 
+  it('deriveExportRunId keeps retry identity tied to the source run', () => {
+    expect(
+      deriveExportRunId(
+        path.join(tempDir, '.agentv', 'results', 'runs', 'demo', '2026-run', 'index.jsonl'),
+      ),
+    ).toBe('2026-run');
+    expect(deriveExportRunId(path.join(tempDir, 'legacy-results.jsonl'))).toBe('legacy-results');
+  });
+
   it('should create benchmark.json matching artifact-writer schema', async () => {
     const outputDir = path.join(tempDir, 'output');
     const content = toJsonl(RESULT_FULL, RESULT_PARTIAL);
@@ -216,6 +238,102 @@ describe('results export', () => {
       transcript_path: 'demo/test-greeting/outputs/transcript.jsonl',
       input_path: 'demo/test-greeting/input.md',
     });
+    expect(entries[0].projection_identity).toMatchObject({
+      schema_version: 'agentv.projection_identity.v1',
+      dimensions: {
+        run_id: 'test',
+        suite: 'demo',
+        eval_path: 'test.jsonl',
+        test_id: 'test-greeting',
+        target: 'gpt-4o',
+        source_target: 'gpt-4o',
+        attempt: 0,
+        variant: null,
+        projection_format: 'execution_trace',
+        projection_version: 'agentv.trace.v1',
+      },
+    });
+    expect(entries[0].export_metadata).toMatchObject({
+      duplicate_policy: 'update',
+    });
+  });
+
+  it('keeps projection IDs stable across repeated exports from the same run', async () => {
+    const sourceFile = path.join(
+      tempDir,
+      '.agentv',
+      'results',
+      'runs',
+      '2026-03-18T10-00-00-000Z',
+      'index.jsonl',
+    );
+    const firstOutputDir = path.join(tempDir, 'first-output');
+    const secondOutputDir = path.join(tempDir, 'second-output');
+    const content = toJsonl(RESULT_FULL);
+
+    await exportResults(sourceFile, content, firstOutputDir);
+    await exportResults(sourceFile, content, secondOutputDir);
+
+    const [first] = readIndex(firstOutputDir);
+    const [second] = readIndex(secondOutputDir);
+    expect(first.projection_identity?.id).toBe(second.projection_identity?.id);
+    expect(first.projection_identity?.key).toBe(second.projection_identity?.key);
+    expect(first.projection_identity?.dimensions.run_id).toBe('2026-03-18T10-00-00-000Z');
+  });
+
+  it('updates duplicate projection artifacts when duplicate policy is update', async () => {
+    const sourceFile = path.join(tempDir, 'runs', 'retry-run', 'index.jsonl');
+    const outputDir = path.join(tempDir, 'output');
+    const updated = { ...RESULT_FULL, output: 'Updated answer.' };
+
+    await exportResults(sourceFile, toJsonl(RESULT_FULL), outputDir, {
+      duplicatePolicy: 'update',
+    });
+    const before = readIndex(outputDir)[0]?.projection_identity?.id;
+    await exportResults(sourceFile, toJsonl(updated), outputDir, {
+      duplicatePolicy: 'update',
+    });
+
+    const [entry] = readIndex(outputDir);
+    expect(entry.projection_identity?.id).toBe(before);
+    expect(entry.export_metadata).toMatchObject({ duplicate_policy: 'update' });
+    expect(readAnswer(outputDir, RESULT_FULL)).toBe('Updated answer.');
+  });
+
+  it('skips duplicate projection artifacts when duplicate policy is skip', async () => {
+    const sourceFile = path.join(tempDir, 'runs', 'retry-run', 'index.jsonl');
+    const outputDir = path.join(tempDir, 'output');
+    const updated = { ...RESULT_FULL, output: 'Skipped answer.' };
+
+    await exportResults(sourceFile, toJsonl(RESULT_FULL), outputDir, {
+      duplicatePolicy: 'update',
+    });
+    const before = readIndex(outputDir)[0]?.projection_identity?.id;
+    await exportResults(sourceFile, toJsonl(updated), outputDir, {
+      duplicatePolicy: 'skip',
+    });
+
+    const [entry] = readIndex(outputDir);
+    expect(entry.projection_identity?.id).toBe(before);
+    expect(entry.export_metadata).toMatchObject({ duplicate_policy: 'skip', skipped: true });
+    expect(readAnswer(outputDir, RESULT_FULL)).toBe('Hello, Alice!');
+  });
+
+  it('fails duplicate projection artifacts when duplicate policy is error', async () => {
+    const sourceFile = path.join(tempDir, 'runs', 'retry-run', 'index.jsonl');
+    const outputDir = path.join(tempDir, 'output');
+    const updated = { ...RESULT_FULL, output: 'Should not write.' };
+
+    await exportResults(sourceFile, toJsonl(RESULT_FULL), outputDir);
+    await expect(
+      exportResults(sourceFile, toJsonl(updated), outputDir, {
+        duplicatePolicy: 'error',
+      }),
+    ).rejects.toThrow('Duplicate export projection');
+
+    const [entry] = readIndex(outputDir);
+    expect(entry.export_metadata).toMatchObject({ duplicate_policy: 'update' });
+    expect(readAnswer(outputDir, RESULT_FULL)).toBe('Hello, Alice!');
   });
 
   it('should create per-test timing.json with run timing', async () => {

--- a/apps/web/src/content/docs/docs/tools/results.mdx
+++ b/apps/web/src/content/docs/docs/tools/results.mdx
@@ -91,10 +91,22 @@ Use `--out docs/<name>.html` when a repository should publish multiple runs. Lin
 Use `results export` when you need the artifact workspace layout itself rather than a rendered report.
 
 ```bash
-agentv results export <run-workspace-or-index.jsonl> [--out <dir>]
+agentv results export <run-workspace-or-index.jsonl> [--out <dir>] [--duplicate-policy update]
 ```
 
 This is useful when a manifest needs to be materialized into a predictable artifact tree for other tooling, review, or archiving. The run workspace is also where generated task bundles live: `index.jsonl` rows may point to per-result `task_dir`, `eval_path`, `targets_path`, `files_path`, and `graders_path` entries. Keep those generated artifacts with the run when sharing or auditing results.
+
+Each exported trace sidecar and `index.jsonl` row includes a stable `projection_identity` derived from AgentV-owned fields: `run_id`, `suite` or `eval_path`, `test_id`, `target`, `source_target`, `attempt`, `variant`, `envelope_id`, `trace_id`, `root_span_id`, and the projection format/version. Retrying the same completed run keeps the same projection ID even when you choose a different `--out` directory, because `run_id` comes from the source run directory or source manifest name rather than the export destination.
+
+Duplicate policy is explicit:
+
+| Policy | Behavior |
+|--------|----------|
+| `update` | Default. Rewrites the local projection for the same identity. |
+| `skip` | Leaves the existing local projection in place and records `export_metadata.duplicate_policy: skip`. |
+| `error` | Fails before rewriting local projection files when the identity already exists. |
+
+`attempt` defaults to `0`, `variant` defaults to `null`, and `source_target` defaults to `target` when a run has no replay source. Replay and rerun sources can set `source_target`, `attempt`, or `variant`; those values are part of the identity, so different attempts, variants, or source targets produce distinct projection IDs.
 
 ## Inspection helpers
 

--- a/packages/core/src/evaluation/projection-identity.ts
+++ b/packages/core/src/evaluation/projection-identity.ts
@@ -1,0 +1,370 @@
+/**
+ * Stable external identity for AgentV-owned export projections.
+ *
+ * Adapter workers use this model to decide whether a completed AgentV run
+ * projection should update, skip, or fail on retry. The identity is derived
+ * only from AgentV-owned dimensions and is serialized with snake_case fields so
+ * local bundles and future SDK adapters share one contract.
+ */
+
+import { createHash } from 'node:crypto';
+import { z } from 'zod';
+
+export const PROJECTION_IDENTITY_SCHEMA_VERSION = 'agentv.projection_identity.v1' as const;
+
+export const EXPORT_DUPLICATE_POLICY_VALUES = ['skip', 'update', 'error'] as const;
+
+export type ExportDuplicatePolicy = (typeof EXPORT_DUPLICATE_POLICY_VALUES)[number];
+
+const PROJECTION_IDENTITY_ISSUE_SEVERITY_VALUES = ['warning', 'error'] as const;
+
+export type ProjectionIdentityIssueSeverity =
+  (typeof PROJECTION_IDENTITY_ISSUE_SEVERITY_VALUES)[number];
+
+export interface ProjectionIdentityIssue {
+  readonly code: string;
+  readonly severity: ProjectionIdentityIssueSeverity;
+  readonly field?: string;
+  readonly message: string;
+}
+
+export interface ProjectionIdentityDimensions {
+  readonly runId: string;
+  readonly suite?: string;
+  readonly evalPath?: string;
+  readonly testId: string;
+  readonly target: string;
+  readonly sourceTarget: string;
+  readonly attempt: number;
+  readonly variant: string | null;
+  readonly envelopeId: string;
+  readonly traceId: string;
+  readonly rootSpanId: string;
+  readonly projectionFormat: string;
+  readonly projectionVersion: string;
+}
+
+export interface ProjectionIdentityInput {
+  readonly runId?: string;
+  readonly suite?: string;
+  readonly evalPath?: string;
+  readonly testId?: string;
+  readonly target?: string;
+  readonly sourceTarget?: string;
+  readonly attempt?: number;
+  readonly variant?: string | null;
+  readonly envelopeId?: string;
+  readonly traceId?: string;
+  readonly rootSpanId?: string;
+  readonly projectionFormat?: string;
+  readonly projectionVersion?: string;
+}
+
+export interface ProjectionIdentity {
+  readonly schemaVersion: typeof PROJECTION_IDENTITY_SCHEMA_VERSION;
+  readonly id: string;
+  readonly key: string;
+  readonly dimensions: ProjectionIdentityDimensions;
+  readonly issues?: readonly ProjectionIdentityIssue[];
+}
+
+export class ProjectionIdentityError extends Error {
+  readonly issues: readonly ProjectionIdentityIssue[];
+
+  constructor(issues: readonly ProjectionIdentityIssue[]) {
+    super(
+      `Projection identity is missing required fields: ${issues.map((i) => i.field).join(', ')}`,
+    );
+    this.name = 'ProjectionIdentityError';
+    this.issues = issues;
+  }
+}
+
+const REQUIRED_STRING_FIELDS = [
+  'runId',
+  'testId',
+  'target',
+  'sourceTarget',
+  'envelopeId',
+  'traceId',
+  'rootSpanId',
+  'projectionFormat',
+  'projectionVersion',
+] as const;
+
+type RequiredStringField = (typeof REQUIRED_STRING_FIELDS)[number];
+
+const DIMENSION_KEY_ORDER = [
+  'projection_format',
+  'projection_version',
+  'run_id',
+  'suite',
+  'eval_path',
+  'test_id',
+  'target',
+  'source_target',
+  'attempt',
+  'variant',
+  'envelope_id',
+  'trace_id',
+  'root_span_id',
+] as const;
+
+function normalizedString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeAttempt(value: number | undefined): number {
+  if (value === undefined) {
+    return 0;
+  }
+  if (!Number.isInteger(value) || value < 0) {
+    throw new ProjectionIdentityError([
+      {
+        code: 'invalid_attempt',
+        severity: 'error',
+        field: 'attempt',
+        message: 'Projection identity attempt must be a non-negative integer.',
+      },
+    ]);
+  }
+  return value;
+}
+
+function normalizeVariant(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return normalizedString(value) ?? null;
+}
+
+function missingRequiredIssue(field: RequiredStringField): ProjectionIdentityIssue {
+  return {
+    code: 'missing_identity_field',
+    severity: 'error',
+    field,
+    message: `Projection identity requires ${field}.`,
+  };
+}
+
+function encodeKeyValue(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return '~';
+  }
+  return encodeURIComponent(String(value));
+}
+
+function dimensionEntries(
+  dimensions: ProjectionIdentityDimensions,
+): Record<string, string | number | null> {
+  return {
+    projection_format: dimensions.projectionFormat,
+    projection_version: dimensions.projectionVersion,
+    run_id: dimensions.runId,
+    suite: dimensions.suite ?? null,
+    eval_path: dimensions.evalPath ?? null,
+    test_id: dimensions.testId,
+    target: dimensions.target,
+    source_target: dimensions.sourceTarget,
+    attempt: dimensions.attempt,
+    variant: dimensions.variant,
+    envelope_id: dimensions.envelopeId,
+    trace_id: dimensions.traceId,
+    root_span_id: dimensions.rootSpanId,
+  };
+}
+
+export function buildProjectionIdentityKey(dimensions: ProjectionIdentityDimensions): string {
+  const entries = dimensionEntries(dimensions);
+  const body = DIMENSION_KEY_ORDER.map((key) => `${key}=${encodeKeyValue(entries[key])}`).join('|');
+  return `${PROJECTION_IDENTITY_SCHEMA_VERSION}:${body}`;
+}
+
+export function buildProjectionIdentity(
+  input: ProjectionIdentityInput,
+  options?: { missingFieldPolicy?: 'error' | 'warn' },
+): ProjectionIdentity {
+  const values = {
+    runId: normalizedString(input.runId),
+    suite: normalizedString(input.suite),
+    evalPath: normalizedString(input.evalPath),
+    testId: normalizedString(input.testId),
+    target: normalizedString(input.target),
+    sourceTarget: normalizedString(input.sourceTarget) ?? normalizedString(input.target),
+    envelopeId: normalizedString(input.envelopeId),
+    traceId: normalizedString(input.traceId),
+    rootSpanId: normalizedString(input.rootSpanId),
+    projectionFormat: normalizedString(input.projectionFormat),
+    projectionVersion: normalizedString(input.projectionVersion),
+  };
+
+  const issues: ProjectionIdentityIssue[] = [];
+  for (const field of REQUIRED_STRING_FIELDS) {
+    if (!values[field]) {
+      issues.push(missingRequiredIssue(field));
+    }
+  }
+  if (!values.suite && !values.evalPath) {
+    issues.push({
+      code: 'missing_suite_or_eval_path',
+      severity: 'warning',
+      field: 'suite/evalPath',
+      message:
+        'Projection identity is more portable when at least one of suite or evalPath is present.',
+    });
+  }
+
+  const errors = issues.filter((issue) => issue.severity === 'error');
+  if (errors.length > 0 && (options?.missingFieldPolicy ?? 'error') === 'error') {
+    throw new ProjectionIdentityError(errors);
+  }
+
+  const dimensions: ProjectionIdentityDimensions = {
+    runId: values.runId ?? 'unknown',
+    suite: values.suite,
+    evalPath: values.evalPath,
+    testId: values.testId ?? 'unknown',
+    target: values.target ?? 'unknown',
+    sourceTarget: values.sourceTarget ?? 'unknown',
+    attempt: normalizeAttempt(input.attempt),
+    variant: normalizeVariant(input.variant),
+    envelopeId: values.envelopeId ?? 'unknown',
+    traceId: values.traceId ?? 'unknown',
+    rootSpanId: values.rootSpanId ?? 'unknown',
+    projectionFormat: values.projectionFormat ?? 'unknown',
+    projectionVersion: values.projectionVersion ?? 'unknown',
+  };
+  const key = buildProjectionIdentityKey(dimensions);
+  const digest = createHash('sha256').update(key).digest('hex');
+
+  return {
+    schemaVersion: PROJECTION_IDENTITY_SCHEMA_VERSION,
+    id: `agentv-prj-${digest.slice(0, 32)}`,
+    key,
+    dimensions,
+    issues: issues.length > 0 ? issues : undefined,
+  };
+}
+
+export const ProjectionIdentityIssueWireSchema = z
+  .object({
+    code: z.string(),
+    severity: z.enum(PROJECTION_IDENTITY_ISSUE_SEVERITY_VALUES),
+    field: z.string().optional(),
+    message: z.string(),
+  })
+  .strict();
+
+export const ProjectionIdentityDimensionsWireSchema = z
+  .object({
+    run_id: z.string(),
+    suite: z.string().optional(),
+    eval_path: z.string().optional(),
+    test_id: z.string(),
+    target: z.string(),
+    source_target: z.string(),
+    attempt: z.number().int().nonnegative(),
+    variant: z.string().nullable(),
+    envelope_id: z.string(),
+    trace_id: z.string(),
+    root_span_id: z.string(),
+    projection_format: z.string(),
+    projection_version: z.string(),
+  })
+  .strict();
+
+export const ProjectionIdentityWireSchema = z
+  .object({
+    schema_version: z.literal(PROJECTION_IDENTITY_SCHEMA_VERSION),
+    id: z.string(),
+    key: z.string(),
+    dimensions: ProjectionIdentityDimensionsWireSchema,
+    issues: z.array(ProjectionIdentityIssueWireSchema).optional(),
+  })
+  .strict();
+
+export type ProjectionIdentityIssueWire = z.infer<typeof ProjectionIdentityIssueWireSchema>;
+export type ProjectionIdentityDimensionsWire = z.infer<
+  typeof ProjectionIdentityDimensionsWireSchema
+>;
+export type ProjectionIdentityWire = z.infer<typeof ProjectionIdentityWireSchema>;
+
+function dropUndefined(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+export function toProjectionIdentityIssueWire(
+  issue: ProjectionIdentityIssue,
+): ProjectionIdentityIssueWire {
+  return ProjectionIdentityIssueWireSchema.parse(
+    dropUndefined({
+      code: issue.code,
+      severity: issue.severity,
+      field: issue.field,
+      message: issue.message,
+    }),
+  );
+}
+
+export function fromProjectionIdentityIssueWire(
+  issue: ProjectionIdentityIssueWire,
+): ProjectionIdentityIssue {
+  return {
+    code: issue.code,
+    severity: issue.severity,
+    field: issue.field,
+    message: issue.message,
+  };
+}
+
+export function toProjectionIdentityWire(identity: ProjectionIdentity): ProjectionIdentityWire {
+  return ProjectionIdentityWireSchema.parse(
+    dropUndefined({
+      schema_version: identity.schemaVersion,
+      id: identity.id,
+      key: identity.key,
+      dimensions: {
+        run_id: identity.dimensions.runId,
+        suite: identity.dimensions.suite,
+        eval_path: identity.dimensions.evalPath,
+        test_id: identity.dimensions.testId,
+        target: identity.dimensions.target,
+        source_target: identity.dimensions.sourceTarget,
+        attempt: identity.dimensions.attempt,
+        variant: identity.dimensions.variant,
+        envelope_id: identity.dimensions.envelopeId,
+        trace_id: identity.dimensions.traceId,
+        root_span_id: identity.dimensions.rootSpanId,
+        projection_format: identity.dimensions.projectionFormat,
+        projection_version: identity.dimensions.projectionVersion,
+      },
+      issues: identity.issues?.map(toProjectionIdentityIssueWire),
+    }),
+  );
+}
+
+export function fromProjectionIdentityWire(input: unknown): ProjectionIdentity {
+  const wire = ProjectionIdentityWireSchema.parse(input);
+  return {
+    schemaVersion: wire.schema_version,
+    id: wire.id,
+    key: wire.key,
+    dimensions: {
+      runId: wire.dimensions.run_id,
+      suite: wire.dimensions.suite,
+      evalPath: wire.dimensions.eval_path,
+      testId: wire.dimensions.test_id,
+      target: wire.dimensions.target,
+      sourceTarget: wire.dimensions.source_target,
+      attempt: wire.dimensions.attempt,
+      variant: wire.dimensions.variant,
+      envelopeId: wire.dimensions.envelope_id,
+      traceId: wire.dimensions.trace_id,
+      rootSpanId: wire.dimensions.root_span_id,
+      projectionFormat: wire.dimensions.projection_format,
+      projectionVersion: wire.dimensions.projection_version,
+    },
+    issues: wire.issues?.map(fromProjectionIdentityIssueWire),
+  };
+}

--- a/packages/core/src/evaluation/run-artifacts.ts
+++ b/packages/core/src/evaluation/run-artifacts.ts
@@ -12,6 +12,14 @@ import path from 'node:path';
 
 import { traceToTranscriptJsonLines } from '../import/types.js';
 import { DEFAULT_THRESHOLD } from './graders/scoring.js';
+import {
+  type ExportDuplicatePolicy,
+  type ProjectionIdentity,
+  type ProjectionIdentityIssueWire,
+  type ProjectionIdentityWire,
+  toProjectionIdentityIssueWire,
+  toProjectionIdentityWire,
+} from './projection-identity.js';
 import type { Message } from './providers/types.js';
 import { extractLastAssistantContent } from './providers/types.js';
 import { normalizeResultRow } from './result-row-schema.js';
@@ -204,6 +212,12 @@ export interface IndexArtifactEntry {
   readonly targets_path?: string;
   readonly files_path?: string;
   readonly graders_path?: string;
+  readonly projection_identity?: ProjectionIdentityWire;
+  readonly export_metadata?: {
+    readonly duplicate_policy: ExportDuplicatePolicy;
+    readonly identity_warnings?: readonly ProjectionIdentityIssueWire[];
+    readonly skipped?: boolean;
+  };
   readonly metadata?: Record<string, unknown>;
 }
 
@@ -413,6 +427,24 @@ function toIndexMetadata(
     ...Object.fromEntries(Object.entries(metadata).filter(([key]) => !reservedKeys.has(key))),
     ...(rerunSource ? { rerun_source: rerunSource } : {}),
     ...(preparedAttempt ? { prepared_attempt: preparedAttempt } : {}),
+  };
+}
+
+function buildExportMetadata(
+  duplicatePolicy: ExportDuplicatePolicy | undefined,
+  projectionIdentity: ProjectionIdentity | undefined,
+  options?: { skipped?: boolean },
+): IndexArtifactEntry['export_metadata'] {
+  if (!duplicatePolicy) {
+    return undefined;
+  }
+  const warnings = projectionIdentity?.issues
+    ?.filter((issue) => issue.severity === 'warning')
+    .map(toProjectionIdentityIssueWire);
+  return {
+    duplicate_policy: duplicatePolicy,
+    identity_warnings: warnings && warnings.length > 0 ? warnings : undefined,
+    skipped: options?.skipped,
   };
 }
 
@@ -700,17 +732,21 @@ function resultHasExecutionTraceTranscript(result: EvaluationResult): boolean {
   return result.output.length > 0 || result.trace.messages.length > 0;
 }
 
-async function writeTraceEnvelopeSidecar(params: {
+interface TraceEnvelopeSidecarParams {
   readonly result: EvaluationResult;
   readonly outputDir: string;
   readonly outputsDir: string;
   readonly evalPath?: string;
   readonly experiment?: string;
-}): Promise<TraceEnvelope> {
+  readonly runId?: string;
+  readonly duplicatePolicy?: ExportDuplicatePolicy;
+}
+
+function buildTraceEnvelopeSidecar(params: TraceEnvelopeSidecarParams): TraceEnvelope {
   const hasTranscript = resultHasExecutionTraceTranscript(params.result);
-  const envelope = buildTraceEnvelopeFromEvaluationResult(params.result, {
+  return buildTraceEnvelopeFromEvaluationResult(params.result, {
     evalPath: params.evalPath,
-    runId: path.basename(params.outputDir),
+    runId: params.runId ?? path.basename(params.outputDir),
     experiment: params.experiment,
     source: { path: RESULT_INDEX_FILENAME },
     capture: { content: 'full', redactionLevel: 'none', redactedFields: [] },
@@ -720,7 +756,14 @@ async function writeTraceEnvelopeSidecar(params: {
       response_path: params.result.output.length > 0 ? 'outputs/response.md' : undefined,
       transcript_path: hasTranscript ? 'outputs/transcript.jsonl' : undefined,
     },
+    duplicatePolicy: params.duplicatePolicy,
   });
+}
+
+async function writeTraceEnvelopeSidecar(
+  params: TraceEnvelopeSidecarParams,
+): Promise<TraceEnvelope> {
+  const envelope = buildTraceEnvelopeSidecar(params);
   await writeFile(
     path.join(params.outputsDir, 'execution-trace.json'),
     `${JSON.stringify(toTraceEnvelopeWire(envelope), null, 2)}\n`,
@@ -742,6 +785,8 @@ export function buildIndexArtifactEntry(
     inputPath?: string;
     responsePath?: string;
     extraIndexFields?: AdditionalResultIndexFields;
+    projectionIdentity?: ProjectionIdentity;
+    duplicatePolicy?: ExportDuplicatePolicy;
   },
 ): IndexArtifactEntry {
   return {
@@ -784,6 +829,10 @@ export function buildIndexArtifactEntry(
       ? toRelativeArtifactPath(options.outputDir, options.responsePath)
       : undefined,
     ...options.extraIndexFields,
+    projection_identity: options.projectionIdentity
+      ? toProjectionIdentityWire(options.projectionIdentity)
+      : undefined,
+    export_metadata: buildExportMetadata(options.duplicatePolicy, options.projectionIdentity),
     metadata: toIndexMetadata(result.metadata),
   };
 }
@@ -791,6 +840,10 @@ export function buildIndexArtifactEntry(
 export function buildResultIndexArtifact(
   result: EvaluationResult,
   extraIndexFields?: AdditionalResultIndexFields,
+  options?: {
+    projectionIdentity?: ProjectionIdentity;
+    duplicatePolicy?: ExportDuplicatePolicy;
+  },
 ): ResultIndexArtifact {
   const artifactSubdir = buildArtifactSubdir(result);
   const input = extractInput(result);
@@ -829,6 +882,10 @@ export function buildResultIndexArtifact(
       ? path.posix.join(artifactSubdir, 'outputs', 'response.md')
       : undefined,
     ...extraIndexFields,
+    projection_identity: options?.projectionIdentity
+      ? toProjectionIdentityWire(options.projectionIdentity)
+      : undefined,
+    export_metadata: buildExportMetadata(options?.duplicatePolicy, options?.projectionIdentity),
     metadata: toIndexMetadata(result.metadata),
   };
 }
@@ -876,6 +933,74 @@ function indexRecordKey(record: unknown): string | undefined {
         : undefined;
   const target = typeof record.target === 'string' ? record.target : undefined;
   return testId ? buildTestTargetKey(testId, target) : undefined;
+}
+
+function projectionIdentityRecordKey(record: unknown): string | undefined {
+  if (!isRecord(record) || !isRecord(record.projection_identity)) {
+    return undefined;
+  }
+  const id = record.projection_identity.id;
+  return typeof id === 'string' && id.trim().length > 0 ? id : undefined;
+}
+
+async function readExistingIndexRecords(outputDir: string): Promise<readonly unknown[]> {
+  const indexPath = path.join(outputDir, RESULT_INDEX_FILENAME);
+  const content = await readFile(indexPath, 'utf8').catch(() => undefined);
+  if (content === undefined) {
+    return [];
+  }
+
+  const records: unknown[] = [];
+  for (const line of content.split('\n')) {
+    if (line.trim().length === 0) {
+      continue;
+    }
+    try {
+      records.push(JSON.parse(line) as unknown);
+    } catch {}
+  }
+  return records;
+}
+
+function existingRecordsByProjectionIdentity(
+  records: readonly unknown[],
+): ReadonlyMap<string, unknown> {
+  const byIdentity = new Map<string, unknown>();
+  for (const record of records) {
+    const key = projectionIdentityRecordKey(record);
+    if (key) {
+      byIdentity.set(key, record);
+    }
+  }
+  return byIdentity;
+}
+
+function skippedExistingRecord(
+  record: unknown,
+  identity: ProjectionIdentity,
+  duplicatePolicy: ExportDuplicatePolicy,
+): unknown {
+  if (!isRecord(record)) {
+    return record;
+  }
+  return {
+    ...record,
+    projection_identity: toProjectionIdentityWire(identity),
+    export_metadata: buildExportMetadata(duplicatePolicy, identity, { skipped: true }),
+  };
+}
+
+function duplicateProjectionMessage(identity: ProjectionIdentity): string {
+  const dimensions = identity.dimensions;
+  return [
+    `Duplicate export projection ${identity.id}`,
+    `test_id=${dimensions.testId}`,
+    `target=${dimensions.target}`,
+    `source_target=${dimensions.sourceTarget}`,
+    `attempt=${dimensions.attempt}`,
+    `variant=${dimensions.variant ?? '<none>'}`,
+    `run_id=${dimensions.runId}`,
+  ].join(' ');
 }
 
 async function rewriteExistingIndexRecords(
@@ -1121,11 +1246,14 @@ export async function writePerTestArtifacts(
   options?: {
     experiment?: string;
     evalFile?: string;
+    runId?: string;
+    duplicatePolicy?: ExportDuplicatePolicy;
     sourceTests?: readonly EvalTest[];
     additionalArtifacts?: AdditionalResultArtifactsWriter;
   },
 ): Promise<void> {
   await mkdir(outputDir, { recursive: true });
+  const duplicatePolicy = options?.duplicatePolicy ?? 'update';
   const testByTestId = new Map((options?.sourceTests ?? []).map((test) => [test.id, test]));
   const indexRecords: ResultIndexArtifact[] = [];
 
@@ -1162,6 +1290,8 @@ export async function writePerTestArtifacts(
       outputsDir,
       evalPath: resolveEnvelopeEvalPath(result, testByTestId, options?.evalFile),
       experiment: options?.experiment,
+      runId: options?.runId,
+      duplicatePolicy,
     });
     if (hasTranscriptProjection(result, envelope)) {
       await writeTranscriptJsonl(path.join(outputsDir, 'transcript.jsonl'), result, envelope);
@@ -1176,7 +1306,10 @@ export async function writePerTestArtifacts(
     );
 
     indexRecords.push({
-      ...buildResultIndexArtifact(result, extraIndexFields),
+      ...buildResultIndexArtifact(result, extraIndexFields, {
+        projectionIdentity: envelope.projectionIdentity,
+        duplicatePolicy,
+      }),
       experiment: options?.experiment,
     });
   }
@@ -1191,6 +1324,8 @@ export async function writeArtifactsFromResults(
     evalFile?: string;
     experiment?: string;
     plannedTestCount?: number;
+    runId?: string;
+    duplicatePolicy?: ExportDuplicatePolicy;
     sourceTests?: readonly EvalTest[];
     additionalArtifacts?: AdditionalResultArtifactsWriter;
   },
@@ -1205,72 +1340,148 @@ export async function writeArtifactsFromResults(
   const benchmarkPath = path.join(outputDir, 'benchmark.json');
   const indexPath = path.join(outputDir, RESULT_INDEX_FILENAME);
   await mkdir(outputDir, { recursive: true });
-  const indexRecords: ResultIndexArtifact[] = [];
+  const duplicatePolicy = options?.duplicatePolicy ?? 'update';
+  const existingRecords = await readExistingIndexRecords(outputDir);
+  const existingByIdentity = existingRecordsByProjectionIdentity(existingRecords);
+  const indexRecords: unknown[] = [];
   const testByTestId = new Map((options?.sourceTests ?? []).map((test) => [test.id, test]));
+  const emittedIdentityIds = new Set<string>();
 
-  for (const result of results) {
+  const plans = results.map((result) => {
     const grading = buildGradingArtifact(result);
     const timing = buildTimingArtifact([result]);
     const artifactSubdir = buildArtifactSubdir(result);
     const testDir = path.join(outputDir, artifactSubdir);
     const gradingPath = path.join(testDir, 'grading.json');
     const perTestTimingPath = path.join(testDir, 'timing.json');
-    await mkdir(testDir, { recursive: true });
-    await writeFile(gradingPath, `${JSON.stringify(grading, null, 2)}\n`, 'utf8');
-    await writeFile(perTestTimingPath, `${JSON.stringify(timing, null, 2)}\n`, 'utf8');
-
     const input = extractInput(result);
     const inputPath = input ? path.join(testDir, 'input.md') : undefined;
-    if (inputPath && input) {
-      await writeFile(inputPath, input, 'utf8');
-    }
-
     const outputsDir = path.join(testDir, 'outputs');
-    await mkdir(outputsDir, { recursive: true });
     const answerPath = result.output.length > 0 ? path.join(outputsDir, 'answer.md') : undefined;
     const responsePath =
       result.output.length > 0 ? path.join(outputsDir, 'response.md') : undefined;
-    if (answerPath && responsePath) {
-      await writeFile(answerPath, result.output, 'utf8');
-      await writeFile(responsePath, result.output, 'utf8');
-    }
-    const envelope = await writeTraceEnvelopeSidecar({
+    const envelope = buildTraceEnvelopeSidecar({
       result,
       outputDir,
       outputsDir,
       evalPath: resolveEnvelopeEvalPath(result, testByTestId, options?.evalFile),
       experiment: options?.experiment,
+      runId: options?.runId,
+      duplicatePolicy,
     });
     const transcriptPath = hasTranscriptProjection(result, envelope)
       ? path.join(outputsDir, 'transcript.jsonl')
       : undefined;
-    if (transcriptPath) {
-      await writeTranscriptJsonl(transcriptPath, result, envelope);
+    const projectionIdentity = envelope.projectionIdentity;
+    if (!projectionIdentity) {
+      throw new Error(`Result ${result.testId ?? 'unknown'} is missing projection identity`);
+    }
+    const identityId = projectionIdentity.id;
+    return {
+      result,
+      grading,
+      timing,
+      testDir,
+      gradingPath,
+      perTestTimingPath,
+      input,
+      inputPath,
+      outputsDir,
+      answerPath,
+      responsePath,
+      envelope,
+      projectionIdentity,
+      transcriptPath,
+      identityId,
+    };
+  });
+
+  if (duplicatePolicy === 'error') {
+    const seen = new Set<string>();
+    for (const plan of plans) {
+      const duplicate =
+        seen.has(plan.identityId) || existingByIdentity.has(plan.identityId)
+          ? plan.projectionIdentity
+          : undefined;
+      if (duplicate) {
+        throw new Error(
+          `${duplicateProjectionMessage(duplicate)}; use --duplicate-policy update or skip`,
+        );
+      }
+      seen.add(plan.identityId);
+    }
+  }
+
+  for (const plan of plans) {
+    const { result, envelope, identityId } = plan;
+    const existing = existingByIdentity.get(identityId);
+    if (duplicatePolicy === 'skip' && existing) {
+      indexRecords.push(skippedExistingRecord(existing, plan.projectionIdentity, duplicatePolicy));
+      emittedIdentityIds.add(identityId);
+      continue;
+    }
+    if (duplicatePolicy === 'skip' && emittedIdentityIds.has(identityId)) {
+      continue;
+    }
+
+    await mkdir(plan.testDir, { recursive: true });
+    await writeFile(plan.gradingPath, `${JSON.stringify(plan.grading, null, 2)}\n`, 'utf8');
+    await writeFile(plan.perTestTimingPath, `${JSON.stringify(plan.timing, null, 2)}\n`, 'utf8');
+
+    if (plan.inputPath && plan.input) {
+      await writeFile(plan.inputPath, plan.input, 'utf8');
+    }
+
+    await mkdir(plan.outputsDir, { recursive: true });
+    if (plan.answerPath && plan.responsePath) {
+      await writeFile(plan.answerPath, result.output, 'utf8');
+      await writeFile(plan.responsePath, result.output, 'utf8');
+    }
+    await writeFile(
+      path.join(plan.outputsDir, 'execution-trace.json'),
+      `${JSON.stringify(toTraceEnvelopeWire(envelope), null, 2)}\n`,
+      'utf8',
+    );
+    if (plan.transcriptPath) {
+      await writeTranscriptJsonl(plan.transcriptPath, result, envelope);
     }
 
     const extraIndexFields = await collectAdditionalIndexFields(
       result,
       outputDir,
-      testDir,
+      plan.testDir,
       testByTestId,
       options?.additionalArtifacts,
     );
 
-    indexRecords.push({
+    const nextRecord = {
       ...buildIndexArtifactEntry(result, {
         outputDir,
-        artifactDir: testDir,
-        gradingPath,
-        timingPath: perTestTimingPath,
-        outputPath: answerPath,
-        answerPath,
-        transcriptPath,
-        inputPath,
-        responsePath,
+        artifactDir: plan.testDir,
+        gradingPath: plan.gradingPath,
+        timingPath: plan.perTestTimingPath,
+        outputPath: plan.answerPath,
+        answerPath: plan.answerPath,
+        transcriptPath: plan.transcriptPath,
+        inputPath: plan.inputPath,
+        responsePath: plan.responsePath,
         extraIndexFields,
+        projectionIdentity: plan.projectionIdentity,
+        duplicatePolicy,
       }),
       experiment: options?.experiment,
-    });
+    };
+    if (duplicatePolicy === 'update' && emittedIdentityIds.has(identityId)) {
+      const existingIndex = indexRecords.findIndex(
+        (record) => projectionIdentityRecordKey(record) === identityId,
+      );
+      if (existingIndex >= 0) {
+        indexRecords[existingIndex] = nextRecord;
+      }
+    } else {
+      indexRecords.push(nextRecord);
+    }
+    emittedIdentityIds.add(identityId);
   }
 
   const timing = buildTimingArtifact(results);

--- a/packages/core/src/evaluation/trace-envelope.ts
+++ b/packages/core/src/evaluation/trace-envelope.ts
@@ -23,6 +23,18 @@
 
 import { createHash } from 'node:crypto';
 import { z } from 'zod';
+import {
+  type ExportDuplicatePolicy,
+  type ProjectionIdentity,
+  type ProjectionIdentityIssue,
+  ProjectionIdentityIssueWireSchema,
+  ProjectionIdentityWireSchema,
+  buildProjectionIdentity,
+  fromProjectionIdentityIssueWire,
+  fromProjectionIdentityWire,
+  toProjectionIdentityIssueWire,
+  toProjectionIdentityWire,
+} from './projection-identity.js';
 import type { Message, ToolCall } from './providers/types.js';
 import type {
   TokenUsage,
@@ -37,6 +49,7 @@ import type { EvaluationResult, EvaluationVerdict, GraderKind } from './types.js
 export const EXECUTION_TRACE_SCHEMA_VERSION = 'agentv.trace.v1' as const;
 
 const TRACE_ENVELOPE_FORMAT = 'otlp_openinference_spans' as const;
+const TRACE_ENVELOPE_PROJECTION_FORMAT = 'execution_trace' as const;
 const TRANSCRIPT_MESSAGE_EVENT_NAME = 'agentv.transcript.message' as const;
 
 const CAPTURE_CONTENT_VALUES = ['none', 'metadata', 'full'] as const;
@@ -160,6 +173,8 @@ export interface TraceEnvelope {
   readonly artifactId: string;
   readonly createdAt: string;
   readonly eval: TraceEnvelopeEval;
+  readonly projectionIdentity?: ProjectionIdentity;
+  readonly exportMetadata?: TraceEnvelopeExportMetadata;
   readonly replay?: TraceEnvelopeReplay;
   readonly trace: TraceEnvelopeBody;
   readonly source: TraceEnvelopeSource;
@@ -167,6 +182,11 @@ export interface TraceEnvelope {
   readonly conversionWarnings?: readonly TraceEnvelopeConversionWarning[];
   readonly artifacts?: Readonly<Record<string, string>>;
   readonly scores?: readonly TraceEnvelopeScore[];
+}
+
+export interface TraceEnvelopeExportMetadata {
+  readonly duplicatePolicy?: ExportDuplicatePolicy;
+  readonly identityWarnings?: readonly ProjectionIdentityIssue[];
 }
 
 const AttributeMapWireSchema = z.record(z.string(), z.unknown());
@@ -305,12 +325,21 @@ export const TraceEnvelopeScoreWireSchema = z
   })
   .strict();
 
+export const TraceEnvelopeExportMetadataWireSchema = z
+  .object({
+    duplicate_policy: z.enum(['skip', 'update', 'error']).optional(),
+    identity_warnings: z.array(ProjectionIdentityIssueWireSchema).optional(),
+  })
+  .strict();
+
 export const TraceEnvelopeWireSchema = z
   .object({
     schema_version: z.literal(EXECUTION_TRACE_SCHEMA_VERSION),
     artifact_id: z.string(),
     created_at: z.string(),
     eval: TraceEnvelopeEvalWireSchema,
+    projection_identity: ProjectionIdentityWireSchema.optional(),
+    export_metadata: TraceEnvelopeExportMetadataWireSchema.optional(),
     replay: TraceEnvelopeReplayWireSchema.optional(),
     trace: TraceEnvelopeBodyWireSchema,
     source: TraceEnvelopeSourceWireSchema,
@@ -332,6 +361,7 @@ export type TraceEnvelopeConversionWarningWire = z.infer<
   typeof TraceEnvelopeConversionWarningWireSchema
 >;
 export type TraceEnvelopeScoreWire = z.infer<typeof TraceEnvelopeScoreWireSchema>;
+export type TraceEnvelopeExportMetadataWire = z.infer<typeof TraceEnvelopeExportMetadataWireSchema>;
 
 export interface BuildTraceEnvelopeOptions {
   readonly evalId?: string;
@@ -345,6 +375,7 @@ export interface BuildTraceEnvelopeOptions {
   readonly replay?: TraceEnvelopeReplay;
   readonly capture?: Partial<TraceEnvelopeCapture>;
   readonly artifacts?: Readonly<Record<string, string | undefined>>;
+  readonly duplicatePolicy?: ExportDuplicatePolicy;
   readonly now?: () => Date;
 }
 
@@ -773,8 +804,8 @@ export function buildTraceEnvelopeFromEvaluationResult(
     'agentv.suite': result.suite,
     'agentv.category': result.category,
     'agentv.eval_path': options.evalPath,
-    'agentv.run_id': options.runId,
-    'agentv.attempt': options.attempt,
+    'agentv.run_id': options.runId ?? result.timestamp,
+    'agentv.attempt': options.attempt ?? 0,
     'agentv.variant': options.variant ?? undefined,
     'agentv.execution_status': result.executionStatus,
     'agentv.failure_stage': result.failureStage,
@@ -911,25 +942,53 @@ export function buildTraceEnvelopeFromEvaluationResult(
   }
 
   const artifactId = `execution-trace-${hashHex([traceId, result.timestamp, result.score], 20)}`;
+  const sourceTarget = options.sourceTarget ?? result.target;
+  const attempt = options.attempt ?? 0;
+  const variant = options.variant ?? null;
+  const runId = options.runId ?? result.timestamp;
   const evalIdentity: TraceEnvelopeEval = {
     evalId: options.evalId,
     evalPath: options.evalPath,
     suite: result.suite,
     testId: result.testId,
     target: result.target,
-    sourceTarget: options.sourceTarget,
-    attempt: options.attempt,
-    variant: options.variant,
-    runId: options.runId,
+    sourceTarget,
+    attempt,
+    variant,
+    runId,
     category: result.category,
     experiment: options.experiment,
   };
+  const projectionIdentity = buildProjectionIdentity({
+    runId,
+    suite: evalIdentity.suite,
+    evalPath: evalIdentity.evalPath,
+    testId: evalIdentity.testId,
+    target: evalIdentity.target,
+    sourceTarget,
+    attempt,
+    variant,
+    envelopeId: artifactId,
+    traceId,
+    rootSpanId,
+    projectionFormat: TRACE_ENVELOPE_PROJECTION_FORMAT,
+    projectionVersion: EXECUTION_TRACE_SCHEMA_VERSION,
+  });
 
   return {
     schemaVersion: EXECUTION_TRACE_SCHEMA_VERSION,
     artifactId,
     createdAt: now.toISOString(),
     eval: evalIdentity,
+    projectionIdentity,
+    exportMetadata: options.duplicatePolicy
+      ? {
+          duplicatePolicy: options.duplicatePolicy,
+          identityWarnings: projectionIdentity.issues?.filter(
+            (issue) => issue.severity === 'warning',
+          ),
+        }
+      : undefined,
     replay: options.replay,
     trace: {
       format: TRACE_ENVELOPE_FORMAT,
@@ -954,6 +1013,12 @@ export function toTraceEnvelopeWire(envelope: TraceEnvelope): TraceEnvelopeWire 
       artifact_id: envelope.artifactId,
       created_at: envelope.createdAt,
       eval: toTraceEnvelopeEvalWire(envelope.eval),
+      projection_identity: envelope.projectionIdentity
+        ? toProjectionIdentityWire(envelope.projectionIdentity)
+        : undefined,
+      export_metadata: envelope.exportMetadata
+        ? toTraceEnvelopeExportMetadataWire(envelope.exportMetadata)
+        : undefined,
       replay: envelope.replay ? toTraceEnvelopeReplayWire(envelope.replay) : undefined,
       trace: toTraceEnvelopeBodyWire(envelope.trace),
       source: toTraceEnvelopeSourceWire(envelope.source),
@@ -972,6 +1037,12 @@ export function fromTraceEnvelopeWire(input: unknown): TraceEnvelope {
     artifactId: wire.artifact_id,
     createdAt: wire.created_at,
     eval: fromTraceEnvelopeEvalWire(wire.eval),
+    projectionIdentity: wire.projection_identity
+      ? fromProjectionIdentityWire(wire.projection_identity)
+      : undefined,
+    exportMetadata: wire.export_metadata
+      ? fromTraceEnvelopeExportMetadataWire(wire.export_metadata)
+      : undefined,
     replay: wire.replay ? fromTraceEnvelopeReplayWire(wire.replay) : undefined,
     trace: fromTraceEnvelopeBodyWire(wire.trace),
     source: fromTraceEnvelopeSourceWire(wire.source),
@@ -1013,6 +1084,26 @@ function fromTraceEnvelopeEvalWire(evaluation: TraceEnvelopeEvalWire): TraceEnve
     runId: evaluation.run_id,
     category: evaluation.category,
     experiment: evaluation.experiment,
+  };
+}
+
+function toTraceEnvelopeExportMetadataWire(
+  metadata: TraceEnvelopeExportMetadata,
+): TraceEnvelopeExportMetadataWire {
+  return TraceEnvelopeExportMetadataWireSchema.parse(
+    dropUndefined({
+      duplicate_policy: metadata.duplicatePolicy,
+      identity_warnings: metadata.identityWarnings?.map(toProjectionIdentityIssueWire),
+    }),
+  );
+}
+
+function fromTraceEnvelopeExportMetadataWire(
+  metadata: TraceEnvelopeExportMetadataWire,
+): TraceEnvelopeExportMetadata {
+  return {
+    duplicatePolicy: metadata.duplicate_policy,
+    identityWarnings: metadata.identity_warnings?.map(fromProjectionIdentityIssueWire),
   };
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export * from './evaluation/content.js';
 export * from './evaluation/types.js';
 export * from './evaluation/trace.js';
 export * from './evaluation/trace-envelope.js';
+export * from './evaluation/projection-identity.js';
 export * from './evaluation/replay-fixtures.js';
 export * from './evaluation/replay-trace-envelopes.js';
 export {

--- a/packages/core/test/evaluation/projection-identity.test.ts
+++ b/packages/core/test/evaluation/projection-identity.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  ProjectionIdentityError,
+  buildProjectionIdentity,
+  buildProjectionIdentityKey,
+  fromProjectionIdentityWire,
+  toProjectionIdentityWire,
+} from '../../src/evaluation/projection-identity.js';
+
+const BASE_INPUT = {
+  runId: '2026-06-19T10-00-00-000Z',
+  suite: 'demo-suite',
+  evalPath: 'evals/demo.eval.yaml',
+  testId: 'case-alpha',
+  target: 'candidate',
+  sourceTarget: 'candidate',
+  attempt: 0,
+  variant: null,
+  envelopeId: 'execution-trace-abc123',
+  traceId: 'trace-abc123',
+  rootSpanId: 'root-abc123',
+  projectionFormat: 'execution_trace',
+  projectionVersion: 'agentv.trace.v1',
+};
+
+describe('projection identity', () => {
+  it('builds a stable canonical key and wire shape', () => {
+    const first = buildProjectionIdentity(BASE_INPUT);
+    const second = buildProjectionIdentity({ ...BASE_INPUT });
+
+    expect(first.id).toBe(second.id);
+    expect(first.key).toBe(second.key);
+    expect(first.key).toBe(buildProjectionIdentityKey(first.dimensions));
+    expect(first.key).toContain('projection_format=execution_trace');
+    expect(first.key).toContain('run_id=2026-06-19T10-00-00-000Z');
+    expect(first.key).toContain('variant=~');
+
+    const wire = toProjectionIdentityWire(first);
+    expect(wire.schema_version).toBe('agentv.projection_identity.v1');
+    expect(wire.dimensions.run_id).toBe(BASE_INPUT.runId);
+    expect(wire.dimensions.root_span_id).toBe(BASE_INPUT.rootSpanId);
+    expect(fromProjectionIdentityWire(wire)).toEqual(first);
+  });
+
+  it('makes attempt, variant, and source_target part of the identity', () => {
+    const base = buildProjectionIdentity(BASE_INPUT);
+    const attempt = buildProjectionIdentity({ ...BASE_INPUT, attempt: 1 });
+    const variant = buildProjectionIdentity({ ...BASE_INPUT, variant: 'canary' });
+    const sourceTarget = buildProjectionIdentity({ ...BASE_INPUT, sourceTarget: 'baseline' });
+
+    expect(new Set([base.id, attempt.id, variant.id, sourceTarget.id]).size).toBe(4);
+  });
+
+  it('fails clearly when required dimensions are missing', () => {
+    expect(() =>
+      buildProjectionIdentity({
+        ...BASE_INPUT,
+        runId: undefined,
+        traceId: '',
+      }),
+    ).toThrow(ProjectionIdentityError);
+
+    try {
+      buildProjectionIdentity({ ...BASE_INPUT, runId: undefined, traceId: '' });
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProjectionIdentityError);
+      expect((error as ProjectionIdentityError).issues.map((issue) => issue.field)).toEqual([
+        'runId',
+        'traceId',
+      ]);
+    }
+  });
+
+  it('warns but remains stable when suite and eval_path are absent', () => {
+    const identity = buildProjectionIdentity({
+      ...BASE_INPUT,
+      suite: undefined,
+      evalPath: undefined,
+    });
+
+    expect(identity.issues).toEqual([
+      {
+        code: 'missing_suite_or_eval_path',
+        severity: 'warning',
+        field: 'suite/evalPath',
+        message:
+          'Projection identity is more portable when at least one of suite or evalPath is present.',
+      },
+    ]);
+    expect(identity.key).toContain('suite=~|eval_path=~');
+  });
+});

--- a/packages/core/test/evaluation/trace-envelope.test.ts
+++ b/packages/core/test/evaluation/trace-envelope.test.ts
@@ -99,6 +99,22 @@ describe('execution trace artifact v1', () => {
     expect(wire.schema_version).toBe(EXECUTION_TRACE_SCHEMA_VERSION);
     expect(wire.artifact_id).toMatch(/^execution-trace-/);
     expect(wire).not.toHaveProperty('envelope_id');
+    expect(wire.projection_identity?.schema_version).toBe('agentv.projection_identity.v1');
+    expect(wire.projection_identity?.dimensions).toMatchObject({
+      run_id: 'run-123',
+      suite: 'trace-evaluation',
+      eval_path: 'examples/showcase/trace-evaluation/evals/coding-agent-replay.eval.yaml',
+      test_id: 'trace-case',
+      target: 'replay_coding_agent',
+      source_target: 'replay_coding_agent',
+      attempt: 0,
+      variant: null,
+      envelope_id: wire.artifact_id,
+      trace_id: wire.trace.trace_id,
+      root_span_id: wire.trace.root_span_id,
+      projection_format: 'execution_trace',
+      projection_version: EXECUTION_TRACE_SCHEMA_VERSION,
+    });
     expect(wire.created_at).toBe('2026-06-15T12:00:05.000Z');
     expect(wire.eval.eval_path).toContain('coding-agent-replay.eval.yaml');
     expect(wire.trace.format).toBe('otlp_openinference_spans');


### PR DESCRIPTION
## Summary

Bead: `av-vwa.16.2`

AgentV exports now carry a stable, vendor-neutral `projection_identity` on trace sidecars and `index.jsonl` rows. The identity is derived from AgentV-owned dimensions including run ID, suite/eval path, test ID, target/source target, attempt, variant, envelope ID, trace/root span IDs, and projection format/version, so adapter workers can retry completed-run projections without inventing backend-specific identity rules.

`agentv results export` now supports explicit duplicate handling with `--duplicate-policy update|skip|error`, defaulting to `update` to preserve existing overwrite behavior. Export metadata records the policy used, and local retry behavior now updates, skips, or fails before rewriting projection files according to that policy.

Docs now describe how run IDs, attempts, variants, source targets, and replay/rerun sources affect identity.

## Verification

- Red UAT from a temporary `origin/main` archive: exporting the same source run to two different `--out` directories produced different pre-change trace IDs (`72e8ae9d779db7e7518542e613e5dcc9` vs `2e2885649768240b8e8b5838201dd471`) because identity depended on the export destination.
- Green UAT on this branch: repeated exports to different output dirs produced the same `projection_identity.id`; `skip` preserved the first artifact; `error` failed with `Duplicate export projection ...`; `update` rewrote the artifact and recorded `export_metadata.duplicate_policy: update`.
- `bun test packages/core/test/evaluation/projection-identity.test.ts packages/core/test/evaluation/trace-envelope.test.ts apps/cli/test/commands/results/export.test.ts apps/cli/test/commands/eval/artifact-writer.test.ts apps/cli/test/commands/results/export-e2e-providers.test.ts` — 106 pass
- `bun run lint` — pass
- `bun run typecheck` — pass

## Post-Deploy Monitoring & Validation

No additional production service monitoring is required because this is local artifact and CLI export behavior.

Validation after merge:
- Watch GitHub Actions for test, lint, typecheck, and docs checks on this PR and the merge commit.
- Search CI logs and user reports for `Duplicate export projection`, `projection_identity`, `export_metadata`, and `--duplicate-policy`.
- Healthy signal: repeated `agentv results export` runs keep stable `projection_identity.id` values and selected duplicate policies are reflected in `export_metadata.duplicate_policy`.
- Failure signals: unexpected duplicate errors under default `update`, missing `projection_identity` in new trace sidecars, or `skip` rewriting existing output files.
- Mitigation: default policy remains `update`; if regressions appear, adapters can ignore the additive metadata while the local export path is fixed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
