### PR TITLE
feat(dashboard): add canonical result table

### DIFF
--- a/.agents/verification.md
+++ b/.agents/verification.md
@@ -42,6 +42,15 @@ cd apps/dashboard && bun run build
 ```
 
 - Running `agentv dashboard` from source reloads the CLI and backend routes, but the Dashboard web UI is served from the static `apps/dashboard/dist/` bundle. If you skip the rebuild, you can silently test stale UI code.
+- Save browser screenshots and other visual UAT artifacts outside the public AgentV repo, then publish them to the private evidence repo on a reviewable branch:
+
+```bash
+agentv-private:evidence/<bead-or-feature-slug>
+```
+
+- Use the existing `agentv-private` checkout or remote when available; do not commit screenshot evidence to the public repo.
+- Include a short README or manifest on the evidence branch with the public PR link, source branch, capture date, and what each artifact shows.
+- Include the private evidence branch, commit, or PR link in the public PR description and tracker handoff.
 
 If `agent-browser --session <name> open <url>` hangs with EAGAIN on ARM64, pre-start Chrome and connect with CDP:
 
@@ -148,5 +157,5 @@ cp "$(git worktree list --porcelain | head -1 | sed 's/worktree //')/.env" .env
 4. Verify no regressions in adjacent areas.
 5. For scoring, threshold, or grader changes, run at least one real eval with a live provider and verify the output JSONL.
 6. For Dashboard config, scoring-display, or dashboard API changes, use `agent-browser` to verify the UI still renders and behaves correctly.
-7. If operator instructions require private visual evidence, save screenshots there and include the resulting paths or commits in the handoff.
+7. If visual evidence was captured, push it to an `agentv-private` evidence branch and include the resulting branch, commit, or PR link in the handoff.
 8. Mark the PR ready only after the checklist is complete and the red or green evidence is attached.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Read the full rationale and examples in [.agents/product-boundary.md](.agents/pr
 - Prefer the primary checkout only for small, clean, bounded work. Use a dedicated worktree from the latest `origin/main` for non-trivial, risky, long-running, or parallel changes.
 - Non-trivial work needs a plan or task list. If the implementation surface starts to balloon, stop and re-plan.
 - Manual red/green UAT is blocking before a branch is ready for review. GitHub Actions is the authoritative merge gate.
+- For browser or screenshot UAT, keep evidence out of the public repo and publish reviewable artifacts to an `agentv-private` evidence branch. See [.agents/verification.md](.agents/verification.md).
 - Wire formats are `snake_case`; internal TypeScript is `camelCase`. Translate only at the boundary.
 - In AgentV, a `project` holds runs, traces, and experiments; a `benchmark` is a curated eval suite. Do not collapse those terms.
 

--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -1279,8 +1279,58 @@ function handleConfig(
 }
 
 function handleFeedbackRead(c: C, { searchDir }: DataContext) {
+  return c.json(readFeedback(feedbackStoreDir(searchDir)));
+}
+
+function feedbackStoreDir(searchDir: string): string {
   const resultsDir = path.join(searchDir, '.agentv', 'results');
-  return c.json(readFeedback(existsSync(resultsDir) ? resultsDir : searchDir));
+  return existsSync(resultsDir) ? resultsDir : searchDir;
+}
+
+async function handleFeedbackWrite(c: C, resultDir: string) {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'Invalid JSON' }, 400);
+  }
+
+  if (!body || typeof body !== 'object') {
+    return c.json({ error: 'Invalid payload' }, 400);
+  }
+
+  const payload = body as Record<string, unknown>;
+  if (!Array.isArray(payload.reviews)) {
+    return c.json({ error: 'Missing reviews array' }, 400);
+  }
+
+  const incoming = payload.reviews as Record<string, unknown>[];
+  for (const review of incoming) {
+    if (typeof review.test_id !== 'string' || typeof review.comment !== 'string') {
+      return c.json({ error: 'Each review must have test_id and comment strings' }, 400);
+    }
+  }
+
+  const existing = readFeedback(resultDir);
+  const now = new Date().toISOString();
+
+  for (const review of incoming) {
+    const newReview: FeedbackReview = {
+      test_id: review.test_id as string,
+      comment: review.comment as string,
+      updated_at: now,
+    };
+
+    const idx = existing.reviews.findIndex((r) => r.test_id === newReview.test_id);
+    if (idx >= 0) {
+      existing.reviews[idx] = newReview;
+    } else {
+      existing.reviews.push(newReview);
+    }
+  }
+
+  writeFeedback(resultDir, existing);
+  return c.json(existing);
 }
 
 function expandHomePath(inputPath: string): string {
@@ -1911,49 +1961,7 @@ export function createApp(
     if (readOnly) {
       return c.json({ error: 'Dashboard is running in read-only mode' }, 403);
     }
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      return c.json({ error: 'Invalid JSON' }, 400);
-    }
-
-    if (!body || typeof body !== 'object') {
-      return c.json({ error: 'Invalid payload' }, 400);
-    }
-
-    const payload = body as Record<string, unknown>;
-    if (!Array.isArray(payload.reviews)) {
-      return c.json({ error: 'Missing reviews array' }, 400);
-    }
-
-    const incoming = payload.reviews as Record<string, unknown>[];
-    for (const review of incoming) {
-      if (typeof review.test_id !== 'string' || typeof review.comment !== 'string') {
-        return c.json({ error: 'Each review must have test_id and comment strings' }, 400);
-      }
-    }
-
-    const existing = readFeedback(resultDir);
-    const now = new Date().toISOString();
-
-    for (const review of incoming) {
-      const newReview: FeedbackReview = {
-        test_id: review.test_id as string,
-        comment: review.comment as string,
-        updated_at: now,
-      };
-
-      const idx = existing.reviews.findIndex((r) => r.test_id === newReview.test_id);
-      if (idx >= 0) {
-        existing.reviews[idx] = newReview;
-      } else {
-        existing.reviews.push(newReview);
-      }
-    }
-
-    writeFeedback(resultDir, existing);
-    return c.json(existing);
+    return handleFeedbackWrite(c, resultDir);
   });
 
   // Aggregated index (unscoped only)
@@ -2065,6 +2073,14 @@ export function createApp(
   app.get('/api/projects/:projectId/compare', (c) => withProject(c, handleCompare));
   app.get('/api/projects/:projectId/targets', (c) => withProject(c, handleTargets));
   app.get('/api/projects/:projectId/feedback', (c) => withProject(c, handleFeedbackRead));
+  app.post('/api/projects/:projectId/feedback', (c) => {
+    if (readOnly) {
+      return c.json({ error: 'Dashboard is running in read-only mode' }, 403);
+    }
+    return withProject(c, (projectContext, ctx) =>
+      handleFeedbackWrite(projectContext, feedbackStoreDir(ctx.searchDir)),
+    );
+  });
 
   // ── Eval runner routes (discovery, launch, status) ────────────────────
 

--- a/apps/dashboard/src/components/EvalDetail.tsx
+++ b/apps/dashboard/src/components/EvalDetail.tsx
@@ -135,7 +135,7 @@ export function EvalDetail({ eval: result, runId, projectId }: EvalDetailProps) 
         )}
         {!isReadOnly && activeTab === 'feedback' && (
           <div className="p-4">
-            <FeedbackPanel testId={result.testId} />
+            <FeedbackPanel testId={result.testId} projectId={projectId} />
           </div>
         )}
       </div>

--- a/apps/dashboard/src/components/FeedbackPanel.tsx
+++ b/apps/dashboard/src/components/FeedbackPanel.tsx
@@ -12,10 +12,15 @@ import { useFeedback } from '~/lib/api';
 
 interface FeedbackPanelProps {
   testId: string;
+  projectId?: string;
 }
 
-async function saveFeedback(testId: string, comment: string) {
-  const res = await fetch('/api/feedback', {
+function feedbackUrl(projectId?: string): string {
+  return projectId ? `/api/projects/${encodeURIComponent(projectId)}/feedback` : '/api/feedback';
+}
+
+async function saveFeedback(testId: string, comment: string, projectId?: string) {
+  const res = await fetch(feedbackUrl(projectId), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ reviews: [{ test_id: testId, comment }] }),
@@ -26,8 +31,8 @@ async function saveFeedback(testId: string, comment: string) {
   return res.json();
 }
 
-export function FeedbackPanel({ testId }: FeedbackPanelProps) {
-  const { data } = useFeedback();
+export function FeedbackPanel({ testId, projectId }: FeedbackPanelProps) {
+  const { data } = useFeedback(projectId);
   const queryClient = useQueryClient();
 
   const existing = data?.reviews?.find((r) => r.test_id === testId);
@@ -42,9 +47,9 @@ export function FeedbackPanel({ testId }: FeedbackPanelProps) {
   }, [existing?.comment]);
 
   const mutation = useMutation({
-    mutationFn: () => saveFeedback(testId, comment),
+    mutationFn: () => saveFeedback(testId, comment, projectId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['feedback'] });
+      queryClient.invalidateQueries({ queryKey: ['feedback', projectId ?? ''] });
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     },

--- a/apps/dashboard/src/components/ResultTable.tsx
+++ b/apps/dashboard/src/components/ResultTable.tsx
@@ -36,7 +36,8 @@ const QUERY_KEYS = {
   view: 'results_view',
   search: 'results_q',
   target: 'results_target',
-  scorer: 'results_scorer',
+  grader: 'results_grader',
+  legacyScorer: 'results_scorer',
   columns: 'results_cols',
 } as const;
 
@@ -47,7 +48,7 @@ function readUrlState(): ResultTableStateInput {
     view: params.get(QUERY_KEYS.view) ?? undefined,
     search: params.get(QUERY_KEYS.search) ?? undefined,
     target: params.get(QUERY_KEYS.target) ?? undefined,
-    scorer: params.get(QUERY_KEYS.scorer) ?? undefined,
+    grader: params.get(QUERY_KEYS.grader) ?? params.get(QUERY_KEYS.legacyScorer) ?? undefined,
     visibleColumnIds:
       params
         .get(QUERY_KEYS.columns)
@@ -70,8 +71,9 @@ function writeUrlState(state: ResultTableState) {
   if (state.target === 'all') params.delete(QUERY_KEYS.target);
   else params.set(QUERY_KEYS.target, state.target);
 
-  if (state.scorer === 'all') params.delete(QUERY_KEYS.scorer);
-  else params.set(QUERY_KEYS.scorer, state.scorer);
+  params.delete(QUERY_KEYS.legacyScorer);
+  if (state.grader === 'all') params.delete(QUERY_KEYS.grader);
+  else params.set(QUERY_KEYS.grader, state.grader);
 
   if (state.visibleColumnIds.length > 0) {
     params.set(QUERY_KEYS.columns, state.visibleColumnIds.join(','));
@@ -129,10 +131,10 @@ function scoreTone(score: number): string {
   return 'text-red-300';
 }
 
-function scorerFailed(score: ScoreEntry): boolean {
+function graderFailed(score: ScoreEntry): boolean {
   return score.verdict === 'fail' || score.assertions?.some((assertion) => !assertion.passed)
     ? true
-    : (score.scores?.some(scorerFailed) ?? false);
+    : (score.scores?.some(graderFailed) ?? false);
 }
 
 export function ResultTable({
@@ -237,7 +239,7 @@ export function ResultTable({
               type="search"
               value={model.state.search}
               onChange={(event) => updateState({ search: event.target.value })}
-              placeholder="Search tests, targets, scorers, assertions"
+              placeholder="Search tests, targets, graders, assertions"
               className="w-full rounded-md border border-gray-700 bg-gray-950 px-3 py-1.5 text-sm text-gray-100 placeholder:text-gray-600 focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500"
             />
           </label>
@@ -259,16 +261,16 @@ export function ResultTable({
           </label>
 
           <label>
-            <span className="sr-only">Filter by scorer</span>
+            <span className="sr-only">Filter by grader</span>
             <select
-              value={model.state.scorer}
-              onChange={(event) => updateState({ scorer: event.target.value })}
+              value={model.state.grader}
+              onChange={(event) => updateState({ grader: event.target.value })}
               className="w-full rounded-md border border-gray-700 bg-gray-950 px-3 py-1.5 text-sm text-gray-100 focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500"
             >
-              <option value="all">All scorers</option>
-              {model.scorerOptions.map((scorer) => (
-                <option key={scorer} value={scorer}>
-                  {scorer}
+              <option value="all">All graders</option>
+              {model.graderOptions.map((grader) => (
+                <option key={grader} value={grader}>
+                  {grader}
                 </option>
               ))}
             </select>
@@ -366,7 +368,7 @@ export function ResultTable({
 }
 
 function isNumericColumn(columnId: string): boolean {
-  return ['duration', 'cost_tokens'].includes(columnId) || columnId.startsWith('scorer:');
+  return ['duration', 'cost_tokens'].includes(columnId) || columnId.startsWith('grader:');
 }
 
 function ResultCell({
@@ -382,10 +384,10 @@ function ResultCell({
   projectId?: string;
   passThreshold: number;
 }) {
-  if (column.id.startsWith('scorer:')) {
-    const scorerName = column.id.slice('scorer:'.length);
+  if (column.id.startsWith('grader:')) {
+    const graderName = column.id.slice('grader:'.length);
     return (
-      <ScorerScoreCell score={row.scorerScores.get(scorerName)} passThreshold={passThreshold} />
+      <GraderScoreCell score={row.graderScores.get(graderName)} passThreshold={passThreshold} />
     );
   }
 
@@ -527,7 +529,7 @@ function CostTokenCell({
   );
 }
 
-function ScorerScoreCell({
+function GraderScoreCell({
   score,
   passThreshold,
 }: {
@@ -535,7 +537,7 @@ function ScorerScoreCell({
   passThreshold: number;
 }) {
   if (!score) return <span className="text-gray-600">-</span>;
-  const failed = score.score < passThreshold || scorerFailed(score);
+  const failed = score.score < passThreshold || graderFailed(score);
   return (
     <div className="min-w-0 text-right">
       <div className={`tabular-nums ${scoreTone(score.score)}`}>{formatPercent(score.score)}</div>

--- a/apps/dashboard/src/components/ResultTable.tsx
+++ b/apps/dashboard/src/components/ResultTable.tsx
@@ -1,0 +1,562 @@
+/**
+ * Canonical dense result table for Dashboard run-result browsing.
+ *
+ * The table keeps view/search/filter/display state in the URL using
+ * `results_*` query params so run and project links remain stable while a
+ * user tunes the local view.
+ */
+
+import type React from 'react';
+import { useEffect, useMemo, useState } from 'react';
+
+import { Link } from '@tanstack/react-router';
+
+import { useFeedback } from '~/lib/api';
+import {
+  RESULT_TABLE_VIEW_PRESETS,
+  type ResultTableColumn,
+  type ResultTableState,
+  type ResultTableStateInput,
+  buildResultTableModel,
+} from '~/lib/result-table';
+import type { EvalResult, ScoreEntry } from '~/lib/types';
+
+import { PassRatePill } from './PassRatePill';
+
+interface ResultTableProps {
+  results: readonly EvalResult[];
+  runId: string;
+  projectId?: string;
+  passThreshold: number;
+  title?: string;
+  emptyMessage?: React.ReactNode;
+}
+
+const QUERY_KEYS = {
+  view: 'results_view',
+  search: 'results_q',
+  target: 'results_target',
+  scorer: 'results_scorer',
+  columns: 'results_cols',
+} as const;
+
+function readUrlState(): ResultTableStateInput {
+  if (typeof window === 'undefined') return {};
+  const params = new URLSearchParams(window.location.search);
+  return {
+    view: params.get(QUERY_KEYS.view) ?? undefined,
+    search: params.get(QUERY_KEYS.search) ?? undefined,
+    target: params.get(QUERY_KEYS.target) ?? undefined,
+    scorer: params.get(QUERY_KEYS.scorer) ?? undefined,
+    visibleColumnIds:
+      params
+        .get(QUERY_KEYS.columns)
+        ?.split(',')
+        .map((value) => value.trim())
+        .filter(Boolean) ?? undefined,
+  };
+}
+
+function writeUrlState(state: ResultTableState) {
+  if (typeof window === 'undefined') return;
+  const params = new URLSearchParams(window.location.search);
+
+  if (state.view === 'all') params.delete(QUERY_KEYS.view);
+  else params.set(QUERY_KEYS.view, state.view);
+
+  if (state.search) params.set(QUERY_KEYS.search, state.search);
+  else params.delete(QUERY_KEYS.search);
+
+  if (state.target === 'all') params.delete(QUERY_KEYS.target);
+  else params.set(QUERY_KEYS.target, state.target);
+
+  if (state.scorer === 'all') params.delete(QUERY_KEYS.scorer);
+  else params.set(QUERY_KEYS.scorer, state.scorer);
+
+  if (state.visibleColumnIds.length > 0) {
+    params.set(QUERY_KEYS.columns, state.visibleColumnIds.join(','));
+  } else {
+    params.delete(QUERY_KEYS.columns);
+  }
+
+  const query = params.toString();
+  const nextUrl = `${window.location.pathname}${query ? `?${query}` : ''}${window.location.hash}`;
+  window.history.replaceState(window.history.state, '', nextUrl);
+}
+
+function formatPercent(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatDuration(durationMs: number | undefined): string {
+  if (durationMs == null) return '-';
+  if (durationMs < 1000) return `${Math.round(durationMs)}ms`;
+  if (durationMs < 60_000) return `${(durationMs / 1000).toFixed(1)}s`;
+  const minutes = Math.floor(durationMs / 60_000);
+  const seconds = Math.round((durationMs % 60_000) / 1000);
+  return `${minutes}m ${seconds}s`;
+}
+
+function formatCost(costUsd: number | undefined): string | undefined {
+  if (costUsd == null) return undefined;
+  if (costUsd === 0) return '$0';
+  if (costUsd < 0.01) return `$${costUsd.toFixed(5)}`;
+  return `$${costUsd.toFixed(4)}`;
+}
+
+function formatTokens(tokens: number | undefined): string | undefined {
+  if (tokens == null) return undefined;
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M tok`;
+  if (tokens >= 1000) return `${(tokens / 1000).toFixed(1)}k tok`;
+  return `${tokens} tok`;
+}
+
+function compactTokenBreakdown(result: EvalResult): string | undefined {
+  const usage = result.tokenUsage;
+  if (!usage) return undefined;
+  const parts = [
+    usage.input != null ? `${usage.input} in` : undefined,
+    usage.output != null ? `${usage.output} out` : undefined,
+    usage.reasoning != null ? `${usage.reasoning} reason` : undefined,
+    usage.cached != null ? `${usage.cached} cached` : undefined,
+  ].filter((part): part is string => Boolean(part));
+  return parts.length > 0 ? parts.join(' / ') : undefined;
+}
+
+function scoreTone(score: number): string {
+  if (score >= 0.8) return 'text-emerald-300';
+  if (score >= 0.5) return 'text-yellow-300';
+  return 'text-red-300';
+}
+
+function scorerFailed(score: ScoreEntry): boolean {
+  return score.verdict === 'fail' || score.assertions?.some((assertion) => !assertion.passed)
+    ? true
+    : (score.scores?.some(scorerFailed) ?? false);
+}
+
+export function ResultTable({
+  results,
+  runId,
+  projectId,
+  passThreshold,
+  title = 'Results',
+  emptyMessage,
+}: ResultTableProps) {
+  const [urlState, setUrlState] = useState<ResultTableStateInput>(() => readUrlState());
+  const { data: feedback } = useFeedback(projectId);
+  const reviewedTestIds = useMemo(
+    () => feedback?.reviews.map((review) => review.test_id) ?? [],
+    [feedback?.reviews],
+  );
+  const model = useMemo(
+    () =>
+      buildResultTableModel({
+        results,
+        passThreshold,
+        reviewedTestIds,
+        state: urlState,
+      }),
+    [passThreshold, results, reviewedTestIds, urlState],
+  );
+  const visibleColumnIds = new Set(model.state.visibleColumnIds);
+
+  useEffect(() => {
+    const handlePopState = () => setUrlState(readUrlState());
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
+
+  function updateState(partial: Partial<ResultTableState>) {
+    const nextState = { ...model.state, ...partial };
+    writeUrlState(nextState);
+    setUrlState(readUrlState());
+  }
+
+  function resetState() {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    for (const key of Object.values(QUERY_KEYS)) {
+      params.delete(key);
+    }
+    const query = params.toString();
+    const nextUrl = `${window.location.pathname}${query ? `?${query}` : ''}${window.location.hash}`;
+    window.history.replaceState(window.history.state, '', nextUrl);
+    setUrlState({});
+  }
+
+  function toggleColumn(columnId: string) {
+    const next = new Set(model.state.visibleColumnIds);
+    if (next.has(columnId)) next.delete(columnId);
+    else next.add(columnId);
+    updateState({ visibleColumnIds: [...next] });
+  }
+
+  if (results.length === 0) {
+    return (
+      <div className="rounded-lg border border-gray-800 bg-gray-900 p-8 text-center">
+        {emptyMessage ?? <p className="text-lg text-gray-400">No evaluations found</p>}
+      </div>
+    );
+  }
+
+  return (
+    <section className="space-y-3">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-baseline sm:justify-between">
+        <h3 className="text-sm font-medium text-gray-400">{title}</h3>
+        <p className="text-xs text-gray-500">
+          {model.filteredRows.length} of {model.rows.length} rows
+        </p>
+      </div>
+
+      <div className="space-y-3 rounded-lg border border-gray-800 bg-gray-900/40 p-3">
+        <div className="flex flex-wrap gap-2">
+          {RESULT_TABLE_VIEW_PRESETS.map((preset) => (
+            <button
+              key={preset.id}
+              type="button"
+              onClick={() => updateState({ view: preset.id })}
+              className={`inline-flex items-center gap-2 rounded-md border px-2.5 py-1.5 text-sm transition-colors ${
+                model.state.view === preset.id
+                  ? 'border-cyan-900/60 bg-cyan-950/30 text-cyan-300'
+                  : 'border-gray-800 bg-gray-950/70 text-gray-400 hover:border-gray-700 hover:text-gray-200'
+              }`}
+            >
+              <span>{preset.label}</span>
+              <span className="tabular-nums text-xs text-gray-500">
+                {model.viewCounts[preset.id]}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        <div className="grid gap-2 lg:grid-cols-[minmax(220px,1fr)_minmax(150px,220px)_minmax(150px,220px)_auto_auto]">
+          <label className="min-w-0">
+            <span className="sr-only">Search results</span>
+            <input
+              type="search"
+              value={model.state.search}
+              onChange={(event) => updateState({ search: event.target.value })}
+              placeholder="Search tests, targets, scorers, assertions"
+              className="w-full rounded-md border border-gray-700 bg-gray-950 px-3 py-1.5 text-sm text-gray-100 placeholder:text-gray-600 focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500"
+            />
+          </label>
+
+          <label>
+            <span className="sr-only">Filter by target</span>
+            <select
+              value={model.state.target}
+              onChange={(event) => updateState({ target: event.target.value })}
+              className="w-full rounded-md border border-gray-700 bg-gray-950 px-3 py-1.5 text-sm text-gray-100 focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500"
+            >
+              <option value="all">All targets</option>
+              {model.targetOptions.map((target) => (
+                <option key={target} value={target}>
+                  {target}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label>
+            <span className="sr-only">Filter by scorer</span>
+            <select
+              value={model.state.scorer}
+              onChange={(event) => updateState({ scorer: event.target.value })}
+              className="w-full rounded-md border border-gray-700 bg-gray-950 px-3 py-1.5 text-sm text-gray-100 focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500"
+            >
+              <option value="all">All scorers</option>
+              {model.scorerOptions.map((scorer) => (
+                <option key={scorer} value={scorer}>
+                  {scorer}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <details className="group relative">
+            <summary className="list-none rounded-md border border-gray-700 bg-gray-950 px-3 py-1.5 text-sm text-gray-300 transition-colors hover:border-gray-600 hover:text-gray-100 focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500">
+              Display
+            </summary>
+            <div className="absolute right-0 z-10 mt-2 w-64 max-w-[calc(100vw-2rem)] rounded-lg border border-gray-800 bg-gray-950 p-3">
+              <div className="mb-2 text-xs font-medium uppercase tracking-wider text-gray-500">
+                Columns
+              </div>
+              <div className="max-h-72 space-y-2 overflow-auto pr-1">
+                {model.columns.map((column) => (
+                  <label key={column.id} className="flex items-center gap-2 text-sm text-gray-300">
+                    <input
+                      type="checkbox"
+                      checked={visibleColumnIds.has(column.id)}
+                      onChange={() => toggleColumn(column.id)}
+                      className="h-4 w-4 rounded border-gray-700 bg-gray-900 text-cyan-500"
+                    />
+                    <span className="min-w-0 truncate" title={column.label}>
+                      {column.label}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          </details>
+
+          <button
+            type="button"
+            onClick={resetState}
+            className="rounded-md px-3 py-1.5 text-sm text-gray-400 transition-colors hover:text-gray-200"
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+
+      {model.filteredRows.length === 0 ? (
+        <div className="rounded-lg border border-gray-800 bg-gray-900 p-8 text-center">
+          <p className="text-lg text-gray-400">No matching evaluations</p>
+          <p className="mt-2 text-sm text-gray-500">Adjust the result filters or display preset.</p>
+        </div>
+      ) : (
+        <div className="max-w-full overflow-x-auto rounded-lg border border-gray-800">
+          <table
+            className="w-full whitespace-nowrap text-left text-sm"
+            style={{ minWidth: `${Math.max(860, model.visibleColumns.length * 136)}px` }}
+          >
+            <thead className="border-b border-gray-800 bg-gray-900/50">
+              <tr>
+                {model.visibleColumns.map((column) => (
+                  <th
+                    key={column.id}
+                    className={`px-4 py-3 font-medium text-gray-400 ${
+                      isNumericColumn(column.id) ? 'text-right' : ''
+                    }`}
+                    title={column.label}
+                  >
+                    <span className="block max-w-48 truncate">{column.label}</span>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-800/50">
+              {model.filteredRows.map((row) => (
+                <tr key={row.key} className="transition-colors hover:bg-gray-900/30">
+                  {model.visibleColumns.map((column) => (
+                    <td
+                      key={`${row.key}:${column.id}`}
+                      className={`px-4 py-3 align-middle ${
+                        isNumericColumn(column.id) ? 'text-right tabular-nums' : ''
+                      }`}
+                    >
+                      <ResultCell
+                        column={column}
+                        row={row}
+                        runId={runId}
+                        projectId={projectId}
+                        passThreshold={passThreshold}
+                      />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function isNumericColumn(columnId: string): boolean {
+  return ['duration', 'cost_tokens'].includes(columnId) || columnId.startsWith('scorer:');
+}
+
+function ResultCell({
+  column,
+  row,
+  runId,
+  projectId,
+  passThreshold,
+}: {
+  column: ResultTableColumn;
+  row: ReturnType<typeof buildResultTableModel>['filteredRows'][number];
+  runId: string;
+  projectId?: string;
+  passThreshold: number;
+}) {
+  if (column.id.startsWith('scorer:')) {
+    const scorerName = column.id.slice('scorer:'.length);
+    return (
+      <ScorerScoreCell score={row.scorerScores.get(scorerName)} passThreshold={passThreshold} />
+    );
+  }
+
+  switch (column.id) {
+    case 'status':
+      return <StatusCell status={row.status} label={row.statusLabel} />;
+    case 'test':
+      return <TestCell row={row} runId={runId} projectId={projectId} />;
+    case 'model_target':
+      return <ModelTargetCell row={row} />;
+    case 'score':
+      return row.executionError ? (
+        <span className="inline-flex rounded-md border border-amber-900/60 bg-amber-950/20 px-2 py-0.5 text-xs font-medium text-amber-300">
+          Execution error
+        </span>
+      ) : (
+        <PassRatePill rate={row.result.score} />
+      );
+    case 'suite':
+      return <TruncatedMuted value={row.suiteLabel} />;
+    case 'category':
+      return <TruncatedMuted value={row.categoryLabel} />;
+    case 'duration':
+      return <span className="text-gray-400">{formatDuration(row.result.durationMs)}</span>;
+    case 'cost_tokens':
+      return <CostTokenCell row={row} />;
+    case 'review':
+      return (
+        <span className={row.reviewed ? 'text-emerald-300' : 'text-gray-500'}>
+          {row.reviewed ? 'Reviewed' : 'Unreviewed'}
+        </span>
+      );
+    case 'error':
+      return <TruncatedMuted value={row.result.error} tone="text-red-300" />;
+    default:
+      return <span className="text-gray-600">-</span>;
+  }
+}
+
+function StatusCell({ status, label }: { status: string; label: string }) {
+  const tone =
+    status === 'passing'
+      ? 'border-emerald-900/60 bg-emerald-950/20 text-emerald-300'
+      : status === 'error'
+        ? 'border-amber-900/60 bg-amber-950/20 text-amber-300'
+        : 'border-red-900/60 bg-red-950/20 text-red-300';
+  const dot =
+    status === 'passing' ? 'bg-emerald-400' : status === 'error' ? 'bg-amber-400' : 'bg-red-400';
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-xs ${tone}`}
+    >
+      <span className={`h-1.5 w-1.5 rounded-full ${dot}`} />
+      {label}
+    </span>
+  );
+}
+
+function TestCell({
+  row,
+  runId,
+  projectId,
+}: {
+  row: ReturnType<typeof buildResultTableModel>['filteredRows'][number];
+  runId: string;
+  projectId?: string;
+}) {
+  const className =
+    'block min-w-0 truncate font-medium text-cyan-400 hover:text-cyan-300 hover:underline';
+
+  return (
+    <div className="max-w-[24rem] min-w-0">
+      {projectId ? (
+        <Link
+          to="/projects/$projectId/evals/$runId/$evalId"
+          params={{ projectId, runId, evalId: row.testId }}
+          className={className}
+          title={row.testId}
+        >
+          {row.testId}
+        </Link>
+      ) : (
+        <Link
+          to="/evals/$runId/$evalId"
+          params={{ runId, evalId: row.testId }}
+          className={className}
+          title={row.testId}
+        >
+          {row.testId}
+        </Link>
+      )}
+      {row.result.error ? (
+        <div className="mt-0.5 truncate text-xs text-red-300" title={row.result.error}>
+          {row.result.error}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ModelTargetCell({
+  row,
+}: {
+  row: ReturnType<typeof buildResultTableModel>['filteredRows'][number];
+}) {
+  return (
+    <div className="max-w-[16rem] min-w-0">
+      <div className="truncate text-gray-300" title={row.targetLabel}>
+        {row.targetLabel}
+      </div>
+      {row.modelLabel ? (
+        <div className="mt-0.5 truncate text-xs text-gray-500" title={row.modelLabel}>
+          {row.modelLabel}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function CostTokenCell({
+  row,
+}: {
+  row: ReturnType<typeof buildResultTableModel>['filteredRows'][number];
+}) {
+  const cost = formatCost(row.result.costUsd);
+  const tokens = formatTokens(row.tokenTotal);
+  const breakdown = compactTokenBreakdown(row.result);
+  if (!cost && !tokens) return <span className="text-gray-600">-</span>;
+
+  return (
+    <div className="min-w-0 text-right">
+      {cost ? <div className="tabular-nums text-gray-300">{cost}</div> : null}
+      {tokens ? (
+        <div className="text-xs tabular-nums text-gray-500" title={breakdown}>
+          {tokens}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ScorerScoreCell({
+  score,
+  passThreshold,
+}: {
+  score: ScoreEntry | undefined;
+  passThreshold: number;
+}) {
+  if (!score) return <span className="text-gray-600">-</span>;
+  const failed = score.score < passThreshold || scorerFailed(score);
+  return (
+    <div className="min-w-0 text-right">
+      <div className={`tabular-nums ${scoreTone(score.score)}`}>{formatPercent(score.score)}</div>
+      <div className={failed ? 'text-xs text-red-300' : 'text-xs text-gray-500'}>
+        {failed ? 'Fail' : (score.verdict ?? 'Pass')}
+      </div>
+    </div>
+  );
+}
+
+function TruncatedMuted({
+  value,
+  tone = 'text-gray-400',
+}: {
+  value: string | undefined;
+  tone?: string;
+}) {
+  if (!value) return <span className="text-gray-600">-</span>;
+  return (
+    <span className={`block max-w-[14rem] truncate ${tone}`} title={value}>
+      {value}
+    </span>
+  );
+}

--- a/apps/dashboard/src/components/RunDetail.tsx
+++ b/apps/dashboard/src/components/RunDetail.tsx
@@ -21,12 +21,12 @@ import { Link } from '@tanstack/react-router';
 
 import type { EvalResult } from '~/lib/types';
 
-import { isPassing, useRunLog, useStudioConfig } from '~/lib/api';
-import { isExecutionError, summarizeQuality } from '~/lib/result-summary';
-import { formatCategoryDisplay, shouldShowSuiteLabels } from '~/lib/run-detail-context';
+import { useRunLog, useStudioConfig } from '~/lib/api';
+import { summarizeQuality } from '~/lib/result-summary';
+import { formatCategoryDisplay } from '~/lib/run-detail-context';
 
-import { EvalSuiteLabel } from './EvalSuiteLabel';
 import { PassRatePill } from './PassRatePill';
+import { ResultTable } from './ResultTable';
 import { StatsCards } from './StatsCards';
 
 interface RunDetailProps {
@@ -119,7 +119,6 @@ export function RunDetail({ results, runId, projectId }: RunDetailProps) {
   const totalCost = results.reduce((sum, r) => sum + (r.costUsd ?? 0), 0);
 
   const categories = buildCategoryGroups(results, passThreshold);
-  const showSuiteLabels = shouldShowSuiteLabels(results);
 
   if (total === 0) {
     return (
@@ -233,98 +232,13 @@ export function RunDetail({ results, runId, projectId }: RunDetailProps) {
         </div>
       </div>
 
-      {/* All Evals */}
-      <div>
-        <h3 className="mb-3 text-sm font-medium text-gray-400">All Evals</h3>
-        <div className="max-w-full overflow-x-auto rounded-lg border border-gray-800">
-          <table className="min-w-[760px] w-full whitespace-nowrap text-left text-sm">
-            <thead className="border-b border-gray-800 bg-gray-900/50">
-              <tr>
-                <th className="w-8 px-4 py-3" />
-                <th className="w-[24rem] px-4 py-3 font-medium text-gray-400">Test ID</th>
-                <th className="w-[12rem] px-4 py-3 font-medium text-gray-400">Target</th>
-                <th className="w-48 px-4 py-3 font-medium text-gray-400">Score</th>
-                <th className="px-4 py-3 text-right font-medium text-gray-400">Duration</th>
-                <th className="px-4 py-3 text-right font-medium text-gray-400">Cost</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-800/50">
-              {results.map((result, idx) => {
-                const isError = isExecutionError(result);
-                const passing = isPassing(result.score, passThreshold);
-                return (
-                  <tr
-                    key={`${result.testId}-${idx}`}
-                    className="transition-colors hover:bg-gray-900/30"
-                  >
-                    {/* Status dot */}
-                    <td className="px-4 py-3 text-center">
-                      {isError ? (
-                        <span className="text-base font-bold text-amber-400">!</span>
-                      ) : (
-                        <span
-                          className={`text-base font-bold ${passing ? 'text-emerald-400' : 'text-red-400'}`}
-                        >
-                          {passing ? '✓' : '✗'}
-                        </span>
-                      )}
-                    </td>
-                    <td className="w-[24rem] max-w-[24rem] px-4 py-3">
-                      <div className="flex min-w-0 items-center gap-2">
-                        {projectId ? (
-                          <Link
-                            to="/projects/$projectId/evals/$runId/$evalId"
-                            params={{ projectId, runId, evalId: result.testId }}
-                            className="min-w-0 flex-1 truncate font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
-                            title={result.testId}
-                          >
-                            {result.testId}
-                          </Link>
-                        ) : (
-                          <Link
-                            to="/evals/$runId/$evalId"
-                            params={{ runId, evalId: result.testId }}
-                            className="min-w-0 flex-1 truncate font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
-                            title={result.testId}
-                          >
-                            {result.testId}
-                          </Link>
-                        )}
-                        {showSuiteLabels ? (
-                          <EvalSuiteLabel suite={result.suite} className="max-w-[10rem]" />
-                        ) : null}
-                      </div>
-                    </td>
-                    <td
-                      className="w-[12rem] max-w-[12rem] truncate px-4 py-3 text-gray-400"
-                      title={result.target ?? undefined}
-                    >
-                      {result.target ?? '-'}
-                    </td>
-                    <td className="px-4 py-3">
-                      {isError ? (
-                        <span className="inline-flex rounded-full bg-amber-900/40 px-2 py-0.5 text-xs font-medium text-amber-300">
-                          Execution error
-                        </span>
-                      ) : (
-                        <PassRatePill rate={result.score} />
-                      )}
-                    </td>
-                    <td className="px-4 py-3 text-right tabular-nums text-gray-400">
-                      {result.durationMs != null
-                        ? `${(result.durationMs / 1000).toFixed(1)}s`
-                        : '-'}
-                    </td>
-                    <td className="px-4 py-3 text-right tabular-nums text-gray-400">
-                      {result.costUsd != null ? `$${result.costUsd.toFixed(4)}` : '-'}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      </div>
+      <ResultTable
+        results={results}
+        runId={runId}
+        projectId={projectId}
+        passThreshold={passThreshold}
+        title="All Evals"
+      />
 
       <ConsoleLogSection runId={runId} projectId={projectId} />
     </div>

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -179,10 +179,13 @@ export const indexOptions = queryOptions({
   queryFn: () => fetchJson<IndexResponse>('/api/index'),
 });
 
-export const feedbackOptions = queryOptions({
-  queryKey: ['feedback'],
-  queryFn: () => fetchJson<FeedbackData>('/api/feedback'),
-});
+export function feedbackOptions(projectId?: string) {
+  const url = projectId ? `${projectApiBase(projectId)}/feedback` : '/api/feedback';
+  return queryOptions({
+    queryKey: ['feedback', projectId ?? ''],
+    queryFn: () => fetchJson<FeedbackData>(url),
+  });
+}
 
 export const experimentsOptions = queryOptions({
   queryKey: ['experiments'],
@@ -294,8 +297,8 @@ export function useIndex() {
   return useQuery(indexOptions);
 }
 
-export function useFeedback() {
-  return useQuery(feedbackOptions);
+export function useFeedback(projectId?: string) {
+  return useQuery(feedbackOptions(projectId));
 }
 
 export function useExperiments() {

--- a/apps/dashboard/src/lib/result-table.test.ts
+++ b/apps/dashboard/src/lib/result-table.test.ts
@@ -16,7 +16,7 @@ function result(overrides: Partial<EvalResult>): EvalResult {
 }
 
 describe('result-table model', () => {
-  it('builds canonical preset counts from execution status, quality score, scorer failures, and review state', () => {
+  it('builds canonical preset counts from execution status, quality score, grader failures, and review state', () => {
     const model = buildResultTableModel({
       passThreshold: 0.8,
       reviewedTestIds: ['passing-case'],
@@ -25,7 +25,7 @@ describe('result-table model', () => {
         result({ testId: 'failing-case', score: 0.4, executionStatus: 'quality_failure' }),
         result({ testId: 'error-case', score: 0, executionStatus: 'execution_error' }),
         result({
-          testId: 'scorer-case',
+          testId: 'grader-case',
           score: 0.9,
           scores: [
             {
@@ -45,21 +45,21 @@ describe('result-table model', () => {
       passing: 2,
       failing: 1,
       errors: 1,
-      scorer_errors: 1,
+      grader_errors: 1,
       unreviewed: 3,
     });
 
-    const scorerErrors = buildResultTableModel({
+    const graderErrors = buildResultTableModel({
       passThreshold: 0.8,
       reviewedTestIds: ['passing-case'],
       results: model.rows.map((row) => row.result),
-      state: { view: 'scorer_errors' },
+      state: { view: 'grader_errors' },
     });
 
-    expect(scorerErrors.filteredRows.map((row) => row.testId)).toEqual(['scorer-case']);
+    expect(graderErrors.filteredRows.map((row) => row.testId)).toEqual(['grader-case']);
   });
 
-  it('combines search, target, and scorer filters', () => {
+  it('combines search, target, and grader filters', () => {
     const model = buildResultTableModel({
       passThreshold: 0.8,
       results: [
@@ -77,14 +77,14 @@ describe('result-table model', () => {
       state: {
         search: 'beta',
         target: 'claude',
-        scorer: 'rubric',
+        grader: 'rubric',
       },
     });
 
     expect(model.filteredRows.map((row) => row.testId)).toEqual(['beta-rubric']);
   });
 
-  it('creates display columns for present metrics and scorer names', () => {
+  it('creates display columns for present metrics and grader names', () => {
     const model = buildResultTableModel({
       passThreshold: 0.8,
       results: [
@@ -111,8 +111,29 @@ describe('result-table model', () => {
       'duration',
       'cost_tokens',
       'review',
-      'scorer:correctness',
+      'grader:correctness',
     ]);
-    expect(model.visibleColumns.map((column) => column.id)).toContain('scorer:correctness');
+    expect(model.visibleColumns.map((column) => column.id)).toContain('grader:correctness');
+  });
+
+  it('accepts legacy scorer URL state as a grader alias', () => {
+    const model = buildResultTableModel({
+      passThreshold: 0.8,
+      results: [
+        result({
+          testId: 'legacy-rubric',
+          scores: [{ name: 'rubric', type: 'llm-grader', score: 1, verdict: 'pass' }],
+        }),
+      ],
+      state: {
+        view: 'scorer_errors',
+        scorer: 'rubric',
+        visibleColumnIds: ['scorer:rubric'],
+      },
+    });
+
+    expect(model.state.view).toBe('grader_errors');
+    expect(model.state.grader).toBe('rubric');
+    expect(model.visibleColumns.map((column) => column.id)).toEqual(['grader:rubric']);
   });
 });

--- a/apps/dashboard/src/lib/result-table.test.ts
+++ b/apps/dashboard/src/lib/result-table.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'bun:test';
+
+import { buildResultTableModel } from './result-table';
+import type { EvalResult } from './types';
+
+function result(overrides: Partial<EvalResult>): EvalResult {
+  return {
+    testId: 'case-a',
+    target: 'codex',
+    score: 1,
+    executionStatus: 'ok',
+    assertions: [],
+    timestamp: '2026-06-19T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('result-table model', () => {
+  it('builds canonical preset counts from execution status, quality score, scorer failures, and review state', () => {
+    const model = buildResultTableModel({
+      passThreshold: 0.8,
+      reviewedTestIds: ['passing-case'],
+      results: [
+        result({ testId: 'passing-case', score: 0.95 }),
+        result({ testId: 'failing-case', score: 0.4, executionStatus: 'quality_failure' }),
+        result({ testId: 'error-case', score: 0, executionStatus: 'execution_error' }),
+        result({
+          testId: 'scorer-case',
+          score: 0.9,
+          scores: [
+            {
+              name: 'rubric',
+              type: 'llm-grader',
+              score: 0.9,
+              verdict: 'pass',
+              assertions: [{ text: 'criterion failed', passed: false }],
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(model.viewCounts).toEqual({
+      all: 4,
+      passing: 2,
+      failing: 1,
+      errors: 1,
+      scorer_errors: 1,
+      unreviewed: 3,
+    });
+
+    const scorerErrors = buildResultTableModel({
+      passThreshold: 0.8,
+      reviewedTestIds: ['passing-case'],
+      results: model.rows.map((row) => row.result),
+      state: { view: 'scorer_errors' },
+    });
+
+    expect(scorerErrors.filteredRows.map((row) => row.testId)).toEqual(['scorer-case']);
+  });
+
+  it('combines search, target, and scorer filters', () => {
+    const model = buildResultTableModel({
+      passThreshold: 0.8,
+      results: [
+        result({
+          testId: 'alpha-json',
+          target: 'codex',
+          scores: [{ name: 'json-schema', type: 'is-json', score: 1, verdict: 'pass' }],
+        }),
+        result({
+          testId: 'beta-rubric',
+          target: 'claude',
+          scores: [{ name: 'rubric', type: 'llm-grader', score: 0.7, verdict: 'fail' }],
+        }),
+      ],
+      state: {
+        search: 'beta',
+        target: 'claude',
+        scorer: 'rubric',
+      },
+    });
+
+    expect(model.filteredRows.map((row) => row.testId)).toEqual(['beta-rubric']);
+  });
+
+  it('creates display columns for present metrics and scorer names', () => {
+    const model = buildResultTableModel({
+      passThreshold: 0.8,
+      results: [
+        result({
+          testId: 'metric-case',
+          suite: 'dataset.eval.yaml',
+          category: 'smoke',
+          target: 'azure',
+          durationMs: 1234,
+          costUsd: 0.0123,
+          tokenUsage: { input: 100, output: 50 },
+          scores: [{ name: 'correctness', type: 'llm-grader', score: 1, verdict: 'pass' }],
+        }),
+      ],
+    });
+
+    expect(model.columns.map((column) => column.id)).toEqual([
+      'status',
+      'test',
+      'model_target',
+      'score',
+      'suite',
+      'category',
+      'duration',
+      'cost_tokens',
+      'review',
+      'scorer:correctness',
+    ]);
+    expect(model.visibleColumns.map((column) => column.id)).toContain('scorer:correctness');
+  });
+});

--- a/apps/dashboard/src/lib/result-table.ts
+++ b/apps/dashboard/src/lib/result-table.ts
@@ -2,7 +2,7 @@
  * Pure view model for Dashboard result tables.
  *
  * Result browsing appears on run detail and drill-down screens. Keep the
- * filtering, preset, scorer-column, and display-column rules here so routes
+ * filtering, preset, grader-column, and display-column rules here so routes
  * can share one dense table contract without adding a new product mode.
  */
 
@@ -14,7 +14,7 @@ export type ResultTableViewId =
   | 'passing'
   | 'failing'
   | 'errors'
-  | 'scorer_errors'
+  | 'grader_errors'
   | 'unreviewed';
 
 export const RESULT_TABLE_VIEW_PRESETS: readonly {
@@ -25,7 +25,7 @@ export const RESULT_TABLE_VIEW_PRESETS: readonly {
   { id: 'passing', label: 'Passing' },
   { id: 'failing', label: 'Failing' },
   { id: 'errors', label: 'Errors' },
-  { id: 'scorer_errors', label: 'Scorer errors' },
+  { id: 'grader_errors', label: 'Grader errors' },
   { id: 'unreviewed', label: 'Unreviewed' },
 ];
 
@@ -33,7 +33,7 @@ export interface ResultTableState {
   readonly view: ResultTableViewId;
   readonly search: string;
   readonly target: string;
-  readonly scorer: string;
+  readonly grader: string;
   readonly visibleColumnIds: readonly string[];
 }
 
@@ -41,6 +41,7 @@ export interface ResultTableStateInput {
   readonly view?: string;
   readonly search?: string;
   readonly target?: string;
+  readonly grader?: string;
   readonly scorer?: string;
   readonly visibleColumnIds?: readonly string[];
 }
@@ -48,7 +49,7 @@ export interface ResultTableStateInput {
 export interface ResultTableColumn {
   readonly id: string;
   readonly label: string;
-  readonly kind: 'base' | 'scorer';
+  readonly kind: 'base' | 'grader';
   readonly defaultVisible: boolean;
 }
 
@@ -63,15 +64,15 @@ export interface ResultTableRow {
   readonly statusLabel: 'Passing' | 'Failing' | 'Error';
   readonly passing: boolean;
   readonly executionError: boolean;
-  readonly scorerError: boolean;
+  readonly graderError: boolean;
   readonly reviewed: boolean;
   readonly targetLabel: string;
   readonly modelLabel?: string;
   readonly suiteLabel?: string;
   readonly categoryLabel?: string;
   readonly tokenTotal?: number;
-  readonly scorerNames: readonly string[];
-  readonly scorerScores: ReadonlyMap<string, ScoreEntry>;
+  readonly graderNames: readonly string[];
+  readonly graderScores: ReadonlyMap<string, ScoreEntry>;
   readonly searchText: string;
 }
 
@@ -82,7 +83,7 @@ export interface ResultTableModel {
   readonly visibleColumns: readonly ResultTableColumn[];
   readonly state: ResultTableState;
   readonly targetOptions: readonly string[];
-  readonly scorerOptions: readonly string[];
+  readonly graderOptions: readonly string[];
   readonly viewCounts: Readonly<Record<ResultTableViewId, number>>;
 }
 
@@ -94,7 +95,7 @@ export interface BuildResultTableModelInput {
 }
 
 const DEFAULT_TARGET = 'all';
-const DEFAULT_SCORER = 'all';
+const DEFAULT_GRADER = 'all';
 
 function cleanString(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
@@ -109,7 +110,7 @@ function uniqueSorted(values: Iterable<string>): string[] {
 }
 
 function scoreLabel(score: ScoreEntry, index: number): string {
-  return cleanString(score.name) ?? cleanString(score.type) ?? `Scorer ${index + 1}`;
+  return cleanString(score.name) ?? cleanString(score.type) ?? `Grader ${index + 1}`;
 }
 
 function scoreHasFailure(score: ScoreEntry, passThreshold: number): boolean {
@@ -132,7 +133,7 @@ function flattenScoreText(scores: readonly ScoreEntry[] | undefined): string[] {
   return parts.filter((part) => part.length > 0);
 }
 
-function buildScorerMap(
+function buildGraderMap(
   scores: readonly ScoreEntry[] | undefined,
 ): ReadonlyMap<string, ScoreEntry> {
   const map = new Map<string, ScoreEntry>();
@@ -184,9 +185,9 @@ function buildRow(
   const executionError = isExecutionError(result);
   const passing = !executionError && result.score >= passThreshold;
   const status: ResultTableRowStatus = executionError ? 'error' : passing ? 'passing' : 'failing';
-  const scorerScores = buildScorerMap(result.scores);
-  const scorerNames = [...scorerScores.keys()];
-  const scorerError =
+  const graderScores = buildGraderMap(result.scores);
+  const graderNames = [...graderScores.keys()];
+  const graderError =
     result.scores?.some((score) => scoreHasFailure(score, passThreshold)) ?? false;
   const model = modelLabel(result);
   const target = targetLabel(result);
@@ -214,15 +215,15 @@ function buildRow(
     statusLabel: executionError ? 'Error' : passing ? 'Passing' : 'Failing',
     passing,
     executionError,
-    scorerError,
+    graderError,
     reviewed: reviewedTestIds.has(result.testId),
     targetLabel: target,
     ...(model && { modelLabel: model }),
     ...(suite && { suiteLabel: suite }),
     ...(category && { categoryLabel: category }),
     ...(tokenTotal !== undefined && { tokenTotal }),
-    scorerNames,
-    scorerScores,
+    graderNames,
+    graderScores,
     searchText: searchParts.join(' ').toLowerCase(),
   };
 }
@@ -231,7 +232,7 @@ function hasMeaningfulTarget(rows: readonly ResultTableRow[]): boolean {
   return rows.some((row) => row.targetLabel !== 'default' || row.modelLabel);
 }
 
-function buildColumns(rows: readonly ResultTableRow[], scorerOptions: readonly string[]) {
+function buildColumns(rows: readonly ResultTableRow[], graderOptions: readonly string[]) {
   const hasSuite = rows.some((row) => row.suiteLabel);
   const hasCategory = rows.some((row) => row.categoryLabel);
   const hasDuration = rows.some((row) => row.result.durationMs != null);
@@ -271,10 +272,10 @@ function buildColumns(rows: readonly ResultTableRow[], scorerOptions: readonly s
     ...(hasError
       ? [{ id: 'error', label: 'Error', kind: 'base' as const, defaultVisible: false }]
       : []),
-    ...scorerOptions.map((name) => ({
-      id: `scorer:${name}`,
+    ...graderOptions.map((name) => ({
+      id: `grader:${name}`,
       label: name,
-      kind: 'scorer' as const,
+      kind: 'grader' as const,
       defaultVisible: true,
     })),
   ];
@@ -283,6 +284,7 @@ function buildColumns(rows: readonly ResultTableRow[], scorerOptions: readonly s
 }
 
 function normalizeView(value: string | undefined): ResultTableViewId {
+  if (value === 'scorer_errors') return 'grader_errors';
   return RESULT_TABLE_VIEW_PRESETS.some((preset) => preset.id === value)
     ? (value as ResultTableViewId)
     : 'all';
@@ -297,22 +299,26 @@ function normalizeState(
   input: ResultTableStateInput | undefined,
   columns: readonly ResultTableColumn[],
   targetOptions: readonly string[],
-  scorerOptions: readonly string[],
+  graderOptions: readonly string[],
 ): ResultTableState {
   const columnIds = new Set(columns.map((column) => column.id));
-  const requestedColumns = input?.visibleColumnIds?.filter((id) => columnIds.has(id)) ?? [];
+  const requestedColumns =
+    input?.visibleColumnIds
+      ?.map((id) => (id.startsWith('scorer:') ? `grader:${id.slice('scorer:'.length)}` : id))
+      .filter((id) => columnIds.has(id)) ?? [];
   const visibleColumnIds =
     requestedColumns.length > 0 ? requestedColumns : defaultVisibleColumnIds(columns);
   const target =
     input?.target && targetOptions.includes(input.target) ? input.target : DEFAULT_TARGET;
-  const scorer =
-    input?.scorer && scorerOptions.includes(input.scorer) ? input.scorer : DEFAULT_SCORER;
+  const requestedGrader = input?.grader ?? input?.scorer;
+  const grader =
+    requestedGrader && graderOptions.includes(requestedGrader) ? requestedGrader : DEFAULT_GRADER;
 
   return {
     view: normalizeView(input?.view),
     search: input?.search?.trim() ?? '',
     target,
-    scorer,
+    grader,
     visibleColumnIds,
   };
 }
@@ -325,8 +331,8 @@ function matchesView(row: ResultTableRow, view: ResultTableViewId): boolean {
       return row.status === 'failing';
     case 'errors':
       return row.status === 'error';
-    case 'scorer_errors':
-      return row.scorerError;
+    case 'grader_errors':
+      return row.graderError;
     case 'unreviewed':
       return !row.reviewed;
     case 'all':
@@ -340,7 +346,7 @@ function viewCounts(rows: readonly ResultTableRow[]): Readonly<Record<ResultTabl
     passing: rows.filter((row) => row.status === 'passing').length,
     failing: rows.filter((row) => row.status === 'failing').length,
     errors: rows.filter((row) => row.status === 'error').length,
-    scorer_errors: rows.filter((row) => row.scorerError).length,
+    grader_errors: rows.filter((row) => row.graderError).length,
     unreviewed: rows.filter((row) => !row.reviewed).length,
   };
 }
@@ -351,16 +357,16 @@ export function buildResultTableModel(input: BuildResultTableModelInput): Result
     buildRow(result, index, input.passThreshold, reviewedTestIds),
   );
   const targetOptions = uniqueSorted(rows.map((row) => row.targetLabel));
-  const scorerOptions = uniqueSorted(rows.flatMap((row) => row.scorerNames));
-  const columns = buildColumns(rows, scorerOptions);
-  const state = normalizeState(input.state, columns, targetOptions, scorerOptions);
+  const graderOptions = uniqueSorted(rows.flatMap((row) => row.graderNames));
+  const columns = buildColumns(rows, graderOptions);
+  const state = normalizeState(input.state, columns, targetOptions, graderOptions);
   const query = state.search.toLowerCase();
   const visibleColumnIds = new Set(state.visibleColumnIds);
 
   const filteredRows = rows.filter((row) => {
     if (!matchesView(row, state.view)) return false;
     if (state.target !== DEFAULT_TARGET && row.targetLabel !== state.target) return false;
-    if (state.scorer !== DEFAULT_SCORER && !row.scorerScores.has(state.scorer)) return false;
+    if (state.grader !== DEFAULT_GRADER && !row.graderScores.has(state.grader)) return false;
     if (query && !row.searchText.includes(query)) return false;
     return true;
   });
@@ -372,7 +378,7 @@ export function buildResultTableModel(input: BuildResultTableModelInput): Result
     visibleColumns: columns.filter((column) => visibleColumnIds.has(column.id)),
     state,
     targetOptions,
-    scorerOptions,
+    graderOptions,
     viewCounts: viewCounts(rows),
   };
 }

--- a/apps/dashboard/src/lib/result-table.ts
+++ b/apps/dashboard/src/lib/result-table.ts
@@ -1,0 +1,378 @@
+/**
+ * Pure view model for Dashboard result tables.
+ *
+ * Result browsing appears on run detail and drill-down screens. Keep the
+ * filtering, preset, scorer-column, and display-column rules here so routes
+ * can share one dense table contract without adding a new product mode.
+ */
+
+import { isExecutionError } from './result-summary';
+import type { EvalResult, ScoreEntry } from './types';
+
+export type ResultTableViewId =
+  | 'all'
+  | 'passing'
+  | 'failing'
+  | 'errors'
+  | 'scorer_errors'
+  | 'unreviewed';
+
+export const RESULT_TABLE_VIEW_PRESETS: readonly {
+  id: ResultTableViewId;
+  label: string;
+}[] = [
+  { id: 'all', label: 'All' },
+  { id: 'passing', label: 'Passing' },
+  { id: 'failing', label: 'Failing' },
+  { id: 'errors', label: 'Errors' },
+  { id: 'scorer_errors', label: 'Scorer errors' },
+  { id: 'unreviewed', label: 'Unreviewed' },
+];
+
+export interface ResultTableState {
+  readonly view: ResultTableViewId;
+  readonly search: string;
+  readonly target: string;
+  readonly scorer: string;
+  readonly visibleColumnIds: readonly string[];
+}
+
+export interface ResultTableStateInput {
+  readonly view?: string;
+  readonly search?: string;
+  readonly target?: string;
+  readonly scorer?: string;
+  readonly visibleColumnIds?: readonly string[];
+}
+
+export interface ResultTableColumn {
+  readonly id: string;
+  readonly label: string;
+  readonly kind: 'base' | 'scorer';
+  readonly defaultVisible: boolean;
+}
+
+export type ResultTableRowStatus = 'passing' | 'failing' | 'error';
+
+export interface ResultTableRow {
+  readonly key: string;
+  readonly result: EvalResult;
+  readonly index: number;
+  readonly testId: string;
+  readonly status: ResultTableRowStatus;
+  readonly statusLabel: 'Passing' | 'Failing' | 'Error';
+  readonly passing: boolean;
+  readonly executionError: boolean;
+  readonly scorerError: boolean;
+  readonly reviewed: boolean;
+  readonly targetLabel: string;
+  readonly modelLabel?: string;
+  readonly suiteLabel?: string;
+  readonly categoryLabel?: string;
+  readonly tokenTotal?: number;
+  readonly scorerNames: readonly string[];
+  readonly scorerScores: ReadonlyMap<string, ScoreEntry>;
+  readonly searchText: string;
+}
+
+export interface ResultTableModel {
+  readonly rows: readonly ResultTableRow[];
+  readonly filteredRows: readonly ResultTableRow[];
+  readonly columns: readonly ResultTableColumn[];
+  readonly visibleColumns: readonly ResultTableColumn[];
+  readonly state: ResultTableState;
+  readonly targetOptions: readonly string[];
+  readonly scorerOptions: readonly string[];
+  readonly viewCounts: Readonly<Record<ResultTableViewId, number>>;
+}
+
+export interface BuildResultTableModelInput {
+  readonly results: readonly EvalResult[];
+  readonly passThreshold: number;
+  readonly state?: ResultTableStateInput;
+  readonly reviewedTestIds?: readonly string[];
+}
+
+const DEFAULT_TARGET = 'all';
+const DEFAULT_SCORER = 'all';
+
+function cleanString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function uniqueSorted(values: Iterable<string>): string[] {
+  return [...new Set([...values].filter((value) => value.trim().length > 0))].sort((a, b) =>
+    a.localeCompare(b),
+  );
+}
+
+function scoreLabel(score: ScoreEntry, index: number): string {
+  return cleanString(score.name) ?? cleanString(score.type) ?? `Scorer ${index + 1}`;
+}
+
+function scoreHasFailure(score: ScoreEntry, passThreshold: number): boolean {
+  if (score.verdict === 'fail') return true;
+  if (score.score < passThreshold) return true;
+  if (score.assertions?.some((assertion) => !assertion.passed)) return true;
+  return score.scores?.some((child) => scoreHasFailure(child, passThreshold)) ?? false;
+}
+
+function flattenScoreText(scores: readonly ScoreEntry[] | undefined): string[] {
+  if (!scores || scores.length === 0) return [];
+  const parts: string[] = [];
+  scores.forEach((score, index) => {
+    parts.push(scoreLabel(score, index), score.type ?? '', score.verdict ?? '');
+    for (const assertion of score.assertions ?? []) {
+      parts.push(assertion.text, assertion.evidence ?? '');
+    }
+    parts.push(...flattenScoreText(score.scores));
+  });
+  return parts.filter((part) => part.length > 0);
+}
+
+function buildScorerMap(
+  scores: readonly ScoreEntry[] | undefined,
+): ReadonlyMap<string, ScoreEntry> {
+  const map = new Map<string, ScoreEntry>();
+  scores?.forEach((score, index) => {
+    const label = scoreLabel(score, index);
+    if (!map.has(label)) {
+      map.set(label, score);
+    }
+  });
+  return map;
+}
+
+function totalTokens(result: EvalResult): number | undefined {
+  const usage = result.tokenUsage;
+  if (!usage) return undefined;
+  const values = [usage.input, usage.output, usage.reasoning, usage.cached].filter(
+    (value): value is number => typeof value === 'number' && Number.isFinite(value),
+  );
+  if (values.length === 0) return undefined;
+  return values.reduce((sum, value) => sum + value, 0);
+}
+
+function modelLabel(result: EvalResult): string | undefined {
+  const direct = cleanString(result.model);
+  if (direct) return direct;
+
+  const metadata = result.metadata;
+  if (!metadata) return undefined;
+  return (
+    cleanString(metadata.model) ??
+    cleanString(metadata.model_name) ??
+    cleanString(metadata.target_model) ??
+    cleanString(metadata.provider_model)
+  );
+}
+
+function targetLabel(result: EvalResult): string {
+  const target = cleanString(result.target) ?? 'default';
+  const targetUsed = cleanString(result.targetUsed);
+  return targetUsed && targetUsed !== target ? `${target} -> ${targetUsed}` : target;
+}
+
+function buildRow(
+  result: EvalResult,
+  index: number,
+  passThreshold: number,
+  reviewedTestIds: ReadonlySet<string>,
+): ResultTableRow {
+  const executionError = isExecutionError(result);
+  const passing = !executionError && result.score >= passThreshold;
+  const status: ResultTableRowStatus = executionError ? 'error' : passing ? 'passing' : 'failing';
+  const scorerScores = buildScorerMap(result.scores);
+  const scorerNames = [...scorerScores.keys()];
+  const scorerError =
+    result.scores?.some((score) => scoreHasFailure(score, passThreshold)) ?? false;
+  const model = modelLabel(result);
+  const target = targetLabel(result);
+  const suite = cleanString(result.suite);
+  const category = cleanString(result.category);
+  const tokenTotal = totalTokens(result);
+  const searchParts = [
+    result.testId,
+    target,
+    model ?? '',
+    suite ?? '',
+    category ?? '',
+    result.executionStatus ?? '',
+    result.error ?? '',
+    ...flattenScoreText(result.scores),
+    ...(result.assertions ?? []).flatMap((assertion) => [assertion.text, assertion.evidence ?? '']),
+  ];
+
+  return {
+    key: `${result.testId}:${result.target ?? ''}:${result.timestamp ?? ''}:${index}`,
+    result,
+    index,
+    testId: result.testId,
+    status,
+    statusLabel: executionError ? 'Error' : passing ? 'Passing' : 'Failing',
+    passing,
+    executionError,
+    scorerError,
+    reviewed: reviewedTestIds.has(result.testId),
+    targetLabel: target,
+    ...(model && { modelLabel: model }),
+    ...(suite && { suiteLabel: suite }),
+    ...(category && { categoryLabel: category }),
+    ...(tokenTotal !== undefined && { tokenTotal }),
+    scorerNames,
+    scorerScores,
+    searchText: searchParts.join(' ').toLowerCase(),
+  };
+}
+
+function hasMeaningfulTarget(rows: readonly ResultTableRow[]): boolean {
+  return rows.some((row) => row.targetLabel !== 'default' || row.modelLabel);
+}
+
+function buildColumns(rows: readonly ResultTableRow[], scorerOptions: readonly string[]) {
+  const hasSuite = rows.some((row) => row.suiteLabel);
+  const hasCategory = rows.some((row) => row.categoryLabel);
+  const hasDuration = rows.some((row) => row.result.durationMs != null);
+  const hasCostOrTokens = rows.some((row) => row.result.costUsd != null || row.tokenTotal != null);
+  const hasError = rows.some((row) => row.result.error);
+
+  const columns: ResultTableColumn[] = [
+    { id: 'status', label: 'Status', kind: 'base', defaultVisible: true },
+    { id: 'test', label: 'Test ID', kind: 'base', defaultVisible: true },
+    {
+      id: 'model_target',
+      label: 'Model / Target',
+      kind: 'base',
+      defaultVisible: hasMeaningfulTarget(rows),
+    },
+    { id: 'score', label: 'Score', kind: 'base', defaultVisible: true },
+    ...(hasSuite
+      ? [{ id: 'suite', label: 'Suite', kind: 'base' as const, defaultVisible: true }]
+      : []),
+    ...(hasCategory
+      ? [{ id: 'category', label: 'Category', kind: 'base' as const, defaultVisible: false }]
+      : []),
+    ...(hasDuration
+      ? [{ id: 'duration', label: 'Duration', kind: 'base' as const, defaultVisible: true }]
+      : []),
+    ...(hasCostOrTokens
+      ? [
+          {
+            id: 'cost_tokens',
+            label: 'Cost / Tokens',
+            kind: 'base' as const,
+            defaultVisible: true,
+          },
+        ]
+      : []),
+    { id: 'review', label: 'Review', kind: 'base', defaultVisible: false },
+    ...(hasError
+      ? [{ id: 'error', label: 'Error', kind: 'base' as const, defaultVisible: false }]
+      : []),
+    ...scorerOptions.map((name) => ({
+      id: `scorer:${name}`,
+      label: name,
+      kind: 'scorer' as const,
+      defaultVisible: true,
+    })),
+  ];
+
+  return columns;
+}
+
+function normalizeView(value: string | undefined): ResultTableViewId {
+  return RESULT_TABLE_VIEW_PRESETS.some((preset) => preset.id === value)
+    ? (value as ResultTableViewId)
+    : 'all';
+}
+
+function defaultVisibleColumnIds(columns: readonly ResultTableColumn[]): string[] {
+  const defaults = columns.filter((column) => column.defaultVisible).map((column) => column.id);
+  return defaults.length > 0 ? defaults : columns.slice(0, 4).map((column) => column.id);
+}
+
+function normalizeState(
+  input: ResultTableStateInput | undefined,
+  columns: readonly ResultTableColumn[],
+  targetOptions: readonly string[],
+  scorerOptions: readonly string[],
+): ResultTableState {
+  const columnIds = new Set(columns.map((column) => column.id));
+  const requestedColumns = input?.visibleColumnIds?.filter((id) => columnIds.has(id)) ?? [];
+  const visibleColumnIds =
+    requestedColumns.length > 0 ? requestedColumns : defaultVisibleColumnIds(columns);
+  const target =
+    input?.target && targetOptions.includes(input.target) ? input.target : DEFAULT_TARGET;
+  const scorer =
+    input?.scorer && scorerOptions.includes(input.scorer) ? input.scorer : DEFAULT_SCORER;
+
+  return {
+    view: normalizeView(input?.view),
+    search: input?.search?.trim() ?? '',
+    target,
+    scorer,
+    visibleColumnIds,
+  };
+}
+
+function matchesView(row: ResultTableRow, view: ResultTableViewId): boolean {
+  switch (view) {
+    case 'passing':
+      return row.status === 'passing';
+    case 'failing':
+      return row.status === 'failing';
+    case 'errors':
+      return row.status === 'error';
+    case 'scorer_errors':
+      return row.scorerError;
+    case 'unreviewed':
+      return !row.reviewed;
+    case 'all':
+      return true;
+  }
+}
+
+function viewCounts(rows: readonly ResultTableRow[]): Readonly<Record<ResultTableViewId, number>> {
+  return {
+    all: rows.length,
+    passing: rows.filter((row) => row.status === 'passing').length,
+    failing: rows.filter((row) => row.status === 'failing').length,
+    errors: rows.filter((row) => row.status === 'error').length,
+    scorer_errors: rows.filter((row) => row.scorerError).length,
+    unreviewed: rows.filter((row) => !row.reviewed).length,
+  };
+}
+
+export function buildResultTableModel(input: BuildResultTableModelInput): ResultTableModel {
+  const reviewedTestIds = new Set(input.reviewedTestIds ?? []);
+  const rows = input.results.map((result, index) =>
+    buildRow(result, index, input.passThreshold, reviewedTestIds),
+  );
+  const targetOptions = uniqueSorted(rows.map((row) => row.targetLabel));
+  const scorerOptions = uniqueSorted(rows.flatMap((row) => row.scorerNames));
+  const columns = buildColumns(rows, scorerOptions);
+  const state = normalizeState(input.state, columns, targetOptions, scorerOptions);
+  const query = state.search.toLowerCase();
+  const visibleColumnIds = new Set(state.visibleColumnIds);
+
+  const filteredRows = rows.filter((row) => {
+    if (!matchesView(row, state.view)) return false;
+    if (state.target !== DEFAULT_TARGET && row.targetLabel !== state.target) return false;
+    if (state.scorer !== DEFAULT_SCORER && !row.scorerScores.has(state.scorer)) return false;
+    if (query && !row.searchText.includes(query)) return false;
+    return true;
+  });
+
+  return {
+    rows,
+    filteredRows,
+    columns,
+    visibleColumns: columns.filter((column) => visibleColumnIds.has(column.id)),
+    state,
+    targetOptions,
+    scorerOptions,
+    viewCounts: viewCounts(rows),
+  };
+}

--- a/apps/dashboard/src/lib/types.ts
+++ b/apps/dashboard/src/lib/types.ts
@@ -46,6 +46,7 @@ export interface TokenUsage {
   input?: number;
   output?: number;
   reasoning?: number;
+  cached?: number;
 }
 
 export interface ScoreEntry {
@@ -57,6 +58,9 @@ export interface ScoreEntry {
   verdict?: string;
   details?: string | Record<string, unknown>;
   durationMs?: number;
+  target?: string;
+  tokenUsage?: TokenUsage;
+  scores?: ScoreEntry[];
 }
 
 export interface AssertionEntry {
@@ -115,6 +119,8 @@ export interface EvalResult {
   suite?: string;
   category?: string;
   target?: string;
+  targetUsed?: string;
+  model?: string;
   experiment?: string;
   score: number;
   executionStatus?: string;
@@ -128,6 +134,7 @@ export interface EvalResult {
   output?: string;
   _toolCalls?: Record<string, unknown>;
   _graderDurationMs?: number;
+  metadata?: Record<string, unknown>;
   source_traceability?: SourceTraceability;
 }
 

--- a/apps/dashboard/src/routes/projects/$projectId_/runs/$runId_.suite.$suite.tsx
+++ b/apps/dashboard/src/routes/projects/$projectId_/runs/$runId_.suite.$suite.tsx
@@ -2,12 +2,12 @@
  * Project-scoped suite drill-down route.
  */
 
-import { Link, createFileRoute } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
 
-import { PassRatePill } from '~/components/PassRatePill';
+import { ResultTable } from '~/components/ResultTable';
 import { StatsCards } from '~/components/StatsCards';
 import { useProjectRunDetail, useStudioConfig } from '~/lib/api';
-import { isExecutionError, summarizeQuality } from '~/lib/result-summary';
+import { summarizeQuality } from '~/lib/result-summary';
 
 export const Route = createFileRoute('/projects/$projectId_/runs/$runId_/suite/$suite')({
   component: ProjectSuitePage,
@@ -68,53 +68,13 @@ function ProjectSuitePage() {
           <p className="text-lg text-gray-400">No evaluations in this suite</p>
         </div>
       ) : (
-        <div className="overflow-hidden rounded-lg border border-gray-800">
-          <table className="w-full text-left text-sm">
-            <thead className="border-b border-gray-800 bg-gray-900/50">
-              <tr>
-                <th className="px-4 py-3 font-medium text-gray-400">Test ID</th>
-                <th className="px-4 py-3 font-medium text-gray-400">Target</th>
-                <th className="w-48 px-4 py-3 font-medium text-gray-400">Score</th>
-                <th className="px-4 py-3 text-right font-medium text-gray-400">Duration</th>
-                <th className="px-4 py-3 text-right font-medium text-gray-400">Cost</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-800/50">
-              {results.map((result, idx) => (
-                <tr
-                  key={`${result.testId}-${idx}`}
-                  className="transition-colors hover:bg-gray-900/30"
-                >
-                  <td className="px-4 py-3">
-                    <Link
-                      to="/projects/$projectId/evals/$runId/$evalId"
-                      params={{ projectId, runId, evalId: result.testId }}
-                      className="font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
-                    >
-                      {result.testId}
-                    </Link>
-                  </td>
-                  <td className="px-4 py-3 text-gray-400">{result.target ?? '-'}</td>
-                  <td className="px-4 py-3">
-                    {isExecutionError(result) ? (
-                      <span className="inline-flex rounded-full bg-amber-900/40 px-2 py-0.5 text-xs font-medium text-amber-300">
-                        Execution error
-                      </span>
-                    ) : (
-                      <PassRatePill rate={result.score} />
-                    )}
-                  </td>
-                  <td className="px-4 py-3 text-right tabular-nums text-gray-400">
-                    {result.durationMs != null ? `${(result.durationMs / 1000).toFixed(1)}s` : '-'}
-                  </td>
-                  <td className="px-4 py-3 text-right tabular-nums text-gray-400">
-                    {result.costUsd != null ? `$${result.costUsd.toFixed(4)}` : '-'}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <ResultTable
+          results={results}
+          runId={runId}
+          projectId={projectId}
+          passThreshold={passThreshold}
+          title="Suite Evals"
+        />
       )}
     </div>
   );

--- a/apps/dashboard/src/routes/runs/$runId_.suite.$suite.tsx
+++ b/apps/dashboard/src/routes/runs/$runId_.suite.$suite.tsx
@@ -6,12 +6,12 @@
  * not a child route.
  */
 
-import { Link, createFileRoute } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
 
-import { PassRatePill } from '~/components/PassRatePill';
+import { ResultTable } from '~/components/ResultTable';
 import { StatsCards } from '~/components/StatsCards';
 import { useRunDetail, useStudioConfig } from '~/lib/api';
-import { isExecutionError, summarizeQuality } from '~/lib/result-summary';
+import { summarizeQuality } from '~/lib/result-summary';
 
 export const Route = createFileRoute('/runs/$runId_/suite/$suite')({
   component: SuitePage,
@@ -70,53 +70,12 @@ function SuitePage() {
           <p className="text-lg text-gray-400">No evaluations in this suite</p>
         </div>
       ) : (
-        <div className="overflow-hidden rounded-lg border border-gray-800">
-          <table className="w-full text-left text-sm">
-            <thead className="border-b border-gray-800 bg-gray-900/50">
-              <tr>
-                <th className="px-4 py-3 font-medium text-gray-400">Test ID</th>
-                <th className="px-4 py-3 font-medium text-gray-400">Target</th>
-                <th className="w-48 px-4 py-3 font-medium text-gray-400">Score</th>
-                <th className="px-4 py-3 text-right font-medium text-gray-400">Duration</th>
-                <th className="px-4 py-3 text-right font-medium text-gray-400">Cost</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-800/50">
-              {results.map((result, idx) => (
-                <tr
-                  key={`${result.testId}-${idx}`}
-                  className="transition-colors hover:bg-gray-900/30"
-                >
-                  <td className="px-4 py-3">
-                    <Link
-                      to="/evals/$runId/$evalId"
-                      params={{ runId, evalId: result.testId }}
-                      className="font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
-                    >
-                      {result.testId}
-                    </Link>
-                  </td>
-                  <td className="px-4 py-3 text-gray-400">{result.target ?? '-'}</td>
-                  <td className="px-4 py-3">
-                    {isExecutionError(result) ? (
-                      <span className="inline-flex rounded-full bg-amber-900/40 px-2 py-0.5 text-xs font-medium text-amber-300">
-                        Execution error
-                      </span>
-                    ) : (
-                      <PassRatePill rate={result.score} />
-                    )}
-                  </td>
-                  <td className="px-4 py-3 text-right tabular-nums text-gray-400">
-                    {result.durationMs != null ? `${(result.durationMs / 1000).toFixed(1)}s` : '-'}
-                  </td>
-                  <td className="px-4 py-3 text-right tabular-nums text-gray-400">
-                    {result.costUsd != null ? `$${result.costUsd.toFixed(4)}` : '-'}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <ResultTable
+          results={results}
+          runId={runId}
+          passThreshold={passThreshold}
+          title="Suite Evals"
+        />
       )}
     </div>
   );


### PR DESCRIPTION
Bead: av-2s7.3

## Summary
- Added a shared canonical ResultTable model/component with built-in views, URL-backed search/filter state, and display column controls.
- Replaced run detail and suite drill-down result browsing with the canonical table, including status, score, duration, cost/tokens, model/target, and dynamic grader columns.
- Renamed result-table UI/model terminology from scorer to grader, with compatibility for legacy `results_scorer` URL state.
- Aligned project-scoped feedback read/write paths so Unreviewed state works consistently in project contexts.
- Updated agent verification instructions to publish screenshot evidence to `agentv-private` evidence branches.

## Verification
- `bun --filter @agentv/dashboard test` - 101 pass
- `bun run typecheck` - pass
- `bun run lint` - pass
- `bun --filter @agentv/dashboard build` - pass; existing Vite large-chunk warning
- Browser UAT with production dashboard bundle and temp 4-row fixture: verified grader presets/copy, search/grader/display URL state, stable row links, mobile horizontal table scrolling, and no visible overflow findings.

## Screenshot Evidence
Private evidence branch: https://github.com/EntityProcess/agentv-private/tree/evidence/av-2s7.3-dashboard-result-table/evidence/av-2s7.3-dashboard-result-table

Private evidence commit: `06c9f46bb64e2185c1c73ef3c9c8dada8e18840a`

Files:
- `desktop-initial.png`
- `desktop-filtered-display.png`
- `mobile-default.png`
- `mobile-table.png`

Local copies remain at `/tmp/agentv-dashboard-result-table-evidence/` for this session only.

## Residual Risks
- UAT fixture server emitted repeated `git ls-tree agentv/results/v1` warnings because the temp fixture lacks the configured results branch; the local UI/API path still served and verified correctly.
- Project-scoped row link construction is implemented in the shared table; the browser fixture was single-run/unregistered, so project-scoped route evidence is covered by source/typecheck rather than fixture UAT.