### PR TITLE
fix(beads): keep bootstrap on agentv-beads

### DIFF
--- a/.agents/workflow.md
+++ b/.agents/workflow.md
@@ -9,7 +9,7 @@ This file expands [AGENTS.md](../AGENTS.md) for day-to-day repo work: tracker ha
 - Keep private launcher names, local paths, session aliases, dispatch policy, and operator workspace details outside this public repository.
 - GitHub remains the PR, CI, review, and merge surface. Use GitHub Issues or Projects for external collaboration only when the user or operator explicitly asks for that workflow.
 - Do not add repo-local tracker directories, tracker JSONL exports, dispatch logs, cross-repo research records, or operator decision records to AgentV commits unless the user explicitly asks for repository-local tracker artifacts.
-- If using Beads, follow the global Beads skill. The only repo-local Beads files intentionally tracked are `.beads/config.yaml` and `.beads/.gitignore`; `.beads/metadata.json` and runtime state stay checkout-local.
+- The only repo-local Beads files intentionally tracked are `.beads/config.yaml`, `.beads/metadata.json`, and `.beads/.gitignore`. Never commit the embedded Dolt database, JSONL exports, backups, locks, logs, or runtime state.
 - Do not commit project-local coordination config files. The safe Beads defaults above are the exception.
 - Do not use `git stash` on shared checkouts. Inspect `git status`, stage only your files, use a dedicated worktree, or ask before moving uncommitted changes.
 

--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -73,10 +73,7 @@ backup/
 *.db-shm
 db.sqlite
 bd.db
-
-# Checkout-local identity. `bd bootstrap` recreates this per checkout.
-metadata.json
-
 # NOTE: Do NOT add negation patterns here.
 # They would override fork protection in .git/info/exclude.
-# config.yaml stays tracked so each checkout knows the AgentV Beads remote.
+# Config files (metadata.json, config.yaml) are tracked by git by default
+# since no pattern above ignores them.

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -54,3 +54,4 @@
 # - github.repo
 
 federation.remote: "git+https://github.com/EntityProcess/agentv-beads.git"
+sync.remote: "git+https://github.com/EntityProcess/agentv-beads.git"

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,0 +1,7 @@
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "embedded",
+  "dolt_database": "av",
+  "project_id": "a7aea826-0087-45fc-93f5-9084e9924e8b"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,6 @@ Read the full rationale and examples in [.agents/product-boundary.md](.agents/pr
 - Start every repo change with `git fetch origin` and `git status --short --branch`.
 - Use `bun` for package and script operations.
 - Use the operator-supplied tracker when present. Do not commit tracker runtime state, local coordination config, or other machine-local artifacts.
-- If using Beads, follow the global Beads skill. AgentV Beads data belongs in `EntityProcess/agentv-beads`; never commit `.beads/metadata.json` or Beads runtime state.
 - Do not use `git stash` on shared checkouts. Stage explicit paths only, and never push directly to `main`.
 - Prefer the primary checkout only for small, clean, bounded work. Use a dedicated worktree from the latest `origin/main` for non-trivial, risky, long-running, or parallel changes.
 - Non-trivial work needs a plan or task list. If the implementation surface starts to balloon, stop and re-plan.


### PR DESCRIPTION
## Summary

Stacked fix for PR #1460 after review/dogfood found two Beads identity regressions.

This keeps PR #1460 from mutating the user-owned branch directly while making the correction reviewable.

## What changed

- Adds `sync.remote` to `.beads/config.yaml` so `bd bootstrap` chooses `EntityProcess/agentv-beads` instead of the code repo when `EntityProcess/agentv` still advertises `refs/dolt/data`.
- Restores the stable `.beads/metadata.json` identity descriptor from `origin/main`, because `bd` currently gets `dolt_database: av` and `project_id` from metadata and does not honor those keys from `config.yaml`.
- Cancels the contradictory docs/ignore changes from PR #1460, leaving the net diff against `origin/main` as only the `sync.remote` line.

## Verification

- Fresh temp clone with staged fix: `bd bootstrap --dry-run --json` planned `action: sync`, `database: av`, `sync_remote: git+https://github.com/EntityProcess/agentv-beads.git`.
- Fresh temp clone actual bootstrap: `bd bootstrap --yes` synced from `agentv-beads`; `bd --readonly count` returned `222`; `bd --readonly list --limit 5 --no-pager` returned real `av-*` issues.
- Existing embedded-Dolt fixture with restored metadata: `bd context --json` resolved database `av`; `bd --readonly count` returned `222`; list returned `av-*` issues without running bootstrap.
- Red check with same embedded store and missing metadata reproduced the failure: default database `beads`, count `0`, no issues.
- `git diff --check` and `git diff --check origin/main...HEAD` passed.

## Notes

Review finding: `federation.remote` is not enough for bootstrap; `bd bootstrap` keys off `sync.remote`. Also, until upstream `bd` can express database identity in tracked config, `.beads/metadata.json` is not disposable for this repo.