### PR TITLE
fix(results): root results branch at a stable deterministic genesis

### DIFF
--- a/packages/core/src/evaluation/results-repo.ts
+++ b/packages/core/src/evaluation/results-repo.ts
@@ -34,6 +34,14 @@ const RESULTS_REPO_COMMIT_EMAIL = 'agentv@results-repo';
 const RESULTS_REPO_COMMIT_NAME = 'AgentV Results';
 export const DEFAULT_RESULTS_BRANCH = 'agentv/results/v1';
 const GIT_EMPTY_TREE = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+// The results branch is a self-rooted orphan whose first commit is a fixed,
+// byte-identical empty-tree genesis. Pinning the message, identity (see
+// ensureResultsRepoCommitIdentity), and author/committer dates makes the root
+// commit SHA deterministic across every machine and clone, so all clients share
+// one genesis and fast-forward/append to a single ref instead of each minting a
+// divergent root. See createOrphanResultsBranch.
+const RESULTS_REPO_GENESIS_MESSAGE = 'chore(results): initialize AgentV results branch';
+const RESULTS_REPO_GENESIS_DATE = '@0 +0000';
 
 export interface ResultsRepoLocalPaths {
   readonly rootDir: string;
@@ -291,8 +299,32 @@ async function resolveDefaultBranch(repoDir: string): Promise<string> {
   return 'main';
 }
 
-async function fetchResultsRepo(repoDir: string, remote = 'origin'): Promise<void> {
+async function fetchResultsRepo(
+  repoDir: string,
+  remote = 'origin',
+  branch?: string,
+): Promise<void> {
   await runGit(['fetch', remote, '--prune'], { cwd: repoDir });
+  // A shallow `--single-branch --branch <default>` clone (e.g. the containerized
+  // deploy) has a fetch refspec covering only the default branch, so the prune
+  // fetch above never learns about the results branch. Fetch it explicitly by
+  // name into its remote-tracking ref so the branch is detected and appended to
+  // rather than re-rooted as a fresh orphan. Tolerate absence: the branch simply
+  // may not exist on the remote yet (first publish).
+  if (branch) {
+    await fetchResultsBranchRef(repoDir, remote, branch);
+  }
+}
+
+async function fetchResultsBranchRef(
+  repoDir: string,
+  remote: string,
+  branch: string,
+): Promise<void> {
+  await runGit(['fetch', remote, `+refs/heads/${branch}:refs/remotes/${remote}/${branch}`], {
+    cwd: repoDir,
+    check: false,
+  });
 }
 
 function remoteBranchRef(branch: string, remote = 'origin'): string {
@@ -373,12 +405,31 @@ async function checkoutConfiguredResultsBranch(
 }
 
 async function createOrphanResultsBranch(repoDir: string, branch: string): Promise<void> {
+  await runGit(['update-ref', `refs/heads/${branch}`, await createResultsGenesisCommit(repoDir)], {
+    cwd: repoDir,
+  });
+}
+
+// Mint the deterministic empty-tree genesis commit (no parents). Tree, message,
+// identity, and author/committer dates are all fixed, so two inits at different
+// wall-clock times — on different machines — produce the identical root SHA.
+async function createResultsGenesisCommit(repoDir: string): Promise<string> {
   await ensureResultsRepoCommitIdentity(repoDir);
   const { stdout } = await runGit(
-    ['commit-tree', GIT_EMPTY_TREE, '-m', 'chore(results): initialize AgentV results branch'],
-    { cwd: repoDir },
+    ['commit-tree', GIT_EMPTY_TREE, '-m', RESULTS_REPO_GENESIS_MESSAGE],
+    {
+      cwd: repoDir,
+      env: {
+        GIT_AUTHOR_NAME: RESULTS_REPO_COMMIT_NAME,
+        GIT_AUTHOR_EMAIL: RESULTS_REPO_COMMIT_EMAIL,
+        GIT_COMMITTER_NAME: RESULTS_REPO_COMMIT_NAME,
+        GIT_COMMITTER_EMAIL: RESULTS_REPO_COMMIT_EMAIL,
+        GIT_AUTHOR_DATE: RESULTS_REPO_GENESIS_DATE,
+        GIT_COMMITTER_DATE: RESULTS_REPO_GENESIS_DATE,
+      },
+    },
   );
-  await runGit(['update-ref', `refs/heads/${branch}`, stdout.trim()], { cwd: repoDir });
+  return stdout.trim();
 }
 
 async function isGitRepository(repoDir: string): Promise<boolean> {
@@ -884,14 +935,18 @@ export async function getResultsRepoSyncStatus(config?: ResultsConfig): Promise<
 
   try {
     if (normalized.repo_path) {
-      await fetchResultsRepo(normalized.path, normalized.remote).catch(() => undefined);
+      await fetchResultsRepo(normalized.path, normalized.remote, normalized.branch).catch(
+        () => undefined,
+      );
       return withGitInspection(
         baseStatus,
         await inspectResultsStorageBranchGit(normalized.path, normalized),
       );
     }
     if (normalized.branch) {
-      await fetchResultsRepo(normalized.path, normalized.remote).catch(() => undefined);
+      await fetchResultsRepo(normalized.path, normalized.remote, normalized.branch).catch(
+        () => undefined,
+      );
       await checkoutConfiguredResultsBranch(normalized.path, normalized);
     }
     return withGitInspection(baseStatus, await inspectResultsRepoGit(normalized.path, normalized));
@@ -910,7 +965,7 @@ export async function syncResultsRepo(config: ResultsConfig): Promise<ResultsRep
 
   try {
     const repoDir = await ensureResultsRepoClone(normalized);
-    await fetchResultsRepo(repoDir, normalized.remote);
+    await fetchResultsRepo(repoDir, normalized.remote, normalized.branch);
     if (!normalized.repo_path) {
       await checkoutConfiguredResultsBranch(repoDir, normalized);
     }
@@ -953,7 +1008,7 @@ export async function syncResultsRepoForProject(config: ResultsConfig): Promise<
     const repoDir = await ensureResultsRepoClone(normalized);
     if (normalized.repo_path) {
       try {
-        await fetchResultsRepo(repoDir, normalized.remote);
+        await fetchResultsRepo(repoDir, normalized.remote, normalized.branch);
       } catch (error) {
         if (normalized.require_push) {
           throw error;
@@ -1003,7 +1058,7 @@ export async function syncResultsRepoForProject(config: ResultsConfig): Promise<
         commitCreated,
       });
     }
-    await fetchResultsRepo(repoDir, normalized.remote);
+    await fetchResultsRepo(repoDir, normalized.remote, normalized.branch);
     await checkoutConfiguredResultsBranch(repoDir, normalized);
     let inspection = await inspectResultsRepoGit(repoDir, normalized);
 
@@ -1152,10 +1207,12 @@ export async function syncResultsRepoForProject(config: ResultsConfig): Promise<
       try {
         await runGit(['push', normalized.remote, `HEAD:${targetBranch}`], { cwd: repoDir });
         pushPerformed = true;
-        await fetchResultsRepo(repoDir, normalized.remote);
+        await fetchResultsRepo(repoDir, normalized.remote, normalized.branch);
         inspection = await inspectResultsRepoGit(repoDir, normalized);
       } catch (error) {
-        await fetchResultsRepo(repoDir, normalized.remote).catch(() => undefined);
+        await fetchResultsRepo(repoDir, normalized.remote, normalized.branch).catch(
+          () => undefined,
+        );
         inspection = await inspectResultsRepoGit(repoDir, normalized);
         const status = withGitInspection(getResultsRepoStatus(normalized), inspection);
         const reason = `Results repo push was rejected: ${getStatusMessage(error)}`;
@@ -1504,11 +1561,26 @@ async function commitResultsRunWithTemporaryIndex(params: {
 
   const destinationRunPath = normalizeDestinationPath(params.destinationPath);
   const destinationTreePath = path.posix.join(RESULTS_REPO_RUNS_DIR, destinationRunPath);
-  const base = await resolveStorageBranchBase({
+  let base = await resolveStorageBranchBase({
     repoDir: params.repoDir,
     normalized,
     preferRemote: params.preferRemoteBase,
   });
+
+  // No local or remote tip exists yet (after fetching the branch by name): this
+  // is the branch's very first commit. Root it at the deterministic empty-tree
+  // genesis and parent the run commit on it, rather than letting the run commit
+  // itself be the parentless root. This keeps the root SHA byte-identical across
+  // clients, so independent first-inits converge on one genesis and reconcile by
+  // fast-forward instead of producing divergent orphans.
+  if (!base.baseRef) {
+    await createOrphanResultsBranch(params.repoDir, normalized.branch);
+    base = await resolveStorageBranchBase({
+      repoDir: params.repoDir,
+      normalized,
+      preferRemote: params.preferRemoteBase,
+    });
+  }
 
   const indexRoot = await mkdtemp(path.join(os.tmpdir(), 'agentv-results-index-'));
   const indexFile = path.join(indexRoot, 'index');
@@ -1634,12 +1706,14 @@ async function pushDirectResultsToStorageBranch(params: {
         last_synced_at: new Date().toISOString(),
         last_error: undefined,
       });
-      await fetchResultsRepo(params.repoDir, params.normalized.remote).catch(() => undefined);
+      await fetchResultsRepo(params.repoDir, params.normalized.remote, params.storageBranch).catch(
+        () => undefined,
+      );
       return;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (attempt < DIRECT_PUSH_MAX_RETRIES && message.includes('non-fast-forward')) {
-        await fetchResultsRepo(params.repoDir, params.normalized.remote);
+        await fetchResultsRepo(params.repoDir, params.normalized.remote, params.storageBranch);
         const remoteRef = remoteBranchRef(params.storageBranch, params.normalized.remote);
         const localOnlyCount = (await gitRefExists(params.repoDir, remoteRef))
           ? await countUnpushedCommits(params.repoDir, remoteRef, params.storageBranch)
@@ -1678,7 +1752,7 @@ export async function directPushResults(params: {
 }): Promise<boolean> {
   const normalized = normalizeResultsConfig(params.config);
   const repoDir = await ensureResultsRepoClone(normalized);
-  await fetchResultsRepo(repoDir, normalized.remote).catch((error) => {
+  await fetchResultsRepo(repoDir, normalized.remote, normalized.branch).catch((error) => {
     if (normalized.require_push) {
       throw error;
     }
@@ -1947,7 +2021,7 @@ export async function setupWipWorktree(params: {
 }): Promise<WipWorktreeHandle> {
   const normalized = normalizeResultsConfig(params.config);
   const cloneDir = await ensureResultsRepoClone(normalized);
-  await fetchResultsRepo(cloneDir, normalized.remote).catch((error) => {
+  await fetchResultsRepo(cloneDir, normalized.remote, normalized.branch).catch((error) => {
     if (normalized.require_push) {
       throw error;
     }

--- a/packages/core/test/evaluation/results-repo.test.ts
+++ b/packages/core/test/evaluation/results-repo.test.ts
@@ -929,6 +929,213 @@ describe('results repo write path', () => {
   }, 20000);
 });
 
+describe('results branch stable genesis', () => {
+  let rootDir: string;
+
+  beforeEach(() => {
+    rootDir = mkdtempSync(path.join(os.tmpdir(), 'agentv-results-genesis-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  // Simulate the containerized deploy: a shallow, single-branch clone whose
+  // fetch refspec covers only the default branch, so the results branch is NOT
+  // present locally and is not brought in by a plain `git fetch --prune`.
+  function shallowCloneDefaultBranchOnly(remoteDir: string, cloneDir: string): void {
+    git(
+      `git clone --depth=1 --filter=blob:none --single-branch --branch main "${remoteDir}" "${cloneDir}"`,
+      rootDir,
+    );
+    git('git config user.email "test@example.com"', cloneDir);
+    git('git config user.name "Test User"', cloneDir);
+    // The clone only knows about main — the results branch must not be local.
+    expect(git('git config --get remote.origin.fetch', cloneDir)).toBe(
+      '+refs/heads/main:refs/remotes/origin/main',
+    );
+    expect(git(`git branch --list ${DEFAULT_RESULTS_BRANCH}`, cloneDir)).toBe('');
+  }
+
+  function rootCommits(remoteDir: string, branch: string): string[] {
+    return git(`git --git-dir "${remoteDir}" rev-list --max-parents=0 ${branch}`, rootDir)
+      .split('\n')
+      .filter(Boolean);
+  }
+
+  function isAncestor(remoteDir: string, ancestor: string, descendant: string): boolean {
+    try {
+      git(
+        `git --git-dir "${remoteDir}" merge-base --is-ancestor ${ancestor} ${descendant}`,
+        rootDir,
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async function publishFromShallowClone(params: {
+    readonly remoteDir: string;
+    readonly cloneName: string;
+    readonly experiment: string;
+    readonly timestamp: string;
+  }): Promise<void> {
+    const cloneDir = path.join(rootDir, params.cloneName);
+    shallowCloneDefaultBranchOnly(params.remoteDir, cloneDir);
+    const fsTimestamp = params.timestamp.replace(/[:.]/g, '-');
+    const sourceDir = path.join(rootDir, `${params.cloneName}-run`);
+    writeRunArtifacts(sourceDir, params.experiment, params.timestamp);
+    await directPushResults({
+      config: {
+        repo_path: cloneDir,
+        branch: DEFAULT_RESULTS_BRANCH,
+        sync: { auto_push: true },
+      },
+      sourceDir,
+      destinationPath: path.join(params.experiment, fsTimestamp),
+      commitMessage: `feat(results): ${params.experiment}`,
+    });
+  }
+
+  it('roots a self-contained orphan with an empty-tree genesis and no main ancestry', async () => {
+    const { remoteDir } = initializeRemoteRepo(rootDir);
+    const mainSha = git(`git --git-dir "${remoteDir}" rev-parse main`, rootDir);
+
+    await publishFromShallowClone({
+      remoteDir,
+      cloneName: 'deploy-boot',
+      experiment: 'expA',
+      timestamp: '2026-06-19T10:00:00.000Z',
+    });
+
+    const roots = rootCommits(remoteDir, DEFAULT_RESULTS_BRANCH);
+    expect(roots).toHaveLength(1);
+    const rootSha = roots[0];
+
+    // Root has an empty tree, zero parents, and the deterministic genesis identity.
+    expect(git(`git --git-dir "${remoteDir}" ls-tree ${rootSha}`, rootDir)).toBe('');
+    expect(
+      git(`git --git-dir "${remoteDir}" rev-list --count --max-parents=0 ${rootSha}`, rootDir),
+    ).toBe('1');
+    expect(git(`git --git-dir "${remoteDir}" show -s --format=%ai ${rootSha}`, rootDir)).toBe(
+      '1970-01-01 00:00:00 +0000',
+    );
+    expect(git(`git --git-dir "${remoteDir}" log -1 --format=%s ${rootSha}`, rootDir)).toBe(
+      'chore(results): initialize AgentV results branch',
+    );
+
+    // The orphan never inherits main's tree or history.
+    expect(isAncestor(remoteDir, mainSha, DEFAULT_RESULTS_BRANCH)).toBe(false);
+    expect(
+      git(`git --git-dir "${remoteDir}" ls-tree -r --name-only ${DEFAULT_RESULTS_BRANCH}`, rootDir),
+    ).toContain('runs/expA/2026-06-19T10-00-00-000Z/benchmark.json');
+  }, 20000);
+
+  it('mints a byte-identical genesis root regardless of wall-clock time', async () => {
+    const initGenesisRoot = async (label: string, runTimestamp: string): Promise<string> => {
+      const repoDir = path.join(rootDir, label);
+      mkdirSync(repoDir, { recursive: true });
+      git('git init --initial-branch=main --quiet', repoDir);
+      git('git config user.email "test@example.com"', repoDir);
+      git('git config user.name "Test User"', repoDir);
+      writeFileSync(path.join(repoDir, 'README.md'), '# project\n');
+      git('git add README.md && git commit --quiet -m "seed"', repoDir);
+      const fsTimestamp = runTimestamp.replace(/[:.]/g, '-');
+      const sourceDir = path.join(rootDir, `${label}-run`);
+      writeRunArtifacts(sourceDir, label, runTimestamp);
+      await directPushResults({
+        config: { repo_path: repoDir, branch: DEFAULT_RESULTS_BRANCH, sync: { auto_push: false } },
+        sourceDir,
+        destinationPath: path.join(label, fsTimestamp),
+        commitMessage: `feat(results): ${label}`,
+      });
+      return git(`git rev-list --max-parents=0 ${DEFAULT_RESULTS_BRANCH}`, repoDir);
+    };
+
+    // Two independent first-inits with different content and run timestamps.
+    const rootA = await initGenesisRoot('clientA', '2020-01-01T00:00:00.000Z');
+    const rootB = await initGenesisRoot('clientB', '2030-12-31T23:59:59.000Z');
+    expect(rootA).toBe(rootB);
+  }, 20000);
+
+  it('appends to the existing remote branch from a fresh clone that lacks it locally', async () => {
+    const { remoteDir } = initializeRemoteRepo(rootDir);
+
+    await publishFromShallowClone({
+      remoteDir,
+      cloneName: 'boot-1',
+      experiment: 'expA',
+      timestamp: '2026-06-19T10:00:00.000Z',
+    });
+    const rootAfterFirst = rootCommits(remoteDir, DEFAULT_RESULTS_BRANCH);
+    const tipAfterFirst = git(
+      `git --git-dir "${remoteDir}" rev-parse ${DEFAULT_RESULTS_BRANCH}`,
+      rootDir,
+    );
+
+    // A brand-new shallow clone that has never seen the results branch publishes again.
+    await publishFromShallowClone({
+      remoteDir,
+      cloneName: 'boot-2',
+      experiment: 'expB',
+      timestamp: '2026-06-19T11:00:00.000Z',
+    });
+
+    // Same single root preserved; history was appended (not replaced).
+    expect(rootCommits(remoteDir, DEFAULT_RESULTS_BRANCH)).toEqual(rootAfterFirst);
+    expect(isAncestor(remoteDir, tipAfterFirst, DEFAULT_RESULTS_BRANCH)).toBe(true);
+    const tree = git(
+      `git --git-dir "${remoteDir}" ls-tree -r --name-only ${DEFAULT_RESULTS_BRANCH}`,
+      rootDir,
+    );
+    expect(tree).toContain('runs/expA/2026-06-19T10-00-00-000Z/benchmark.json');
+    expect(tree).toContain('runs/expB/2026-06-19T11-00-00-000Z/benchmark.json');
+  }, 30000);
+
+  it('reconciles two independent first-inits onto a single shared genesis', async () => {
+    const { remoteDir } = initializeRemoteRepo(rootDir);
+
+    // Two deploy boots each clone master-only and create their own genesis locally.
+    const cloneA = path.join(rootDir, 'concurrent-a');
+    const cloneB = path.join(rootDir, 'concurrent-b');
+    shallowCloneDefaultBranchOnly(remoteDir, cloneA);
+    shallowCloneDefaultBranchOnly(remoteDir, cloneB);
+
+    const runA = path.join(rootDir, 'concurrent-a-run');
+    const runB = path.join(rootDir, 'concurrent-b-run');
+    writeRunArtifacts(runA, 'expA', '2026-06-19T10:00:00.000Z');
+    writeRunArtifacts(runB, 'expB', '2026-06-19T11:00:00.000Z');
+
+    // Client A publishes first and wins the race to create the remote branch.
+    await directPushResults({
+      config: { repo_path: cloneA, branch: DEFAULT_RESULTS_BRANCH, sync: { auto_push: true } },
+      sourceDir: runA,
+      destinationPath: path.join('expA', '2026-06-19T10-00-00-000Z'),
+      commitMessage: 'feat(results): expA',
+    });
+
+    // Client B initialized its own genesis before A pushed; its push is a
+    // non-fast-forward, but because both share the deterministic genesis it
+    // reconciles by re-basing onto the remote tip instead of diverging.
+    await directPushResults({
+      config: { repo_path: cloneB, branch: DEFAULT_RESULTS_BRANCH, sync: { auto_push: true } },
+      sourceDir: runB,
+      destinationPath: path.join('expB', '2026-06-19T11-00-00-000Z'),
+      commitMessage: 'feat(results): expB',
+    });
+
+    // One shared root, both runs present.
+    expect(rootCommits(remoteDir, DEFAULT_RESULTS_BRANCH)).toHaveLength(1);
+    const tree = git(
+      `git --git-dir "${remoteDir}" ls-tree -r --name-only ${DEFAULT_RESULTS_BRANCH}`,
+      rootDir,
+    );
+    expect(tree).toContain('runs/expA/2026-06-19T10-00-00-000Z/benchmark.json');
+    expect(tree).toContain('runs/expB/2026-06-19T11-00-00-000Z/benchmark.json');
+  }, 30000);
+});
+
 describe('buildWipBranchName', () => {
   it('produces an agentv/wip/<hostname>/<basename> branch name', () => {
     const runDir = '/some/path/.agentv/results/runs/default/2026-01-15T10-00-00';


### PR DESCRIPTION
## Summary

Makes the git-native results branch (e.g. `agentv/results/v1`) a **self-rooted orphan with its own, stable history** — first results push builds on a fixed genesis, and the branch is **never based on `main`**. This mirrors entire-cli's `entire/checkpoints/v1` model (and the single-ref/append philosophy beads uses over Dolt's `refs/dolt/data`).

### Problem
`createOrphanResultsBranch` minted the genesis with `git commit-tree <empty-tree>` **without pinning author/committer dates**, so the root SHA embedded wall-clock time and was **non-deterministic**. In the containerized deploy — which clones eval repos `--depth=1 --filter=blob:none --single-branch --branch master` and re-clones every boot — the results branch is never present locally, and the publish path didn't fetch it by name. So each boot minted a *different* divergent orphan root and pushes were rejected non-fast-forward / reconciled by replacing the base ("uses the latest base") instead of all clients sharing one genesis and appending.

### Fix (3 parts)
1. **Deterministic genesis:** `createOrphanResultsBranch` pins identity **and** dates to epoch `@0 +0000` → byte-identical empty-tree root SHA everywhere. (Stricter than entire-cli, which uses `time.Now()`.) Concurrent first-inits converge by fast-forward instead of diverging.
2. **Root + append:** brand-new branches root at that genesis and parent the first run commit on it (own, independent history).
3. **Detect-remote-first:** `fetchResultsRepo` now also fetches `refs/heads/<branch>` by name (tolerant of absence) across publish/checkout/sync/WIP paths, so shallow single-branch clones discover the remote tip and **append**; the genesis is created only when the branch is truly absent on the remote.

### Compatibility
No one-time re-init needed — existing branches keep their root via the append path (we base on the remote tip, whatever it is). The flat `runs/` layout and missing-branch tolerance (#1439) are untouched.

## Testing
- Full core `bun test`: **1911 pass / 0 fail** (results-repo.test.ts 36/36, +4 new); `tsc --noEmit` 0 errors; `biome check` clean; `bun run build` success.
- New tests assert: self-rooted orphan (empty-tree genesis, zero parents, `main` not an ancestor — incl. the simulated shallow `--single-branch` publish); genesis determinism across wall-clock times; append-from-fresh-clone preserves the root; two independent first-inits reconcile onto one shared genesis.
- Manual UAT (tmp-git deploy reproduction): post-fix the remote branch has a single empty-tree root dated `1970-01-01`, history `genesis → expA → expB`, `master` not an ancestor, and the second shallow-clone boot's push now succeeds by appending (previously rejected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
