### PR TITLE
feat(evals): support suite input shorthand

### DIFF
--- a/apps/web/src/content/docs/docs/evaluation/eval-cases.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/eval-cases.mdx
@@ -41,6 +41,16 @@ The simplest form is a string, which expands to a single user message:
 input: What is 15 + 27?
 ```
 
+Structured object input also expands to a single user message while preserving the object for code graders and batch runners:
+
+```yaml
+input:
+  request:
+    type: classify_ticket
+  ticket:
+    title: Login button is broken
+```
+
 For multi-turn or system messages, use a message array:
 
 ```yaml

--- a/apps/web/src/content/docs/docs/evaluation/eval-cases.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/eval-cases.mdx
@@ -51,6 +51,8 @@ input:
     title: Login button is broken
 ```
 
+Top-level `role` is reserved for message objects. If your structured payload needs its own role field, nest it under another key.
+
 For multi-turn or system messages, use a message array:
 
 ```yaml

--- a/apps/web/src/content/docs/docs/evaluation/eval-files.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/eval-files.mdx
@@ -145,8 +145,11 @@ The effective input at runtime becomes `[...suite input, ...test input]`.
 
 Suite-level `input` accepts the same formats as test-level `input`:
 - **String** — wrapped as `[{ role: "user", content: "..." }]`
-- **Object** — wrapped as structured user-message content
+- **Object without a top-level `role` key** — wrapped as structured user-message content
+- **Single message object** — a `{ role, content }` object using a supported message role
 - **Message array** — used as-is, including system messages and file references
+
+The top-level `role` key is reserved for message objects. If your structured payload needs a field named `role`, nest it under another key.
 
 ```yaml
 input:

--- a/apps/web/src/content/docs/docs/evaluation/eval-files.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/eval-files.mdx
@@ -118,11 +118,17 @@ The `input` field defines messages that are **prepended** to every test's input.
 
 ```yaml
 description: Travel assistant evaluation
-input:
-  - role: user
-    content:
-      - type: file
-        value: ./system-prompt.md
+input: "Answer as a concise travel assistant."
+
+tests: ./cases.yaml
+```
+
+Use a block scalar for multi-line shared instructions:
+
+```yaml
+input: |
+  Read AGENTS.md before answering.
+  Explain the tradeoffs clearly.
 
 tests: ./cases.yaml
 ```
@@ -139,7 +145,18 @@ The effective input at runtime becomes `[...suite input, ...test input]`.
 
 Suite-level `input` accepts the same formats as test-level `input`:
 - **String** — wrapped as `[{ role: "user", content: "..." }]`
-- **Message array** — used as-is, including file references
+- **Object** — wrapped as structured user-message content
+- **Message array** — used as-is, including system messages and file references
+
+```yaml
+input:
+  - role: system
+    content: You are a careful reviewer.
+  - role: user
+    content:
+      - type: file
+        value: ./system-prompt.md
+```
 
 To opt out for a specific test, set `execution.skip_defaults: true` (same flag that skips suite-level `assertions`).
 

--- a/apps/web/src/content/docs/docs/evaluation/examples.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/examples.mdx
@@ -371,11 +371,9 @@ Share a common prompt or system instruction across all tests. Suite-level `input
 
 ```yaml
 description: Travel assistant evaluation
-input:
-  - role: user
-    content:
-      - type: file
-        value: ./system-prompt.md
+input: |
+  You are a knowledgeable travel assistant.
+  Always include a practical safety tip.
 
 tests: ./cases.yaml
 ```

--- a/examples/features/suite-level-input/evals/dataset.eval.yaml
+++ b/examples/features/suite-level-input/evals/dataset.eval.yaml
@@ -9,7 +9,7 @@ execution:
   target: llm
 
 # Suite-level input: prepended to every test's input messages.
-# Accepts the same formats as test-level input (string or message array).
+# Accepts the same formats as test-level input (string, object, or message array).
 # Skipped for tests with execution.skip_defaults: true.
 input:
   - role: user

--- a/packages/core/src/evaluation/loaders/shorthand-expansion.ts
+++ b/packages/core/src/evaluation/loaders/shorthand-expansion.ts
@@ -2,7 +2,7 @@
  * Shorthand expansion utilities for input/expected_output fields.
  *
  * Supports:
- * - `input` with string shorthand or message array
+ * - `input` with string/object shorthand, single message objects, or message arrays
  * - `input_files` shorthand (string input only): expands to type:file + type:text content blocks
  * - `expected_output` with string/object shorthand or message array
  */
@@ -15,7 +15,8 @@ import { isJsonObject, isTestMessage } from '../types.js';
  *
  * Supports:
  * - String: "What is 2+2?" -> [{ role: 'user', content: "What is 2+2?" }]
- * - Object (without role key): { accuracy: 0.9 } -> [{ role: 'user', content: { accuracy: 0.9 } }]
+ * - Object without role key: { accuracy: 0.9 } -> [{ role: 'user', content: { accuracy: 0.9 } }]
+ * - Object with role key: treated as a single message and must be valid message-shaped input
  * - Array of messages: Already in message format, passthrough
  *
  * @param value The raw `input` value from YAML/JSONL

--- a/packages/core/src/evaluation/validation/eval-file.schema.ts
+++ b/packages/core/src/evaluation/validation/eval-file.schema.ts
@@ -12,23 +12,23 @@ import { z } from 'zod';
 // Shared primitives
 // ---------------------------------------------------------------------------
 
-/** Message content: string or structured array */
+const JsonObjectSchema = z.object({}).catchall(z.unknown());
+
+/** Message content: string, structured object, or structured array */
 const ContentItemSchema = z.object({
   type: z.enum(['text', 'file', 'image']),
   value: z.string(),
 });
 
-const MessageContentSchema = z.union([z.string(), z.array(ContentItemSchema)]);
+const MessageContentSchema = z.union([z.string(), JsonObjectSchema, z.array(ContentItemSchema)]);
 
 const MessageSchema = z.object({
   role: z.enum(['system', 'user', 'assistant', 'tool']),
   content: MessageContentSchema,
 });
 
-const JsonObjectSchema = z.object({}).catchall(z.unknown());
-
-/** Input: string shorthand or message array */
-const InputSchema = z.union([z.string(), z.array(MessageSchema)]);
+/** Input: string/object shorthand or message array */
+const InputSchema = z.union([z.string(), JsonObjectSchema, z.array(MessageSchema)]);
 
 /** Expected output: string, object, or message array */
 const ExpectedOutputSchema = z.union([z.string(), JsonObjectSchema, z.array(MessageSchema)]);

--- a/packages/core/src/evaluation/validation/eval-file.schema.ts
+++ b/packages/core/src/evaluation/validation/eval-file.schema.ts
@@ -27,8 +27,15 @@ const MessageSchema = z.object({
   content: MessageContentSchema,
 });
 
-/** Input: string/object shorthand or message array */
-const InputSchema = z.union([z.string(), JsonObjectSchema, z.array(MessageSchema)]);
+const InputObjectShorthandSchema = z.object({ role: z.never().optional() }).catchall(z.unknown());
+
+/** Input: string/object shorthand, single message, or message array */
+const InputSchema = z.union([
+  z.string(),
+  MessageSchema,
+  InputObjectShorthandSchema,
+  z.array(MessageSchema),
+]);
 
 /** Expected output: string, object, or message array */
 const ExpectedOutputSchema = z.union([z.string(), JsonObjectSchema, z.array(MessageSchema)]);

--- a/packages/core/src/evaluation/validation/eval-validator.ts
+++ b/packages/core/src/evaluation/validation/eval-validator.ts
@@ -595,7 +595,7 @@ function validateMessages(
 
     // Validate role field
     const role = message.role;
-    const validRoles = ['system', 'user', 'assistant'];
+    const validRoles = ['system', 'user', 'assistant', 'tool'];
     if (!validRoles.includes(role as string)) {
       errors.push({
         severity: 'error',

--- a/packages/core/src/evaluation/validation/eval-validator.ts
+++ b/packages/core/src/evaluation/validation/eval-validator.ts
@@ -218,22 +218,8 @@ export async function validateEvalFile(filePath: string): Promise<ValidationResu
     }
   }
 
-  // Validate suite-level input (optional: string shorthand or message array)
-  const suiteInput = parsed.input;
-  if (suiteInput !== undefined) {
-    if (typeof suiteInput === 'string') {
-      // String shorthand is valid
-    } else if (Array.isArray(suiteInput)) {
-      validateMessages(suiteInput, 'input', absolutePath, errors);
-    } else {
-      errors.push({
-        severity: 'error',
-        filePath: absolutePath,
-        location: 'input',
-        message: "Invalid suite-level 'input' field (must be a string or array of messages)",
-      });
-    }
-  }
+  // Validate suite-level input (optional: string/object shorthand or message array)
+  validateInputField(parsed.input, 'input', absolutePath, errors);
 
   const cases: JsonValue | undefined = parsed.tests;
 
@@ -395,29 +381,10 @@ export async function validateEvalFile(filePath: string): Promise<ValidationResu
       });
     }
 
-    // input field (string shorthand or message array)
-    const inputField = evalCase.input;
-    if (inputField !== undefined) {
-      if (typeof inputField === 'string') {
-        // String shorthand is valid - no further validation needed
-      } else if (Array.isArray(inputField)) {
-        validateMessages(inputField, `${location}.input`, absolutePath, errors);
-      } else {
-        errors.push({
-          severity: 'error',
-          filePath: absolutePath,
-          location: `${location}.input`,
-          message: "Invalid 'input' field (must be a string or array of messages)",
-        });
-      }
-    } else {
-      errors.push({
-        severity: 'error',
-        filePath: absolutePath,
-        location: `${location}.input`,
-        message: "Missing 'input' field (must be a string or array of messages)",
-      });
-    }
+    // input field (string/object shorthand or message array)
+    validateInputField(evalCase.input, `${location}.input`, absolutePath, errors, {
+      required: true,
+    });
 
     // expected_output field (string/object shorthand or message array)
     const expectedOutputField = evalCase.expected_output;
@@ -701,6 +668,52 @@ function validateMessages(
       });
     }
   }
