### PR TITLE
fix(artifacts): write trace sidecars to canonical path

### DIFF
--- a/packages/core/src/evaluation/run-artifacts.ts
+++ b/packages/core/src/evaluation/run-artifacts.ts
@@ -1417,7 +1417,7 @@ export async function writeArtifactsFromResults(
       await writeFile(plan.responsePath, result.output, 'utf8');
     }
     await writeFile(
-      path.join(plan.outputsDir, 'execution-trace.json'),
+      path.join(plan.outputsDir, 'trace.json'),
       `${JSON.stringify(toTraceEnvelopeWire(envelope), null, 2)}\n`,
       'utf8',
     );


### PR DESCRIPTION
## Summary

`writeArtifactsFromResults` now writes trace sidecars to the canonical `outputs/trace.json` path that the trace envelope advertises. Before this fix, aggregate artifact writes produced `outputs/execution-trace.json` while the wire contract and transcript projection tests pointed at `outputs/trace.json`, so transcript-related artifact reads failed with `ENOENT`.

## Verification

- Reproduced the CI failure locally in `apps/cli/test/commands/eval/artifact-writer.test.ts`.
- `bun --filter @agentv/core build`
- `bun --filter agentv test test/commands/eval/artifact-writer.test.ts`
- `bun run test`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)