+}
+
+function validateInputField(
+  inputField: JsonValue | undefined,
+  location: string,
+  filePath: string,
+  errors: ValidationError[],
+  options: { readonly required?: boolean } = {},
+): void {
+  if (inputField === undefined) {
+    if (options.required) {
+      errors.push({
+        severity: 'error',
+        filePath,
+        location,
+        message: "Missing 'input' field (must be a string, object, or array of messages)",
+      });
+    }
+    return;
+  }
+
+  if (typeof inputField === 'string') {
+    // String shorthand is valid.
+    return;
+  }
+
+  if (Array.isArray(inputField)) {
+    validateMessages(inputField, location, filePath, errors);
+    return;
+  }
+
+  if (isObject(inputField)) {
+    if ('role' in inputField) {
+      validateMessages([inputField], location, filePath, errors);
+    }
+    // Structured object shorthand is valid and expands to one user message.
+    return;
+  }
+
+  const label = location === 'input' ? "suite-level 'input'" : "'input'";
+  errors.push({
+    severity: 'error',
+    filePath,
+    location,
+    message: `Invalid ${label} field (must be a string, object, or array of messages)`,
+  });
 }
 
 function validateMetadata(parsed: JsonObject, filePath: string, errors: ValidationError[]): void {

--- a/packages/core/test/evaluation/loaders/shorthand-expansion.test.ts
+++ b/packages/core/test/evaluation/loaders/shorthand-expansion.test.ts
@@ -23,6 +23,20 @@ describe('expandInputShorthand', () => {
     expect(result).toEqual([{ role: 'user', content: structured }]);
   });
 
+  it('passes through single message object', () => {
+    const message = { role: 'user', content: { task: 'classify' } };
+
+    const result = expandInputShorthand(message);
+
+    expect(result).toEqual([message]);
+  });
+
+  it('does not treat objects with reserved role key as structured shorthand', () => {
+    const result = expandInputShorthand({ role: 'admin', task: 'classify' });
+
+    expect(result).toBeUndefined();
+  });
+
   it('passes through message array', () => {
     const messages = [
       { role: 'system', content: 'You are a calculator' },

--- a/packages/core/test/evaluation/loaders/shorthand-expansion.test.ts
+++ b/packages/core/test/evaluation/loaders/shorthand-expansion.test.ts
@@ -15,6 +15,14 @@ describe('expandInputShorthand', () => {
     expect(result).toEqual([{ role: 'user', content: 'What is 2+2?' }]);
   });
 
+  it('expands structured object to single user message', () => {
+    const structured = { task: 'classify', labels: ['bug', 'feature'] };
+
+    const result = expandInputShorthand(structured);
+
+    expect(result).toEqual([{ role: 'user', content: structured }]);
+  });
+
   it('passes through message array', () => {
     const messages = [
       { role: 'system', content: 'You are a calculator' },

--- a/packages/core/test/evaluation/suite-level-input.test.ts
+++ b/packages/core/test/evaluation/suite-level-input.test.ts
@@ -48,6 +48,62 @@ tests:
     });
   });
 
+  it('prepends suite-level input block scalar to each test input', async () => {
+    await writeFile(
+      path.join(tempDir, 'block-input.eval.yaml'),
+      `input: |
+  Read AGENTS.md before answering.
+  Mention tradeoffs.
+tests:
+  - id: block-test
+    criteria: "Uses shared instructions"
+    input: "Summarize the repo."
+`,
+    );
+
+    const tests = await loadTests(path.join(tempDir, 'block-input.eval.yaml'), tempDir);
+
+    expect(tests).toHaveLength(1);
+    expect(tests[0].input).toHaveLength(2);
+    expect(tests[0].input[0]).toEqual({
+      role: 'user',
+      content: 'Read AGENTS.md before answering.\nMention tradeoffs.\n',
+    });
+    expect(tests[0].input[1]).toEqual({ role: 'user', content: 'Summarize the repo.' });
+  });
+
+  it('prepends suite-level structured input object to each test input', async () => {
+    await writeFile(
+      path.join(tempDir, 'object-input.eval.yaml'),
+      `input:
+  instruction: "Classify the request"
+  labels:
+    - bug
+    - feature
+tests:
+  - id: object-test
+    criteria: "Uses shared structured context"
+    input: "The login button is broken."
+`,
+    );
+
+    const tests = await loadTests(path.join(tempDir, 'object-input.eval.yaml'), tempDir);
+
+    expect(tests).toHaveLength(1);
+    expect(tests[0].input).toHaveLength(2);
+    expect(tests[0].input[0]).toEqual({
+      role: 'user',
+      content: {
+        instruction: 'Classify the request',
+        labels: ['bug', 'feature'],
+      },
+    });
+    expect(tests[0].input[1]).toEqual({
+      role: 'user',
+      content: 'The login button is broken.',
+    });
+  });
+
   it('prepends suite-level input message array to each test input', async () => {
     await writeFile(
       path.join(tempDir, 'array-input.eval.yaml'),

--- a/packages/core/test/evaluation/validation/eval-file-schema.test.ts
+++ b/packages/core/test/evaluation/validation/eval-file-schema.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'bun:test';
+
+import { EvalFileSchema } from '../../../src/evaluation/validation/eval-file.schema.js';
+
+describe('EvalFileSchema input shorthand', () => {
+  const baseTest = {
+    id: 'test-1',
+    criteria: 'Goal',
+    input: 'Classify this request.',
+  };
+
+  it('accepts structured object input shorthand without a top-level role key', () => {
+    const result = EvalFileSchema.safeParse({
+      input: { task: 'classify', labels: ['bug', 'feature'] },
+      tests: [baseTest],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a single message-shaped input object with a top-level role key', () => {
+    const result = EvalFileSchema.safeParse({
+      input: { role: 'user', content: { task: 'classify' } },
+      tests: [baseTest],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects object input with a reserved top-level role key unless it is a valid message', () => {
+    const result = EvalFileSchema.safeParse({
+      input: { role: 'admin', task: 'classify' },
+      tests: [baseTest],
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/core/test/evaluation/validation/eval-validator.test.ts
+++ b/packages/core/test/evaluation/validation/eval-validator.test.ts
@@ -73,6 +73,47 @@ tests:
     expect(result.errors).toHaveLength(0);
   });
 
+  it('validates eval file with suite-level single-message input object', async () => {
+    const filePath = path.join(tempDir, 'suite-input-message-object.yaml');
+    await writeFile(
+      filePath,
+      `input:
+  role: user
+  content:
+    task: classify
+tests:
+  - id: test-1
+    criteria: Goal
+    input: "The login button is broken."
+`,
+    );
+
+    const result = await validateEvalFile(filePath);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('rejects suite-level object input with invalid reserved role', async () => {
+    const filePath = path.join(tempDir, 'suite-input-invalid-role-object.yaml');
+    await writeFile(
+      filePath,
+      `input:
+  role: admin
+  task: classify
+tests:
+  - id: test-1
+    criteria: Goal
+    input: "The login button is broken."
+`,
+    );
+
+    const result = await validateEvalFile(filePath);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((error) => error.location === 'input[0].role')).toBe(true);
+  });
+
   it('validates eval file with test-level structured object input shorthand', async () => {
     const filePath = path.join(tempDir, 'test-input-object.yaml');
     await writeFile(
@@ -90,6 +131,25 @@ tests:
 
     expect(result.valid).toBe(true);
     expect(result.errors).toHaveLength(0);
+  });
+
+  it('rejects test-level object input with invalid reserved role', async () => {
+    const filePath = path.join(tempDir, 'test-input-invalid-role-object.yaml');
+    await writeFile(
+      filePath,
+      `tests:
+  - id: test-1
+    criteria: Goal
+    input:
+      role: admin
+      task: classify
+`,
+    );
+
+    const result = await validateEvalFile(filePath);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((error) => error.location === 'tests[0].input[0].role')).toBe(true);
   });
 
   it('validates eval file with input alias message array', async () => {

--- a/packages/core/test/evaluation/validation/eval-validator.test.ts
+++ b/packages/core/test/evaluation/validation/eval-validator.test.ts
@@ -34,6 +34,64 @@ describe('validateEvalFile', () => {
     expect(result.errors).toHaveLength(0);
   });
 
+  it('validates eval file with suite-level input block shorthand', async () => {
+    const filePath = path.join(tempDir, 'suite-input-block.yaml');
+    await writeFile(
+      filePath,
+      `input: |
+  Read AGENTS.md before answering.
+tests:
+  - id: test-1
+    criteria: Goal
+    input: "What is 2+2?"
+`,
+    );
+
+    const result = await validateEvalFile(filePath);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('validates eval file with suite-level structured object input shorthand', async () => {
+    const filePath = path.join(tempDir, 'suite-input-object.yaml');
+    await writeFile(
+      filePath,
+      `input:
+  instruction: Classify the request
+  labels: [bug, feature]
+tests:
+  - id: test-1
+    criteria: Goal
+    input: "The login button is broken."
+`,
+    );
+
+    const result = await validateEvalFile(filePath);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('validates eval file with test-level structured object input shorthand', async () => {
+    const filePath = path.join(tempDir, 'test-input-object.yaml');
+    await writeFile(
+      filePath,
+      `tests:
+  - id: test-1
+    criteria: Goal
+    input:
+      question: "What is 2+2?"
+      format: terse
+`,
+    );
+
+    const result = await validateEvalFile(filePath);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
   it('validates eval file with input alias message array', async () => {
     const filePath = path.join(tempDir, 'input-array.yaml');
     await writeFile(

--- a/skills-data/agentv-bench/references/eval-yaml-spec.md
+++ b/skills-data/agentv-bench/references/eval-yaml-spec.md
@@ -11,12 +11,13 @@ The grader agent uses this to evaluate assertions without the CLI.
 - `description` (string, optional) — description
 - `execution` (object, optional) — `target`, `model`, etc.
 - `workspace` (object, optional) — workspace config (template, hooks)
+- `input` (string | object | Message[], optional) — suite-level input prepended to each test. String/block shorthand expands to a user message.
 - `tests` (array, required) — test cases
 
 ### Per-test fields
 
 - `id` (string, required) — unique test identifier
-- `input` (string | Message[], required) — task input. String shorthand expands to `[{role: user, content: "..."}]`
+- `input` (string | object | Message[], required) — task input. String shorthand expands to `[{role: user, content: "..."}]`; object shorthand preserves structured user content.
 - `expected_output` (string | Message[], optional) — reference answer. String shorthand expands to `[{role: assistant, content: "..."}]`
 - `criteria` (string, optional) — human-readable success criteria
 - `assertions` (array, optional) — grader assertions

--- a/skills-data/agentv-bench/references/eval-yaml-spec.md
+++ b/skills-data/agentv-bench/references/eval-yaml-spec.md
@@ -11,13 +11,13 @@ The grader agent uses this to evaluate assertions without the CLI.
 - `description` (string, optional) — description
 - `execution` (object, optional) — `target`, `model`, etc.
 - `workspace` (object, optional) — workspace config (template, hooks)
-- `input` (string | object | Message[], optional) — suite-level input prepended to each test. String/block shorthand expands to a user message.
+- `input` (string | object | Message | Message[], optional) — suite-level input prepended to each test. String/block shorthand expands to a user message.
 - `tests` (array, required) — test cases
 
 ### Per-test fields
 
 - `id` (string, required) — unique test identifier
-- `input` (string | object | Message[], required) — task input. String shorthand expands to `[{role: user, content: "..."}]`; object shorthand preserves structured user content.
+- `input` (string | object | Message | Message[], required) — task input. String shorthand expands to `[{role: user, content: "..."}]`; object shorthand preserves structured user content when the object has no top-level `role`. Top-level `role` is reserved for message objects.
 - `expected_output` (string | Message[], optional) — reference answer. String shorthand expands to `[{role: assistant, content: "..."}]`
 - `criteria` (string, optional) — human-readable success criteria
 - `assertions` (array, optional) — grader assertions

--- a/skills-data/agentv-eval-writer/SKILL.md
+++ b/skills-data/agentv-eval-writer/SKILL.md
@@ -129,7 +129,8 @@ tests:
 
 **Shorthand forms:**
 - `input` (string, including YAML block scalars) expands to `[{role: "user", content: "..."}]`
-- `input` (object) expands to `[{role: "user", content: {...}}]`
+- `input` (object without a top-level `role`) expands to `[{role: "user", content: {...}}]`
+- top-level `role` is reserved for message objects; use `{role, content}` when you mean a message, or nest payload role data under another key
 - `expected_output` (string/object) expands to `[{role: "assistant", content: ...}]`
 - Use these canonical field names on disk; keep the wire format `snake_case`
 
@@ -175,7 +176,7 @@ tests: ./cases.yaml
 ```
 
 Effective input: `[...suite input, ...test input]`. Skipped when `execution.skip_defaults: true`.
-Accepts the same formats as test `input`: string/block scalar, structured object, or full message array. Use the full message array only when you need roles, multiple messages, or file/image content blocks.
+Accepts the same formats as test `input`: string/block scalar, structured object without a top-level `role`, single message object, or full message array. Use the full message array only when you need multiple messages or file/image content blocks.
 
 ## Tests as String Path
 

--- a/skills-data/agentv-eval-writer/SKILL.md
+++ b/skills-data/agentv-eval-writer/SKILL.md
@@ -119,7 +119,7 @@ tests:
 |-------|----------|-------------|
 | `id` | yes | Unique identifier |
 | `criteria` | yes | What the response should accomplish |
-| `input` | yes | Input to the agent (string shorthand or full message array) |
+| `input` | yes | Input to the agent (string/object shorthand or full message array) |
 | `expected_output` | no | Gold-standard reference answer (string shorthand or full message array) |
 | `assertions` | no | Graders: deterministic checks, rubrics, and LLM/code graders |
 | `execution` | no | Per-case execution overrides |
@@ -128,7 +128,8 @@ tests:
 | `conversation_id` | no | Thread grouping |
 
 **Shorthand forms:**
-- `input` (string) expands to `[{role: "user", content: "..."}]`
+- `input` (string, including YAML block scalars) expands to `[{role: "user", content: "..."}]`
+- `input` (object) expands to `[{role: "user", content: {...}}]`
 - `expected_output` (string/object) expands to `[{role: "assistant", content: ...}]`
 - Use these canonical field names on disk; keep the wire format `snake_case`
 
@@ -158,14 +159,12 @@ requires:
 
 ## Suite-level Input
 
-Prepend shared input messages to every test (like suite-level `assertions`). Avoids repeating the same prompt file in each test:
+Prepend shared input messages to every test (like suite-level `assertions`). Avoids repeating the same prompt or instruction in each test:
 
 ```yaml
-input:
-  - role: user
-    content:
-      - type: file
-        value: ./system-prompt.md
+input: |
+  Read AGENTS.md before answering.
+  Explain tradeoffs clearly.
 
 tests: ./cases.yaml
 
@@ -176,7 +175,7 @@ tests: ./cases.yaml
 ```
 
 Effective input: `[...suite input, ...test input]`. Skipped when `execution.skip_defaults: true`.
-Accepts same formats as test `input` (string or message array).
+Accepts the same formats as test `input`: string/block scalar, structured object, or full message array. Use the full message array only when you need roles, multiple messages, or file/image content blocks.
 
 ## Tests as String Path
 

--- a/skills-data/agentv-eval-writer/references/eval-schema.json
+++ b/skills-data/agentv-eval-writer/references/eval-schema.json
@@ -50,18 +50,33 @@
               "type": "string"
             },
             {
+              "type": "object",
+              "properties": {},
+              "additionalProperties": {}
+            },
+            {
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
                   "role": {
                     "type": "string",
-                    "enum": ["system", "user", "assistant", "tool"]
+                    "enum": [
+                      "system",
+                      "user",
+                      "assistant",
+                      "tool"
+                    ]
                   },
                   "content": {
                     "anyOf": [
                       {
                         "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": {}
                       },
                       {
                         "type": "array",
@@ -70,20 +85,30 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "enum": ["text", "file", "image"]
+                              "enum": [
+                                "text",
+                                "file",
+                                "image"
+                              ]
                             },
                             "value": {
                               "type": "string"
                             }
                           },
-                          "required": ["type", "value"],
+                          "required": [
+                            "type",
+                            "value"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     ]
                   }
                 },
-                "required": ["role", "content"],
+                "required": [
+                  "role",
+                  "content"
+                ],
                 "additionalProperties": false
               }
             }
@@ -120,18 +145,33 @@
                         "type": "string"
                       },
                       {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": {}
+                      },
+                      {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
                             "role": {
                               "type": "string",
-                              "enum": ["system", "user", "assistant", "tool"]
+                              "enum": [
+                                "system",
+                                "user",
+                                "assistant",
+                                "tool"
+                              ]
                             },
                             "content": {
                               "anyOf": [
                                 {
                                   "type": "string"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {},
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "array",
@@ -140,20 +180,30 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": ["text", "file", "image"]
+                                        "enum": [
+                                          "text",
+                                          "file",
+                                          "image"
+                                        ]
                                       },
                                       "value": {
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["type", "value"],
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               ]
                             }
                           },
-                          "required": ["role", "content"],
+                          "required": [
+                            "role",
+                            "content"
+                          ],
                           "additionalProperties": false
                         }
                       }
@@ -182,12 +232,22 @@
                           "properties": {
                             "role": {
                               "type": "string",
-                              "enum": ["system", "user", "assistant", "tool"]
+                              "enum": [
+                                "system",
+                                "user",
+                                "assistant",
+                                "tool"
+                              ]
                             },
                             "content": {
                               "anyOf": [
                                 {
                                   "type": "string"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {},
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "array",
@@ -196,20 +256,30 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": ["text", "file", "image"]
+                                        "enum": [
+                                          "text",
+                                          "file",
+                                          "image"
+                                        ]
                                       },
                                       "value": {
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["type", "value"],
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               ]
                             }
                           },
-                          "required": ["role", "content"],
+                          "required": [
+                            "role",
+                            "content"
+                          ],
                           "additionalProperties": false
                         }
                       }
@@ -253,7 +323,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["code-grader", "code_grader"]
+                              "enum": [
+                                "code-grader",
+                                "code_grader"
+                              ]
                             },
                             "command": {
                               "anyOf": [
@@ -327,12 +400,18 @@
                                     ]
                                   }
                                 },
-                                "required": ["type", "command"],
+                                "required": [
+                                  "type",
+                                  "command"
+                                ],
                                 "additionalProperties": false
                               }
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -369,7 +448,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["llm-grader", "llm_grader"]
+                              "enum": [
+                                "llm-grader",
+                                "llm_grader"
+                              ]
                             },
                             "prompt": {
                               "anyOf": [
@@ -427,7 +509,10 @@
                                   },
                                   "operator": {
                                     "type": "string",
-                                    "enum": ["correctness", "contradiction"]
+                                    "enum": [
+                                      "correctness",
+                                      "contradiction"
+                                    ]
                                   },
                                   "weight": {
                                     "type": "number"
@@ -468,7 +553,10 @@
                                           "minLength": 1
                                         }
                                       },
-                                      "required": ["score_range", "outcome"],
+                                      "required": [
+                                        "score_range",
+                                        "outcome"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   }
@@ -519,12 +607,17 @@
                                     ]
                                   }
                                 },
-                                "required": ["type", "command"],
+                                "required": [
+                                  "type",
+                                  "command"
+                                ],
                                 "additionalProperties": false
                               }
                             }
                           },
-                          "required": ["type"],
+                          "required": [
+                            "type"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -535,7 +628,9 @@
                               "minLength": 1
                             }
                           },
-                          "required": ["include"],
+                          "required": [
+                            "include"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -598,7 +693,9 @@
                                       }
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -614,7 +711,10 @@
                                       "maximum": 1
                                     }
                                   },
-                                  "required": ["type", "threshold"],
+                                  "required": [
+                                    "type",
+                                    "threshold"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -631,7 +731,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "path"],
+                                  "required": [
+                                    "type",
+                                    "path"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -648,13 +751,18 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
                             }
                           },
-                          "required": ["type", "aggregator"],
+                          "required": [
+                            "type",
+                            "aggregator"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -691,11 +799,20 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["tool-trajectory", "tool_trajectory"]
+                              "enum": [
+                                "tool-trajectory",
+                                "tool_trajectory"
+                              ]
                             },
                             "mode": {
                               "type": "string",
-                              "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                              "enum": [
+                                "any_order",
+                                "in_order",
+                                "exact",
+                                "subset",
+                                "superset"
+                              ]
                             },
                             "minimums": {
                               "type": "object",
@@ -736,7 +853,12 @@
                                     "anyOf": [
                                       {
                                         "type": "string",
-                                        "enum": ["exact", "ignore", "subset", "superset"]
+                                        "enum": [
+                                          "exact",
+                                          "ignore",
+                                          "subset",
+                                          "superset"
+                                        ]
                                       },
                                       {
                                         "type": "array",
@@ -750,7 +872,12 @@
                                     "anyOf": [
                                       {
                                         "type": "string",
-                                        "enum": ["exact", "ignore", "subset", "superset"]
+                                        "enum": [
+                                          "exact",
+                                          "ignore",
+                                          "subset",
+                                          "superset"
+                                        ]
                                       },
                                       {
                                         "type": "array",
@@ -761,7 +888,9 @@
                                     ]
                                   }
                                 },
-                                "required": ["tool"],
+                                "required": [
+                                  "tool"
+                                ],
                                 "additionalProperties": false
                               }
                             },
@@ -769,7 +898,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -783,7 +917,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -794,7 +933,10 @@
                               ]
                             }
                           },
-                          "required": ["type", "mode"],
+                          "required": [
+                            "type",
+                            "mode"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -831,7 +973,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["field-accuracy", "field_accuracy"]
+                              "enum": [
+                                "field-accuracy",
+                                "field_accuracy"
+                              ]
                             },
                             "fields": {
                               "type": "array",
@@ -843,7 +988,11 @@
                                   },
                                   "match": {
                                     "type": "string",
-                                    "enum": ["exact", "numeric_tolerance", "date"]
+                                    "enum": [
+                                      "exact",
+                                      "numeric_tolerance",
+                                      "date"
+                                    ]
                                   },
                                   "required": {
                                     "type": "boolean"
@@ -865,17 +1014,26 @@
                                     }
                                   }
                                 },
-                                "required": ["path", "match"],
+                                "required": [
+                                  "path",
+                                  "match"
+                                ],
                                 "additionalProperties": false
                               },
                               "minItems": 1
                             },
                             "aggregation": {
                               "type": "string",
-                              "enum": ["weighted_average", "all_or_nothing"]
+                              "enum": [
+                                "weighted_average",
+                                "all_or_nothing"
+                              ]
                             }
                           },
-                          "required": ["type", "fields"],
+                          "required": [
+                            "type",
+                            "fields"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -919,7 +1077,10 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["type", "threshold"],
+                          "required": [
+                            "type",
+                            "threshold"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -963,7 +1124,10 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["type", "budget"],
+                          "required": [
+                            "type",
+                            "budget"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -1000,7 +1164,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["token-usage", "token_usage"]
+                              "enum": [
+                                "token-usage",
+                                "token_usage"
+                              ]
                             },
                             "max_total": {
                               "type": "number",
@@ -1015,7 +1182,9 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["type"],
+                          "required": [
+                            "type"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -1052,7 +1221,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["execution-metrics", "execution_metrics"]
+                              "enum": [
+                                "execution-metrics",
+                                "execution_metrics"
+                              ]
                             },
                             "max_tool_calls": {
                               "type": "number",
@@ -1084,7 +1256,9 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["type"],
+                          "required": [
+                            "type"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -1127,7 +1301,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["type", "value"],
+                          "required": [
+                            "type",
+                            "value"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -1170,7 +1347,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["type", "value"],
+                          "required": [
+                            "type",
+                            "value"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -1207,10 +1387,15 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["is-json", "is_json"]
+                              "enum": [
+                                "is-json",
+                                "is_json"
+                              ]
                             }
                           },
-                          "required": ["type"],
+                          "required": [
+                            "type"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -1253,7 +1438,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["type", "value"],
+                          "required": [
+                            "type",
+                            "value"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -1305,7 +1493,10 @@
                                   },
                                   "operator": {
                                     "type": "string",
-                                    "enum": ["correctness", "contradiction"]
+                                    "enum": [
+                                      "correctness",
+                                      "contradiction"
+                                    ]
                                   },
                                   "weight": {
                                     "type": "number"
@@ -1346,7 +1537,10 @@
                                           "minLength": 1
                                         }
                                       },
-                                      "required": ["score_range", "outcome"],
+                                      "required": [
+                                        "score_range",
+                                        "outcome"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   }
@@ -1356,7 +1550,10 @@
                               "minItems": 1
                             }
                           },
-                          "required": ["type", "criteria"],
+                          "required": [
+                            "type",
+                            "criteria"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -1400,7 +1597,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["code-grader", "code_grader"]
+                              "enum": [
+                                "code-grader",
+                                "code_grader"
+                              ]
                             },
                             "command": {
                               "anyOf": [
@@ -1474,12 +1674,18 @@
                                     ]
                                   }
                                 },
-                                "required": ["type", "command"],
+                                "required": [
+                                  "type",
+                                  "command"
+                                ],
                                 "additionalProperties": false
                               }
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -1516,7 +1722,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["llm-grader", "llm_grader"]
+                              "enum": [
+                                "llm-grader",
+                                "llm_grader"
+                              ]
                             },
                             "prompt": {
                               "anyOf": [
@@ -1574,7 +1783,10 @@
                                   },
                                   "operator": {
                                     "type": "string",
-                                    "enum": ["correctness", "contradiction"]
+                                    "enum": [
+                                      "correctness",
+                                      "contradiction"
+                                    ]
                                   },
                                   "weight": {
                                     "type": "number"
@@ -1615,7 +1827,10 @@
                                           "minLength": 1
                                         }
                                       },
-                                      "required": ["score_range", "outcome"],
+                                      "required": [
+                                        "score_range",
+                                        "outcome"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   }
@@ -1666,12 +1881,17 @@
                                     ]
                                   }
                                 },
-                                "required": ["type", "command"],
+                                "required": [
+                                  "type",
+                                  "command"
+                                ],
                                 "additionalProperties": false
                               }
                             }
                           },
-                          "required": ["type"],
+                          "required": [
+                            "type"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -1682,7 +1902,9 @@
                               "minLength": 1
                             }
                           },
-                          "required": ["include"],
+                          "required": [
+                            "include"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -1745,7 +1967,9 @@
                                       }
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -1761,7 +1985,10 @@
                                       "maximum": 1
                                     }
                                   },
-                                  "required": ["type", "threshold"],
+                                  "required": [
+                                    "type",
+                                    "threshold"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -1778,7 +2005,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "path"],
+                                  "required": [
+                                    "type",
+                                    "path"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -1795,13 +2025,18 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
                             }
                           },
-                          "required": ["type", "aggregator"],
+                          "required": [
+                            "type",
+                            "aggregator"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -1838,11 +2073,20 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["tool-trajectory", "tool_trajectory"]
+                              "enum": [
+                                "tool-trajectory",
+                                "tool_trajectory"
+                              ]
                             },
                             "mode": {
                               "type": "string",
-                              "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                              "enum": [
+                                "any_order",
+                                "in_order",
+                                "exact",
+                                "subset",
+                                "superset"
+                              ]
                             },
                             "minimums": {
                               "type": "object",
@@ -1883,7 +2127,12 @@
                                     "anyOf": [
                                       {
                                         "type": "string",
-                                        "enum": ["exact", "ignore", "subset", "superset"]
+                                        "enum": [
+                                          "exact",
+                                          "ignore",
+                                          "subset",
+                                          "superset"
+                                        ]
                                       },
                                       {
                                         "type": "array",
@@ -1897,7 +2146,12 @@
                                     "anyOf": [
                                       {
                                         "type": "string",
-                                        "enum": ["exact", "ignore", "subset", "superset"]
+                                        "enum": [
+                                          "exact",
+                                          "ignore",
+                                          "subset",
+                                          "superset"
+                                        ]
                                       },
                                       {
                                         "type": "array",
@@ -1908,7 +2162,9 @@
                                     ]
                                   }
                                 },
-                                "required": ["tool"],
+                                "required": [
+                                  "tool"
+                                ],
                                 "additionalProperties": false
                               }
                             },
@@ -1916,7 +2172,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -1930,7 +2191,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -1941,7 +2207,10 @@
                               ]
                             }
                           },
-                          "required": ["type", "mode"],
+                          "required": [
+                            "type",
+                            "mode"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -1978,7 +2247,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["field-accuracy", "field_accuracy"]
+                              "enum": [
+                                "field-accuracy",
+                                "field_accuracy"
+                              ]
                             },
                             "fields": {
                               "type": "array",
@@ -1990,7 +2262,11 @@
                                   },
                                   "match": {
                                     "type": "string",
-                                    "enum": ["exact", "numeric_tolerance", "date"]
+                                    "enum": [
+                                      "exact",
+                                      "numeric_tolerance",
+                                      "date"
+                                    ]
                                   },
                                   "required": {
                                     "type": "boolean"
@@ -2012,17 +2288,26 @@
                                     }
                                   }
                                 },
-                                "required": ["path", "match"],
+                                "required": [
+                                  "path",
+                                  "match"
+                                ],
                                 "additionalProperties": false
                               },
                               "minItems": 1
                             },
                             "aggregation": {
                               "type": "string",
-                              "enum": ["weighted_average", "all_or_nothing"]
+                              "enum": [
+                                "weighted_average",
+                                "all_or_nothing"
+                              ]
                             }
                           },
-                          "required": ["type", "fields"],
+                          "required": [
+                            "type",
+                            "fields"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -2066,7 +2351,10 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["type", "threshold"],
+                          "required": [
+                            "type",
+                            "threshold"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -2110,7 +2398,10 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["type", "budget"],
+                          "required": [
+                            "type",
+                            "budget"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -2147,7 +2438,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["token-usage", "token_usage"]
+                              "enum": [
+                                "token-usage",
+                                "token_usage"
+                              ]
                             },
                             "max_total": {
                               "type": "number",
@@ -2162,7 +2456,9 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["type"],
+                          "required": [
+                            "type"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -2199,7 +2495,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["execution-metrics", "execution_metrics"]
+                              "enum": [
+                                "execution-metrics",
+                                "execution_metrics"
+                              ]
                             },
                             "max_tool_calls": {
                               "type": "number",
@@ -2231,7 +2530,9 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["type"],
+                          "required": [
+                            "type"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -2274,7 +2575,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["type", "value"],
+                          "required": [
+                            "type",
+                            "value"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -2317,7 +2621,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["type", "value"],
+                          "required": [
+                            "type",
+                            "value"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -2354,10 +2661,15 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["is-json", "is_json"]
+                              "enum": [
+                                "is-json",
+                                "is_json"
+                              ]
                             }
                           },
-                          "required": ["type"],
+                          "required": [
+                            "type"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -2400,7 +2712,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["type", "value"],
+                          "required": [
+                            "type",
+                            "value"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -2452,7 +2767,10 @@
                                   },
                                   "operator": {
                                     "type": "string",
-                                    "enum": ["correctness", "contradiction"]
+                                    "enum": [
+                                      "correctness",
+                                      "contradiction"
+                                    ]
                                   },
                                   "weight": {
                                     "type": "number"
@@ -2493,7 +2811,10 @@
                                           "minLength": 1
                                         }
                                       },
-                                      "required": ["score_range", "outcome"],
+                                      "required": [
+                                        "score_range",
+                                        "outcome"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   }
@@ -2503,7 +2824,10 @@
                               "minItems": 1
                             }
                           },
-                          "required": ["type", "criteria"],
+                          "required": [
+                            "type",
+                            "criteria"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -2575,7 +2899,11 @@
                                         },
                                         "reset": {
                                           "type": "string",
-                                          "enum": ["none", "fast", "strict"]
+                                          "enum": [
+                                            "none",
+                                            "fast",
+                                            "strict"
+                                          ]
                                         }
                                       },
                                       "additionalProperties": false
@@ -2620,7 +2948,11 @@
                                         },
                                         "reset": {
                                           "type": "string",
-                                          "enum": ["none", "fast", "strict"]
+                                          "enum": [
+                                            "none",
+                                            "fast",
+                                            "strict"
+                                          ]
                                         }
                                       },
                                       "additionalProperties": false
@@ -2665,7 +2997,11 @@
                                         },
                                         "reset": {
                                           "type": "string",
-                                          "enum": ["none", "fast", "strict"]
+                                          "enum": [
+                                            "none",
+                                            "fast",
+                                            "strict"
+                                          ]
                                         }
                                       },
                                       "additionalProperties": false
@@ -2710,7 +3046,11 @@
                                         },
                                         "reset": {
                                           "type": "string",
-                                          "enum": ["none", "fast", "strict"]
+                                          "enum": [
+                                            "none",
+                                            "fast",
+                                            "strict"
+                                          ]
                                         }
                                       },
                                       "additionalProperties": false
@@ -2719,7 +3059,9 @@
                                   "additionalProperties": false
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -2768,7 +3110,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["code-grader", "code_grader"]
+                                  "enum": [
+                                    "code-grader",
+                                    "code_grader"
+                                  ]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -2842,12 +3187,18 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type", "command"],
+                              "required": [
+                                "type",
+                                "command"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2884,7 +3235,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["llm-grader", "llm_grader"]
+                                  "enum": [
+                                    "llm-grader",
+                                    "llm_grader"
+                                  ]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -2942,7 +3296,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -2983,7 +3340,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -3034,12 +3394,17 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3050,7 +3415,9 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": ["include"],
+                              "required": [
+                                "include"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3113,7 +3480,9 @@
                                           }
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -3129,7 +3498,10 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": ["type", "threshold"],
+                                      "required": [
+                                        "type",
+                                        "threshold"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -3146,7 +3518,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type", "path"],
+                                      "required": [
+                                        "type",
+                                        "path"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -3163,13 +3538,18 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["type", "aggregator"],
+                              "required": [
+                                "type",
+                                "aggregator"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3206,11 +3586,20 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["tool-trajectory", "tool_trajectory"]
+                                  "enum": [
+                                    "tool-trajectory",
+                                    "tool_trajectory"
+                                  ]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                                  "enum": [
+                                    "any_order",
+                                    "in_order",
+                                    "exact",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -3251,7 +3640,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -3265,7 +3659,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -3276,7 +3675,9 @@
                                         ]
                                       }
                                     },
-                                    "required": ["tool"],
+                                    "required": [
+                                      "tool"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 },
@@ -3284,7 +3685,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -3298,7 +3704,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -3309,7 +3720,10 @@
                                   ]
                                 }
                               },
-                              "required": ["type", "mode"],
+                              "required": [
+                                "type",
+                                "mode"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3346,7 +3760,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["field-accuracy", "field_accuracy"]
+                                  "enum": [
+                                    "field-accuracy",
+                                    "field_accuracy"
+                                  ]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -3358,7 +3775,11 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": ["exact", "numeric_tolerance", "date"]
+                                        "enum": [
+                                          "exact",
+                                          "numeric_tolerance",
+                                          "date"
+                                        ]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -3380,17 +3801,26 @@
                                         }
                                       }
                                     },
-                                    "required": ["path", "match"],
+                                    "required": [
+                                      "path",
+                                      "match"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": ["weighted_average", "all_or_nothing"]
+                                  "enum": [
+                                    "weighted_average",
+                                    "all_or_nothing"
+                                  ]
                                 }
                               },
-                              "required": ["type", "fields"],
+                              "required": [
+                                "type",
+                                "fields"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3434,7 +3864,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "threshold"],
+                              "required": [
+                                "type",
+                                "threshold"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3478,7 +3911,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "budget"],
+                              "required": [
+                                "type",
+                                "budget"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3515,7 +3951,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["token-usage", "token_usage"]
+                                  "enum": [
+                                    "token-usage",
+                                    "token_usage"
+                                  ]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -3530,7 +3969,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3567,7 +4008,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["execution-metrics", "execution_metrics"]
+                                  "enum": [
+                                    "execution-metrics",
+                                    "execution_metrics"
+                                  ]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -3599,7 +4043,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3642,7 +4088,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3685,7 +4134,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3722,10 +4174,15 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["is-json", "is_json"]
+                                  "enum": [
+                                    "is-json",
+                                    "is_json"
+                                  ]
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3768,7 +4225,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3820,7 +4280,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -3861,7 +4324,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -3871,7 +4337,10 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": ["type", "criteria"],
+                              "required": [
+                                "type",
+                                "criteria"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -3915,7 +4384,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["code-grader", "code_grader"]
+                                  "enum": [
+                                    "code-grader",
+                                    "code_grader"
+                                  ]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -3989,12 +4461,18 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type", "command"],
+                              "required": [
+                                "type",
+                                "command"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -4031,7 +4509,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["llm-grader", "llm_grader"]
+                                  "enum": [
+                                    "llm-grader",
+                                    "llm_grader"
+                                  ]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -4089,7 +4570,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -4130,7 +4614,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -4181,12 +4668,17 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -4197,7 +4689,9 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": ["include"],
+                              "required": [
+                                "include"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -4260,7 +4754,9 @@
                                           }
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -4276,7 +4772,10 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": ["type", "threshold"],
+                                      "required": [
+                                        "type",
+                                        "threshold"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -4293,7 +4792,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type", "path"],
+                                      "required": [
+                                        "type",
+                                        "path"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -4310,13 +4812,18 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["type", "aggregator"],
+                              "required": [
+                                "type",
+                                "aggregator"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -4353,11 +4860,20 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["tool-trajectory", "tool_trajectory"]
+                                  "enum": [
+                                    "tool-trajectory",
+                                    "tool_trajectory"
+                                  ]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                                  "enum": [
+                                    "any_order",
+                                    "in_order",
+                                    "exact",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -4398,7 +4914,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -4412,7 +4933,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -4423,7 +4949,9 @@
                                         ]
                                       }
                                     },
-                                    "required": ["tool"],
+                                    "required": [
+                                      "tool"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 },
@@ -4431,7 +4959,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -4445,7 +4978,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -4456,7 +4994,10 @@
                                   ]
                                 }
                               },
-                              "required": ["type", "mode"],
+                              "required": [
+                                "type",
+                                "mode"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -4493,7 +5034,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["field-accuracy", "field_accuracy"]
+                                  "enum": [
+                                    "field-accuracy",
+                                    "field_accuracy"
+                                  ]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -4505,7 +5049,11 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": ["exact", "numeric_tolerance", "date"]
+                                        "enum": [
+                                          "exact",
+                                          "numeric_tolerance",
+                                          "date"
+                                        ]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -4527,17 +5075,26 @@
                                         }
                                       }
                                     },
-                                    "required": ["path", "match"],
+                                    "required": [
+                                      "path",
+                                      "match"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": ["weighted_average", "all_or_nothing"]
+                                  "enum": [
+                                    "weighted_average",
+                                    "all_or_nothing"
+                                  ]
                                 }
                               },
-                              "required": ["type", "fields"],
+                              "required": [
+                                "type",
+                                "fields"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -4581,7 +5138,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "threshold"],
+                              "required": [
+                                "type",
+                                "threshold"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -4625,7 +5185,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "budget"],
+                              "required": [
+                                "type",
+                                "budget"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -4662,7 +5225,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["token-usage", "token_usage"]
+                                  "enum": [
+                                    "token-usage",
+                                    "token_usage"
+                                  ]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -4677,7 +5243,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -4714,7 +5282,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["execution-metrics", "execution_metrics"]
+                                  "enum": [
+                                    "execution-metrics",
+                                    "execution_metrics"
+                                  ]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -4746,7 +5317,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -4789,7 +5362,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -4832,7 +5408,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -4869,10 +5448,15 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["is-json", "is_json"]
+                                  "enum": [
+                                    "is-json",
+                                    "is_json"
+                                  ]
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -4915,7 +5499,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -4967,7 +5554,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -5008,7 +5598,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -5018,7 +5611,10 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": ["type", "criteria"],
+                              "required": [
+                                "type",
+                                "criteria"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -5039,7 +5635,11 @@
                           },
                           "strategy": {
                             "type": "string",
-                            "enum": ["pass_at_k", "mean", "confidence_interval"]
+                            "enum": [
+                              "pass_at_k",
+                              "mean",
+                              "confidence_interval"
+                            ]
                           },
                           "cost_limit_usd": {
                             "type": "number",
@@ -5050,7 +5650,9 @@
                             "minimum": 0
                           }
                         },
-                        "required": ["count"],
+                        "required": [
+                          "count"
+                        ],
                         "additionalProperties": false
                       },
                       "budget_usd": {
@@ -5083,7 +5685,10 @@
                       },
                       "isolation": {
                         "type": "string",
-                        "enum": ["shared", "per_test"]
+                        "enum": [
+                          "shared",
+                          "per_test"
+                        ]
                       },
                       "repos": {
                         "type": "array",
@@ -5165,7 +5770,11 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": ["none", "fast", "strict"]
+                                "enum": [
+                                  "none",
+                                  "fast",
+                                  "strict"
+                                ]
                               }
                             },
                             "additionalProperties": false
@@ -5210,7 +5819,11 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": ["none", "fast", "strict"]
+                                "enum": [
+                                  "none",
+                                  "fast",
+                                  "strict"
+                                ]
                               }
                             },
                             "additionalProperties": false
@@ -5255,7 +5868,11 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": ["none", "fast", "strict"]
+                                "enum": [
+                                  "none",
+                                  "fast",
+                                  "strict"
+                                ]
                               }
                             },
                             "additionalProperties": false
@@ -5300,7 +5917,11 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": ["none", "fast", "strict"]
+                                "enum": [
+                                  "none",
+                                  "fast",
+                                  "strict"
+                                ]
                               }
                             },
                             "additionalProperties": false
@@ -5310,7 +5931,11 @@
                       },
                       "mode": {
                         "type": "string",
-                        "enum": ["pooled", "temp", "static"]
+                        "enum": [
+                          "pooled",
+                          "temp",
+                          "static"
+                        ]
                       },
                       "path": {
                         "type": "string"
@@ -5333,7 +5958,9 @@
                             "minimum": 0.1
                           }
                         },
-                        "required": ["image"],
+                        "required": [
+                          "image"
+                        ],
                         "additionalProperties": false
                       }
                     },
@@ -5357,11 +5984,17 @@
                   },
                   "on_dependency_failure": {
                     "type": "string",
-                    "enum": ["skip", "fail", "run"]
+                    "enum": [
+                      "skip",
+                      "fail",
+                      "run"
+                    ]
                   },
                   "mode": {
                     "type": "string",
-                    "enum": ["conversation"]
+                    "enum": [
+                      "conversation"
+                    ]
                   },
                   "turns": {
                     "type": "array",
@@ -5379,19 +6012,31 @@
                                   "type": "string"
                                 },
                                 {
+                                  "type": "object",
+                                  "properties": {},
+                                  "additionalProperties": {}
+                                },
+                                {
                                   "type": "array",
                                   "items": {
                                     "type": "object",
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": ["text", "file", "image"]
+                                        "enum": [
+                                          "text",
+                                          "file",
+                                          "image"
+                                        ]
                                       },
                                       "value": {
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["type", "value"],
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
@@ -5410,19 +6055,31 @@
                                   "type": "string"
                                 },
                                 {
+                                  "type": "object",
+                                  "properties": {},
+                                  "additionalProperties": {}
+                                },
+                                {
                                   "type": "array",
                                   "items": {
                                     "type": "object",
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": ["text", "file", "image"]
+                                        "enum": [
+                                          "text",
+                                          "file",
+                                          "image"
+                                        ]
                                       },
                                       "value": {
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["type", "value"],
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
@@ -5473,7 +6130,10 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["code-grader", "code_grader"]
+                                        "enum": [
+                                          "code-grader",
+                                          "code_grader"
+                                        ]
                                       },
                                       "command": {
                                         "anyOf": [
@@ -5547,12 +6207,18 @@
                                               ]
                                             }
                                           },
-                                          "required": ["type", "command"],
+                                          "required": [
+                                            "type",
+                                            "command"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -5589,7 +6255,10 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["llm-grader", "llm_grader"]
+                                        "enum": [
+                                          "llm-grader",
+                                          "llm_grader"
+                                        ]
                                       },
                                       "prompt": {
                                         "anyOf": [
@@ -5647,7 +6316,10 @@
                                             },
                                             "operator": {
                                               "type": "string",
-                                              "enum": ["correctness", "contradiction"]
+                                              "enum": [
+                                                "correctness",
+                                                "contradiction"
+                                              ]
                                             },
                                             "weight": {
                                               "type": "number"
@@ -5688,7 +6360,10 @@
                                                     "minLength": 1
                                                   }
                                                 },
-                                                "required": ["score_range", "outcome"],
+                                                "required": [
+                                                  "score_range",
+                                                  "outcome"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             }
@@ -5739,12 +6414,17 @@
                                               ]
                                             }
                                           },
-                                          "required": ["type", "command"],
+                                          "required": [
+                                            "type",
+                                            "command"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
                                     },
-                                    "required": ["type"],
+                                    "required": [
+                                      "type"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -5755,7 +6435,9 @@
                                         "minLength": 1
                                       }
                                     },
-                                    "required": ["include"],
+                                    "required": [
+                                      "include"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -5818,7 +6500,9 @@
                                                 }
                                               }
                                             },
-                                            "required": ["type"],
+                                            "required": [
+                                              "type"
+                                            ],
                                             "additionalProperties": false
                                           },
                                           {
@@ -5834,7 +6518,10 @@
                                                 "maximum": 1
                                               }
                                             },
-                                            "required": ["type", "threshold"],
+                                            "required": [
+                                              "type",
+                                              "threshold"
+                                            ],
                                             "additionalProperties": false
                                           },
                                           {
@@ -5851,7 +6538,10 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["type", "path"],
+                                            "required": [
+                                              "type",
+                                              "path"
+                                            ],
                                             "additionalProperties": false
                                           },
                                           {
@@ -5868,13 +6558,18 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["type"],
+                                            "required": [
+                                              "type"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
                                       }
                                     },
-                                    "required": ["type", "aggregator"],
+                                    "required": [
+                                      "type",
+                                      "aggregator"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -5911,7 +6606,10 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["tool-trajectory", "tool_trajectory"]
+                                        "enum": [
+                                          "tool-trajectory",
+                                          "tool_trajectory"
+                                        ]
                                       },
                                       "mode": {
                                         "type": "string",
@@ -5962,7 +6660,12 @@
                                               "anyOf": [
                                                 {
                                                   "type": "string",
-                                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                                  "enum": [
+                                                    "exact",
+                                                    "ignore",
+                                                    "subset",
+                                                    "superset"
+                                                  ]
                                                 },
                                                 {
                                                   "type": "array",
@@ -5976,7 +6679,12 @@
                                               "anyOf": [
                                                 {
                                                   "type": "string",
-                                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                                  "enum": [
+                                                    "exact",
+                                                    "ignore",
+                                                    "subset",
+                                                    "superset"
+                                                  ]
                                                 },
                                                 {
                                                   "type": "array",
@@ -5987,7 +6695,9 @@
                                               ]
                                             }
                                           },
-                                          "required": ["tool"],
+                                          "required": [
+                                            "tool"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       },
@@ -5995,7 +6705,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -6009,7 +6724,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -6020,7 +6740,10 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "mode"],
+                                    "required": [
+                                      "type",
+                                      "mode"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -6057,7 +6780,10 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["field-accuracy", "field_accuracy"]
+                                        "enum": [
+                                          "field-accuracy",
+                                          "field_accuracy"
+                                        ]
                                       },
                                       "fields": {
                                         "type": "array",
@@ -6069,7 +6795,11 @@
                                             },
                                             "match": {
                                               "type": "string",
-                                              "enum": ["exact", "numeric_tolerance", "date"]
+                                              "enum": [
+                                                "exact",
+                                                "numeric_tolerance",
+                                                "date"
+                                              ]
                                             },
                                             "required": {
                                               "type": "boolean"
@@ -6091,17 +6821,26 @@
                                               }
                                             }
                                           },
-                                          "required": ["path", "match"],
+                                          "required": [
+                                            "path",
+                                            "match"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         "minItems": 1
                                       },
                                       "aggregation": {
                                         "type": "string",
-                                        "enum": ["weighted_average", "all_or_nothing"]
+                                        "enum": [
+                                          "weighted_average",
+                                          "all_or_nothing"
+                                        ]
                                       }
                                     },
-                                    "required": ["type", "fields"],
+                                    "required": [
+                                      "type",
+                                      "fields"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -6145,7 +6884,10 @@
                                         "minimum": 0
                                       }
                                     },
-                                    "required": ["type", "threshold"],
+                                    "required": [
+                                      "type",
+                                      "threshold"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -6189,7 +6931,10 @@
                                         "minimum": 0
                                       }
                                     },
-                                    "required": ["type", "budget"],
+                                    "required": [
+                                      "type",
+                                      "budget"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -6226,7 +6971,10 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["token-usage", "token_usage"]
+                                        "enum": [
+                                          "token-usage",
+                                          "token_usage"
+                                        ]
                                       },
                                       "max_total": {
                                         "type": "number",
@@ -6241,7 +6989,9 @@
                                         "minimum": 0
                                       }
                                     },
-                                    "required": ["type"],
+                                    "required": [
+                                      "type"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -6278,7 +7028,10 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["execution-metrics", "execution_metrics"]
+                                        "enum": [
+                                          "execution-metrics",
+                                          "execution_metrics"
+                                        ]
                                       },
                                       "max_tool_calls": {
                                         "type": "number",
@@ -6310,7 +7063,9 @@
                                         "minimum": 0
                                       }
                                     },
-                                    "required": ["type"],
+                                    "required": [
+                                      "type"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -6353,7 +7108,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["type", "value"],
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -6396,7 +7154,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["type", "value"],
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -6433,10 +7194,15 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["is-json", "is_json"]
+                                        "enum": [
+                                          "is-json",
+                                          "is_json"
+                                        ]
                                       }
                                     },
-                                    "required": ["type"],
+                                    "required": [
+                                      "type"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -6479,7 +7245,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["type", "value"],
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -6531,7 +7300,10 @@
                                             },
                                             "operator": {
                                               "type": "string",
-                                              "enum": ["correctness", "contradiction"]
+                                              "enum": [
+                                                "correctness",
+                                                "contradiction"
+                                              ]
                                             },
                                             "weight": {
                                               "type": "number"
@@ -6572,7 +7344,10 @@
                                                     "minLength": 1
                                                   }
                                                 },
-                                                "required": ["score_range", "outcome"],
+                                                "required": [
+                                                  "score_range",
+                                                  "outcome"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             }
@@ -6582,7 +7357,10 @@
                                         "minItems": 1
                                       }
                                     },
-                                    "required": ["type", "criteria"],
+                                    "required": [
+                                      "type",
+                                      "criteria"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 ]
@@ -6591,25 +7369,36 @@
                           }
                         }
                       },
-                      "required": ["input"],
+                      "required": [
+                        "input"
+                      ],
                       "additionalProperties": false
                     },
                     "minItems": 1
                   },
                   "aggregation": {
                     "type": "string",
-                    "enum": ["mean", "min", "max"]
+                    "enum": [
+                      "mean",
+                      "min",
+                      "max"
+                    ]
                   },
                   "on_turn_failure": {
                     "type": "string",
-                    "enum": ["continue", "stop"]
+                    "enum": [
+                      "continue",
+                      "stop"
+                    ]
                   },
                   "window_size": {
                     "type": "integer",
                     "minimum": 1
                   }
                 },
-                "required": ["id"],
+                "required": [
+                  "id"
+                ],
                 "additionalProperties": false
               }
             },
@@ -6643,18 +7432,33 @@
                         "type": "string"
                       },
                       {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": {}
+                      },
+                      {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
                             "role": {
                               "type": "string",
-                              "enum": ["system", "user", "assistant", "tool"]
+                              "enum": [
+                                "system",
+                                "user",
+                                "assistant",
+                                "tool"
+                              ]
                             },
                             "content": {
                               "anyOf": [
                                 {
                                   "type": "string"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {},
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "array",
@@ -6663,20 +7467,30 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": ["text", "file", "image"]
+                                        "enum": [
+                                          "text",
+                                          "file",
+                                          "image"
+                                        ]
                                       },
                                       "value": {
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["type", "value"],
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               ]
                             }
                           },
-                          "required": ["role", "content"],
+                          "required": [
+                            "role",
+                            "content"
+                          ],
                           "additionalProperties": false
                         }
                       }
@@ -6705,12 +7519,22 @@
                           "properties": {
                             "role": {
                               "type": "string",
-                              "enum": ["system", "user", "assistant", "tool"]
+                              "enum": [
+                                "system",
+                                "user",
+                                "assistant",
+                                "tool"
+                              ]
                             },
                             "content": {
                               "anyOf": [
                                 {
                                   "type": "string"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {},
+                                  "additionalProperties": {}
                                 },
                                 {
                                   "type": "array",
@@ -6719,20 +7543,30 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": ["text", "file", "image"]
+                                        "enum": [
+                                          "text",
+                                          "file",
+                                          "image"
+                                        ]
                                       },
                                       "value": {
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["type", "value"],
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               ]
                             }
                           },
-                          "required": ["role", "content"],
+                          "required": [
+                            "role",
+                            "content"
+                          ],
                           "additionalProperties": false
                         }
                       }
@@ -6776,7 +7610,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["code-grader", "code_grader"]
+                              "enum": [
+                                "code-grader",
+                                "code_grader"
+                              ]
                             },
                             "command": {
                               "anyOf": [
@@ -6850,12 +7687,18 @@
                                     ]
                                   }
                                 },
-                                "required": ["type", "command"],
+                                "required": [
+                                  "type",
+                                  "command"
+                                ],
                                 "additionalProperties": false
                               }
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -6892,7 +7735,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["llm-grader", "llm_grader"]
+                              "enum": [
+                                "llm-grader",
+                                "llm_grader"
+                              ]
                             },
                             "prompt": {
                               "anyOf": [
@@ -6950,7 +7796,10 @@
                                   },
                                   "operator": {
                                     "type": "string",
-                                    "enum": ["correctness", "contradiction"]
+                                    "enum": [
+                                      "correctness",
+                                      "contradiction"
+                                    ]
                                   },
                                   "weight": {
                                     "type": "number"
@@ -6991,7 +7840,10 @@
                                           "minLength": 1
                                         }
                                       },
-                                      "required": ["score_range", "outcome"],
+                                      "required": [
+                                        "score_range",
+                                        "outcome"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   }
@@ -7042,12 +7894,17 @@
                                     ]
                                   }
                                 },
-                                "required": ["type", "command"],
+                                "required": [
+                                  "type",
+                                  "command"
+                                ],
                                 "additionalProperties": false
                               }
                             }
                           },
-                          "required": ["type"],
+                          "required": [
+                            "type"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -7058,7 +7915,9 @@
                               "minLength": 1
                             }
                           },
-                          "required": ["include"],
+                          "required": [
+                            "include"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -7121,7 +7980,9 @@
                                       }
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -7137,7 +7998,10 @@
                                       "maximum": 1
                                     }
                                   },
-                                  "required": ["type", "threshold"],
+                                  "required": [
+                                    "type",
+                                    "threshold"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -7154,7 +8018,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "path"],
+                                  "required": [
+                                    "type",
+                                    "path"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -7171,13 +8038,18 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
                             }
                           },
-                          "required": ["type", "aggregator"],
+                          "required": [
+                            "type",
+                            "aggregator"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -7214,11 +8086,20 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["tool-trajectory", "tool_trajectory"]
+                              "enum": [
+                                "tool-trajectory",
+                                "tool_trajectory"
+                              ]
                             },
                             "mode": {
                               "type": "string",
-                              "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                              "enum": [
+                                "any_order",
+                                "in_order",
+                                "exact",
+                                "subset",
+                                "superset"
+                              ]
                             },
                             "minimums": {
                               "type": "object",
@@ -7259,7 +8140,12 @@
                                     "anyOf": [
                                       {
                                         "type": "string",
-                                        "enum": ["exact", "ignore", "subset", "superset"]
+                                        "enum": [
+                                          "exact",
+                                          "ignore",
+                                          "subset",
+                                          "superset"
+                                        ]
                                       },
                                       {
                                         "type": "array",
@@ -7273,7 +8159,12 @@
                                     "anyOf": [
                                       {
                                         "type": "string",
-                                        "enum": ["exact", "ignore", "subset", "superset"]
+                                        "enum": [
+                                          "exact",
+                                          "ignore",
+                                          "subset",
+                                          "superset"
+                                        ]
                                       },
                                       {
                                         "type": "array",
@@ -7284,7 +8175,9 @@
                                     ]
                                   }
                                 },
-                                "required": ["tool"],
+                                "required": [
+                                  "tool"
+                                ],
                                 "additionalProperties": false
                               }
                             },
@@ -7292,7 +8185,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -7306,7 +8204,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -7317,7 +8220,10 @@
                               ]
                             }
                           },
-                          "required": ["type", "mode"],
+                          "required": [
+                            "type",
+                            "mode"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -7354,7 +8260,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["field-accuracy", "field_accuracy"]
+                              "enum": [
+                                "field-accuracy",
+                                "field_accuracy"
+                              ]
                             },
                             "fields": {
                               "type": "array",
@@ -7366,7 +8275,11 @@
                                   },
                                   "match": {
                                     "type": "string",
-                                    "enum": ["exact", "numeric_tolerance", "date"]
+                                    "enum": [
+                                      "exact",
+                                      "numeric_tolerance",
+                                      "date"
+                                    ]
                                   },
                                   "required": {
                                     "type": "boolean"
@@ -7388,17 +8301,26 @@
                                     }
                                   }
                                 },
-                                "required": ["path", "match"],
+                                "required": [
+                                  "path",
+                                  "match"
+                                ],
                                 "additionalProperties": false
                               },
                               "minItems": 1
                             },
                             "aggregation": {
                               "type": "string",
-                              "enum": ["weighted_average", "all_or_nothing"]
+                              "enum": [
+                                "weighted_average",
+                                "all_or_nothing"
+                              ]
                             }
                           },
-                          "required": ["type", "fields"],
+                          "required": [
+                            "type",
+                            "fields"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -7442,7 +8364,10 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["type", "threshold"],
+                          "required": [
+                            "type",
+                            "threshold"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -7486,7 +8411,10 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["type", "budget"],
+                          "required": [
+                            "type",
+                            "budget"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -7523,7 +8451,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["token-usage", "token_usage"]
+                              "enum": [
+                                "token-usage",
+                                "token_usage"
+                              ]
                             },
                             "max_total": {
                               "type": "number",
@@ -7538,7 +8469,9 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["type"],
+                          "required": [
+                            "type"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -7575,7 +8508,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["execution-metrics", "execution_metrics"]
+                              "enum": [
+                                "execution-metrics",
+                                "execution_metrics"
+                              ]
                             },
                             "max_tool_calls": {
                               "type": "number",
@@ -7607,7 +8543,9 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["type"],
+                          "required": [
+                            "type"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -7650,7 +8588,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["type", "value"],
+                          "required": [
+                            "type",
+                            "value"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -7693,7 +8634,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["type", "value"],
+                          "required": [
+                            "type",
+                            "value"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -7730,10 +8674,15 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["is-json", "is_json"]
+                              "enum": [
+                                "is-json",
+                                "is_json"
+                              ]
                             }
                           },
-                          "required": ["type"],
+                          "required": [
+                            "type"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -7776,7 +8725,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["type", "value"],
+                          "required": [
+                            "type",
+                            "value"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -7828,7 +8780,10 @@
                                   },
                                   "operator": {
                                     "type": "string",
-                                    "enum": ["correctness", "contradiction"]
+                                    "enum": [
+                                      "correctness",
+                                      "contradiction"
+                                    ]
                                   },
                                   "weight": {
                                     "type": "number"
@@ -7869,7 +8824,10 @@
                                           "minLength": 1
                                         }
                                       },
-                                      "required": ["score_range", "outcome"],
+                                      "required": [
+                                        "score_range",
+                                        "outcome"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   }
@@ -7879,7 +8837,10 @@
                               "minItems": 1
                             }
                           },
-                          "required": ["type", "criteria"],
+                          "required": [
+                            "type",
+                            "criteria"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -7923,7 +8884,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["code-grader", "code_grader"]
+                              "enum": [
+                                "code-grader",
+                                "code_grader"
+                              ]
                             },
                             "command": {
                               "anyOf": [
@@ -7997,12 +8961,18 @@
                                     ]
                                   }
                                 },
-                                "required": ["type", "command"],
+                                "required": [
+                                  "type",
+                                  "command"
+                                ],
                                 "additionalProperties": false
                               }
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -8039,7 +9009,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["llm-grader", "llm_grader"]
+                              "enum": [
+                                "llm-grader",
+                                "llm_grader"
+                              ]
                             },
                             "prompt": {
                               "anyOf": [
@@ -8097,7 +9070,10 @@
                                   },
                                   "operator": {
                                     "type": "string",
-                                    "enum": ["correctness", "contradiction"]
+                                    "enum": [
+                                      "correctness",
+                                      "contradiction"
+                                    ]
                                   },
                                   "weight": {
                                     "type": "number"
@@ -8138,7 +9114,10 @@
                                           "minLength": 1
                                         }
                                       },
-                                      "required": ["score_range", "outcome"],
+                                      "required": [
+                                        "score_range",
+                                        "outcome"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   }
@@ -8189,12 +9168,17 @@
                                     ]
                                   }
                                 },
-                                "required": ["type", "command"],
+                                "required": [
+                                  "type",
+                                  "command"
+                                ],
                                 "additionalProperties": false
                               }
                             }
                           },
-                          "required": ["type"],
+                          "required": [
+                            "type"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -8205,7 +9189,9 @@
                               "minLength": 1
                             }
                           },
-                          "required": ["include"],
+                          "required": [
+                            "include"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -8268,7 +9254,9 @@
                                       }
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -8284,7 +9272,10 @@
                                       "maximum": 1
                                     }
                                   },
-                                  "required": ["type", "threshold"],
+                                  "required": [
+                                    "type",
+                                    "threshold"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -8301,7 +9292,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "path"],
+                                  "required": [
+                                    "type",
+                                    "path"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -8318,13 +9312,18 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
                             }
                           },
-                          "required": ["type", "aggregator"],
+                          "required": [
+                            "type",
+                            "aggregator"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -8361,11 +9360,20 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["tool-trajectory", "tool_trajectory"]
+                              "enum": [
+                                "tool-trajectory",
+                                "tool_trajectory"
+                              ]
                             },
                             "mode": {
                               "type": "string",
-                              "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                              "enum": [
+                                "any_order",
+                                "in_order",
+                                "exact",
+                                "subset",
+                                "superset"
+                              ]
                             },
                             "minimums": {
                               "type": "object",
@@ -8406,7 +9414,12 @@
                                     "anyOf": [
                                       {
                                         "type": "string",
-                                        "enum": ["exact", "ignore", "subset", "superset"]
+                                        "enum": [
+                                          "exact",
+                                          "ignore",
+                                          "subset",
+                                          "superset"
+                                        ]
                                       },
                                       {
                                         "type": "array",
@@ -8420,7 +9433,12 @@
                                     "anyOf": [
                                       {
                                         "type": "string",
-                                        "enum": ["exact", "ignore", "subset", "superset"]
+                                        "enum": [
+                                          "exact",
+                                          "ignore",
+                                          "subset",
+                                          "superset"
+                                        ]
                                       },
                                       {
                                         "type": "array",
@@ -8431,7 +9449,9 @@
                                     ]
                                   }
                                 },
-                                "required": ["tool"],
+                                "required": [
+                                  "tool"
+                                ],
                                 "additionalProperties": false
                               }
                             },
@@ -8439,7 +9459,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -8453,7 +9478,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -8464,7 +9494,10 @@
                               ]
                             }
                           },
-                          "required": ["type", "mode"],
+                          "required": [
+                            "type",
+                            "mode"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -8501,7 +9534,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["field-accuracy", "field_accuracy"]
+                              "enum": [
+                                "field-accuracy",
+                                "field_accuracy"
+                              ]
                             },
                             "fields": {
                               "type": "array",
@@ -8513,7 +9549,11 @@
                                   },
                                   "match": {
                                     "type": "string",
-                                    "enum": ["exact", "numeric_tolerance", "date"]
+                                    "enum": [
+                                      "exact",
+                                      "numeric_tolerance",
+                                      "date"
+                                    ]
                                   },
                                   "required": {
                                     "type": "boolean"
@@ -8535,17 +9575,26 @@
                                     }
                                   }
                                 },
-                                "required": ["path", "match"],
+                                "required": [
+                                  "path",
+                                  "match"
+                                ],
                                 "additionalProperties": false
                               },
                               "minItems": 1
                             },
                             "aggregation": {
                               "type": "string",
-                              "enum": ["weighted_average", "all_or_nothing"]
+                              "enum": [
+                                "weighted_average",
+                                "all_or_nothing"
+                              ]
                             }
                           },
-                          "required": ["type", "fields"],
+                          "required": [
+                            "type",
+                            "fields"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -8589,7 +9638,10 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["type", "threshold"],
+                          "required": [
+                            "type",
+                            "threshold"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -8633,7 +9685,10 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["type", "budget"],
+                          "required": [
+                            "type",
+                            "budget"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -8670,7 +9725,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["token-usage", "token_usage"]
+                              "enum": [
+                                "token-usage",
+                                "token_usage"
+                              ]
                             },
                             "max_total": {
                               "type": "number",
@@ -8685,7 +9743,9 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["type"],
+                          "required": [
+                            "type"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -8722,7 +9782,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["execution-metrics", "execution_metrics"]
+                              "enum": [
+                                "execution-metrics",
+                                "execution_metrics"
+                              ]
                             },
                             "max_tool_calls": {
                               "type": "number",
@@ -8754,7 +9817,9 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["type"],
+                          "required": [
+                            "type"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -8797,7 +9862,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["type", "value"],
+                          "required": [
+                            "type",
+                            "value"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -8840,7 +9908,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["type", "value"],
+                          "required": [
+                            "type",
+                            "value"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -8877,10 +9948,15 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": ["is-json", "is_json"]
+                              "enum": [
+                                "is-json",
+                                "is_json"
+                              ]
                             }
                           },
-                          "required": ["type"],
+                          "required": [
+                            "type"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -8923,7 +9999,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["type", "value"],
+                          "required": [
+                            "type",
+                            "value"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -8975,7 +10054,10 @@
                                   },
                                   "operator": {
                                     "type": "string",
-                                    "enum": ["correctness", "contradiction"]
+                                    "enum": [
+                                      "correctness",
+                                      "contradiction"
+                                    ]
                                   },
                                   "weight": {
                                     "type": "number"
@@ -9016,7 +10098,10 @@
                                           "minLength": 1
                                         }
                                       },
-                                      "required": ["score_range", "outcome"],
+                                      "required": [
+                                        "score_range",
+                                        "outcome"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   }
@@ -9026,7 +10111,10 @@
                               "minItems": 1
                             }
                           },
-                          "required": ["type", "criteria"],
+                          "required": [
+                            "type",
+                            "criteria"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -9098,7 +10186,11 @@
                                         },
                                         "reset": {
                                           "type": "string",
-                                          "enum": ["none", "fast", "strict"]
+                                          "enum": [
+                                            "none",
+                                            "fast",
+                                            "strict"
+                                          ]
                                         }
                                       },
                                       "additionalProperties": false
@@ -9143,7 +10235,11 @@
                                         },
                                         "reset": {
                                           "type": "string",
-                                          "enum": ["none", "fast", "strict"]
+                                          "enum": [
+                                            "none",
+                                            "fast",
+                                            "strict"
+                                          ]
                                         }
                                       },
                                       "additionalProperties": false
@@ -9188,7 +10284,11 @@
                                         },
                                         "reset": {
                                           "type": "string",
-                                          "enum": ["none", "fast", "strict"]
+                                          "enum": [
+                                            "none",
+                                            "fast",
+                                            "strict"
+                                          ]
                                         }
                                       },
                                       "additionalProperties": false
@@ -9233,7 +10333,11 @@
                                         },
                                         "reset": {
                                           "type": "string",
-                                          "enum": ["none", "fast", "strict"]
+                                          "enum": [
+                                            "none",
+                                            "fast",
+                                            "strict"
+                                          ]
                                         }
                                       },
                                       "additionalProperties": false
@@ -9242,7 +10346,9 @@
                                   "additionalProperties": false
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -9291,7 +10397,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["code-grader", "code_grader"]
+                                  "enum": [
+                                    "code-grader",
+                                    "code_grader"
+                                  ]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -9365,12 +10474,18 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type", "command"],
+                              "required": [
+                                "type",
+                                "command"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9407,7 +10522,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["llm-grader", "llm_grader"]
+                                  "enum": [
+                                    "llm-grader",
+                                    "llm_grader"
+                                  ]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -9465,7 +10583,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -9506,7 +10627,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -9557,12 +10681,17 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9573,7 +10702,9 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": ["include"],
+                              "required": [
+                                "include"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9636,7 +10767,9 @@
                                           }
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -9652,7 +10785,10 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": ["type", "threshold"],
+                                      "required": [
+                                        "type",
+                                        "threshold"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -9669,7 +10805,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type", "path"],
+                                      "required": [
+                                        "type",
+                                        "path"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -9686,13 +10825,18 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["type", "aggregator"],
+                              "required": [
+                                "type",
+                                "aggregator"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9729,11 +10873,20 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["tool-trajectory", "tool_trajectory"]
+                                  "enum": [
+                                    "tool-trajectory",
+                                    "tool_trajectory"
+                                  ]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                                  "enum": [
+                                    "any_order",
+                                    "in_order",
+                                    "exact",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -9774,7 +10927,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -9788,7 +10946,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -9799,7 +10962,9 @@
                                         ]
                                       }
                                     },
-                                    "required": ["tool"],
+                                    "required": [
+                                      "tool"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 },
@@ -9807,7 +10972,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -9821,7 +10991,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -9832,7 +11007,10 @@
                                   ]
                                 }
                               },
-                              "required": ["type", "mode"],
+                              "required": [
+                                "type",
+                                "mode"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9869,7 +11047,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["field-accuracy", "field_accuracy"]
+                                  "enum": [
+                                    "field-accuracy",
+                                    "field_accuracy"
+                                  ]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -9881,7 +11062,11 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": ["exact", "numeric_tolerance", "date"]
+                                        "enum": [
+                                          "exact",
+                                          "numeric_tolerance",
+                                          "date"
+                                        ]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -9903,17 +11088,26 @@
                                         }
                                       }
                                     },
-                                    "required": ["path", "match"],
+                                    "required": [
+                                      "path",
+                                      "match"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": ["weighted_average", "all_or_nothing"]
+                                  "enum": [
+                                    "weighted_average",
+                                    "all_or_nothing"
+                                  ]
                                 }
                               },
-                              "required": ["type", "fields"],
+                              "required": [
+                                "type",
+                                "fields"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9957,7 +11151,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "threshold"],
+                              "required": [
+                                "type",
+                                "threshold"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -10001,7 +11198,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "budget"],
+                              "required": [
+                                "type",
+                                "budget"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -10038,7 +11238,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["token-usage", "token_usage"]
+                                  "enum": [
+                                    "token-usage",
+                                    "token_usage"
+                                  ]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -10053,7 +11256,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -10090,7 +11295,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["execution-metrics", "execution_metrics"]
+                                  "enum": [
+                                    "execution-metrics",
+                                    "execution_metrics"
+                                  ]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -10122,7 +11330,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -10165,7 +11375,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -10208,7 +11421,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -10245,10 +11461,15 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["is-json", "is_json"]
+                                  "enum": [
+                                    "is-json",
+                                    "is_json"
+                                  ]
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -10291,7 +11512,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -10343,7 +11567,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -10384,7 +11611,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -10394,7 +11624,10 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": ["type", "criteria"],
+                              "required": [
+                                "type",
+                                "criteria"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -10438,7 +11671,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["code-grader", "code_grader"]
+                                  "enum": [
+                                    "code-grader",
+                                    "code_grader"
+                                  ]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -10512,12 +11748,18 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type", "command"],
+                              "required": [
+                                "type",
+                                "command"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -10554,7 +11796,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["llm-grader", "llm_grader"]
+                                  "enum": [
+                                    "llm-grader",
+                                    "llm_grader"
+                                  ]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -10612,7 +11857,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -10653,7 +11901,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -10704,12 +11955,17 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -10720,7 +11976,9 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": ["include"],
+                              "required": [
+                                "include"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -10783,7 +12041,9 @@
                                           }
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -10799,7 +12059,10 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": ["type", "threshold"],
+                                      "required": [
+                                        "type",
+                                        "threshold"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -10816,7 +12079,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type", "path"],
+                                      "required": [
+                                        "type",
+                                        "path"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -10833,13 +12099,18 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["type", "aggregator"],
+                              "required": [
+                                "type",
+                                "aggregator"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -10876,11 +12147,20 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["tool-trajectory", "tool_trajectory"]
+                                  "enum": [
+                                    "tool-trajectory",
+                                    "tool_trajectory"
+                                  ]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                                  "enum": [
+                                    "any_order",
+                                    "in_order",
+                                    "exact",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -10921,7 +12201,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -10935,7 +12220,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -10946,7 +12236,9 @@
                                         ]
                                       }
                                     },
-                                    "required": ["tool"],
+                                    "required": [
+                                      "tool"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 },
@@ -10954,7 +12246,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -10968,7 +12265,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -10979,7 +12281,10 @@
                                   ]
                                 }
                               },
-                              "required": ["type", "mode"],
+                              "required": [
+                                "type",
+                                "mode"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -11016,7 +12321,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["field-accuracy", "field_accuracy"]
+                                  "enum": [
+                                    "field-accuracy",
+                                    "field_accuracy"
+                                  ]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -11028,7 +12336,11 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": ["exact", "numeric_tolerance", "date"]
+                                        "enum": [
+                                          "exact",
+                                          "numeric_tolerance",
+                                          "date"
+                                        ]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -11050,17 +12362,26 @@
                                         }
                                       }
                                     },
-                                    "required": ["path", "match"],
+                                    "required": [
+                                      "path",
+                                      "match"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": ["weighted_average", "all_or_nothing"]
+                                  "enum": [
+                                    "weighted_average",
+                                    "all_or_nothing"
+                                  ]
                                 }
                               },
-                              "required": ["type", "fields"],
+                              "required": [
+                                "type",
+                                "fields"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -11104,7 +12425,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "threshold"],
+                              "required": [
+                                "type",
+                                "threshold"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -11148,7 +12472,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "budget"],
+                              "required": [
+                                "type",
+                                "budget"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -11185,7 +12512,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["token-usage", "token_usage"]
+                                  "enum": [
+                                    "token-usage",
+                                    "token_usage"
+                                  ]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -11200,7 +12530,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -11237,7 +12569,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["execution-metrics", "execution_metrics"]
+                                  "enum": [
+                                    "execution-metrics",
+                                    "execution_metrics"
+                                  ]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -11269,7 +12604,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -11312,7 +12649,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -11355,7 +12695,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -11392,10 +12735,15 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["is-json", "is_json"]
+                                  "enum": [
+                                    "is-json",
+                                    "is_json"
+                                  ]
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -11438,7 +12786,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -11490,7 +12841,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -11531,7 +12885,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -11541,7 +12898,10 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": ["type", "criteria"],
+                              "required": [
+                                "type",
+                                "criteria"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -11562,7 +12922,11 @@
                           },
                           "strategy": {
                             "type": "string",
-                            "enum": ["pass_at_k", "mean", "confidence_interval"]
+                            "enum": [
+                              "pass_at_k",
+                              "mean",
+                              "confidence_interval"
+                            ]
                           },
                           "cost_limit_usd": {
                             "type": "number",
@@ -11573,7 +12937,9 @@
                             "minimum": 0
                           }
                         },
-                        "required": ["count"],
+                        "required": [
+                          "count"
+                        ],
                         "additionalProperties": false
                       },
                       "budget_usd": {
@@ -11606,7 +12972,10 @@
                       },
                       "isolation": {
                         "type": "string",
-                        "enum": ["shared", "per_test"]
+                        "enum": [
+                          "shared",
+                          "per_test"
+                        ]
                       },
                       "repos": {
                         "type": "array",
@@ -11688,7 +13057,11 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": ["none", "fast", "strict"]
+                                "enum": [
+                                  "none",
+                                  "fast",
+                                  "strict"
+                                ]
                               }
                             },
                             "additionalProperties": false
@@ -11733,7 +13106,11 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": ["none", "fast", "strict"]
+                                "enum": [
+                                  "none",
+                                  "fast",
+                                  "strict"
+                                ]
                               }
                             },
                             "additionalProperties": false
@@ -11778,7 +13155,11 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": ["none", "fast", "strict"]
+                                "enum": [
+                                  "none",
+                                  "fast",
+                                  "strict"
+                                ]
                               }
                             },
                             "additionalProperties": false
@@ -11823,7 +13204,11 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": ["none", "fast", "strict"]
+                                "enum": [
+                                  "none",
+                                  "fast",
+                                  "strict"
+                                ]
                               }
                             },
                             "additionalProperties": false
@@ -11833,7 +13218,11 @@
                       },
                       "mode": {
                         "type": "string",
-                        "enum": ["pooled", "temp", "static"]
+                        "enum": [
+                          "pooled",
+                          "temp",
+                          "static"
+                        ]
                       },
                       "path": {
                         "type": "string"
@@ -11856,7 +13245,9 @@
                             "minimum": 0.1
                           }
                         },
-                        "required": ["image"],
+                        "required": [
+                          "image"
+                        ],
                         "additionalProperties": false
                       }
                     },
@@ -11880,11 +13271,17 @@
                   },
                   "on_dependency_failure": {
                     "type": "string",
-                    "enum": ["skip", "fail", "run"]
+                    "enum": [
+                      "skip",
+                      "fail",
+                      "run"
+                    ]
                   },
                   "mode": {
                     "type": "string",
-                    "enum": ["conversation"]
+                    "enum": [
+                      "conversation"
+                    ]
                   },
                   "turns": {
                     "type": "array",
@@ -11902,19 +13299,31 @@
                                   "type": "string"
                                 },
                                 {
+                                  "type": "object",
+                                  "properties": {},
+                                  "additionalProperties": {}
+                                },
+                                {
                                   "type": "array",
                                   "items": {
                                     "type": "object",
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": ["text", "file", "image"]
+                                        "enum": [
+                                          "text",
+                                          "file",
+                                          "image"
+                                        ]
                                       },
                                       "value": {
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["type", "value"],
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
@@ -11933,19 +13342,31 @@
                                   "type": "string"
                                 },
                                 {
+                                  "type": "object",
+                                  "properties": {},
+                                  "additionalProperties": {}
+                                },
+                                {
                                   "type": "array",
                                   "items": {
                                     "type": "object",
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": ["text", "file", "image"]
+                                        "enum": [
+                                          "text",
+                                          "file",
+                                          "image"
+                                        ]
                                       },
                                       "value": {
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["type", "value"],
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
@@ -11996,7 +13417,10 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["code-grader", "code_grader"]
+                                        "enum": [
+                                          "code-grader",
+                                          "code_grader"
+                                        ]
                                       },
                                       "command": {
                                         "anyOf": [
@@ -12070,12 +13494,18 @@
                                               ]
                                             }
                                           },
-                                          "required": ["type", "command"],
+                                          "required": [
+                                            "type",
+                                            "command"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -12112,7 +13542,10 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["llm-grader", "llm_grader"]
+                                        "enum": [
+                                          "llm-grader",
+                                          "llm_grader"
+                                        ]
                                       },
                                       "prompt": {
                                         "anyOf": [
@@ -12170,7 +13603,10 @@
                                             },
                                             "operator": {
                                               "type": "string",
-                                              "enum": ["correctness", "contradiction"]
+                                              "enum": [
+                                                "correctness",
+                                                "contradiction"
+                                              ]
                                             },
                                             "weight": {
                                               "type": "number"
@@ -12211,7 +13647,10 @@
                                                     "minLength": 1
                                                   }
                                                 },
-                                                "required": ["score_range", "outcome"],
+                                                "required": [
+                                                  "score_range",
+                                                  "outcome"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             }
@@ -12262,12 +13701,17 @@
                                               ]
                                             }
                                           },
-                                          "required": ["type", "command"],
+                                          "required": [
+                                            "type",
+                                            "command"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
                                     },
-                                    "required": ["type"],
+                                    "required": [
+                                      "type"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -12278,7 +13722,9 @@
                                         "minLength": 1
                                       }
                                     },
-                                    "required": ["include"],
+                                    "required": [
+                                      "include"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -12341,7 +13787,9 @@
                                                 }
                                               }
                                             },
-                                            "required": ["type"],
+                                            "required": [
+                                              "type"
+                                            ],
                                             "additionalProperties": false
                                           },
                                           {
@@ -12357,7 +13805,10 @@
                                                 "maximum": 1
                                               }
                                             },
-                                            "required": ["type", "threshold"],
+                                            "required": [
+                                              "type",
+                                              "threshold"
+                                            ],
                                             "additionalProperties": false
                                           },
                                           {
@@ -12374,7 +13825,10 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["type", "path"],
+                                            "required": [
+                                              "type",
+                                              "path"
+                                            ],
                                             "additionalProperties": false
                                           },
                                           {
@@ -12391,13 +13845,18 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["type"],
+                                            "required": [
+                                              "type"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
                                       }
                                     },
-                                    "required": ["type", "aggregator"],
+                                    "required": [
+                                      "type",
+                                      "aggregator"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -12434,7 +13893,10 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["tool-trajectory", "tool_trajectory"]
+                                        "enum": [
+                                          "tool-trajectory",
+                                          "tool_trajectory"
+                                        ]
                                       },
                                       "mode": {
                                         "type": "string",
@@ -12485,7 +13947,12 @@
                                               "anyOf": [
                                                 {
                                                   "type": "string",
-                                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                                  "enum": [
+                                                    "exact",
+                                                    "ignore",
+                                                    "subset",
+                                                    "superset"
+                                                  ]
                                                 },
                                                 {
                                                   "type": "array",
@@ -12499,7 +13966,12 @@
                                               "anyOf": [
                                                 {
                                                   "type": "string",
-                                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                                  "enum": [
+                                                    "exact",
+                                                    "ignore",
+                                                    "subset",
+                                                    "superset"
+                                                  ]
                                                 },
                                                 {
                                                   "type": "array",
@@ -12510,7 +13982,9 @@
                                               ]
                                             }
                                           },
-                                          "required": ["tool"],
+                                          "required": [
+                                            "tool"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       },
@@ -12518,7 +13992,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -12532,7 +14011,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -12543,7 +14027,10 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "mode"],
+                                    "required": [
+                                      "type",
+                                      "mode"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -12580,7 +14067,10 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["field-accuracy", "field_accuracy"]
+                                        "enum": [
+                                          "field-accuracy",
+                                          "field_accuracy"
+                                        ]
                                       },
                                       "fields": {
                                         "type": "array",
@@ -12592,7 +14082,11 @@
                                             },
                                             "match": {
                                               "type": "string",
-                                              "enum": ["exact", "numeric_tolerance", "date"]
+                                              "enum": [
+                                                "exact",
+                                                "numeric_tolerance",
+                                                "date"
+                                              ]
                                             },
                                             "required": {
                                               "type": "boolean"
@@ -12614,17 +14108,26 @@
                                               }
                                             }
                                           },
-                                          "required": ["path", "match"],
+                                          "required": [
+                                            "path",
+                                            "match"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         "minItems": 1
                                       },
                                       "aggregation": {
                                         "type": "string",
-                                        "enum": ["weighted_average", "all_or_nothing"]
+                                        "enum": [
+                                          "weighted_average",
+                                          "all_or_nothing"
+                                        ]
                                       }
                                     },
-                                    "required": ["type", "fields"],
+                                    "required": [
+                                      "type",
+                                      "fields"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -12668,7 +14171,10 @@
                                         "minimum": 0
                                       }
                                     },
-                                    "required": ["type", "threshold"],
+                                    "required": [
+                                      "type",
+                                      "threshold"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -12712,7 +14218,10 @@
                                         "minimum": 0
                                       }
                                     },
-                                    "required": ["type", "budget"],
+                                    "required": [
+                                      "type",
+                                      "budget"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -12749,7 +14258,10 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["token-usage", "token_usage"]
+                                        "enum": [
+                                          "token-usage",
+                                          "token_usage"
+                                        ]
                                       },
                                       "max_total": {
                                         "type": "number",
@@ -12764,7 +14276,9 @@
                                         "minimum": 0
                                       }
                                     },
-                                    "required": ["type"],
+                                    "required": [
+                                      "type"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -12801,7 +14315,10 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["execution-metrics", "execution_metrics"]
+                                        "enum": [
+                                          "execution-metrics",
+                                          "execution_metrics"
+                                        ]
                                       },
                                       "max_tool_calls": {
                                         "type": "number",
@@ -12833,7 +14350,9 @@
                                         "minimum": 0
                                       }
                                     },
-                                    "required": ["type"],
+                                    "required": [
+                                      "type"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -12876,7 +14395,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["type", "value"],
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -12919,7 +14441,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["type", "value"],
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -12956,10 +14481,15 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["is-json", "is_json"]
+                                        "enum": [
+                                          "is-json",
+                                          "is_json"
+                                        ]
                                       }
                                     },
-                                    "required": ["type"],
+                                    "required": [
+                                      "type"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -13002,7 +14532,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["type", "value"],
+                                    "required": [
+                                      "type",
+                                      "value"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
@@ -13054,7 +14587,10 @@
                                             },
                                             "operator": {
                                               "type": "string",
-                                              "enum": ["correctness", "contradiction"]
+                                              "enum": [
+                                                "correctness",
+                                                "contradiction"
+                                              ]
                                             },
                                             "weight": {
                                               "type": "number"
@@ -13095,7 +14631,10 @@
                                                     "minLength": 1
                                                   }
                                                 },
-                                                "required": ["score_range", "outcome"],
+                                                "required": [
+                                                  "score_range",
+                                                  "outcome"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             }
@@ -13105,7 +14644,10 @@
                                         "minItems": 1
                                       }
                                     },
-                                    "required": ["type", "criteria"],
+                                    "required": [
+                                      "type",
+                                      "criteria"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 ]
@@ -13114,25 +14656,36 @@
                           }
                         }
                       },
-                      "required": ["input"],
+                      "required": [
+                        "input"
+                      ],
                       "additionalProperties": false
                     },
                     "minItems": 1
                   },
                   "aggregation": {
                     "type": "string",
-                    "enum": ["mean", "min", "max"]
+                    "enum": [
+                      "mean",
+                      "min",
+                      "max"
+                    ]
                   },
                   "on_turn_failure": {
                     "type": "string",
-                    "enum": ["continue", "stop"]
+                    "enum": [
+                      "continue",
+                      "stop"
+                    ]
                   },
                   "window_size": {
                     "type": "integer",
                     "minimum": 1
                   }
                 },
-                "required": ["id"],
+                "required": [
+                  "id"
+                ],
                 "additionalProperties": false
               }
             },
@@ -13210,7 +14763,11 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": ["none", "fast", "strict"]
+                                "enum": [
+                                  "none",
+                                  "fast",
+                                  "strict"
+                                ]
                               }
                             },
                             "additionalProperties": false
@@ -13255,7 +14812,11 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": ["none", "fast", "strict"]
+                                "enum": [
+                                  "none",
+                                  "fast",
+                                  "strict"
+                                ]
                               }
                             },
                             "additionalProperties": false
@@ -13300,7 +14861,11 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": ["none", "fast", "strict"]
+                                "enum": [
+                                  "none",
+                                  "fast",
+                                  "strict"
+                                ]
                               }
                             },
                             "additionalProperties": false
@@ -13345,7 +14910,11 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": ["none", "fast", "strict"]
+                                "enum": [
+                                  "none",
+                                  "fast",
+                                  "strict"
+                                ]
                               }
                             },
                             "additionalProperties": false
@@ -13354,7 +14923,9 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "additionalProperties": false
                   }
                 ]
@@ -13403,7 +14974,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["code-grader", "code_grader"]
+                        "enum": [
+                          "code-grader",
+                          "code_grader"
+                        ]
                       },
                       "command": {
                         "anyOf": [
@@ -13477,12 +15051,18 @@
                               ]
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": ["type", "command"],
+                    "required": [
+                      "type",
+                      "command"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -13519,7 +15099,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["llm-grader", "llm_grader"]
+                        "enum": [
+                          "llm-grader",
+                          "llm_grader"
+                        ]
                       },
                       "prompt": {
                         "anyOf": [
@@ -13577,7 +15160,10 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": ["correctness", "contradiction"]
+                              "enum": [
+                                "correctness",
+                                "contradiction"
+                              ]
                             },
                             "weight": {
                               "type": "number"
@@ -13618,7 +15204,10 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": ["score_range", "outcome"],
+                                "required": [
+                                  "score_range",
+                                  "outcome"
+                                ],
                                 "additionalProperties": false
                               }
                             }
@@ -13669,12 +15258,17 @@
                               ]
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -13685,7 +15279,9 @@
                         "minLength": 1
                       }
                     },
-                    "required": ["include"],
+                    "required": [
+                      "include"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -13748,7 +15344,9 @@
                                 }
                               }
                             },
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -13764,7 +15362,10 @@
                                 "maximum": 1
                               }
                             },
-                            "required": ["type", "threshold"],
+                            "required": [
+                              "type",
+                              "threshold"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -13781,7 +15382,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["type", "path"],
+                            "required": [
+                              "type",
+                              "path"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -13798,13 +15402,18 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "additionalProperties": false
                           }
                         ]
                       }
                     },
-                    "required": ["type", "aggregator"],
+                    "required": [
+                      "type",
+                      "aggregator"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -13841,11 +15450,20 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["tool-trajectory", "tool_trajectory"]
+                        "enum": [
+                          "tool-trajectory",
+                          "tool_trajectory"
+                        ]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                        "enum": [
+                          "any_order",
+                          "in_order",
+                          "exact",
+                          "subset",
+                          "superset"
+                        ]
                       },
                       "minimums": {
                         "type": "object",
@@ -13886,7 +15504,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -13900,7 +15523,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -13911,7 +15539,9 @@
                               ]
                             }
                           },
-                          "required": ["tool"],
+                          "required": [
+                            "tool"
+                          ],
                           "additionalProperties": false
                         }
                       },
@@ -13919,7 +15549,12 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": ["exact", "ignore", "subset", "superset"]
+                            "enum": [
+                              "exact",
+                              "ignore",
+                              "subset",
+                              "superset"
+                            ]
                           },
                           {
                             "type": "array",
@@ -13933,7 +15568,12 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": ["exact", "ignore", "subset", "superset"]
+                            "enum": [
+                              "exact",
+                              "ignore",
+                              "subset",
+                              "superset"
+                            ]
                           },
                           {
                             "type": "array",
@@ -13944,7 +15584,10 @@
                         ]
                       }
                     },
-                    "required": ["type", "mode"],
+                    "required": [
+                      "type",
+                      "mode"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -13981,7 +15624,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["field-accuracy", "field_accuracy"]
+                        "enum": [
+                          "field-accuracy",
+                          "field_accuracy"
+                        ]
                       },
                       "fields": {
                         "type": "array",
@@ -13993,7 +15639,11 @@
                             },
                             "match": {
                               "type": "string",
-                              "enum": ["exact", "numeric_tolerance", "date"]
+                              "enum": [
+                                "exact",
+                                "numeric_tolerance",
+                                "date"
+                              ]
                             },
                             "required": {
                               "type": "boolean"
@@ -14015,17 +15665,26 @@
                               }
                             }
                           },
-                          "required": ["path", "match"],
+                          "required": [
+                            "path",
+                            "match"
+                          ],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": ["weighted_average", "all_or_nothing"]
+                        "enum": [
+                          "weighted_average",
+                          "all_or_nothing"
+                        ]
                       }
                     },
-                    "required": ["type", "fields"],
+                    "required": [
+                      "type",
+                      "fields"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14069,7 +15728,10 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type", "threshold"],
+                    "required": [
+                      "type",
+                      "threshold"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14113,7 +15775,10 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type", "budget"],
+                    "required": [
+                      "type",
+                      "budget"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14150,7 +15815,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["token-usage", "token_usage"]
+                        "enum": [
+                          "token-usage",
+                          "token_usage"
+                        ]
                       },
                       "max_total": {
                         "type": "number",
@@ -14165,7 +15833,9 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14202,7 +15872,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["execution-metrics", "execution_metrics"]
+                        "enum": [
+                          "execution-metrics",
+                          "execution_metrics"
+                        ]
                       },
                       "max_tool_calls": {
                         "type": "number",
@@ -14234,7 +15907,9 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14277,7 +15952,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14320,7 +15998,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14357,10 +16038,15 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["is-json", "is_json"]
+                        "enum": [
+                          "is-json",
+                          "is_json"
+                        ]
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14403,7 +16089,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14455,7 +16144,10 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": ["correctness", "contradiction"]
+                              "enum": [
+                                "correctness",
+                                "contradiction"
+                              ]
                             },
                             "weight": {
                               "type": "number"
@@ -14496,7 +16188,10 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": ["score_range", "outcome"],
+                                "required": [
+                                  "score_range",
+                                  "outcome"
+                                ],
                                 "additionalProperties": false
                               }
                             }
@@ -14506,7 +16201,10 @@
                         "minItems": 1
                       }
                     },
-                    "required": ["type", "criteria"],
+                    "required": [
+                      "type",
+                      "criteria"
+                    ],
                     "additionalProperties": false
                   }
                 ]
@@ -14550,7 +16248,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["code-grader", "code_grader"]
+                        "enum": [
+                          "code-grader",
+                          "code_grader"
+                        ]
                       },
                       "command": {
                         "anyOf": [
@@ -14624,12 +16325,18 @@
                               ]
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": ["type", "command"],
+                    "required": [
+                      "type",
+                      "command"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14666,7 +16373,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["llm-grader", "llm_grader"]
+                        "enum": [
+                          "llm-grader",
+                          "llm_grader"
+                        ]
                       },
                       "prompt": {
                         "anyOf": [
@@ -14724,7 +16434,10 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": ["correctness", "contradiction"]
+                              "enum": [
+                                "correctness",
+                                "contradiction"
+                              ]
                             },
                             "weight": {
                               "type": "number"
@@ -14765,7 +16478,10 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": ["score_range", "outcome"],
+                                "required": [
+                                  "score_range",
+                                  "outcome"
+                                ],
                                 "additionalProperties": false
                               }
                             }
@@ -14816,12 +16532,17 @@
                               ]
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14832,7 +16553,9 @@
                         "minLength": 1
                       }
                     },
-                    "required": ["include"],
+                    "required": [
+                      "include"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14895,7 +16618,9 @@
                                 }
                               }
                             },
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -14911,7 +16636,10 @@
                                 "maximum": 1
                               }
                             },
-                            "required": ["type", "threshold"],
+                            "required": [
+                              "type",
+                              "threshold"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -14928,7 +16656,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["type", "path"],
+                            "required": [
+                              "type",
+                              "path"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -14945,13 +16676,18 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "additionalProperties": false
                           }
                         ]
                       }
                     },
-                    "required": ["type", "aggregator"],
+                    "required": [
+                      "type",
+                      "aggregator"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14988,11 +16724,20 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["tool-trajectory", "tool_trajectory"]
+                        "enum": [
+                          "tool-trajectory",
+                          "tool_trajectory"
+                        ]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                        "enum": [
+                          "any_order",
+                          "in_order",
+                          "exact",
+                          "subset",
+                          "superset"
+                        ]
                       },
                       "minimums": {
                         "type": "object",
@@ -15033,7 +16778,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -15047,7 +16797,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -15058,7 +16813,9 @@
                               ]
                             }
                           },
-                          "required": ["tool"],
+                          "required": [
+                            "tool"
+                          ],
                           "additionalProperties": false
                         }
                       },
@@ -15066,7 +16823,12 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": ["exact", "ignore", "subset", "superset"]
+                            "enum": [
+                              "exact",
+                              "ignore",
+                              "subset",
+                              "superset"
+                            ]
                           },
                           {
                             "type": "array",
@@ -15080,7 +16842,12 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": ["exact", "ignore", "subset", "superset"]
+                            "enum": [
+                              "exact",
+                              "ignore",
+                              "subset",
+                              "superset"
+                            ]
                           },
                           {
                             "type": "array",
@@ -15091,7 +16858,10 @@
                         ]
                       }
                     },
-                    "required": ["type", "mode"],
+                    "required": [
+                      "type",
+                      "mode"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15128,7 +16898,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["field-accuracy", "field_accuracy"]
+                        "enum": [
+                          "field-accuracy",
+                          "field_accuracy"
+                        ]
                       },
                       "fields": {
                         "type": "array",
@@ -15140,7 +16913,11 @@
                             },
                             "match": {
                               "type": "string",
-                              "enum": ["exact", "numeric_tolerance", "date"]
+                              "enum": [
+                                "exact",
+                                "numeric_tolerance",
+                                "date"
+                              ]
                             },
                             "required": {
                               "type": "boolean"
@@ -15162,17 +16939,26 @@
                               }
                             }
                           },
-                          "required": ["path", "match"],
+                          "required": [
+                            "path",
+                            "match"
+                          ],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": ["weighted_average", "all_or_nothing"]
+                        "enum": [
+                          "weighted_average",
+                          "all_or_nothing"
+                        ]
                       }
                     },
-                    "required": ["type", "fields"],
+                    "required": [
+                      "type",
+                      "fields"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15216,7 +17002,10 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type", "threshold"],
+                    "required": [
+                      "type",
+                      "threshold"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15260,7 +17049,10 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type", "budget"],
+                    "required": [
+                      "type",
+                      "budget"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15297,7 +17089,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["token-usage", "token_usage"]
+                        "enum": [
+                          "token-usage",
+                          "token_usage"
+                        ]
                       },
                       "max_total": {
                         "type": "number",
@@ -15312,7 +17107,9 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15349,7 +17146,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["execution-metrics", "execution_metrics"]
+                        "enum": [
+                          "execution-metrics",
+                          "execution_metrics"
+                        ]
                       },
                       "max_tool_calls": {
                         "type": "number",
@@ -15381,7 +17181,9 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15424,7 +17226,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15467,7 +17272,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15504,10 +17312,15 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["is-json", "is_json"]
+                        "enum": [
+                          "is-json",
+                          "is_json"
+                        ]
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15550,7 +17363,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15602,7 +17418,10 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": ["correctness", "contradiction"]
+                              "enum": [
+                                "correctness",
+                                "contradiction"
+                              ]
                             },
                             "weight": {
                               "type": "number"
@@ -15643,7 +17462,10 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": ["score_range", "outcome"],
+                                "required": [
+                                  "score_range",
+                                  "outcome"
+                                ],
                                 "additionalProperties": false
                               }
                             }
@@ -15653,7 +17475,10 @@
                         "minItems": 1
                       }
                     },
-                    "required": ["type", "criteria"],
+                    "required": [
+                      "type",
+                      "criteria"
+                    ],
                     "additionalProperties": false
                   }
                 ]
@@ -15674,7 +17499,11 @@
                 },
                 "strategy": {
                   "type": "string",
-                  "enum": ["pass_at_k", "mean", "confidence_interval"]
+                  "enum": [
+                    "pass_at_k",
+                    "mean",
+                    "confidence_interval"
+                  ]
                 },
                 "cost_limit_usd": {
                   "type": "number",
@@ -15685,7 +17514,9 @@
                   "minimum": 0
                 }
               },
-              "required": ["count"],
+              "required": [
+                "count"
+              ],
               "additionalProperties": false
             },
             "budget_usd": {
@@ -15748,7 +17579,10 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["code-grader", "code_grader"]
+                    "enum": [
+                      "code-grader",
+                      "code_grader"
+                    ]
                   },
                   "command": {
                     "anyOf": [
@@ -15822,12 +17656,18 @@
                           ]
                         }
                       },
-                      "required": ["type", "command"],
+                      "required": [
+                        "type",
+                        "command"
+                      ],
                       "additionalProperties": false
                     }
                   }
                 },
-                "required": ["type", "command"],
+                "required": [
+                  "type",
+                  "command"
+                ],
                 "additionalProperties": false
               },
               {
@@ -15864,7 +17704,10 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["llm-grader", "llm_grader"]
+                    "enum": [
+                      "llm-grader",
+                      "llm_grader"
+                    ]
                   },
                   "prompt": {
                     "anyOf": [
@@ -15922,7 +17765,10 @@
                         },
                         "operator": {
                           "type": "string",
-                          "enum": ["correctness", "contradiction"]
+                          "enum": [
+                            "correctness",
+                            "contradiction"
+                          ]
                         },
                         "weight": {
                           "type": "number"
@@ -15963,7 +17809,10 @@
                                 "minLength": 1
                               }
                             },
-                            "required": ["score_range", "outcome"],
+                            "required": [
+                              "score_range",
+                              "outcome"
+                            ],
                             "additionalProperties": false
                           }
                         }
@@ -16014,12 +17863,17 @@
                           ]
                         }
                       },
-                      "required": ["type", "command"],
+                      "required": [
+                        "type",
+                        "command"
+                      ],
                       "additionalProperties": false
                     }
                   }
                 },
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "additionalProperties": false
               },
               {
@@ -16030,7 +17884,9 @@
                     "minLength": 1
                   }
                 },
-                "required": ["include"],
+                "required": [
+                  "include"
+                ],
                 "additionalProperties": false
               },
               {
@@ -16093,7 +17949,9 @@
                             }
                           }
                         },
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "additionalProperties": false
                       },
                       {
@@ -16109,7 +17967,10 @@
                             "maximum": 1
                           }
                         },
-                        "required": ["type", "threshold"],
+                        "required": [
+                          "type",
+                          "threshold"
+                        ],
                         "additionalProperties": false
                       },
                       {
@@ -16126,7 +17987,10 @@
                             "type": "string"
                           }
                         },
-                        "required": ["type", "path"],
+                        "required": [
+                          "type",
+                          "path"
+                        ],
                         "additionalProperties": false
                       },
                       {
@@ -16143,13 +18007,18 @@
                             "type": "string"
                           }
                         },
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "additionalProperties": false
                       }
                     ]
                   }
                 },
-                "required": ["type", "aggregator"],
+                "required": [
+                  "type",
+                  "aggregator"
+                ],
                 "additionalProperties": false
               },
               {
@@ -16186,11 +18055,20 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["tool-trajectory", "tool_trajectory"]
+                    "enum": [
+                      "tool-trajectory",
+                      "tool_trajectory"
+                    ]
                   },
                   "mode": {
                     "type": "string",
-                    "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                    "enum": [
+                      "any_order",
+                      "in_order",
+                      "exact",
+                      "subset",
+                      "superset"
+                    ]
                   },
                   "minimums": {
                     "type": "object",
@@ -16231,7 +18109,12 @@
                           "anyOf": [
                             {
                               "type": "string",
-                              "enum": ["exact", "ignore", "subset", "superset"]
+                              "enum": [
+                                "exact",
+                                "ignore",
+                                "subset",
+                                "superset"
+                              ]
                             },
                             {
                               "type": "array",
@@ -16245,7 +18128,12 @@
                           "anyOf": [
                             {
                               "type": "string",
-                              "enum": ["exact", "ignore", "subset", "superset"]
+                              "enum": [
+                                "exact",
+                                "ignore",
+                                "subset",
+                                "superset"
+                              ]
                             },
                             {
                               "type": "array",
@@ -16256,7 +18144,9 @@
                           ]
                         }
                       },
-                      "required": ["tool"],
+                      "required": [
+                        "tool"
+                      ],
                       "additionalProperties": false
                     }
                   },
@@ -16264,7 +18154,12 @@
                     "anyOf": [
                       {
                         "type": "string",
-                        "enum": ["exact", "ignore", "subset", "superset"]
+                        "enum": [
+                          "exact",
+                          "ignore",
+                          "subset",
+                          "superset"
+                        ]
                       },
                       {
                         "type": "array",
@@ -16278,7 +18173,12 @@
                     "anyOf": [
                       {
                         "type": "string",
-                        "enum": ["exact", "ignore", "subset", "superset"]
+                        "enum": [
+                          "exact",
+                          "ignore",
+                          "subset",
+                          "superset"
+                        ]
                       },
                       {
                         "type": "array",
@@ -16289,7 +18189,10 @@
                     ]
                   }
                 },
-                "required": ["type", "mode"],
+                "required": [
+                  "type",
+                  "mode"
+                ],
                 "additionalProperties": false
               },
               {
@@ -16326,7 +18229,10 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["field-accuracy", "field_accuracy"]
+                    "enum": [
+                      "field-accuracy",
+                      "field_accuracy"
+                    ]
                   },
                   "fields": {
                     "type": "array",
@@ -16338,7 +18244,11 @@
                         },
                         "match": {
                           "type": "string",
-                          "enum": ["exact", "numeric_tolerance", "date"]
+                          "enum": [
+                            "exact",
+                            "numeric_tolerance",
+                            "date"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -16360,17 +18270,26 @@
                           }
                         }
                       },
-                      "required": ["path", "match"],
+                      "required": [
+                        "path",
+                        "match"
+                      ],
                       "additionalProperties": false
                     },
                     "minItems": 1
                   },
                   "aggregation": {
                     "type": "string",
-                    "enum": ["weighted_average", "all_or_nothing"]
+                    "enum": [
+                      "weighted_average",
+                      "all_or_nothing"
+                    ]
                   }
                 },
-                "required": ["type", "fields"],
+                "required": [
+                  "type",
+                  "fields"
+                ],
                 "additionalProperties": false
               },
               {
@@ -16414,7 +18333,10 @@
                     "minimum": 0
                   }
                 },
-                "required": ["type", "threshold"],
+                "required": [
+                  "type",
+                  "threshold"
+                ],
                 "additionalProperties": false
               },
               {
@@ -16458,7 +18380,10 @@
                     "minimum": 0
                   }
                 },
-                "required": ["type", "budget"],
+                "required": [
+                  "type",
+                  "budget"
+                ],
                 "additionalProperties": false
               },
               {
@@ -16495,7 +18420,10 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["token-usage", "token_usage"]
+                    "enum": [
+                      "token-usage",
+                      "token_usage"
+                    ]
                   },
                   "max_total": {
                     "type": "number",
@@ -16510,7 +18438,9 @@
                     "minimum": 0
                   }
                 },
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "additionalProperties": false
               },
               {
@@ -16547,7 +18477,10 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["execution-metrics", "execution_metrics"]
+                    "enum": [
+                      "execution-metrics",
+                      "execution_metrics"
+                    ]
                   },
                   "max_tool_calls": {
                     "type": "number",
@@ -16579,7 +18512,9 @@
                     "minimum": 0
                   }
                 },
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "additionalProperties": false
               },
               {
@@ -16622,7 +18557,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["type", "value"],
+                "required": [
+                  "type",
+                  "value"
+                ],
                 "additionalProperties": false
               },
               {
@@ -16665,7 +18603,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["type", "value"],
+                "required": [
+                  "type",
+                  "value"
+                ],
                 "additionalProperties": false
               },
               {
@@ -16702,10 +18643,15 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["is-json", "is_json"]
+                    "enum": [
+                      "is-json",
+                      "is_json"
+                    ]
                   }
                 },
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "additionalProperties": false
               },
               {
@@ -16748,7 +18694,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["type", "value"],
+                "required": [
+                  "type",
+                  "value"
+                ],
                 "additionalProperties": false
               },
               {
@@ -16800,7 +18749,10 @@
                         },
                         "operator": {
                           "type": "string",
-                          "enum": ["correctness", "contradiction"]
+                          "enum": [
+                            "correctness",
+                            "contradiction"
+                          ]
                         },
                         "weight": {
                           "type": "number"
@@ -16841,7 +18793,10 @@
                                 "minLength": 1
                               }
                             },
-                            "required": ["score_range", "outcome"],
+                            "required": [
+                              "score_range",
+                              "outcome"
+                            ],
                             "additionalProperties": false
                           }
                         }
@@ -16851,7 +18806,10 @@
                     "minItems": 1
                   }
                 },
-                "required": ["type", "criteria"],
+                "required": [
+                  "type",
+                  "criteria"
+                ],
                 "additionalProperties": false
               }
             ]
@@ -16880,7 +18838,10 @@
                 ]
               }
             },
-            "required": ["type", "command"],
+            "required": [
+              "type",
+              "command"
+            ],
             "additionalProperties": false
           }
         },
@@ -16894,7 +18855,10 @@
                 },
                 "isolation": {
                   "type": "string",
-                  "enum": ["shared", "per_test"]
+                  "enum": [
+                    "shared",
+                    "per_test"
+                  ]
                 },
                 "repos": {
                   "type": "array",
@@ -16976,7 +18940,11 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": ["none", "fast", "strict"]
+                          "enum": [
+                            "none",
+                            "fast",
+                            "strict"
+                          ]
                         }
                       },
                       "additionalProperties": false
@@ -17021,7 +18989,11 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": ["none", "fast", "strict"]
+                          "enum": [
+                            "none",
+                            "fast",
+                            "strict"
+                          ]
                         }
                       },
                       "additionalProperties": false
@@ -17066,7 +19038,11 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": ["none", "fast", "strict"]
+                          "enum": [
+                            "none",
+                            "fast",
+                            "strict"
+                          ]
                         }
                       },
                       "additionalProperties": false
@@ -17111,7 +19087,11 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": ["none", "fast", "strict"]
+                          "enum": [
+                            "none",
+                            "fast",
+                            "strict"
+                          ]
                         }
                       },
                       "additionalProperties": false
@@ -17121,7 +19101,11 @@
                 },
                 "mode": {
                   "type": "string",
-                  "enum": ["pooled", "temp", "static"]
+                  "enum": [
+                    "pooled",
+                    "temp",
+                    "static"
+                  ]
                 },
                 "path": {
                   "type": "string"
@@ -17144,7 +19128,9 @@
                       "minimum": 0.1
                     }
                   },
-                  "required": ["image"],
+                  "required": [
+                    "image"
+                  ],
                   "additionalProperties": false
                 }
               },
@@ -17156,7 +19142,9 @@
           ]
         }
       },
-      "required": ["tests"],
+      "required": [
+        "tests"
+      ],
       "additionalProperties": false
     }
   }

--- a/skills-data/agentv-eval-writer/references/eval-schema.json
+++ b/skills-data/agentv-eval-writer/references/eval-schema.json
@@ -51,7 +51,51 @@
             },
             {
               "type": "object",
-              "properties": {},
+              "properties": {
+                "role": {
+                  "type": "string",
+                  "enum": ["system", "user", "assistant", "tool"]
+                },
+                "content": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {},
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": ["text", "file", "image"]
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["type", "value"],
+                        "additionalProperties": false
+                      }
+                    }
+                  ]
+                }
+              },
+              "required": ["role", "content"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "role": {
+                  "not": {}
+                }
+              },
               "additionalProperties": {}
             },
             {
@@ -131,7 +175,51 @@
                       },
                       {
                         "type": "object",
-                        "properties": {},
+                        "properties": {
+                          "role": {
+                            "type": "string",
+                            "enum": ["system", "user", "assistant", "tool"]
+                          },
+                          "content": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": {}
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": ["text", "file", "image"]
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["type", "value"],
+                                  "additionalProperties": false
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "required": ["role", "content"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "role": {
+                            "not": {}
+                          }
+                        },
                         "additionalProperties": {}
                       },
                       {
@@ -6679,7 +6767,51 @@
                       },
                       {
                         "type": "object",
-                        "properties": {},
+                        "properties": {
+                          "role": {
+                            "type": "string",
+                            "enum": ["system", "user", "assistant", "tool"]
+                          },
+                          "content": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": {}
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": ["text", "file", "image"]
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["type", "value"],
+                                  "additionalProperties": false
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "required": ["role", "content"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "role": {
+                            "not": {}
+                          }
+                        },
                         "additionalProperties": {}
                       },
                       {

--- a/skills-data/agentv-eval-writer/references/eval-schema.json
+++ b/skills-data/agentv-eval-writer/references/eval-schema.json
@@ -61,12 +61,7 @@
                 "properties": {
                   "role": {
                     "type": "string",
-                    "enum": [
-                      "system",
-                      "user",
-                      "assistant",
-                      "tool"
-                    ]
+                    "enum": ["system", "user", "assistant", "tool"]
                   },
                   "content": {
                     "anyOf": [
@@ -85,30 +80,20 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "text",
-                                "file",
-                                "image"
-                              ]
+                              "enum": ["text", "file", "image"]
                             },
                             "value": {
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type",
-                            "value"
-                          ],
+                          "required": ["type", "value"],
                           "additionalProperties": false
                         }
                       }
                     ]
                   }
                 },
-                "required": [
-                  "role",
-                  "content"
-                ],
+                "required": ["role", "content"],
                 "additionalProperties": false
               }
             }
@@ -156,12 +141,7 @@
                           "properties": {
                             "role": {
                               "type": "string",
-                              "enum": [
-                                "system",
-                                "user",
-                                "assistant",
-                                "tool"
-                              ]
+                              "enum": ["system", "user", "assistant", "tool"]
                             },
                             "content": {
                               "anyOf": [
@@ -180,30 +160,20 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "text",
-                                          "file",
-                                          "image"
-                                        ]
+                                        "enum": ["text", "file", "image"]
                                       },
                                       "value": {
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "value"
-                                    ],
+                                    "required": ["type", "value"],
                                     "additionalProperties": false
                                   }
                                 }
                               ]
                             }
                           },
-                          "required": [
-                            "role",
-                            "content"
-                          ],
+                          "required": ["role", "content"],
                           "additionalProperties": false
                         }
                       }
@@ -232,12 +202,7 @@
                           "properties": {
                             "role": {
                               "type": "string",
-                              "enum": [
-                                "system",
-                                "user",
-                                "assistant",
-                                "tool"
-                              ]
+                              "enum": ["system", "user", "assistant", "tool"]
                             },
                             "content": {
                               "anyOf": [
@@ -256,30 +221,20 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "text",
-                                          "file",
-                                          "image"
-                                        ]
+                                        "enum": ["text", "file", "image"]
                                       },
                                       "value": {
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "value"
-                                    ],
+                                    "required": ["type", "value"],
                                     "additionalProperties": false
                                   }
                                 }
                               ]
                             }
                           },
-                          "required": [
-                            "role",
-                            "content"
-                          ],
+                          "required": ["role", "content"],
                           "additionalProperties": false
                         }
                       }
@@ -323,10 +278,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "code-grader",
-                                "code_grader"
-                              ]
+                              "enum": ["code-grader", "code_grader"]
                             },
                             "command": {
                               "anyOf": [
@@ -400,18 +352,12 @@
                                     ]
                                   }
                                 },
-                                "required": [
-                                  "type",
-                                  "command"
-                                ],
+                                "required": ["type", "command"],
                                 "additionalProperties": false
                               }
                             }
                           },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
+                          "required": ["type", "command"],
                           "additionalProperties": false
                         },
                         {
@@ -448,10 +394,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "llm-grader",
-                                "llm_grader"
-                              ]
+                              "enum": ["llm-grader", "llm_grader"]
                             },
                             "prompt": {
                               "anyOf": [
@@ -509,10 +452,7 @@
                                   },
                                   "operator": {
                                     "type": "string",
-                                    "enum": [
-                                      "correctness",
-                                      "contradiction"
-                                    ]
+                                    "enum": ["correctness", "contradiction"]
                                   },
                                   "weight": {
                                     "type": "number"
@@ -553,10 +493,7 @@
                                           "minLength": 1
                                         }
                                       },
-                                      "required": [
-                                        "score_range",
-                                        "outcome"
-                                      ],
+                                      "required": ["score_range", "outcome"],
                                       "additionalProperties": false
                                     }
                                   }
@@ -607,17 +544,12 @@
                                     ]
                                   }
                                 },
-                                "required": [
-                                  "type",
-                                  "command"
-                                ],
+                                "required": ["type", "command"],
                                 "additionalProperties": false
                               }
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
+                          "required": ["type"],
                           "additionalProperties": false
                         },
                         {
@@ -628,9 +560,7 @@
                               "minLength": 1
                             }
                           },
-                          "required": [
-                            "include"
-                          ],
+                          "required": ["include"],
                           "additionalProperties": false
                         },
                         {
@@ -693,9 +623,7 @@
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -711,10 +639,7 @@
                                       "maximum": 1
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "threshold"
-                                  ],
+                                  "required": ["type", "threshold"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -731,10 +656,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "path"
-                                  ],
+                                  "required": ["type", "path"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -751,18 +673,13 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 }
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "aggregator"
-                          ],
+                          "required": ["type", "aggregator"],
                           "additionalProperties": false
                         },
                         {
@@ -799,20 +716,11 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "tool-trajectory",
-                                "tool_trajectory"
-                              ]
+                              "enum": ["tool-trajectory", "tool_trajectory"]
                             },
                             "mode": {
                               "type": "string",
-                              "enum": [
-                                "any_order",
-                                "in_order",
-                                "exact",
-                                "subset",
-                                "superset"
-                              ]
+                              "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                             },
                             "minimums": {
                               "type": "object",
@@ -853,12 +761,7 @@
                                     "anyOf": [
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "ignore",
-                                          "subset",
-                                          "superset"
-                                        ]
+                                        "enum": ["exact", "ignore", "subset", "superset"]
                                       },
                                       {
                                         "type": "array",
@@ -872,12 +775,7 @@
                                     "anyOf": [
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "ignore",
-                                          "subset",
-                                          "superset"
-                                        ]
+                                        "enum": ["exact", "ignore", "subset", "superset"]
                                       },
                                       {
                                         "type": "array",
@@ -888,9 +786,7 @@
                                     ]
                                   }
                                 },
-                                "required": [
-                                  "tool"
-                                ],
+                                "required": ["tool"],
                                 "additionalProperties": false
                               }
                             },
@@ -898,12 +794,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -917,12 +808,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -933,10 +819,7 @@
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "mode"
-                          ],
+                          "required": ["type", "mode"],
                           "additionalProperties": false
                         },
                         {
@@ -973,10 +856,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "field-accuracy",
-                                "field_accuracy"
-                              ]
+                              "enum": ["field-accuracy", "field_accuracy"]
                             },
                             "fields": {
                               "type": "array",
@@ -988,11 +868,7 @@
                                   },
                                   "match": {
                                     "type": "string",
-                                    "enum": [
-                                      "exact",
-                                      "numeric_tolerance",
-                                      "date"
-                                    ]
+                                    "enum": ["exact", "numeric_tolerance", "date"]
                                   },
                                   "required": {
                                     "type": "boolean"
@@ -1014,26 +890,17 @@
                                     }
                                   }
                                 },
-                                "required": [
-                                  "path",
-                                  "match"
-                                ],
+                                "required": ["path", "match"],
                                 "additionalProperties": false
                               },
                               "minItems": 1
                             },
                             "aggregation": {
                               "type": "string",
-                              "enum": [
-                                "weighted_average",
-                                "all_or_nothing"
-                              ]
+                              "enum": ["weighted_average", "all_or_nothing"]
                             }
                           },
-                          "required": [
-                            "type",
-                            "fields"
-                          ],
+                          "required": ["type", "fields"],
                           "additionalProperties": false
                         },
                         {
@@ -1077,10 +944,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "type",
-                            "threshold"
-                          ],
+                          "required": ["type", "threshold"],
                           "additionalProperties": false
                         },
                         {
@@ -1124,10 +988,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "type",
-                            "budget"
-                          ],
+                          "required": ["type", "budget"],
                           "additionalProperties": false
                         },
                         {
@@ -1164,10 +1025,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "token-usage",
-                                "token_usage"
-                              ]
+                              "enum": ["token-usage", "token_usage"]
                             },
                             "max_total": {
                               "type": "number",
@@ -1182,9 +1040,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
+                          "required": ["type"],
                           "additionalProperties": false
                         },
                         {
@@ -1221,10 +1077,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "execution-metrics",
-                                "execution_metrics"
-                              ]
+                              "enum": ["execution-metrics", "execution_metrics"]
                             },
                             "max_tool_calls": {
                               "type": "number",
@@ -1256,9 +1109,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
+                          "required": ["type"],
                           "additionalProperties": false
                         },
                         {
@@ -1301,10 +1152,7 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type",
-                            "value"
-                          ],
+                          "required": ["type", "value"],
                           "additionalProperties": false
                         },
                         {
@@ -1347,10 +1195,7 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type",
-                            "value"
-                          ],
+                          "required": ["type", "value"],
                           "additionalProperties": false
                         },
                         {
@@ -1387,15 +1232,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "is-json",
-                                "is_json"
-                              ]
+                              "enum": ["is-json", "is_json"]
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
+                          "required": ["type"],
                           "additionalProperties": false
                         },
                         {
@@ -1438,10 +1278,7 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type",
-                            "value"
-                          ],
+                          "required": ["type", "value"],
                           "additionalProperties": false
                         },
                         {
@@ -1493,10 +1330,7 @@
                                   },
                                   "operator": {
                                     "type": "string",
-                                    "enum": [
-                                      "correctness",
-                                      "contradiction"
-                                    ]
+                                    "enum": ["correctness", "contradiction"]
                                   },
                                   "weight": {
                                     "type": "number"
@@ -1537,10 +1371,7 @@
                                           "minLength": 1
                                         }
                                       },
-                                      "required": [
-                                        "score_range",
-                                        "outcome"
-                                      ],
+                                      "required": ["score_range", "outcome"],
                                       "additionalProperties": false
                                     }
                                   }
@@ -1550,10 +1381,7 @@
                               "minItems": 1
                             }
                           },
-                          "required": [
-                            "type",
-                            "criteria"
-                          ],
+                          "required": ["type", "criteria"],
                           "additionalProperties": false
                         }
                       ]
@@ -1597,10 +1425,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "code-grader",
-                                "code_grader"
-                              ]
+                              "enum": ["code-grader", "code_grader"]
                             },
                             "command": {
                               "anyOf": [
@@ -1674,18 +1499,12 @@
                                     ]
                                   }
                                 },
-                                "required": [
-                                  "type",
-                                  "command"
-                                ],
+                                "required": ["type", "command"],
                                 "additionalProperties": false
                               }
                             }
                           },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
+                          "required": ["type", "command"],
                           "additionalProperties": false
                         },
                         {
@@ -1722,10 +1541,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "llm-grader",
-                                "llm_grader"
-                              ]
+                              "enum": ["llm-grader", "llm_grader"]
                             },
                             "prompt": {
                               "anyOf": [
@@ -1783,10 +1599,7 @@
                                   },
                                   "operator": {
                                     "type": "string",
-                                    "enum": [
-                                      "correctness",
-                                      "contradiction"
-                                    ]
+                                    "enum": ["correctness", "contradiction"]
                                   },
                                   "weight": {
                                     "type": "number"
@@ -1827,10 +1640,7 @@
                                           "minLength": 1
                                         }
                                       },
-                                      "required": [
-                                        "score_range",
-                                        "outcome"
-                                      ],
+                                      "required": ["score_range", "outcome"],
                                       "additionalProperties": false
                                     }
                                   }
@@ -1881,17 +1691,12 @@
                                     ]
                                   }
                                 },
-                                "required": [
-                                  "type",
-                                  "command"
-                                ],
+                                "required": ["type", "command"],
                                 "additionalProperties": false
                               }
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
+                          "required": ["type"],
                           "additionalProperties": false
                         },
                         {
@@ -1902,9 +1707,7 @@
                               "minLength": 1
                             }
                           },
-                          "required": [
-                            "include"
-                          ],
+                          "required": ["include"],
                           "additionalProperties": false
                         },
                         {
@@ -1967,9 +1770,7 @@
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -1985,10 +1786,7 @@
                                       "maximum": 1
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "threshold"
-                                  ],
+                                  "required": ["type", "threshold"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -2005,10 +1803,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "path"
-                                  ],
+                                  "required": ["type", "path"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -2025,18 +1820,13 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 }
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "aggregator"
-                          ],
+                          "required": ["type", "aggregator"],
                           "additionalProperties": false
                         },
                         {
@@ -2073,20 +1863,11 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "tool-trajectory",
-                                "tool_trajectory"
-                              ]
+                              "enum": ["tool-trajectory", "tool_trajectory"]
                             },
                             "mode": {
                               "type": "string",
-                              "enum": [
-                                "any_order",
-                                "in_order",
-                                "exact",
-                                "subset",
-                                "superset"
-                              ]
+                              "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                             },
                             "minimums": {
                               "type": "object",
@@ -2127,12 +1908,7 @@
                                     "anyOf": [
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "ignore",
-                                          "subset",
-                                          "superset"
-                                        ]
+                                        "enum": ["exact", "ignore", "subset", "superset"]
                                       },
                                       {
                                         "type": "array",
@@ -2146,12 +1922,7 @@
                                     "anyOf": [
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "ignore",
-                                          "subset",
-                                          "superset"
-                                        ]
+                                        "enum": ["exact", "ignore", "subset", "superset"]
                                       },
                                       {
                                         "type": "array",
@@ -2162,9 +1933,7 @@
                                     ]
                                   }
                                 },
-                                "required": [
-                                  "tool"
-                                ],
+                                "required": ["tool"],
                                 "additionalProperties": false
                               }
                             },
@@ -2172,12 +1941,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -2191,12 +1955,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -2207,10 +1966,7 @@
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "mode"
-                          ],
+                          "required": ["type", "mode"],
                           "additionalProperties": false
                         },
                         {
@@ -2247,10 +2003,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "field-accuracy",
-                                "field_accuracy"
-                              ]
+                              "enum": ["field-accuracy", "field_accuracy"]
                             },
                             "fields": {
                               "type": "array",
@@ -2262,11 +2015,7 @@
                                   },
                                   "match": {
                                     "type": "string",
-                                    "enum": [
-                                      "exact",
-                                      "numeric_tolerance",
-                                      "date"
-                                    ]
+                                    "enum": ["exact", "numeric_tolerance", "date"]
                                   },
                                   "required": {
                                     "type": "boolean"
@@ -2288,26 +2037,17 @@
                                     }
                                   }
                                 },
-                                "required": [
-                                  "path",
-                                  "match"
-                                ],
+                                "required": ["path", "match"],
                                 "additionalProperties": false
                               },
                               "minItems": 1
                             },
                             "aggregation": {
                               "type": "string",
-                              "enum": [
-                                "weighted_average",
-                                "all_or_nothing"
-                              ]
+                              "enum": ["weighted_average", "all_or_nothing"]
                             }
                           },
-                          "required": [
-                            "type",
-                            "fields"
-                          ],
+                          "required": ["type", "fields"],
                           "additionalProperties": false
                         },
                         {
@@ -2351,10 +2091,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "type",
-                            "threshold"
-                          ],
+                          "required": ["type", "threshold"],
                           "additionalProperties": false
                         },
                         {
@@ -2398,10 +2135,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "type",
-                            "budget"
-                          ],
+                          "required": ["type", "budget"],
                           "additionalProperties": false
                         },
                         {
@@ -2438,10 +2172,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "token-usage",
-                                "token_usage"
-                              ]
+                              "enum": ["token-usage", "token_usage"]
                             },
                             "max_total": {
                               "type": "number",
@@ -2456,9 +2187,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
+                          "required": ["type"],
                           "additionalProperties": false
                         },
                         {
@@ -2495,10 +2224,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "execution-metrics",
-                                "execution_metrics"
-                              ]
+                              "enum": ["execution-metrics", "execution_metrics"]
                             },
                             "max_tool_calls": {
                               "type": "number",
@@ -2530,9 +2256,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
+                          "required": ["type"],
                           "additionalProperties": false
                         },
                         {
@@ -2575,10 +2299,7 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type",
-                            "value"
-                          ],
+                          "required": ["type", "value"],
                           "additionalProperties": false
                         },
                         {
@@ -2621,10 +2342,7 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type",
-                            "value"
-                          ],
+                          "required": ["type", "value"],
                           "additionalProperties": false
                         },
                         {
@@ -2661,15 +2379,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "is-json",
-                                "is_json"
-                              ]
+                              "enum": ["is-json", "is_json"]
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
+                          "required": ["type"],
                           "additionalProperties": false
                         },
                         {
@@ -2712,10 +2425,7 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type",
-                            "value"
-                          ],
+                          "required": ["type", "value"],
                           "additionalProperties": false
                         },
                         {
@@ -2767,10 +2477,7 @@
                                   },
                                   "operator": {
                                     "type": "string",
-                                    "enum": [
-                                      "correctness",
-                                      "contradiction"
-                                    ]
+                                    "enum": ["correctness", "contradiction"]
                                   },
                                   "weight": {
                                     "type": "number"
@@ -2811,10 +2518,7 @@
                                           "minLength": 1
                                         }
                                       },
-                                      "required": [
-                                        "score_range",
-                                        "outcome"
-                                      ],
+                                      "required": ["score_range", "outcome"],
                                       "additionalProperties": false
                                     }
                                   }
@@ -2824,10 +2528,7 @@
                               "minItems": 1
                             }
                           },
-                          "required": [
-                            "type",
-                            "criteria"
-                          ],
+                          "required": ["type", "criteria"],
                           "additionalProperties": false
                         }
                       ]
@@ -2899,11 +2600,7 @@
                                         },
                                         "reset": {
                                           "type": "string",
-                                          "enum": [
-                                            "none",
-                                            "fast",
-                                            "strict"
-                                          ]
+                                          "enum": ["none", "fast", "strict"]
                                         }
                                       },
                                       "additionalProperties": false
@@ -2948,11 +2645,7 @@
                                         },
                                         "reset": {
                                           "type": "string",
-                                          "enum": [
-                                            "none",
-                                            "fast",
-                                            "strict"
-                                          ]
+                                          "enum": ["none", "fast", "strict"]
                                         }
                                       },
                                       "additionalProperties": false
@@ -2997,11 +2690,7 @@
                                         },
                                         "reset": {
                                           "type": "string",
-                                          "enum": [
-                                            "none",
-                                            "fast",
-                                            "strict"
-                                          ]
+                                          "enum": ["none", "fast", "strict"]
                                         }
                                       },
                                       "additionalProperties": false
@@ -3046,11 +2735,7 @@
                                         },
                                         "reset": {
                                           "type": "string",
-                                          "enum": [
-                                            "none",
-                                            "fast",
-                                            "strict"
-                                          ]
+                                          "enum": ["none", "fast", "strict"]
                                         }
                                       },
                                       "additionalProperties": false
@@ -3059,9 +2744,7 @@
                                   "additionalProperties": false
                                 }
                               },
-                              "required": [
-                                "name"
-                              ],
+                              "required": ["name"],
                               "additionalProperties": false
                             }
                           ]
@@ -3110,10 +2793,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "code-grader",
-                                    "code_grader"
-                                  ]
+                                  "enum": ["code-grader", "code_grader"]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -3187,18 +2867,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type",
-                                "command"
-                              ],
+                              "required": ["type", "command"],
                               "additionalProperties": false
                             },
                             {
@@ -3235,10 +2909,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "llm-grader",
-                                    "llm_grader"
-                                  ]
+                                  "enum": ["llm-grader", "llm_grader"]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -3296,10 +2967,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -3340,10 +3008,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -3394,17 +3059,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -3415,9 +3075,7 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": [
-                                "include"
-                              ],
+                              "required": ["include"],
                               "additionalProperties": false
                             },
                             {
@@ -3480,9 +3138,7 @@
                                           }
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -3498,10 +3154,7 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "threshold"
-                                      ],
+                                      "required": ["type", "threshold"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -3518,10 +3171,7 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "path"
-                                      ],
+                                      "required": ["type", "path"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -3538,18 +3188,13 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "aggregator"
-                              ],
+                              "required": ["type", "aggregator"],
                               "additionalProperties": false
                             },
                             {
@@ -3586,20 +3231,11 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "tool-trajectory",
-                                    "tool_trajectory"
-                                  ]
+                                  "enum": ["tool-trajectory", "tool_trajectory"]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": [
-                                    "any_order",
-                                    "in_order",
-                                    "exact",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -3640,12 +3276,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -3659,12 +3290,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -3675,9 +3301,7 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "tool"
-                                    ],
+                                    "required": ["tool"],
                                     "additionalProperties": false
                                   }
                                 },
@@ -3685,12 +3309,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -3704,12 +3323,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -3720,10 +3334,7 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "mode"
-                              ],
+                              "required": ["type", "mode"],
                               "additionalProperties": false
                             },
                             {
@@ -3760,10 +3371,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "field-accuracy",
-                                    "field_accuracy"
-                                  ]
+                                  "enum": ["field-accuracy", "field_accuracy"]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -3775,11 +3383,7 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "numeric_tolerance",
-                                          "date"
-                                        ]
+                                        "enum": ["exact", "numeric_tolerance", "date"]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -3801,26 +3405,17 @@
                                         }
                                       }
                                     },
-                                    "required": [
-                                      "path",
-                                      "match"
-                                    ],
+                                    "required": ["path", "match"],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": [
-                                    "weighted_average",
-                                    "all_or_nothing"
-                                  ]
+                                  "enum": ["weighted_average", "all_or_nothing"]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "fields"
-                              ],
+                              "required": ["type", "fields"],
                               "additionalProperties": false
                             },
                             {
@@ -3864,10 +3459,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "threshold"
-                              ],
+                              "required": ["type", "threshold"],
                               "additionalProperties": false
                             },
                             {
@@ -3911,10 +3503,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "budget"
-                              ],
+                              "required": ["type", "budget"],
                               "additionalProperties": false
                             },
                             {
@@ -3951,10 +3540,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "token-usage",
-                                    "token_usage"
-                                  ]
+                                  "enum": ["token-usage", "token_usage"]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -3969,9 +3555,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -4008,10 +3592,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "execution-metrics",
-                                    "execution_metrics"
-                                  ]
+                                  "enum": ["execution-metrics", "execution_metrics"]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -4043,9 +3624,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -4088,10 +3667,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -4134,10 +3710,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -4174,15 +3747,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "is-json",
-                                    "is_json"
-                                  ]
+                                  "enum": ["is-json", "is_json"]
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -4225,10 +3793,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -4280,10 +3845,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -4324,10 +3886,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -4337,10 +3896,7 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": [
-                                "type",
-                                "criteria"
-                              ],
+                              "required": ["type", "criteria"],
                               "additionalProperties": false
                             }
                           ]
@@ -4384,10 +3940,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "code-grader",
-                                    "code_grader"
-                                  ]
+                                  "enum": ["code-grader", "code_grader"]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -4461,18 +4014,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type",
-                                "command"
-                              ],
+                              "required": ["type", "command"],
                               "additionalProperties": false
                             },
                             {
@@ -4509,10 +4056,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "llm-grader",
-                                    "llm_grader"
-                                  ]
+                                  "enum": ["llm-grader", "llm_grader"]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -4570,10 +4114,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -4614,10 +4155,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -4668,17 +4206,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -4689,9 +4222,7 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": [
-                                "include"
-                              ],
+                              "required": ["include"],
                               "additionalProperties": false
                             },
                             {
@@ -4754,9 +4285,7 @@
                                           }
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -4772,10 +4301,7 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "threshold"
-                                      ],
+                                      "required": ["type", "threshold"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -4792,10 +4318,7 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "path"
-                                      ],
+                                      "required": ["type", "path"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -4812,18 +4335,13 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "aggregator"
-                              ],
+                              "required": ["type", "aggregator"],
                               "additionalProperties": false
                             },
                             {
@@ -4860,20 +4378,11 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "tool-trajectory",
-                                    "tool_trajectory"
-                                  ]
+                                  "enum": ["tool-trajectory", "tool_trajectory"]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": [
-                                    "any_order",
-                                    "in_order",
-                                    "exact",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -4914,12 +4423,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -4933,12 +4437,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -4949,9 +4448,7 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "tool"
-                                    ],
+                                    "required": ["tool"],
                                     "additionalProperties": false
                                   }
                                 },
@@ -4959,12 +4456,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -4978,12 +4470,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -4994,10 +4481,7 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "mode"
-                              ],
+                              "required": ["type", "mode"],
                               "additionalProperties": false
                             },
                             {
@@ -5034,10 +4518,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "field-accuracy",
-                                    "field_accuracy"
-                                  ]
+                                  "enum": ["field-accuracy", "field_accuracy"]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -5049,11 +4530,7 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "numeric_tolerance",
-                                          "date"
-                                        ]
+                                        "enum": ["exact", "numeric_tolerance", "date"]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -5075,26 +4552,17 @@
                                         }
                                       }
                                     },
-                                    "required": [
-                                      "path",
-                                      "match"
-                                    ],
+                                    "required": ["path", "match"],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": [
-                                    "weighted_average",
-                                    "all_or_nothing"
-                                  ]
+                                  "enum": ["weighted_average", "all_or_nothing"]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "fields"
-                              ],
+                              "required": ["type", "fields"],
                               "additionalProperties": false
                             },
                             {
@@ -5138,10 +4606,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "threshold"
-                              ],
+                              "required": ["type", "threshold"],
                               "additionalProperties": false
                             },
                             {
@@ -5185,10 +4650,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "budget"
-                              ],
+                              "required": ["type", "budget"],
                               "additionalProperties": false
                             },
                             {
@@ -5225,10 +4687,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "token-usage",
-                                    "token_usage"
-                                  ]
+                                  "enum": ["token-usage", "token_usage"]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -5243,9 +4702,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -5282,10 +4739,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "execution-metrics",
-                                    "execution_metrics"
-                                  ]
+                                  "enum": ["execution-metrics", "execution_metrics"]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -5317,9 +4771,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -5362,10 +4814,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -5408,10 +4857,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -5448,15 +4894,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "is-json",
-                                    "is_json"
-                                  ]
+                                  "enum": ["is-json", "is_json"]
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -5499,10 +4940,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -5554,10 +4992,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -5598,10 +5033,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -5611,10 +5043,7 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": [
-                                "type",
-                                "criteria"
-                              ],
+                              "required": ["type", "criteria"],
                               "additionalProperties": false
                             }
                           ]
@@ -5635,11 +5064,7 @@
                           },
                           "strategy": {
                             "type": "string",
-                            "enum": [
-                              "pass_at_k",
-                              "mean",
-                              "confidence_interval"
-                            ]
+                            "enum": ["pass_at_k", "mean", "confidence_interval"]
                           },
                           "cost_limit_usd": {
                             "type": "number",
@@ -5650,9 +5075,7 @@
                             "minimum": 0
                           }
                         },
-                        "required": [
-                          "count"
-                        ],
+                        "required": ["count"],
                         "additionalProperties": false
                       },
                       "budget_usd": {
@@ -5685,10 +5108,7 @@
                       },
                       "isolation": {
                         "type": "string",
-                        "enum": [
-                          "shared",
-                          "per_test"
-                        ]
+                        "enum": ["shared", "per_test"]
                       },
                       "repos": {
                         "type": "array",
@@ -5770,11 +5190,7 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": [
-                                  "none",
-                                  "fast",
-                                  "strict"
-                                ]
+                                "enum": ["none", "fast", "strict"]
                               }
                             },
                             "additionalProperties": false
@@ -5819,11 +5235,7 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": [
-                                  "none",
-                                  "fast",
-                                  "strict"
-                                ]
+                                "enum": ["none", "fast", "strict"]
                               }
                             },
                             "additionalProperties": false
@@ -5868,11 +5280,7 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": [
-                                  "none",
-                                  "fast",
-                                  "strict"
-                                ]
+                                "enum": ["none", "fast", "strict"]
                               }
                             },
                             "additionalProperties": false
@@ -5917,11 +5325,7 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": [
-                                  "none",
-                                  "fast",
-                                  "strict"
-                                ]
+                                "enum": ["none", "fast", "strict"]
                               }
                             },
                             "additionalProperties": false
@@ -5931,11 +5335,7 @@
                       },
                       "mode": {
                         "type": "string",
-                        "enum": [
-                          "pooled",
-                          "temp",
-                          "static"
-                        ]
+                        "enum": ["pooled", "temp", "static"]
                       },
                       "path": {
                         "type": "string"
@@ -5958,9 +5358,7 @@
                             "minimum": 0.1
                           }
                         },
-                        "required": [
-                          "image"
-                        ],
+                        "required": ["image"],
                         "additionalProperties": false
                       }
                     },
@@ -5984,17 +5382,11 @@
                   },
                   "on_dependency_failure": {
                     "type": "string",
-                    "enum": [
-                      "skip",
-                      "fail",
-                      "run"
-                    ]
+                    "enum": ["skip", "fail", "run"]
                   },
                   "mode": {
                     "type": "string",
-                    "enum": [
-                      "conversation"
-                    ]
+                    "enum": ["conversation"]
                   },
                   "turns": {
                     "type": "array",
@@ -6023,20 +5415,13 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "text",
-                                          "file",
-                                          "image"
-                                        ]
+                                        "enum": ["text", "file", "image"]
                                       },
                                       "value": {
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "value"
-                                    ],
+                                    "required": ["type", "value"],
                                     "additionalProperties": false
                                   }
                                 }
@@ -6066,20 +5451,13 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "text",
-                                          "file",
-                                          "image"
-                                        ]
+                                        "enum": ["text", "file", "image"]
                                       },
                                       "value": {
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "value"
-                                    ],
+                                    "required": ["type", "value"],
                                     "additionalProperties": false
                                   }
                                 }
@@ -6130,10 +5508,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "code-grader",
-                                          "code_grader"
-                                        ]
+                                        "enum": ["code-grader", "code_grader"]
                                       },
                                       "command": {
                                         "anyOf": [
@@ -6207,18 +5582,12 @@
                                               ]
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "command"
-                                          ],
+                                          "required": ["type", "command"],
                                           "additionalProperties": false
                                         }
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -6255,10 +5624,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "llm-grader",
-                                          "llm_grader"
-                                        ]
+                                        "enum": ["llm-grader", "llm_grader"]
                                       },
                                       "prompt": {
                                         "anyOf": [
@@ -6316,10 +5682,7 @@
                                             },
                                             "operator": {
                                               "type": "string",
-                                              "enum": [
-                                                "correctness",
-                                                "contradiction"
-                                              ]
+                                              "enum": ["correctness", "contradiction"]
                                             },
                                             "weight": {
                                               "type": "number"
@@ -6360,10 +5723,7 @@
                                                     "minLength": 1
                                                   }
                                                 },
-                                                "required": [
-                                                  "score_range",
-                                                  "outcome"
-                                                ],
+                                                "required": ["score_range", "outcome"],
                                                 "additionalProperties": false
                                               }
                                             }
@@ -6414,17 +5774,12 @@
                                               ]
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "command"
-                                          ],
+                                          "required": ["type", "command"],
                                           "additionalProperties": false
                                         }
                                       }
                                     },
-                                    "required": [
-                                      "type"
-                                    ],
+                                    "required": ["type"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -6435,9 +5790,7 @@
                                         "minLength": 1
                                       }
                                     },
-                                    "required": [
-                                      "include"
-                                    ],
+                                    "required": ["include"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -6500,9 +5853,7 @@
                                                 }
                                               }
                                             },
-                                            "required": [
-                                              "type"
-                                            ],
+                                            "required": ["type"],
                                             "additionalProperties": false
                                           },
                                           {
@@ -6518,10 +5869,7 @@
                                                 "maximum": 1
                                               }
                                             },
-                                            "required": [
-                                              "type",
-                                              "threshold"
-                                            ],
+                                            "required": ["type", "threshold"],
                                             "additionalProperties": false
                                           },
                                           {
@@ -6538,10 +5886,7 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": [
-                                              "type",
-                                              "path"
-                                            ],
+                                            "required": ["type", "path"],
                                             "additionalProperties": false
                                           },
                                           {
@@ -6558,18 +5903,13 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": [
-                                              "type"
-                                            ],
+                                            "required": ["type"],
                                             "additionalProperties": false
                                           }
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "aggregator"
-                                    ],
+                                    "required": ["type", "aggregator"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -6606,10 +5946,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "tool-trajectory",
-                                          "tool_trajectory"
-                                        ]
+                                        "enum": ["tool-trajectory", "tool_trajectory"]
                                       },
                                       "mode": {
                                         "type": "string",
@@ -6660,12 +5997,7 @@
                                               "anyOf": [
                                                 {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "exact",
-                                                    "ignore",
-                                                    "subset",
-                                                    "superset"
-                                                  ]
+                                                  "enum": ["exact", "ignore", "subset", "superset"]
                                                 },
                                                 {
                                                   "type": "array",
@@ -6679,12 +6011,7 @@
                                               "anyOf": [
                                                 {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "exact",
-                                                    "ignore",
-                                                    "subset",
-                                                    "superset"
-                                                  ]
+                                                  "enum": ["exact", "ignore", "subset", "superset"]
                                                 },
                                                 {
                                                   "type": "array",
@@ -6695,9 +6022,7 @@
                                               ]
                                             }
                                           },
-                                          "required": [
-                                            "tool"
-                                          ],
+                                          "required": ["tool"],
                                           "additionalProperties": false
                                         }
                                       },
@@ -6705,12 +6030,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -6724,12 +6044,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -6740,10 +6055,7 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "mode"
-                                    ],
+                                    "required": ["type", "mode"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -6780,10 +6092,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "field-accuracy",
-                                          "field_accuracy"
-                                        ]
+                                        "enum": ["field-accuracy", "field_accuracy"]
                                       },
                                       "fields": {
                                         "type": "array",
@@ -6795,11 +6104,7 @@
                                             },
                                             "match": {
                                               "type": "string",
-                                              "enum": [
-                                                "exact",
-                                                "numeric_tolerance",
-                                                "date"
-                                              ]
+                                              "enum": ["exact", "numeric_tolerance", "date"]
                                             },
                                             "required": {
                                               "type": "boolean"
@@ -6821,26 +6126,17 @@
                                               }
                                             }
                                           },
-                                          "required": [
-                                            "path",
-                                            "match"
-                                          ],
+                                          "required": ["path", "match"],
                                           "additionalProperties": false
                                         },
                                         "minItems": 1
                                       },
                                       "aggregation": {
                                         "type": "string",
-                                        "enum": [
-                                          "weighted_average",
-                                          "all_or_nothing"
-                                        ]
+                                        "enum": ["weighted_average", "all_or_nothing"]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "fields"
-                                    ],
+                                    "required": ["type", "fields"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -6884,10 +6180,7 @@
                                         "minimum": 0
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "threshold"
-                                    ],
+                                    "required": ["type", "threshold"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -6931,10 +6224,7 @@
                                         "minimum": 0
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "budget"
-                                    ],
+                                    "required": ["type", "budget"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -6971,10 +6261,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "token-usage",
-                                          "token_usage"
-                                        ]
+                                        "enum": ["token-usage", "token_usage"]
                                       },
                                       "max_total": {
                                         "type": "number",
@@ -6989,9 +6276,7 @@
                                         "minimum": 0
                                       }
                                     },
-                                    "required": [
-                                      "type"
-                                    ],
+                                    "required": ["type"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -7028,10 +6313,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "execution-metrics",
-                                          "execution_metrics"
-                                        ]
+                                        "enum": ["execution-metrics", "execution_metrics"]
                                       },
                                       "max_tool_calls": {
                                         "type": "number",
@@ -7063,9 +6345,7 @@
                                         "minimum": 0
                                       }
                                     },
-                                    "required": [
-                                      "type"
-                                    ],
+                                    "required": ["type"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -7108,10 +6388,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "value"
-                                    ],
+                                    "required": ["type", "value"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -7154,10 +6431,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "value"
-                                    ],
+                                    "required": ["type", "value"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -7194,15 +6468,10 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "is-json",
-                                          "is_json"
-                                        ]
+                                        "enum": ["is-json", "is_json"]
                                       }
                                     },
-                                    "required": [
-                                      "type"
-                                    ],
+                                    "required": ["type"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -7245,10 +6514,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "value"
-                                    ],
+                                    "required": ["type", "value"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -7300,10 +6566,7 @@
                                             },
                                             "operator": {
                                               "type": "string",
-                                              "enum": [
-                                                "correctness",
-                                                "contradiction"
-                                              ]
+                                              "enum": ["correctness", "contradiction"]
                                             },
                                             "weight": {
                                               "type": "number"
@@ -7344,10 +6607,7 @@
                                                     "minLength": 1
                                                   }
                                                 },
-                                                "required": [
-                                                  "score_range",
-                                                  "outcome"
-                                                ],
+                                                "required": ["score_range", "outcome"],
                                                 "additionalProperties": false
                                               }
                                             }
@@ -7357,10 +6617,7 @@
                                         "minItems": 1
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "criteria"
-                                    ],
+                                    "required": ["type", "criteria"],
                                     "additionalProperties": false
                                   }
                                 ]
@@ -7369,36 +6626,25 @@
                           }
                         }
                       },
-                      "required": [
-                        "input"
-                      ],
+                      "required": ["input"],
                       "additionalProperties": false
                     },
                     "minItems": 1
                   },
                   "aggregation": {
                     "type": "string",
-                    "enum": [
-                      "mean",
-                      "min",
-                      "max"
-                    ]
+                    "enum": ["mean", "min", "max"]
                   },
                   "on_turn_failure": {
                     "type": "string",
-                    "enum": [
-                      "continue",
-                      "stop"
-                    ]
+                    "enum": ["continue", "stop"]
                   },
                   "window_size": {
                     "type": "integer",
                     "minimum": 1
                   }
                 },
-                "required": [
-                  "id"
-                ],
+                "required": ["id"],
                 "additionalProperties": false
               }
             },
@@ -7443,12 +6689,7 @@
                           "properties": {
                             "role": {
                               "type": "string",
-                              "enum": [
-                                "system",
-                                "user",
-                                "assistant",
-                                "tool"
-                              ]
+                              "enum": ["system", "user", "assistant", "tool"]
                             },
                             "content": {
                               "anyOf": [
@@ -7467,30 +6708,20 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "text",
-                                          "file",
-                                          "image"
-                                        ]
+                                        "enum": ["text", "file", "image"]
                                       },
                                       "value": {
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "value"
-                                    ],
+                                    "required": ["type", "value"],
                                     "additionalProperties": false
                                   }
                                 }
                               ]
                             }
                           },
-                          "required": [
-                            "role",
-                            "content"
-                          ],
+                          "required": ["role", "content"],
                           "additionalProperties": false
                         }
                       }
@@ -7519,12 +6750,7 @@
                           "properties": {
                             "role": {
                               "type": "string",
-                              "enum": [
-                                "system",
-                                "user",
-                                "assistant",
-                                "tool"
-                              ]
+                              "enum": ["system", "user", "assistant", "tool"]
                             },
                             "content": {
                               "anyOf": [
@@ -7543,30 +6769,20 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "text",
-                                          "file",
-                                          "image"
-                                        ]
+                                        "enum": ["text", "file", "image"]
                                       },
                                       "value": {
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "value"
-                                    ],
+                                    "required": ["type", "value"],
                                     "additionalProperties": false
                                   }
                                 }
                               ]
                             }
                           },
-                          "required": [
-                            "role",
-                            "content"
-                          ],
+                          "required": ["role", "content"],
                           "additionalProperties": false
                         }
                       }
@@ -7610,10 +6826,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "code-grader",
-                                "code_grader"
-                              ]
+                              "enum": ["code-grader", "code_grader"]
                             },
                             "command": {
                               "anyOf": [
@@ -7687,18 +6900,12 @@
                                     ]
                                   }
                                 },
-                                "required": [
-                                  "type",
-                                  "command"
-                                ],
+                                "required": ["type", "command"],
                                 "additionalProperties": false
                               }
                             }
                           },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
+                          "required": ["type", "command"],
                           "additionalProperties": false
                         },
                         {
@@ -7735,10 +6942,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "llm-grader",
-                                "llm_grader"
-                              ]
+                              "enum": ["llm-grader", "llm_grader"]
                             },
                             "prompt": {
                               "anyOf": [
@@ -7796,10 +7000,7 @@
                                   },
                                   "operator": {
                                     "type": "string",
-                                    "enum": [
-                                      "correctness",
-                                      "contradiction"
-                                    ]
+                                    "enum": ["correctness", "contradiction"]
                                   },
                                   "weight": {
                                     "type": "number"
@@ -7840,10 +7041,7 @@
                                           "minLength": 1
                                         }
                                       },
-                                      "required": [
-                                        "score_range",
-                                        "outcome"
-                                      ],
+                                      "required": ["score_range", "outcome"],
                                       "additionalProperties": false
                                     }
                                   }
@@ -7894,17 +7092,12 @@
                                     ]
                                   }
                                 },
-                                "required": [
-                                  "type",
-                                  "command"
-                                ],
+                                "required": ["type", "command"],
                                 "additionalProperties": false
                               }
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
+                          "required": ["type"],
                           "additionalProperties": false
                         },
                         {
@@ -7915,9 +7108,7 @@
                               "minLength": 1
                             }
                           },
-                          "required": [
-                            "include"
-                          ],
+                          "required": ["include"],
                           "additionalProperties": false
                         },
                         {
@@ -7980,9 +7171,7 @@
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -7998,10 +7187,7 @@
                                       "maximum": 1
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "threshold"
-                                  ],
+                                  "required": ["type", "threshold"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -8018,10 +7204,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "path"
-                                  ],
+                                  "required": ["type", "path"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -8038,18 +7221,13 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 }
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "aggregator"
-                          ],
+                          "required": ["type", "aggregator"],
                           "additionalProperties": false
                         },
                         {
@@ -8086,20 +7264,11 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "tool-trajectory",
-                                "tool_trajectory"
-                              ]
+                              "enum": ["tool-trajectory", "tool_trajectory"]
                             },
                             "mode": {
                               "type": "string",
-                              "enum": [
-                                "any_order",
-                                "in_order",
-                                "exact",
-                                "subset",
-                                "superset"
-                              ]
+                              "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                             },
                             "minimums": {
                               "type": "object",
@@ -8140,12 +7309,7 @@
                                     "anyOf": [
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "ignore",
-                                          "subset",
-                                          "superset"
-                                        ]
+                                        "enum": ["exact", "ignore", "subset", "superset"]
                                       },
                                       {
                                         "type": "array",
@@ -8159,12 +7323,7 @@
                                     "anyOf": [
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "ignore",
-                                          "subset",
-                                          "superset"
-                                        ]
+                                        "enum": ["exact", "ignore", "subset", "superset"]
                                       },
                                       {
                                         "type": "array",
@@ -8175,9 +7334,7 @@
                                     ]
                                   }
                                 },
-                                "required": [
-                                  "tool"
-                                ],
+                                "required": ["tool"],
                                 "additionalProperties": false
                               }
                             },
@@ -8185,12 +7342,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -8204,12 +7356,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -8220,10 +7367,7 @@
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "mode"
-                          ],
+                          "required": ["type", "mode"],
                           "additionalProperties": false
                         },
                         {
@@ -8260,10 +7404,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "field-accuracy",
-                                "field_accuracy"
-                              ]
+                              "enum": ["field-accuracy", "field_accuracy"]
                             },
                             "fields": {
                               "type": "array",
@@ -8275,11 +7416,7 @@
                                   },
                                   "match": {
                                     "type": "string",
-                                    "enum": [
-                                      "exact",
-                                      "numeric_tolerance",
-                                      "date"
-                                    ]
+                                    "enum": ["exact", "numeric_tolerance", "date"]
                                   },
                                   "required": {
                                     "type": "boolean"
@@ -8301,26 +7438,17 @@
                                     }
                                   }
                                 },
-                                "required": [
-                                  "path",
-                                  "match"
-                                ],
+                                "required": ["path", "match"],
                                 "additionalProperties": false
                               },
                               "minItems": 1
                             },
                             "aggregation": {
                               "type": "string",
-                              "enum": [
-                                "weighted_average",
-                                "all_or_nothing"
-                              ]
+                              "enum": ["weighted_average", "all_or_nothing"]
                             }
                           },
-                          "required": [
-                            "type",
-                            "fields"
-                          ],
+                          "required": ["type", "fields"],
                           "additionalProperties": false
                         },
                         {
@@ -8364,10 +7492,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "type",
-                            "threshold"
-                          ],
+                          "required": ["type", "threshold"],
                           "additionalProperties": false
                         },
                         {
@@ -8411,10 +7536,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "type",
-                            "budget"
-                          ],
+                          "required": ["type", "budget"],
                           "additionalProperties": false
                         },
                         {
@@ -8451,10 +7573,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "token-usage",
-                                "token_usage"
-                              ]
+                              "enum": ["token-usage", "token_usage"]
                             },
                             "max_total": {
                               "type": "number",
@@ -8469,9 +7588,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
+                          "required": ["type"],
                           "additionalProperties": false
                         },
                         {
@@ -8508,10 +7625,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "execution-metrics",
-                                "execution_metrics"
-                              ]
+                              "enum": ["execution-metrics", "execution_metrics"]
                             },
                             "max_tool_calls": {
                               "type": "number",
@@ -8543,9 +7657,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
+                          "required": ["type"],
                           "additionalProperties": false
                         },
                         {
@@ -8588,10 +7700,7 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type",
-                            "value"
-                          ],
+                          "required": ["type", "value"],
                           "additionalProperties": false
                         },
                         {
@@ -8634,10 +7743,7 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type",
-                            "value"
-                          ],
+                          "required": ["type", "value"],
                           "additionalProperties": false
                         },
                         {
@@ -8674,15 +7780,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "is-json",
-                                "is_json"
-                              ]
+                              "enum": ["is-json", "is_json"]
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
+                          "required": ["type"],
                           "additionalProperties": false
                         },
                         {
@@ -8725,10 +7826,7 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type",
-                            "value"
-                          ],
+                          "required": ["type", "value"],
                           "additionalProperties": false
                         },
                         {
@@ -8780,10 +7878,7 @@
                                   },
                                   "operator": {
                                     "type": "string",
-                                    "enum": [
-                                      "correctness",
-                                      "contradiction"
-                                    ]
+                                    "enum": ["correctness", "contradiction"]
                                   },
                                   "weight": {
                                     "type": "number"
@@ -8824,10 +7919,7 @@
                                           "minLength": 1
                                         }
                                       },
-                                      "required": [
-                                        "score_range",
-                                        "outcome"
-                                      ],
+                                      "required": ["score_range", "outcome"],
                                       "additionalProperties": false
                                     }
                                   }
@@ -8837,10 +7929,7 @@
                               "minItems": 1
                             }
                           },
-                          "required": [
-                            "type",
-                            "criteria"
-                          ],
+                          "required": ["type", "criteria"],
                           "additionalProperties": false
                         }
                       ]
@@ -8884,10 +7973,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "code-grader",
-                                "code_grader"
-                              ]
+                              "enum": ["code-grader", "code_grader"]
                             },
                             "command": {
                               "anyOf": [
@@ -8961,18 +8047,12 @@
                                     ]
                                   }
                                 },
-                                "required": [
-                                  "type",
-                                  "command"
-                                ],
+                                "required": ["type", "command"],
                                 "additionalProperties": false
                               }
                             }
                           },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
+                          "required": ["type", "command"],
                           "additionalProperties": false
                         },
                         {
@@ -9009,10 +8089,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "llm-grader",
-                                "llm_grader"
-                              ]
+                              "enum": ["llm-grader", "llm_grader"]
                             },
                             "prompt": {
                               "anyOf": [
@@ -9070,10 +8147,7 @@
                                   },
                                   "operator": {
                                     "type": "string",
-                                    "enum": [
-                                      "correctness",
-                                      "contradiction"
-                                    ]
+                                    "enum": ["correctness", "contradiction"]
                                   },
                                   "weight": {
                                     "type": "number"
@@ -9114,10 +8188,7 @@
                                           "minLength": 1
                                         }
                                       },
-                                      "required": [
-                                        "score_range",
-                                        "outcome"
-                                      ],
+                                      "required": ["score_range", "outcome"],
                                       "additionalProperties": false
                                     }
                                   }
@@ -9168,17 +8239,12 @@
                                     ]
                                   }
                                 },
-                                "required": [
-                                  "type",
-                                  "command"
-                                ],
+                                "required": ["type", "command"],
                                 "additionalProperties": false
                               }
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
+                          "required": ["type"],
                           "additionalProperties": false
                         },
                         {
@@ -9189,9 +8255,7 @@
                               "minLength": 1
                             }
                           },
-                          "required": [
-                            "include"
-                          ],
+                          "required": ["include"],
                           "additionalProperties": false
                         },
                         {
@@ -9254,9 +8318,7 @@
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -9272,10 +8334,7 @@
                                       "maximum": 1
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "threshold"
-                                  ],
+                                  "required": ["type", "threshold"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -9292,10 +8351,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "path"
-                                  ],
+                                  "required": ["type", "path"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -9312,18 +8368,13 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 }
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "aggregator"
-                          ],
+                          "required": ["type", "aggregator"],
                           "additionalProperties": false
                         },
                         {
@@ -9360,20 +8411,11 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "tool-trajectory",
-                                "tool_trajectory"
-                              ]
+                              "enum": ["tool-trajectory", "tool_trajectory"]
                             },
                             "mode": {
                               "type": "string",
-                              "enum": [
-                                "any_order",
-                                "in_order",
-                                "exact",
-                                "subset",
-                                "superset"
-                              ]
+                              "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                             },
                             "minimums": {
                               "type": "object",
@@ -9414,12 +8456,7 @@
                                     "anyOf": [
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "ignore",
-                                          "subset",
-                                          "superset"
-                                        ]
+                                        "enum": ["exact", "ignore", "subset", "superset"]
                                       },
                                       {
                                         "type": "array",
@@ -9433,12 +8470,7 @@
                                     "anyOf": [
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "ignore",
-                                          "subset",
-                                          "superset"
-                                        ]
+                                        "enum": ["exact", "ignore", "subset", "superset"]
                                       },
                                       {
                                         "type": "array",
@@ -9449,9 +8481,7 @@
                                     ]
                                   }
                                 },
-                                "required": [
-                                  "tool"
-                                ],
+                                "required": ["tool"],
                                 "additionalProperties": false
                               }
                             },
@@ -9459,12 +8489,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -9478,12 +8503,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -9494,10 +8514,7 @@
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "mode"
-                          ],
+                          "required": ["type", "mode"],
                           "additionalProperties": false
                         },
                         {
@@ -9534,10 +8551,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "field-accuracy",
-                                "field_accuracy"
-                              ]
+                              "enum": ["field-accuracy", "field_accuracy"]
                             },
                             "fields": {
                               "type": "array",
@@ -9549,11 +8563,7 @@
                                   },
                                   "match": {
                                     "type": "string",
-                                    "enum": [
-                                      "exact",
-                                      "numeric_tolerance",
-                                      "date"
-                                    ]
+                                    "enum": ["exact", "numeric_tolerance", "date"]
                                   },
                                   "required": {
                                     "type": "boolean"
@@ -9575,26 +8585,17 @@
                                     }
                                   }
                                 },
-                                "required": [
-                                  "path",
-                                  "match"
-                                ],
+                                "required": ["path", "match"],
                                 "additionalProperties": false
                               },
                               "minItems": 1
                             },
                             "aggregation": {
                               "type": "string",
-                              "enum": [
-                                "weighted_average",
-                                "all_or_nothing"
-                              ]
+                              "enum": ["weighted_average", "all_or_nothing"]
                             }
                           },
-                          "required": [
-                            "type",
-                            "fields"
-                          ],
+                          "required": ["type", "fields"],
                           "additionalProperties": false
                         },
                         {
@@ -9638,10 +8639,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "type",
-                            "threshold"
-                          ],
+                          "required": ["type", "threshold"],
                           "additionalProperties": false
                         },
                         {
@@ -9685,10 +8683,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "type",
-                            "budget"
-                          ],
+                          "required": ["type", "budget"],
                           "additionalProperties": false
                         },
                         {
@@ -9725,10 +8720,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "token-usage",
-                                "token_usage"
-                              ]
+                              "enum": ["token-usage", "token_usage"]
                             },
                             "max_total": {
                               "type": "number",
@@ -9743,9 +8735,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
+                          "required": ["type"],
                           "additionalProperties": false
                         },
                         {
@@ -9782,10 +8772,7 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "execution-metrics",
-                                "execution_metrics"
-                              ]
+                              "enum": ["execution-metrics", "execution_metrics"]
                             },
                             "max_tool_calls": {
                               "type": "number",
@@ -9817,9 +8804,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
+                          "required": ["type"],
                           "additionalProperties": false
                         },
                         {
@@ -9862,10 +8847,7 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type",
-                            "value"
-                          ],
+                          "required": ["type", "value"],
                           "additionalProperties": false
                         },
                         {
@@ -9908,10 +8890,7 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type",
-                            "value"
-                          ],
+                          "required": ["type", "value"],
                           "additionalProperties": false
                         },
                         {
@@ -9948,15 +8927,10 @@
                             },
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "is-json",
-                                "is_json"
-                              ]
+                              "enum": ["is-json", "is_json"]
                             }
                           },
-                          "required": [
-                            "type"
-                          ],
+                          "required": ["type"],
                           "additionalProperties": false
                         },
                         {
@@ -9999,10 +8973,7 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type",
-                            "value"
-                          ],
+                          "required": ["type", "value"],
                           "additionalProperties": false
                         },
                         {
@@ -10054,10 +9025,7 @@
                                   },
                                   "operator": {
                                     "type": "string",
-                                    "enum": [
-                                      "correctness",
-                                      "contradiction"
-                                    ]
+                                    "enum": ["correctness", "contradiction"]
                                   },
                                   "weight": {
                                     "type": "number"
@@ -10098,10 +9066,7 @@
                                           "minLength": 1
                                         }
                                       },
-                                      "required": [
-                                        "score_range",
-                                        "outcome"
-                                      ],
+                                      "required": ["score_range", "outcome"],
                                       "additionalProperties": false
                                     }
                                   }
@@ -10111,10 +9076,7 @@
                               "minItems": 1
                             }
                           },
-                          "required": [
-                            "type",
-                            "criteria"
-                          ],
+                          "required": ["type", "criteria"],
                           "additionalProperties": false
                         }
                       ]
@@ -10186,11 +9148,7 @@
                                         },
                                         "reset": {
                                           "type": "string",
-                                          "enum": [
-                                            "none",
-                                            "fast",
-                                            "strict"
-                                          ]
+                                          "enum": ["none", "fast", "strict"]
                                         }
                                       },
                                       "additionalProperties": false
@@ -10235,11 +9193,7 @@
                                         },
                                         "reset": {
                                           "type": "string",
-                                          "enum": [
-                                            "none",
-                                            "fast",
-                                            "strict"
-                                          ]
+                                          "enum": ["none", "fast", "strict"]
                                         }
                                       },
                                       "additionalProperties": false
@@ -10284,11 +9238,7 @@
                                         },
                                         "reset": {
                                           "type": "string",
-                                          "enum": [
-                                            "none",
-                                            "fast",
-                                            "strict"
-                                          ]
+                                          "enum": ["none", "fast", "strict"]
                                         }
                                       },
                                       "additionalProperties": false
@@ -10333,11 +9283,7 @@
                                         },
                                         "reset": {
                                           "type": "string",
-                                          "enum": [
-                                            "none",
-                                            "fast",
-                                            "strict"
-                                          ]
+                                          "enum": ["none", "fast", "strict"]
                                         }
                                       },
                                       "additionalProperties": false
@@ -10346,9 +9292,7 @@
                                   "additionalProperties": false
                                 }
                               },
-                              "required": [
-                                "name"
-                              ],
+                              "required": ["name"],
                               "additionalProperties": false
                             }
                           ]
@@ -10397,10 +9341,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "code-grader",
-                                    "code_grader"
-                                  ]
+                                  "enum": ["code-grader", "code_grader"]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -10474,18 +9415,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type",
-                                "command"
-                              ],
+                              "required": ["type", "command"],
                               "additionalProperties": false
                             },
                             {
@@ -10522,10 +9457,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "llm-grader",
-                                    "llm_grader"
-                                  ]
+                                  "enum": ["llm-grader", "llm_grader"]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -10583,10 +9515,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -10627,10 +9556,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -10681,17 +9607,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -10702,9 +9623,7 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": [
-                                "include"
-                              ],
+                              "required": ["include"],
                               "additionalProperties": false
                             },
                             {
@@ -10767,9 +9686,7 @@
                                           }
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -10785,10 +9702,7 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "threshold"
-                                      ],
+                                      "required": ["type", "threshold"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -10805,10 +9719,7 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "path"
-                                      ],
+                                      "required": ["type", "path"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -10825,18 +9736,13 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "aggregator"
-                              ],
+                              "required": ["type", "aggregator"],
                               "additionalProperties": false
                             },
                             {
@@ -10873,20 +9779,11 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "tool-trajectory",
-                                    "tool_trajectory"
-                                  ]
+                                  "enum": ["tool-trajectory", "tool_trajectory"]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": [
-                                    "any_order",
-                                    "in_order",
-                                    "exact",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -10927,12 +9824,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -10946,12 +9838,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -10962,9 +9849,7 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "tool"
-                                    ],
+                                    "required": ["tool"],
                                     "additionalProperties": false
                                   }
                                 },
@@ -10972,12 +9857,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -10991,12 +9871,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -11007,10 +9882,7 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "mode"
-                              ],
+                              "required": ["type", "mode"],
                               "additionalProperties": false
                             },
                             {
@@ -11047,10 +9919,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "field-accuracy",
-                                    "field_accuracy"
-                                  ]
+                                  "enum": ["field-accuracy", "field_accuracy"]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -11062,11 +9931,7 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "numeric_tolerance",
-                                          "date"
-                                        ]
+                                        "enum": ["exact", "numeric_tolerance", "date"]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -11088,26 +9953,17 @@
                                         }
                                       }
                                     },
-                                    "required": [
-                                      "path",
-                                      "match"
-                                    ],
+                                    "required": ["path", "match"],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": [
-                                    "weighted_average",
-                                    "all_or_nothing"
-                                  ]
+                                  "enum": ["weighted_average", "all_or_nothing"]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "fields"
-                              ],
+                              "required": ["type", "fields"],
                               "additionalProperties": false
                             },
                             {
@@ -11151,10 +10007,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "threshold"
-                              ],
+                              "required": ["type", "threshold"],
                               "additionalProperties": false
                             },
                             {
@@ -11198,10 +10051,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "budget"
-                              ],
+                              "required": ["type", "budget"],
                               "additionalProperties": false
                             },
                             {
@@ -11238,10 +10088,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "token-usage",
-                                    "token_usage"
-                                  ]
+                                  "enum": ["token-usage", "token_usage"]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -11256,9 +10103,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -11295,10 +10140,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "execution-metrics",
-                                    "execution_metrics"
-                                  ]
+                                  "enum": ["execution-metrics", "execution_metrics"]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -11330,9 +10172,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -11375,10 +10215,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -11421,10 +10258,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -11461,15 +10295,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "is-json",
-                                    "is_json"
-                                  ]
+                                  "enum": ["is-json", "is_json"]
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -11512,10 +10341,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -11567,10 +10393,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -11611,10 +10434,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -11624,10 +10444,7 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": [
-                                "type",
-                                "criteria"
-                              ],
+                              "required": ["type", "criteria"],
                               "additionalProperties": false
                             }
                           ]
@@ -11671,10 +10488,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "code-grader",
-                                    "code_grader"
-                                  ]
+                                  "enum": ["code-grader", "code_grader"]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -11748,18 +10562,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type",
-                                "command"
-                              ],
+                              "required": ["type", "command"],
                               "additionalProperties": false
                             },
                             {
@@ -11796,10 +10604,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "llm-grader",
-                                    "llm_grader"
-                                  ]
+                                  "enum": ["llm-grader", "llm_grader"]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -11857,10 +10662,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -11901,10 +10703,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -11955,17 +10754,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -11976,9 +10770,7 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": [
-                                "include"
-                              ],
+                              "required": ["include"],
                               "additionalProperties": false
                             },
                             {
@@ -12041,9 +10833,7 @@
                                           }
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -12059,10 +10849,7 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "threshold"
-                                      ],
+                                      "required": ["type", "threshold"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -12079,10 +10866,7 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "path"
-                                      ],
+                                      "required": ["type", "path"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -12099,18 +10883,13 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "aggregator"
-                              ],
+                              "required": ["type", "aggregator"],
                               "additionalProperties": false
                             },
                             {
@@ -12147,20 +10926,11 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "tool-trajectory",
-                                    "tool_trajectory"
-                                  ]
+                                  "enum": ["tool-trajectory", "tool_trajectory"]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": [
-                                    "any_order",
-                                    "in_order",
-                                    "exact",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -12201,12 +10971,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -12220,12 +10985,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -12236,9 +10996,7 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "tool"
-                                    ],
+                                    "required": ["tool"],
                                     "additionalProperties": false
                                   }
                                 },
@@ -12246,12 +11004,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -12265,12 +11018,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -12281,10 +11029,7 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "mode"
-                              ],
+                              "required": ["type", "mode"],
                               "additionalProperties": false
                             },
                             {
@@ -12321,10 +11066,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "field-accuracy",
-                                    "field_accuracy"
-                                  ]
+                                  "enum": ["field-accuracy", "field_accuracy"]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -12336,11 +11078,7 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "numeric_tolerance",
-                                          "date"
-                                        ]
+                                        "enum": ["exact", "numeric_tolerance", "date"]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -12362,26 +11100,17 @@
                                         }
                                       }
                                     },
-                                    "required": [
-                                      "path",
-                                      "match"
-                                    ],
+                                    "required": ["path", "match"],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": [
-                                    "weighted_average",
-                                    "all_or_nothing"
-                                  ]
+                                  "enum": ["weighted_average", "all_or_nothing"]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "fields"
-                              ],
+                              "required": ["type", "fields"],
                               "additionalProperties": false
                             },
                             {
@@ -12425,10 +11154,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "threshold"
-                              ],
+                              "required": ["type", "threshold"],
                               "additionalProperties": false
                             },
                             {
@@ -12472,10 +11198,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "budget"
-                              ],
+                              "required": ["type", "budget"],
                               "additionalProperties": false
                             },
                             {
@@ -12512,10 +11235,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "token-usage",
-                                    "token_usage"
-                                  ]
+                                  "enum": ["token-usage", "token_usage"]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -12530,9 +11250,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -12569,10 +11287,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "execution-metrics",
-                                    "execution_metrics"
-                                  ]
+                                  "enum": ["execution-metrics", "execution_metrics"]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -12604,9 +11319,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -12649,10 +11362,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -12695,10 +11405,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -12735,15 +11442,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "is-json",
-                                    "is_json"
-                                  ]
+                                  "enum": ["is-json", "is_json"]
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -12786,10 +11488,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -12841,10 +11540,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -12885,10 +11581,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -12898,10 +11591,7 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": [
-                                "type",
-                                "criteria"
-                              ],
+                              "required": ["type", "criteria"],
                               "additionalProperties": false
                             }
                           ]
@@ -12922,11 +11612,7 @@
                           },
                           "strategy": {
                             "type": "string",
-                            "enum": [
-                              "pass_at_k",
-                              "mean",
-                              "confidence_interval"
-                            ]
+                            "enum": ["pass_at_k", "mean", "confidence_interval"]
                           },
                           "cost_limit_usd": {
                             "type": "number",
@@ -12937,9 +11623,7 @@
                             "minimum": 0
                           }
                         },
-                        "required": [
-                          "count"
-                        ],
+                        "required": ["count"],
                         "additionalProperties": false
                       },
                       "budget_usd": {
@@ -12972,10 +11656,7 @@
                       },
                       "isolation": {
                         "type": "string",
-                        "enum": [
-                          "shared",
-                          "per_test"
-                        ]
+                        "enum": ["shared", "per_test"]
                       },
                       "repos": {
                         "type": "array",
@@ -13057,11 +11738,7 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": [
-                                  "none",
-                                  "fast",
-                                  "strict"
-                                ]
+                                "enum": ["none", "fast", "strict"]
                               }
                             },
                             "additionalProperties": false
@@ -13106,11 +11783,7 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": [
-                                  "none",
-                                  "fast",
-                                  "strict"
-                                ]
+                                "enum": ["none", "fast", "strict"]
                               }
                             },
                             "additionalProperties": false
@@ -13155,11 +11828,7 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": [
-                                  "none",
-                                  "fast",
-                                  "strict"
-                                ]
+                                "enum": ["none", "fast", "strict"]
                               }
                             },
                             "additionalProperties": false
@@ -13204,11 +11873,7 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": [
-                                  "none",
-                                  "fast",
-                                  "strict"
-                                ]
+                                "enum": ["none", "fast", "strict"]
                               }
                             },
                             "additionalProperties": false
@@ -13218,11 +11883,7 @@
                       },
                       "mode": {
                         "type": "string",
-                        "enum": [
-                          "pooled",
-                          "temp",
-                          "static"
-                        ]
+                        "enum": ["pooled", "temp", "static"]
                       },
                       "path": {
                         "type": "string"
@@ -13245,9 +11906,7 @@
                             "minimum": 0.1
                           }
                         },
-                        "required": [
-                          "image"
-                        ],
+                        "required": ["image"],
                         "additionalProperties": false
                       }
                     },
@@ -13271,17 +11930,11 @@
                   },
                   "on_dependency_failure": {
                     "type": "string",
-                    "enum": [
-                      "skip",
-                      "fail",
-                      "run"
-                    ]
+                    "enum": ["skip", "fail", "run"]
                   },
                   "mode": {
                     "type": "string",
-                    "enum": [
-                      "conversation"
-                    ]
+                    "enum": ["conversation"]
                   },
                   "turns": {
                     "type": "array",
@@ -13310,20 +11963,13 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "text",
-                                          "file",
-                                          "image"
-                                        ]
+                                        "enum": ["text", "file", "image"]
                                       },
                                       "value": {
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "value"
-                                    ],
+                                    "required": ["type", "value"],
                                     "additionalProperties": false
                                   }
                                 }
@@ -13353,20 +11999,13 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "text",
-                                          "file",
-                                          "image"
-                                        ]
+                                        "enum": ["text", "file", "image"]
                                       },
                                       "value": {
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "value"
-                                    ],
+                                    "required": ["type", "value"],
                                     "additionalProperties": false
                                   }
                                 }
@@ -13417,10 +12056,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "code-grader",
-                                          "code_grader"
-                                        ]
+                                        "enum": ["code-grader", "code_grader"]
                                       },
                                       "command": {
                                         "anyOf": [
@@ -13494,18 +12130,12 @@
                                               ]
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "command"
-                                          ],
+                                          "required": ["type", "command"],
                                           "additionalProperties": false
                                         }
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -13542,10 +12172,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "llm-grader",
-                                          "llm_grader"
-                                        ]
+                                        "enum": ["llm-grader", "llm_grader"]
                                       },
                                       "prompt": {
                                         "anyOf": [
@@ -13603,10 +12230,7 @@
                                             },
                                             "operator": {
                                               "type": "string",
-                                              "enum": [
-                                                "correctness",
-                                                "contradiction"
-                                              ]
+                                              "enum": ["correctness", "contradiction"]
                                             },
                                             "weight": {
                                               "type": "number"
@@ -13647,10 +12271,7 @@
                                                     "minLength": 1
                                                   }
                                                 },
-                                                "required": [
-                                                  "score_range",
-                                                  "outcome"
-                                                ],
+                                                "required": ["score_range", "outcome"],
                                                 "additionalProperties": false
                                               }
                                             }
@@ -13701,17 +12322,12 @@
                                               ]
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "command"
-                                          ],
+                                          "required": ["type", "command"],
                                           "additionalProperties": false
                                         }
                                       }
                                     },
-                                    "required": [
-                                      "type"
-                                    ],
+                                    "required": ["type"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -13722,9 +12338,7 @@
                                         "minLength": 1
                                       }
                                     },
-                                    "required": [
-                                      "include"
-                                    ],
+                                    "required": ["include"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -13787,9 +12401,7 @@
                                                 }
                                               }
                                             },
-                                            "required": [
-                                              "type"
-                                            ],
+                                            "required": ["type"],
                                             "additionalProperties": false
                                           },
                                           {
@@ -13805,10 +12417,7 @@
                                                 "maximum": 1
                                               }
                                             },
-                                            "required": [
-                                              "type",
-                                              "threshold"
-                                            ],
+                                            "required": ["type", "threshold"],
                                             "additionalProperties": false
                                           },
                                           {
@@ -13825,10 +12434,7 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": [
-                                              "type",
-                                              "path"
-                                            ],
+                                            "required": ["type", "path"],
                                             "additionalProperties": false
                                           },
                                           {
@@ -13845,18 +12451,13 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": [
-                                              "type"
-                                            ],
+                                            "required": ["type"],
                                             "additionalProperties": false
                                           }
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "aggregator"
-                                    ],
+                                    "required": ["type", "aggregator"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -13893,10 +12494,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "tool-trajectory",
-                                          "tool_trajectory"
-                                        ]
+                                        "enum": ["tool-trajectory", "tool_trajectory"]
                                       },
                                       "mode": {
                                         "type": "string",
@@ -13947,12 +12545,7 @@
                                               "anyOf": [
                                                 {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "exact",
-                                                    "ignore",
-                                                    "subset",
-                                                    "superset"
-                                                  ]
+                                                  "enum": ["exact", "ignore", "subset", "superset"]
                                                 },
                                                 {
                                                   "type": "array",
@@ -13966,12 +12559,7 @@
                                               "anyOf": [
                                                 {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "exact",
-                                                    "ignore",
-                                                    "subset",
-                                                    "superset"
-                                                  ]
+                                                  "enum": ["exact", "ignore", "subset", "superset"]
                                                 },
                                                 {
                                                   "type": "array",
@@ -13982,9 +12570,7 @@
                                               ]
                                             }
                                           },
-                                          "required": [
-                                            "tool"
-                                          ],
+                                          "required": ["tool"],
                                           "additionalProperties": false
                                         }
                                       },
@@ -13992,12 +12578,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -14011,12 +12592,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -14027,10 +12603,7 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "mode"
-                                    ],
+                                    "required": ["type", "mode"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -14067,10 +12640,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "field-accuracy",
-                                          "field_accuracy"
-                                        ]
+                                        "enum": ["field-accuracy", "field_accuracy"]
                                       },
                                       "fields": {
                                         "type": "array",
@@ -14082,11 +12652,7 @@
                                             },
                                             "match": {
                                               "type": "string",
-                                              "enum": [
-                                                "exact",
-                                                "numeric_tolerance",
-                                                "date"
-                                              ]
+                                              "enum": ["exact", "numeric_tolerance", "date"]
                                             },
                                             "required": {
                                               "type": "boolean"
@@ -14108,26 +12674,17 @@
                                               }
                                             }
                                           },
-                                          "required": [
-                                            "path",
-                                            "match"
-                                          ],
+                                          "required": ["path", "match"],
                                           "additionalProperties": false
                                         },
                                         "minItems": 1
                                       },
                                       "aggregation": {
                                         "type": "string",
-                                        "enum": [
-                                          "weighted_average",
-                                          "all_or_nothing"
-                                        ]
+                                        "enum": ["weighted_average", "all_or_nothing"]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "fields"
-                                    ],
+                                    "required": ["type", "fields"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -14171,10 +12728,7 @@
                                         "minimum": 0
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "threshold"
-                                    ],
+                                    "required": ["type", "threshold"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -14218,10 +12772,7 @@
                                         "minimum": 0
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "budget"
-                                    ],
+                                    "required": ["type", "budget"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -14258,10 +12809,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "token-usage",
-                                          "token_usage"
-                                        ]
+                                        "enum": ["token-usage", "token_usage"]
                                       },
                                       "max_total": {
                                         "type": "number",
@@ -14276,9 +12824,7 @@
                                         "minimum": 0
                                       }
                                     },
-                                    "required": [
-                                      "type"
-                                    ],
+                                    "required": ["type"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -14315,10 +12861,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "execution-metrics",
-                                          "execution_metrics"
-                                        ]
+                                        "enum": ["execution-metrics", "execution_metrics"]
                                       },
                                       "max_tool_calls": {
                                         "type": "number",
@@ -14350,9 +12893,7 @@
                                         "minimum": 0
                                       }
                                     },
-                                    "required": [
-                                      "type"
-                                    ],
+                                    "required": ["type"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -14395,10 +12936,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "value"
-                                    ],
+                                    "required": ["type", "value"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -14441,10 +12979,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "value"
-                                    ],
+                                    "required": ["type", "value"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -14481,15 +13016,10 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "is-json",
-                                          "is_json"
-                                        ]
+                                        "enum": ["is-json", "is_json"]
                                       }
                                     },
-                                    "required": [
-                                      "type"
-                                    ],
+                                    "required": ["type"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -14532,10 +13062,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "value"
-                                    ],
+                                    "required": ["type", "value"],
                                     "additionalProperties": false
                                   },
                                   {
@@ -14587,10 +13114,7 @@
                                             },
                                             "operator": {
                                               "type": "string",
-                                              "enum": [
-                                                "correctness",
-                                                "contradiction"
-                                              ]
+                                              "enum": ["correctness", "contradiction"]
                                             },
                                             "weight": {
                                               "type": "number"
@@ -14631,10 +13155,7 @@
                                                     "minLength": 1
                                                   }
                                                 },
-                                                "required": [
-                                                  "score_range",
-                                                  "outcome"
-                                                ],
+                                                "required": ["score_range", "outcome"],
                                                 "additionalProperties": false
                                               }
                                             }
@@ -14644,10 +13165,7 @@
                                         "minItems": 1
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "criteria"
-                                    ],
+                                    "required": ["type", "criteria"],
                                     "additionalProperties": false
                                   }
                                 ]
@@ -14656,36 +13174,25 @@
                           }
                         }
                       },
-                      "required": [
-                        "input"
-                      ],
+                      "required": ["input"],
                       "additionalProperties": false
                     },
                     "minItems": 1
                   },
                   "aggregation": {
                     "type": "string",
-                    "enum": [
-                      "mean",
-                      "min",
-                      "max"
-                    ]
+                    "enum": ["mean", "min", "max"]
                   },
                   "on_turn_failure": {
                     "type": "string",
-                    "enum": [
-                      "continue",
-                      "stop"
-                    ]
+                    "enum": ["continue", "stop"]
                   },
                   "window_size": {
                     "type": "integer",
                     "minimum": 1
                   }
                 },
-                "required": [
-                  "id"
-                ],
+                "required": ["id"],
                 "additionalProperties": false
               }
             },
@@ -14763,11 +13270,7 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": [
-                                  "none",
-                                  "fast",
-                                  "strict"
-                                ]
+                                "enum": ["none", "fast", "strict"]
                               }
                             },
                             "additionalProperties": false
@@ -14812,11 +13315,7 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": [
-                                  "none",
-                                  "fast",
-                                  "strict"
-                                ]
+                                "enum": ["none", "fast", "strict"]
                               }
                             },
                             "additionalProperties": false
@@ -14861,11 +13360,7 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": [
-                                  "none",
-                                  "fast",
-                                  "strict"
-                                ]
+                                "enum": ["none", "fast", "strict"]
                               }
                             },
                             "additionalProperties": false
@@ -14910,11 +13405,7 @@
                               },
                               "reset": {
                                 "type": "string",
-                                "enum": [
-                                  "none",
-                                  "fast",
-                                  "strict"
-                                ]
+                                "enum": ["none", "fast", "strict"]
                               }
                             },
                             "additionalProperties": false
@@ -14923,9 +13414,7 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": [
-                      "name"
-                    ],
+                    "required": ["name"],
                     "additionalProperties": false
                   }
                 ]
@@ -14974,10 +13463,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "code-grader",
-                          "code_grader"
-                        ]
+                        "enum": ["code-grader", "code_grader"]
                       },
                       "command": {
                         "anyOf": [
@@ -15051,18 +13537,12 @@
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
+                          "required": ["type", "command"],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": [
-                      "type",
-                      "command"
-                    ],
+                    "required": ["type", "command"],
                     "additionalProperties": false
                   },
                   {
@@ -15099,10 +13579,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "llm-grader",
-                          "llm_grader"
-                        ]
+                        "enum": ["llm-grader", "llm_grader"]
                       },
                       "prompt": {
                         "anyOf": [
@@ -15160,10 +13637,7 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": [
-                                "correctness",
-                                "contradiction"
-                              ]
+                              "enum": ["correctness", "contradiction"]
                             },
                             "weight": {
                               "type": "number"
@@ -15204,10 +13678,7 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": [
-                                  "score_range",
-                                  "outcome"
-                                ],
+                                "required": ["score_range", "outcome"],
                                 "additionalProperties": false
                               }
                             }
@@ -15258,17 +13729,12 @@
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
+                          "required": ["type", "command"],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -15279,9 +13745,7 @@
                         "minLength": 1
                       }
                     },
-                    "required": [
-                      "include"
-                    ],
+                    "required": ["include"],
                     "additionalProperties": false
                   },
                   {
@@ -15344,9 +13808,7 @@
                                 }
                               }
                             },
-                            "required": [
-                              "type"
-                            ],
+                            "required": ["type"],
                             "additionalProperties": false
                           },
                           {
@@ -15362,10 +13824,7 @@
                                 "maximum": 1
                               }
                             },
-                            "required": [
-                              "type",
-                              "threshold"
-                            ],
+                            "required": ["type", "threshold"],
                             "additionalProperties": false
                           },
                           {
@@ -15382,10 +13841,7 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "type",
-                              "path"
-                            ],
+                            "required": ["type", "path"],
                             "additionalProperties": false
                           },
                           {
@@ -15402,18 +13858,13 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "type"
-                            ],
+                            "required": ["type"],
                             "additionalProperties": false
                           }
                         ]
                       }
                     },
-                    "required": [
-                      "type",
-                      "aggregator"
-                    ],
+                    "required": ["type", "aggregator"],
                     "additionalProperties": false
                   },
                   {
@@ -15450,20 +13901,11 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "tool-trajectory",
-                          "tool_trajectory"
-                        ]
+                        "enum": ["tool-trajectory", "tool_trajectory"]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": [
-                          "any_order",
-                          "in_order",
-                          "exact",
-                          "subset",
-                          "superset"
-                        ]
+                        "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                       },
                       "minimums": {
                         "type": "object",
@@ -15504,12 +13946,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -15523,12 +13960,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -15539,9 +13971,7 @@
                               ]
                             }
                           },
-                          "required": [
-                            "tool"
-                          ],
+                          "required": ["tool"],
                           "additionalProperties": false
                         }
                       },
@@ -15549,12 +13979,7 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": [
-                              "exact",
-                              "ignore",
-                              "subset",
-                              "superset"
-                            ]
+                            "enum": ["exact", "ignore", "subset", "superset"]
                           },
                           {
                             "type": "array",
@@ -15568,12 +13993,7 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": [
-                              "exact",
-                              "ignore",
-                              "subset",
-                              "superset"
-                            ]
+                            "enum": ["exact", "ignore", "subset", "superset"]
                           },
                           {
                             "type": "array",
@@ -15584,10 +14004,7 @@
                         ]
                       }
                     },
-                    "required": [
-                      "type",
-                      "mode"
-                    ],
+                    "required": ["type", "mode"],
                     "additionalProperties": false
                   },
                   {
@@ -15624,10 +14041,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "field-accuracy",
-                          "field_accuracy"
-                        ]
+                        "enum": ["field-accuracy", "field_accuracy"]
                       },
                       "fields": {
                         "type": "array",
@@ -15639,11 +14053,7 @@
                             },
                             "match": {
                               "type": "string",
-                              "enum": [
-                                "exact",
-                                "numeric_tolerance",
-                                "date"
-                              ]
+                              "enum": ["exact", "numeric_tolerance", "date"]
                             },
                             "required": {
                               "type": "boolean"
@@ -15665,26 +14075,17 @@
                               }
                             }
                           },
-                          "required": [
-                            "path",
-                            "match"
-                          ],
+                          "required": ["path", "match"],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": [
-                          "weighted_average",
-                          "all_or_nothing"
-                        ]
+                        "enum": ["weighted_average", "all_or_nothing"]
                       }
                     },
-                    "required": [
-                      "type",
-                      "fields"
-                    ],
+                    "required": ["type", "fields"],
                     "additionalProperties": false
                   },
                   {
@@ -15728,10 +14129,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type",
-                      "threshold"
-                    ],
+                    "required": ["type", "threshold"],
                     "additionalProperties": false
                   },
                   {
@@ -15775,10 +14173,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type",
-                      "budget"
-                    ],
+                    "required": ["type", "budget"],
                     "additionalProperties": false
                   },
                   {
@@ -15815,10 +14210,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "token-usage",
-                          "token_usage"
-                        ]
+                        "enum": ["token-usage", "token_usage"]
                       },
                       "max_total": {
                         "type": "number",
@@ -15833,9 +14225,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -15872,10 +14262,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "execution-metrics",
-                          "execution_metrics"
-                        ]
+                        "enum": ["execution-metrics", "execution_metrics"]
                       },
                       "max_tool_calls": {
                         "type": "number",
@@ -15907,9 +14294,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -15952,10 +14337,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
+                    "required": ["type", "value"],
                     "additionalProperties": false
                   },
                   {
@@ -15998,10 +14380,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
+                    "required": ["type", "value"],
                     "additionalProperties": false
                   },
                   {
@@ -16038,15 +14417,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "is-json",
-                          "is_json"
-                        ]
+                        "enum": ["is-json", "is_json"]
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -16089,10 +14463,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
+                    "required": ["type", "value"],
                     "additionalProperties": false
                   },
                   {
@@ -16144,10 +14515,7 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": [
-                                "correctness",
-                                "contradiction"
-                              ]
+                              "enum": ["correctness", "contradiction"]
                             },
                             "weight": {
                               "type": "number"
@@ -16188,10 +14556,7 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": [
-                                  "score_range",
-                                  "outcome"
-                                ],
+                                "required": ["score_range", "outcome"],
                                 "additionalProperties": false
                               }
                             }
@@ -16201,10 +14566,7 @@
                         "minItems": 1
                       }
                     },
-                    "required": [
-                      "type",
-                      "criteria"
-                    ],
+                    "required": ["type", "criteria"],
                     "additionalProperties": false
                   }
                 ]
@@ -16248,10 +14610,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "code-grader",
-                          "code_grader"
-                        ]
+                        "enum": ["code-grader", "code_grader"]
                       },
                       "command": {
                         "anyOf": [
@@ -16325,18 +14684,12 @@
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
+                          "required": ["type", "command"],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": [
-                      "type",
-                      "command"
-                    ],
+                    "required": ["type", "command"],
                     "additionalProperties": false
                   },
                   {
@@ -16373,10 +14726,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "llm-grader",
-                          "llm_grader"
-                        ]
+                        "enum": ["llm-grader", "llm_grader"]
                       },
                       "prompt": {
                         "anyOf": [
@@ -16434,10 +14784,7 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": [
-                                "correctness",
-                                "contradiction"
-                              ]
+                              "enum": ["correctness", "contradiction"]
                             },
                             "weight": {
                               "type": "number"
@@ -16478,10 +14825,7 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": [
-                                  "score_range",
-                                  "outcome"
-                                ],
+                                "required": ["score_range", "outcome"],
                                 "additionalProperties": false
                               }
                             }
@@ -16532,17 +14876,12 @@
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
+                          "required": ["type", "command"],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -16553,9 +14892,7 @@
                         "minLength": 1
                       }
                     },
-                    "required": [
-                      "include"
-                    ],
+                    "required": ["include"],
                     "additionalProperties": false
                   },
                   {
@@ -16618,9 +14955,7 @@
                                 }
                               }
                             },
-                            "required": [
-                              "type"
-                            ],
+                            "required": ["type"],
                             "additionalProperties": false
                           },
                           {
@@ -16636,10 +14971,7 @@
                                 "maximum": 1
                               }
                             },
-                            "required": [
-                              "type",
-                              "threshold"
-                            ],
+                            "required": ["type", "threshold"],
                             "additionalProperties": false
                           },
                           {
@@ -16656,10 +14988,7 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "type",
-                              "path"
-                            ],
+                            "required": ["type", "path"],
                             "additionalProperties": false
                           },
                           {
@@ -16676,18 +15005,13 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "type"
-                            ],
+                            "required": ["type"],
                             "additionalProperties": false
                           }
                         ]
                       }
                     },
-                    "required": [
-                      "type",
-                      "aggregator"
-                    ],
+                    "required": ["type", "aggregator"],
                     "additionalProperties": false
                   },
                   {
@@ -16724,20 +15048,11 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "tool-trajectory",
-                          "tool_trajectory"
-                        ]
+                        "enum": ["tool-trajectory", "tool_trajectory"]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": [
-                          "any_order",
-                          "in_order",
-                          "exact",
-                          "subset",
-                          "superset"
-                        ]
+                        "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                       },
                       "minimums": {
                         "type": "object",
@@ -16778,12 +15093,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -16797,12 +15107,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -16813,9 +15118,7 @@
                               ]
                             }
                           },
-                          "required": [
-                            "tool"
-                          ],
+                          "required": ["tool"],
                           "additionalProperties": false
                         }
                       },
@@ -16823,12 +15126,7 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": [
-                              "exact",
-                              "ignore",
-                              "subset",
-                              "superset"
-                            ]
+                            "enum": ["exact", "ignore", "subset", "superset"]
                           },
                           {
                             "type": "array",
@@ -16842,12 +15140,7 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": [
-                              "exact",
-                              "ignore",
-                              "subset",
-                              "superset"
-                            ]
+                            "enum": ["exact", "ignore", "subset", "superset"]
                           },
                           {
                             "type": "array",
@@ -16858,10 +15151,7 @@
                         ]
                       }
                     },
-                    "required": [
-                      "type",
-                      "mode"
-                    ],
+                    "required": ["type", "mode"],
                     "additionalProperties": false
                   },
                   {
@@ -16898,10 +15188,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "field-accuracy",
-                          "field_accuracy"
-                        ]
+                        "enum": ["field-accuracy", "field_accuracy"]
                       },
                       "fields": {
                         "type": "array",
@@ -16913,11 +15200,7 @@
                             },
                             "match": {
                               "type": "string",
-                              "enum": [
-                                "exact",
-                                "numeric_tolerance",
-                                "date"
-                              ]
+                              "enum": ["exact", "numeric_tolerance", "date"]
                             },
                             "required": {
                               "type": "boolean"
@@ -16939,26 +15222,17 @@
                               }
                             }
                           },
-                          "required": [
-                            "path",
-                            "match"
-                          ],
+                          "required": ["path", "match"],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": [
-                          "weighted_average",
-                          "all_or_nothing"
-                        ]
+                        "enum": ["weighted_average", "all_or_nothing"]
                       }
                     },
-                    "required": [
-                      "type",
-                      "fields"
-                    ],
+                    "required": ["type", "fields"],
                     "additionalProperties": false
                   },
                   {
@@ -17002,10 +15276,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type",
-                      "threshold"
-                    ],
+                    "required": ["type", "threshold"],
                     "additionalProperties": false
                   },
                   {
@@ -17049,10 +15320,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type",
-                      "budget"
-                    ],
+                    "required": ["type", "budget"],
                     "additionalProperties": false
                   },
                   {
@@ -17089,10 +15357,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "token-usage",
-                          "token_usage"
-                        ]
+                        "enum": ["token-usage", "token_usage"]
                       },
                       "max_total": {
                         "type": "number",
@@ -17107,9 +15372,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -17146,10 +15409,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "execution-metrics",
-                          "execution_metrics"
-                        ]
+                        "enum": ["execution-metrics", "execution_metrics"]
                       },
                       "max_tool_calls": {
                         "type": "number",
@@ -17181,9 +15441,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -17226,10 +15484,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
+                    "required": ["type", "value"],
                     "additionalProperties": false
                   },
                   {
@@ -17272,10 +15527,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
+                    "required": ["type", "value"],
                     "additionalProperties": false
                   },
                   {
@@ -17312,15 +15564,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "is-json",
-                          "is_json"
-                        ]
+                        "enum": ["is-json", "is_json"]
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -17363,10 +15610,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
+                    "required": ["type", "value"],
                     "additionalProperties": false
                   },
                   {
@@ -17418,10 +15662,7 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": [
-                                "correctness",
-                                "contradiction"
-                              ]
+                              "enum": ["correctness", "contradiction"]
                             },
                             "weight": {
                               "type": "number"
@@ -17462,10 +15703,7 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": [
-                                  "score_range",
-                                  "outcome"
-                                ],
+                                "required": ["score_range", "outcome"],
                                 "additionalProperties": false
                               }
                             }
@@ -17475,10 +15713,7 @@
                         "minItems": 1
                       }
                     },
-                    "required": [
-                      "type",
-                      "criteria"
-                    ],
+                    "required": ["type", "criteria"],
                     "additionalProperties": false
                   }
                 ]
@@ -17499,11 +15734,7 @@
                 },
                 "strategy": {
                   "type": "string",
-                  "enum": [
-                    "pass_at_k",
-                    "mean",
-                    "confidence_interval"
-                  ]
+                  "enum": ["pass_at_k", "mean", "confidence_interval"]
                 },
                 "cost_limit_usd": {
                   "type": "number",
@@ -17514,9 +15745,7 @@
                   "minimum": 0
                 }
               },
-              "required": [
-                "count"
-              ],
+              "required": ["count"],
               "additionalProperties": false
             },
             "budget_usd": {
@@ -17579,10 +15808,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "code-grader",
-                      "code_grader"
-                    ]
+                    "enum": ["code-grader", "code_grader"]
                   },
                   "command": {
                     "anyOf": [
@@ -17656,18 +15882,12 @@
                           ]
                         }
                       },
-                      "required": [
-                        "type",
-                        "command"
-                      ],
+                      "required": ["type", "command"],
                       "additionalProperties": false
                     }
                   }
                 },
-                "required": [
-                  "type",
-                  "command"
-                ],
+                "required": ["type", "command"],
                 "additionalProperties": false
               },
               {
@@ -17704,10 +15924,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "llm-grader",
-                      "llm_grader"
-                    ]
+                    "enum": ["llm-grader", "llm_grader"]
                   },
                   "prompt": {
                     "anyOf": [
@@ -17765,10 +15982,7 @@
                         },
                         "operator": {
                           "type": "string",
-                          "enum": [
-                            "correctness",
-                            "contradiction"
-                          ]
+                          "enum": ["correctness", "contradiction"]
                         },
                         "weight": {
                           "type": "number"
@@ -17809,10 +16023,7 @@
                                 "minLength": 1
                               }
                             },
-                            "required": [
-                              "score_range",
-                              "outcome"
-                            ],
+                            "required": ["score_range", "outcome"],
                             "additionalProperties": false
                           }
                         }
@@ -17863,17 +16074,12 @@
                           ]
                         }
                       },
-                      "required": [
-                        "type",
-                        "command"
-                      ],
+                      "required": ["type", "command"],
                       "additionalProperties": false
                     }
                   }
                 },
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "additionalProperties": false
               },
               {
@@ -17884,9 +16090,7 @@
                     "minLength": 1
                   }
                 },
-                "required": [
-                  "include"
-                ],
+                "required": ["include"],
                 "additionalProperties": false
               },
               {
@@ -17949,9 +16153,7 @@
                             }
                           }
                         },
-                        "required": [
-                          "type"
-                        ],
+                        "required": ["type"],
                         "additionalProperties": false
                       },
                       {
@@ -17967,10 +16169,7 @@
                             "maximum": 1
                           }
                         },
-                        "required": [
-                          "type",
-                          "threshold"
-                        ],
+                        "required": ["type", "threshold"],
                         "additionalProperties": false
                       },
                       {
@@ -17987,10 +16186,7 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "type",
-                          "path"
-                        ],
+                        "required": ["type", "path"],
                         "additionalProperties": false
                       },
                       {
@@ -18007,18 +16203,13 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "type"
-                        ],
+                        "required": ["type"],
                         "additionalProperties": false
                       }
                     ]
                   }
                 },
-                "required": [
-                  "type",
-                  "aggregator"
-                ],
+                "required": ["type", "aggregator"],
                 "additionalProperties": false
               },
               {
@@ -18055,20 +16246,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "tool-trajectory",
-                      "tool_trajectory"
-                    ]
+                    "enum": ["tool-trajectory", "tool_trajectory"]
                   },
                   "mode": {
                     "type": "string",
-                    "enum": [
-                      "any_order",
-                      "in_order",
-                      "exact",
-                      "subset",
-                      "superset"
-                    ]
+                    "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                   },
                   "minimums": {
                     "type": "object",
@@ -18109,12 +16291,7 @@
                           "anyOf": [
                             {
                               "type": "string",
-                              "enum": [
-                                "exact",
-                                "ignore",
-                                "subset",
-                                "superset"
-                              ]
+                              "enum": ["exact", "ignore", "subset", "superset"]
                             },
                             {
                               "type": "array",
@@ -18128,12 +16305,7 @@
                           "anyOf": [
                             {
                               "type": "string",
-                              "enum": [
-                                "exact",
-                                "ignore",
-                                "subset",
-                                "superset"
-                              ]
+                              "enum": ["exact", "ignore", "subset", "superset"]
                             },
                             {
                               "type": "array",
@@ -18144,9 +16316,7 @@
                           ]
                         }
                       },
-                      "required": [
-                        "tool"
-                      ],
+                      "required": ["tool"],
                       "additionalProperties": false
                     }
                   },
@@ -18154,12 +16324,7 @@
                     "anyOf": [
                       {
                         "type": "string",
-                        "enum": [
-                          "exact",
-                          "ignore",
-                          "subset",
-                          "superset"
-                        ]
+                        "enum": ["exact", "ignore", "subset", "superset"]
                       },
                       {
                         "type": "array",
@@ -18173,12 +16338,7 @@
                     "anyOf": [
                       {
                         "type": "string",
-                        "enum": [
-                          "exact",
-                          "ignore",
-                          "subset",
-                          "superset"
-                        ]
+                        "enum": ["exact", "ignore", "subset", "superset"]
                       },
                       {
                         "type": "array",
@@ -18189,10 +16349,7 @@
                     ]
                   }
                 },
-                "required": [
-                  "type",
-                  "mode"
-                ],
+                "required": ["type", "mode"],
                 "additionalProperties": false
               },
               {
@@ -18229,10 +16386,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "field-accuracy",
-                      "field_accuracy"
-                    ]
+                    "enum": ["field-accuracy", "field_accuracy"]
                   },
                   "fields": {
                     "type": "array",
@@ -18244,11 +16398,7 @@
                         },
                         "match": {
                           "type": "string",
-                          "enum": [
-                            "exact",
-                            "numeric_tolerance",
-                            "date"
-                          ]
+                          "enum": ["exact", "numeric_tolerance", "date"]
                         },
                         "required": {
                           "type": "boolean"
@@ -18270,26 +16420,17 @@
                           }
                         }
                       },
-                      "required": [
-                        "path",
-                        "match"
-                      ],
+                      "required": ["path", "match"],
                       "additionalProperties": false
                     },
                     "minItems": 1
                   },
                   "aggregation": {
                     "type": "string",
-                    "enum": [
-                      "weighted_average",
-                      "all_or_nothing"
-                    ]
+                    "enum": ["weighted_average", "all_or_nothing"]
                   }
                 },
-                "required": [
-                  "type",
-                  "fields"
-                ],
+                "required": ["type", "fields"],
                 "additionalProperties": false
               },
               {
@@ -18333,10 +16474,7 @@
                     "minimum": 0
                   }
                 },
-                "required": [
-                  "type",
-                  "threshold"
-                ],
+                "required": ["type", "threshold"],
                 "additionalProperties": false
               },
               {
@@ -18380,10 +16518,7 @@
                     "minimum": 0
                   }
                 },
-                "required": [
-                  "type",
-                  "budget"
-                ],
+                "required": ["type", "budget"],
                 "additionalProperties": false
               },
               {
@@ -18420,10 +16555,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "token-usage",
-                      "token_usage"
-                    ]
+                    "enum": ["token-usage", "token_usage"]
                   },
                   "max_total": {
                     "type": "number",
@@ -18438,9 +16570,7 @@
                     "minimum": 0
                   }
                 },
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "additionalProperties": false
               },
               {
@@ -18477,10 +16607,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "execution-metrics",
-                      "execution_metrics"
-                    ]
+                    "enum": ["execution-metrics", "execution_metrics"]
                   },
                   "max_tool_calls": {
                     "type": "number",
@@ -18512,9 +16639,7 @@
                     "minimum": 0
                   }
                 },
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "additionalProperties": false
               },
               {
@@ -18557,10 +16682,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "type",
-                  "value"
-                ],
+                "required": ["type", "value"],
                 "additionalProperties": false
               },
               {
@@ -18603,10 +16725,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "type",
-                  "value"
-                ],
+                "required": ["type", "value"],
                 "additionalProperties": false
               },
               {
@@ -18643,15 +16762,10 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "is-json",
-                      "is_json"
-                    ]
+                    "enum": ["is-json", "is_json"]
                   }
                 },
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "additionalProperties": false
               },
               {
@@ -18694,10 +16808,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "type",
-                  "value"
-                ],
+                "required": ["type", "value"],
                 "additionalProperties": false
               },
               {
@@ -18749,10 +16860,7 @@
                         },
                         "operator": {
                           "type": "string",
-                          "enum": [
-                            "correctness",
-                            "contradiction"
-                          ]
+                          "enum": ["correctness", "contradiction"]
                         },
                         "weight": {
                           "type": "number"
@@ -18793,10 +16901,7 @@
                                 "minLength": 1
                               }
                             },
-                            "required": [
-                              "score_range",
-                              "outcome"
-                            ],
+                            "required": ["score_range", "outcome"],
                             "additionalProperties": false
                           }
                         }
@@ -18806,10 +16911,7 @@
                     "minItems": 1
                   }
                 },
-                "required": [
-                  "type",
-                  "criteria"
-                ],
+                "required": ["type", "criteria"],
                 "additionalProperties": false
               }
             ]
@@ -18838,10 +16940,7 @@
                 ]
               }
             },
-            "required": [
-              "type",
-              "command"
-            ],
+            "required": ["type", "command"],
             "additionalProperties": false
           }
         },
@@ -18855,10 +16954,7 @@
                 },
                 "isolation": {
                   "type": "string",
-                  "enum": [
-                    "shared",
-                    "per_test"
-                  ]
+                  "enum": ["shared", "per_test"]
                 },
                 "repos": {
                   "type": "array",
@@ -18940,11 +17036,7 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": [
-                            "none",
-                            "fast",
-                            "strict"
-                          ]
+                          "enum": ["none", "fast", "strict"]
                         }
                       },
                       "additionalProperties": false
@@ -18989,11 +17081,7 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": [
-                            "none",
-                            "fast",
-                            "strict"
-                          ]
+                          "enum": ["none", "fast", "strict"]
                         }
                       },
                       "additionalProperties": false
@@ -19038,11 +17126,7 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": [
-                            "none",
-                            "fast",
-                            "strict"
-                          ]
+                          "enum": ["none", "fast", "strict"]
                         }
                       },
                       "additionalProperties": false
@@ -19087,11 +17171,7 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": [
-                            "none",
-                            "fast",
-                            "strict"
-                          ]
+                          "enum": ["none", "fast", "strict"]
                         }
                       },
                       "additionalProperties": false
@@ -19101,11 +17181,7 @@
                 },
                 "mode": {
                   "type": "string",
-                  "enum": [
-                    "pooled",
-                    "temp",
-                    "static"
-                  ]
+                  "enum": ["pooled", "temp", "static"]
                 },
                 "path": {
                   "type": "string"
@@ -19128,9 +17204,7 @@
                       "minimum": 0.1
                     }
                   },
-                  "required": [
-                    "image"
-                  ],
+                  "required": ["image"],
                   "additionalProperties": false
                 }
               },
@@ -19142,9 +17216,7 @@
           ]
         }
       },
-      "required": [
-        "tests"
-      ],
+      "required": ["tests"],
       "additionalProperties": false
     }
   }


### PR DESCRIPTION
## Summary

Suite-level `input` now accepts the same shorthand authors already use in test cases, closing the gap where shared suite instructions appeared to require full chat-message objects. Authors can write plain strings, YAML block scalars, structured objects, or full message arrays at the suite level, and the schema/validator/docs now describe that contract consistently.

Before:

```yaml
input:
  - role: user
    content:
      - type: text
        value: Read AGENTS.md before answering.
```

After:

```yaml
input: |
  Read AGENTS.md before answering.
```

Structured shared input is also valid:

```yaml
input:
  instruction: Classify the request
  labels: [bug, feature]
```

## What Changed

- Aligns the manual eval validator and generated eval JSON schema with runtime shorthand expansion for suite-level `input`.
- Keeps existing full message arrays supported, including role/content forms and file content blocks.
- Adds regression coverage for suite-level string/block/object shorthand plus test-level object input parity.
- Updates human-facing docs and AI-facing eval-writing references so authors see the shorthand path first.

## Verification

- `bun --filter @agentv/core test ./test/evaluation/suite-level-input.test.ts ./test/evaluation/loaders/shorthand-expansion.test.ts ./test/evaluation/validation/eval-validator.test.ts ./test/evaluation/validation/eval-schema-sync.test.ts`
- `bun apps/cli/src/cli.ts validate examples/features/suite-level-input-files/evals/dataset.eval.yaml`
- `bun --filter @agentv/core typecheck`
- `bun run validate:examples`
- `bunx biome check packages/core/src/evaluation/validation/eval-file.schema.ts packages/core/src/evaluation/validation/eval-validator.ts packages/core/test/evaluation/loaders/shorthand-expansion.test.ts packages/core/test/evaluation/suite-level-input.test.ts packages/core/test/evaluation/validation/eval-validator.test.ts`
- `bun --filter @agentv/core generate:schema`
- `bun --filter @agentv/core build`
- `git diff --check`

## Remaining Risk

- The generated JSON schema diff is large because the object shorthand is expanded through repeated inline schemas; `eval-schema-sync` covers drift against the Zod source.
- Structured objects with a top-level `role` key continue to be treated as chat-message-shaped input and must satisfy message validation, matching the existing runtime shorthand behavior.

## Post-Deploy Monitoring & Validation

No runtime service deployment is required for this local eval parser/schema/docs change. After merge, use CI as the merge gate and confirm the schema sync, example validation, core typecheck, and targeted eval tests stay green.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
