### PR TITLE
docs(phoenix): document read-only AgentV boundary

### DIFF
--- a/.agents/product-boundary.md
+++ b/.agents/product-boundary.md
@@ -19,6 +19,18 @@ AgentV aims to be the repo-native, workspace-native evaluation framework for AI 
 - Adapter boundaries: integrate with Phoenix, Harbor, Opik, and provider-specific systems through narrow adapters instead of absorbing their concepts into core.
 - AI-native extensibility: keep the core small and composable so engineers and coding agents can extend it with plugins, wrappers, and harness-specific glue.
 
+## Phoenix Boundary
+
+After the 2026-06-20 product decision, Phoenix is not an AgentV artifact owner or projection target.
+
+AgentV must not export or project completed AgentV runs, traces, transcripts, datasets, experiments, or indexes into Phoenix. AgentV-owned Git/GitHub run artifacts and the local Dashboard remain the supported zero-infra inspection path for AgentV run, trace, session, transcript, and comparison data.
+
+Phoenix may be referenced as UI inspiration and as optional external trace infrastructure when Codex, Arize, or another hook already emitted spans independently. The supported integration shape is read-only correlation/read-through through Phoenix GraphQL/API using safe `external_trace` metadata. That metadata can point from an AgentV artifact to an external Phoenix trace or session, but Phoenix does not become the storage, transcript, index, or run system of record.
+
+Dashboard must not require the `px` CLI at runtime, must not query Phoenix database tables directly, and must not introduce a Phoenix runtime dependency for the zero-infra local path. If Phoenix data is surfaced later, it should be through the public Phoenix GraphQL/API boundary and should degrade cleanly when Phoenix is unavailable.
+
+AgentV transcript artifacts are not Phoenix-native conversation inputs. Model-call spans may contain cumulative input messages, so treating Phoenix span input as a linear transcript can duplicate or distort the conversation. Keep AgentV transcript/index/storage semantics in AgentV artifacts.
+
 ## Design Principles
 
 ### 1. Lightweight Core, Plugin Extensibility

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,14 @@ AgentV aims to be the repo-native, workspace-native evaluation framework for AI 
 - Adapter boundaries: integrate with Phoenix, Harbor, Opik, and provider-specific systems through narrow adapters instead of absorbing their concepts into core.
 - AI-native extensibility: keep the core small and composable so engineers and coding agents can extend it with plugins, wrappers, and harness-specific glue.
 
+Phoenix boundary after the 2026-06-20 product decision:
+
+- AgentV-owned run bundles, traces, transcripts, datasets, experiments, indexes, and Git-backed artifacts are not exported or projected into Phoenix.
+- The local Dashboard is the supported zero-infra inspection path for AgentV run, trace, and session artifacts.
+- Phoenix may be referenced as UI inspiration and optional external trace infrastructure only when Codex, Arize, or another hook already emitted spans independently.
+- Optional Phoenix integration is read-only correlation/read-through through Phoenix GraphQL/API using safe `external_trace` metadata.
+- Dashboard must not require the `px` CLI at runtime or query Phoenix database tables directly.
+
 Design guardrails:
 
 - Prefer core primitives plus plugins or wrappers over new built-ins.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,35 +1,36 @@
 # AgentV Roadmap
 
-Last updated: 2026-06-19
+Last updated: 2026-06-21
 
 This roadmap translates [STRATEGY.md](STRATEGY.md) into the next few product phases. It is intentionally short: the goal is to keep priorities and boundaries visible without turning the roadmap into a plan dump.
 
 ## Guardrails
 
 - AgentV remains the repo-native, workspace-native runner, grader, and artifact source of truth.
-- Phoenix is the preferred shared UI for traces, experiments, and longitudinal results analysis.
-- The AgentV Dashboard stays valuable as the zero-infra local cockpit; this roadmap does not deprecate it.
+- The AgentV Dashboard is the supported zero-infra local cockpit for AgentV-owned runs, traces, sessions, transcripts, and Git-backed artifacts.
+- Phoenix is optional external trace infrastructure only when Codex, Arize, or another hook already emitted spans independently; AgentV may correlate with those sessions but does not write AgentV artifacts into Phoenix.
 - Harbor stays an optional benchmark-grade runner boundary, not AgentV core.
 - AgentV YAML remains the authoring surface even when execution moves behind another runner; prefer a lightweight translation layer over duplicated specs.
-- Adapters, workers, and artifact projections are preferred over rebuilding adjacent platforms inside AgentV.
+- Adapters, workers, and artifact projections are preferred over rebuilding adjacent platforms inside AgentV, except Phoenix: Phoenix integration is read-only correlation/read-through and not an AgentV-to-Phoenix projection path.
 
-## Phase 1: Finish the artifact and projection foundation
+## Phase 1: Finish the artifact and local inspection foundation
 
 - Keep the canonical handoff surface centered on completed run bundles, `index.jsonl`, grading/timing artifacts, and `outputs/trace.json` sidecars.
-- Finish the vendor-neutral projection/export seams that let completed runs be re-read, compared, exported, and attached to adapters without vendor-specific logic in core.
+- Finish the vendor-neutral local export seams that let completed runs be re-read, compared, exported, and attached to non-Phoenix adapters without vendor-specific logic in core.
 - Keep OTLP/OpenInference mapping generic and reusable before building backend-specific upload or import paths.
 
-## Phase 2: Make Phoenix the shared UI over AgentV-native execution
+## Phase 2: Keep Phoenix read-only and externally owned
 
-- Add a Phoenix-triggered AgentV worker/runner contract so Phoenix can request or attach to real AgentV runs without owning workspace lifecycle, target execution, or grader semantics.
-- Project completed AgentV run bundles and execution traces into Phoenix through adapter workers that preserve AgentV IDs, score provenance, and links back to local artifacts.
-- Keep missing worker/config/trace state explicit: failures should surface as execution or import errors, not as silent evaluator passes.
+- Document the Phoenix boundary across public docs, CLI help, Dashboard copy, and AI-facing guides.
+- Allow optional read-only Phoenix session links or views through Phoenix GraphQL/API when safe `external_trace` metadata points at spans emitted independently by Codex, Arize, or another hook.
+- Keep Phoenix from owning AgentV transcript, index, run, dataset, experiment, or storage state.
+- Keep Dashboard free of a Phoenix runtime dependency: no `px` CLI requirement and no direct reads from Phoenix database tables.
 
 ## Phase 3: Strengthen the local cockpit and the product boundary
 
 - Keep the AgentV Dashboard focused on quick local inspection, comparison, and zero-infra review.
-- Add lightweight handoff points between local AgentV artifacts and Phoenix when a shared UI exists.
-- Clarify the split across docs, CLI help, Dashboard copy, and skills so users know when to stay local and when to attach Phoenix.
+- Add lightweight links from local AgentV artifacts to external trace viewers when safe metadata exists.
+- Clarify the split across docs, CLI help, Dashboard copy, and skills so users know that AgentV artifacts stay local/Git-backed and Phoenix is optional read-only context.
 - Docs hygiene follow-up: split large AI-facing guidance such as `AGENTS.md` into linked instruction files if that makes the boundary easier to maintain.
 
 ## Phase 4: Extend outward through optional boundaries
@@ -37,6 +38,7 @@ This roadmap translates [STRATEGY.md](STRATEGY.md) into the next few product pha
 - Harbor: move toward Harbor becoming the benchmark-grade runner behind a lightweight translation layer from AgentV YAML, while AgentV stays the authoring, gating, import, and comparison surface.
 - Harbor: in the near term, launch or import benchmark-grade runs through a runner boundary; over time, converge on Harbor as the execution layer for the suites it already owns.
 - Opik and similar systems: consume completed AgentV projection bundles as post-run adapters rather than as runtime owners.
+- Phoenix: remain excluded from AgentV post-run export/projection; use read-only correlation/read-through only.
 - Additional observability backends should reuse the same projection and export seams instead of adding new core product models.
 
 ## Not On This Roadmap
@@ -44,3 +46,5 @@ This roadmap translates [STRATEGY.md](STRATEGY.md) into the next few product pha
 - Rebuilding Phoenix, Opik, Langfuse, or similar products inside AgentV.
 - Turning AgentV into a hosted experiment platform, benchmark catalog, or generic dashboard platform.
 - Deleting the local Dashboard in favor of Phoenix.
+- Exporting or projecting AgentV runs, traces, transcripts, datasets, experiments, or indexes into Phoenix.
+- Requiring `px`, Phoenix database access, or Phoenix-owned storage for Dashboard runtime.

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -1,6 +1,6 @@
 ---
 name: AgentV
-last_updated: 2026-06-19
+last_updated: 2026-06-21
 ---
 
 # AgentV Strategy
@@ -11,7 +11,7 @@ Teams evaluating coding agents and other tool-using workflows need results from 
 
 ## Our approach
 
-AgentV stays repo-native and workspace-native: it runs or imports evaluations around the user's existing harness, writes portable run artifacts, and keeps core primitives focused on execution, grading, routing, and results storage. It integrates outward through clear adapter boundaries so teams can use Phoenix for experiment and trace UI, Harbor for benchmark-grade execution, and post-run/export adapters for adjacent systems without AgentV trying to own every layer.
+AgentV stays repo-native and workspace-native: it runs or imports evaluations around the user's existing harness, writes portable run artifacts, and keeps core primitives focused on execution, grading, routing, and results storage. It integrates outward through clear boundaries: Phoenix can be correlated with as an optional external trace database when spans were emitted independently, Harbor can provide benchmark-grade execution, and post-run/export adapters can serve adjacent systems without AgentV trying to own every layer.
 
 ## Who it's for
 
@@ -40,7 +40,7 @@ _Why it serves the approach:_ Portable artifacts let local runs, CI, static repo
 
 ### Adapter-led integrations
 
-Add Phoenix, Harbor, Opik, Langfuse, and similar systems through narrow adapter, runner, or export boundaries rather than copying their product models into core.
+Add Phoenix, Harbor, Opik, Langfuse, and similar systems through narrow correlation, runner, adapter, or export boundaries rather than copying their product models into core. For Phoenix specifically, the supported boundary is read-only correlation/read-through from safe `external_trace` metadata; AgentV does not export or project completed runs, traces, transcripts, datasets, experiments, or indexes into Phoenix.
 
 _Why it serves the approach:_ This expands AgentV's reach without turning it into a hosted observability stack, benchmark platform, or integration kitchen sink.
 
@@ -53,5 +53,7 @@ _Why it serves the approach:_ The product wins when the core primitives make rea
 ## Not working on
 
 - Rebuilding Phoenix, Opik, Langfuse, or similar experiment and trace UIs inside AgentV.
+- Exporting or projecting AgentV-owned completed runs, traces, transcripts, datasets, experiments, or indexes into Phoenix.
+- Making Phoenix, the `px` CLI, or Phoenix database tables part of the zero-infra local Dashboard path.
 - Owning Harbor's benchmark packaging, verifier images, or suite-specific runtime contracts inside AgentV core.
 - Expanding AgentV into a generic benchmark catalog or a general-purpose dashboard platform when repo-native evals, static artifacts, and adapters already cover the job.

--- a/apps/cli/src/commands/results/export.ts
+++ b/apps/cli/src/commands/results/export.ts
@@ -162,7 +162,8 @@ export const resultsExportCommand = command({
     }),
     projectionBundle: flag({
       long: 'projection-bundle',
-      description: 'Write a vendor-neutral projection_bundle.json alongside exported artifacts',
+      description:
+        'Write a local vendor-neutral projection_bundle.json for non-Phoenix adapters; no service calls',
     }),
     dryRun: flag({
       long: 'dry-run',

--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -2624,7 +2624,8 @@ function resolveStudioDistDir(): string | undefined {
 
 export const resultsServeCommand = command({
   name: 'dashboard',
-  description: 'Start AgentV Dashboard — a local dashboard for reviewing evaluation results',
+  description:
+    'Start AgentV Dashboard - the zero-infra local viewer for AgentV-owned result artifacts',
   args: {
     source: positional({
       type: optional(string),

--- a/apps/web/src/content/docs/docs/integrations/phoenix.mdx
+++ b/apps/web/src/content/docs/docs/integrations/phoenix.mdx
@@ -1,108 +1,80 @@
 ---
-title: Phoenix Adapter
-description: Convert AgentV eval YAML into Phoenix datasets and experiments while keeping AgentV as the source of truth.
+title: Phoenix
+description: How AgentV relates to Phoenix without making Phoenix the owner of AgentV artifacts.
 sidebar:
   order: 4
 ---
 
-The Phoenix adapter converts AgentV eval YAML suites into Phoenix dataset and
-experiment payloads. Use it when your team already reviews experiments in
-Phoenix but wants AgentV eval files, graders, result JSONL, and run artifacts to
-remain the canonical source.
+AgentV keeps completed runs, traces, transcripts, experiments, and indexes in
+AgentV-owned local or Git-backed artifacts. The supported zero-infra inspection
+path is the local [Dashboard](/docs/tools/dashboard/) and result artifact tools.
+Phoenix is optional external trace infrastructure, not the storage or projection
+target for AgentV artifacts.
 
-The adapter is intentionally narrow. It supports deterministic assertions that
-map cleanly to Phoenix CODE evaluators and reports unsupported AgentV families
-instead of silently dropping semantics.
+## Supported Boundary
 
-## Quick Start
+AgentV does not export or project completed AgentV runs, traces, transcripts,
+datasets, experiments, or indexes into Phoenix.
 
-From the AgentV repository root:
+Phoenix can still appear in AgentV workflows in two narrow ways:
 
-```bash
-bun --filter @agentv/phoenix-adapter phoenix:assert-smoke
-```
+- As UI inspiration for local trace and session review.
+- As an optional external trace database when Codex, Arize, or another hook
+  already emitted spans independently.
 
-This runs a dry-run smoke conversion for the deterministic assertion example and
-writes a structural report to `/tmp/agentv-phoenix-assert-smoke.json`.
+When an AgentV run artifact includes safe `external_trace` metadata, AgentV may
+link to that external Phoenix session. A future read-through can use Phoenix
+GraphQL/API to read the referenced session, but AgentV must not write AgentV
+artifacts into Phoenix as part of that flow.
 
-Run a broader dry run:
+## Local Inspection
 
-```bash
-bun --filter @agentv/phoenix-adapter phoenix:dry-run
-```
-
-Run one eval source directly:
+Use Dashboard for AgentV-owned run and trace review:
 
 ```bash
-bun packages/phoenix-adapter/src/cli.ts run \
-  --dry-run \
-  --agentv-root . \
-  --eval-file examples/features/assert/evals/dataset.eval.yaml \
-  --out reports/phoenix-assert.json
+agentv dashboard
 ```
 
-## Supported Evaluators
+Dashboard reads configured project run sources, local `.agentv/results/runs/`
+workspaces, remote results repositories, trace sidecars, transcripts, and
+artifact manifests. It does not require Phoenix, the `px` CLI, Phoenix database
+tables, or any Phoenix runtime process.
 
-| AgentV assertion family | Phoenix adapter behavior |
-| --- | --- |
-| `contains` | Converts to deterministic Phoenix evaluator logic |
-| `regex` | Converts to deterministic Phoenix evaluator logic |
-| `equals` | Converts to deterministic Phoenix evaluator logic |
-| `is-json` | Converts to deterministic Phoenix evaluator logic |
-| `llm-grader`, rubrics, `code-grader`, `tool-trajectory`, composite, metrics, and custom families | Reported as unsupported in the adapter report |
+## External Trace Metadata
 
-Unsupported families do not fail conversion by default. Add
-`--fail-on-unsupported` when a parity report should fail CI if any suite needs a
-manual Phoenix-specific evaluator.
+AgentV artifacts may carry metadata such as:
 
-```bash
-bun packages/phoenix-adapter/src/cli.ts run \
-  --dry-run \
-  --agentv-root . \
-  --filter examples/features/assert \
-  --fail-on-unsupported
+```json
+{
+  "external_trace": {
+    "provider": "phoenix",
+    "source": "codex",
+    "project": "agentv-dogfood",
+    "session_id": "codex-session-123",
+    "trace_id": "phoenix-trace-456",
+    "ui_url": "https://phoenix.example/projects/agentv-dogfood/traces/phoenix-trace-456"
+  }
+}
 ```
 
-## When to Use the Adapter
+Only safe link and identity fields should be surfaced. Secrets, API keys,
+authorization headers, raw tool payloads, and local filesystem paths should stay
+out of `external_trace` metadata.
 
-Use the Phoenix adapter for:
+## Transcript Boundary
 
-- deterministic assertion suites that should appear as Phoenix datasets and
-  experiments
-- parity checks that prove Phoenix row IDs match AgentV test IDs
-- integration smoke tests before writing a custom Phoenix evaluator
+AgentV transcript artifacts are not Phoenix-native conversation inputs.
+Model-call spans may carry cumulative input messages, so treating Phoenix span
+inputs as a linear transcript can duplicate prior turns and distort the
+conversation. Keep transcript, index, and storage semantics in AgentV artifacts;
+use Phoenix only as optional external context when safe metadata points at an
+already-existing session.
 
-Keep the eval in AgentV when you need:
+## Non-Goals
 
-- workspace setup, lifecycle hooks, Docker workspaces, or repo materialization
-- code graders that execute commands in the AgentV workspace
-- tool trajectory, trace, cost, latency, or composite scoring
-- rich rubric semantics that need AgentV's assertion objects in result JSONL
-
-Those features can still be represented in Phoenix with custom task and
-evaluator code, but the adapter does not attempt a lossy automatic conversion.
-
-## Traces vs Datasets
-
-The Phoenix adapter creates dataset and experiment payloads. It is separate from
-AgentV's OpenTelemetry trace export.
-
-For trace export, use AgentV's standard OTel options:
-
-```bash
-agentv eval evals/my-eval.yaml --otel-file traces/eval.otlp.json
-```
-
-For live OTel export to Phoenix, use a local `.agentv/otel-backends/phoenix.mjs`
-resolver that imports `phoenixOtelBackend` from `@agentv/phoenix-adapter`, then select it
-with `--otel-backend phoenix`. General live export options are documented in
-[Running Evaluations](/docs/evaluation/running-evals/#live-otel-export/).
-
-## Package Docs
-
-The adapter package includes the implementation README, support matrix, and
-verification notes:
-
-- [`packages/phoenix-adapter/README.md`](https://github.com/EntityProcess/agentv/tree/main/packages/phoenix-adapter)
-- [`packages/phoenix-adapter/docs/support-matrix.md`](https://github.com/EntityProcess/agentv/blob/main/packages/phoenix-adapter/docs/support-matrix.md)
-- [`packages/phoenix-adapter/docs/e2e-verification.md`](https://github.com/EntityProcess/agentv/blob/main/packages/phoenix-adapter/docs/e2e-verification.md)
+- No AgentV-to-Phoenix export or projection of completed runs, traces,
+  transcripts, datasets, experiments, or indexes.
+- No Phoenix-owned AgentV transcript, index, or storage model.
+- No Dashboard runtime dependency on Phoenix or `px`.
+- No direct Dashboard access to Phoenix database tables.
+- No Phoenix dataset or experiment creation as part of the zero-infra local path.

--- a/apps/web/src/content/docs/docs/tools/dashboard.mdx
+++ b/apps/web/src/content/docs/docs/tools/dashboard.mdx
@@ -41,6 +41,19 @@ agentv dashboard --dir /path/to/project
 
 Dashboard does not accept a run workspace directory or `index.jsonl` manifest as a direct source. It reads one configured run source per project: the project's `.agentv/results/runs/` tree, plus an external results repository or run directory configured under `results:` in YAML. For one-off inspection of a copied run bundle, use `agentv results report <run-workspace-or-index.jsonl>`.
 
+## Data boundary
+
+Dashboard is the supported zero-infra inspection path for AgentV-owned runs,
+trace sidecars, transcripts, sessions, and Git-backed result artifacts. It does
+not require Phoenix, the `px` CLI, a Phoenix database, or a hosted Dashboard
+service.
+
+If a trace artifact includes safe `external_trace` metadata for spans that were
+already emitted to Phoenix by Codex, Arize, or another hook, Dashboard may show
+that external reference. AgentV still treats the local/Git-backed run artifacts
+as canonical and does not export or project completed runs, transcripts,
+datasets, experiments, or indexes into Phoenix.
+
 ## Options
 
 | Option | Description |

--- a/apps/web/src/content/docs/docs/tools/prepare.mdx
+++ b/apps/web/src/content/docs/docs/tools/prepare.mdx
@@ -74,7 +74,8 @@ Use `--response` when the final answer text should be graded independently of th
 
 - Use provider-native settings, target hooks, or environment variables to enable session logs.
 - Use AgentV's OTLP options during normal eval runs, such as `--otel-file` or `--export-otel`, when AgentV is the runner.
-- For Opik, Phoenix, Langfuse, or another backend, treat their traces as external artifacts that can be imported or projected back into AgentV later.
+- For Opik, Langfuse, or another export-capable backend, treat their traces as external artifacts that can be imported or projected back into AgentV later.
+- For Phoenix, use only optional read-only GraphQL/API correlation when safe `external_trace` metadata points to spans already emitted independently by Codex, Arize, or another hook.
 
 AgentV remains responsible for eval definitions, workspace setup, grading, result bundles, and CI gates. Live trace storage, dashboards, and provider-specific run monitoring belong in the observability backend or the external harness.
 

--- a/apps/web/src/content/docs/docs/tools/results.mdx
+++ b/apps/web/src/content/docs/docs/tools/results.mdx
@@ -123,6 +123,11 @@ span references, score provenance, artifact-relative paths, capture/redaction
 summary, and conversion warnings. It does not call Phoenix, Opik, Braintrust,
 Langfuse, Hugging Face, or any other live service.
 
+Do not use `results export` as an AgentV-to-Phoenix path. Phoenix is read-only
+external trace correlation only when safe `external_trace` metadata points at
+spans emitted independently; AgentV does not project completed runs, traces,
+transcripts, datasets, experiments, or indexes into Phoenix.
+
 For adapter development and CI snapshots, use dry-run mode:
 
 ```bash

--- a/docs/adr/2026-06-11-phoenix-observability-adapter.md
+++ b/docs/adr/2026-06-11-phoenix-observability-adapter.md
@@ -2,7 +2,13 @@
 
 Date: 2026-06-11
 
-Status: Proposed
+Status: Superseded in part by [2026-06-21 Phoenix read-only correlation boundary](2026-06-21-phoenix-read-only-correlation-boundary.md)
+
+This ADR remains useful for the narrower point that Phoenix-specific behavior
+does not belong in `packages/core`. Its earlier allowance for Phoenix dataset,
+experiment, trace import/export helpers is superseded: Phoenix is now read-only
+correlation/read-through for externally emitted traces, not an AgentV artifact
+projection target.
 
 ## Context
 
@@ -14,7 +20,7 @@ Relevant existing seams already point in this direction:
 
 - Provider and grader registries support narrow registration points.
 - `.agentv/providers/`, `.agentv/assertions/`, and `.agentv/graders/` use convention-based local discovery instead of a broad plugin host.
-- `packages/phoenix-adapter/` already keeps Phoenix dataset and experiment behavior outside core and reports unsupported mappings explicitly.
+- Earlier `packages/phoenix-adapter/` experiments kept Phoenix-specific behavior outside core and reported unsupported mappings explicitly. That experiment is not the supported product path for AgentV completed runs or transcripts.
 - The trace evaluation plan requires generic OTLP/OpenInference mapping without Phoenix-specific assumptions in core.
 
 ## Decision
@@ -33,13 +39,15 @@ Phoenix integration should live outside core behind an adapter boundary, current
 
 - a Phoenix OTel backend resolver;
 - Phoenix/OpenInference span-kind mapping;
-- Phoenix trace import/export helpers;
-- Phoenix dataset and experiment helpers;
+- read-only Phoenix GraphQL/API helpers for externally emitted trace/session correlation;
 - explicit unsupported/lossy mapping reports.
 
 ## Minimal extension seam
 
-If `--otel-backend phoenix` needs first-class ergonomics, add the smallest observability backend extension seam rather than hard-coding Phoenix in core.
+Historical note: this ADR originally considered a first-class `--otel-backend phoenix`
+ergonomics path. That must not be used to make Phoenix a Dashboard dependency or
+an AgentV-owned artifact destination. Any future Phoenix work should be framed as
+read-only correlation/read-through for externally emitted spans.
 
 A resolver should be approximately:
 
@@ -64,7 +72,7 @@ Registration/discovery should remain boring and local-first. In this ADR, "plugi
 - keep `execution.otel_backend: <name>` and `--otel-backend <name>` as the user-facing selectors;
 - do not add package names, package auto-installation, a remote marketplace, trust prompts, or a general-purpose plugin host for this need.
 
-The Phoenix adapter can then expose a resolver, for example `phoenixOtelBackend`, and users can opt in from project config or a local `.agentv/otel-backends/phoenix.mjs` file. Reusable npm packages can come later only if repeated project-local resolver files become real friction.
+The earlier prototype exposed a resolver, for example `phoenixOtelBackend`, so users could opt in from project config or a local `.agentv/otel-backends/phoenix.mjs` file. Treat that as a custom/legacy path, not as the supported AgentV-to-Phoenix product boundary.
 
 ## Migration path for Phoenix
 
@@ -74,7 +82,7 @@ The Phoenix adapter can then expose a resolver, for example `phoenixOtelBackend`
    - `--otel-file` for offline OTLP JSON export
 2. Add a tiny backend resolver seam only if ergonomic backend names are needed.
 3. Implement Phoenix endpoint/header/project routing in the Phoenix adapter boundary, not in core.
-4. Keep Phoenix dataset, experiment, and trace-source behavior in `packages/phoenix-adapter/`.
+4. Keep any Phoenix read-through behavior outside core and behind Phoenix GraphQL/API.
 5. Consider moving existing vendor-specific core presets to the same resolver model later, but do not couple that cleanup to the Phoenix decision unless the implementation already touches the preset registry.
 
 ## Consequences
@@ -83,19 +91,19 @@ Positive:
 
 - Keeps core aligned with AgentV's lightweight-core and composition principles.
 - Prevents Phoenix concepts from leaking into the generic trace model.
-- Gives Phoenix users an ergonomic path without blocking generic OTLP users.
+- Gives Phoenix users a read-only correlation path without blocking generic OTLP users.
 - Reuses AgentV's existing pattern of narrow registries and convention-based local discovery.
 
 Negative:
 
-- `--otel-backend phoenix` requires a small extension seam or adapter shim instead of a one-line core preset.
+- Any maintained Phoenix OTel resolver must stay outside the zero-infra Dashboard path.
 - Existing vendor presets in core remain an architectural inconsistency until migrated.
 - Package-level resolver sharing may need a future decision if many backend adapters emerge.
 
 ## Tracker impact
 
-- `av-vwa.6` remains valid: core should map trace artifacts to and from generic OTLP/OpenInference shapes, while Phoenix-specific dataset, experiment, project, and span-kind behavior stays in adapter space.
-- `av-vwa.6.1` should be revised from adding a Phoenix preset in core to adding the minimal observability backend extension seam plus a Phoenix resolver in the Phoenix adapter. If the extension seam is not approved, defer the bead and document generic OTLP environment-variable configuration for Phoenix instead.
+- `av-vwa.6` remains valid only for generic trace artifacts and OTLP/OpenInference shapes. Phoenix-specific read-through stays outside core and must not become AgentV-to-Phoenix artifact projection.
+- `av-vwa.6.1` is superseded as a Phoenix preset/resolver task unless it is reframed under the read-only external-trace correlation boundary.
 
 ## Open questions
 

--- a/docs/adr/2026-06-21-phoenix-read-only-correlation-boundary.md
+++ b/docs/adr/2026-06-21-phoenix-read-only-correlation-boundary.md
@@ -1,0 +1,68 @@
+# ADR: Keep Phoenix read-only at the AgentV artifact boundary
+
+Date: 2026-06-21
+
+Status: Accepted
+
+## Context
+
+AgentV's canonical inspection path is local and Git-backed: completed run bundles,
+`index.jsonl`, trace sidecars, transcripts, reports, and Dashboard read models.
+Earlier Phoenix integration language described Phoenix as a shared UI or as a
+place to project AgentV datasets, experiments, completed runs, traces, or
+transcripts. That expands Phoenix from an adjacent tool into an owner of AgentV
+state.
+
+The 2026-06-20 product decision narrowed the boundary. Phoenix can remain useful
+when Codex, Arize, or another hook already emitted spans independently, but
+AgentV should not write its completed artifacts into Phoenix or make Phoenix part
+of the zero-infra local path.
+
+## Decision
+
+AgentV does not export or project completed AgentV runs, traces, transcripts,
+datasets, experiments, or indexes into Phoenix.
+
+AgentV-owned run artifacts and the local Dashboard remain the supported
+zero-infra inspection path for AgentV run, trace, session, transcript, and
+comparison data.
+
+Phoenix integration, when present, is read-only correlation/read-through:
+
+- AgentV artifacts may carry safe `external_trace` metadata that identifies an
+  external Phoenix trace or session.
+- Dashboard or CLI features may use Phoenix GraphQL/API to read that external
+  session in a future follow-up.
+- Phoenix does not own AgentV transcript, index, run, dataset, experiment, or
+  storage state.
+- Dashboard must not require the `px` CLI at runtime.
+- Dashboard must not query Phoenix database tables directly.
+- The local Dashboard path must work without any Phoenix runtime dependency.
+
+AgentV transcript artifacts are not Phoenix-native conversation inputs. A
+model-call span may include cumulative input messages, so converting Phoenix span
+inputs into AgentV transcripts would duplicate prior turns and lose AgentV's
+artifact semantics.
+
+## Consequences
+
+Positive:
+
+- Keeps AgentV's source of truth portable across local development and CI.
+- Avoids a second write path for run, transcript, trace, and index state.
+- Leaves room for optional Phoenix read-through without coupling Dashboard to a
+  Phoenix runtime, database schema, or CLI.
+
+Negative:
+
+- Phoenix will not be the default shared UI for AgentV-owned run results.
+- Teams that want Phoenix views must rely on independently emitted traces or a
+  separate custom workflow outside the supported AgentV artifact path.
+
+## Follow-up
+
+`av-kve.7` may add read-only Phoenix GraphQL/API read-through for externally
+emitted sessions that are already referenced by `external_trace` metadata. That
+work must not add AgentV-to-Phoenix export/projection, direct Phoenix database
+access, `px` runtime requirements, Phoenix-owned indexes, or Phoenix transcript
+ingestion.

--- a/docs/plans/trace-evaluation-architecture.md
+++ b/docs/plans/trace-evaluation-architecture.md
@@ -16,6 +16,13 @@ namespace for persisted trace sidecars. The trace read-model contract in
 this older plan is a derived internal projection over that artifact, not a
 separate versioned document that users produce.
 
+Update, 2026-06-21: Phoenix-specific parts of this older plan are superseded by
+the read-only Phoenix correlation boundary in
+[docs/adr/2026-06-21-phoenix-read-only-correlation-boundary.md](../adr/2026-06-21-phoenix-read-only-correlation-boundary.md).
+Do not use U4 or the Phoenix dataset/experiment notes below as current product
+scope. AgentV does not export or project completed runs, traces, transcripts,
+datasets, experiments, or indexes into Phoenix.
+
 ---
 
 ## Problem Frame
@@ -40,7 +47,7 @@ The best-practice direction is clear: larger players own trace stores, dashboard
 
 - R6. AgentV OTLP export must continue to emit standards-aligned GenAI spans, especially `invoke_agent`, `chat`, and `execute_tool` operations.
 - R7. AgentV must map trace artifacts to and from OTLP/OpenInference-style traces without making Phoenix-specific assumptions in core.
-- R8. Phoenix integration must use AgentV as the eval-definition and grader layer while Phoenix remains the trace/dataset/experiment backend.
+- R8. Phoenix integration, if present, must be read-only correlation/read-through for externally emitted traces; Phoenix must not become the AgentV trace, dataset, experiment, transcript, or index backend.
 - R9. Unsupported or lossy mappings must be explicit in conversion reports instead of silently approximated.
 
 **Post-Hoc Trace And Transcript Evaluation**
@@ -76,7 +83,7 @@ The best-practice direction is clear: larger players own trace stores, dashboard
 ## Key Technical Decisions
 
 - **Start from realistic characterization evals:** The first implementation phase should collect a small set of real trace fixtures and write evals that answer useful agent-quality questions. The trace artifact contract should be pressure-tested by those evals before broad schema or adapter work expands.
-- **Normalize first, grade second:** Graders should consume AgentV's trace artifact contract. Importers translate raw sources into the contract; exporters translate the contract into OTLP/OpenInference/Phoenix shapes. This avoids coupling graders to Phoenix, Pi, VS Code, or provider-specific logs.
+- **Normalize first, grade second:** Graders should consume AgentV's trace artifact contract. Importers translate raw sources into the contract; exporters translate the contract into backend-neutral OTLP/OpenInference shapes. This avoids coupling graders to Phoenix, Pi, VS Code, or provider-specific logs.
 - **OTel is an interchange layer, not the canonical model:** VS Code and industry tooling make OTLP/HTTP and GenAI span semantics important, but entireio-style logs and Pi sessions prove valuable traces are often transcript or lifecycle JSON. AgentV should support OTel strongly without making it mandatory.
 - **Tool sequence grading is turn-centric, not span-centric:** The trace artifact should model sessions, turns, messages, tool calls, tool results, and selected branches as a projection over the canonical trace artifact.
 - **Coding-agent transcripts are trace sources:** `agentv import claude`, `agentv import codex`, `agentv import copilot`, and `agentv eval --transcript` already establish transcript import as offline grading infrastructure. The architecture should extend that path into trace artifact normalization instead of creating a separate trace-only mechanism.
@@ -201,13 +208,13 @@ The exact schema belongs in implementation, but these concepts should be stable:
 - **Test Scenarios:** Import an AgentV OTLP file into a trace artifact, export it back, and verify tool call order, call IDs, token usage, durations, redaction state, and grader score events survive when representable.
 - **Verification:** `agentv trace show` and `agentv trace score` should work from OTLP artifacts without requiring an `agentv.score` attribute for trace-only evaluation.
 
-### U4. Phoenix Adapter Trace Evaluation Path
+### U4. Phoenix Read-Only Correlation Path
 
-- **Goal:** Extend the Phoenix integration so Phoenix can be a trace source and experiment backend while AgentV remains the grader/eval definition layer.
-- **Files:** `packages/phoenix-adapter/src/`, `packages/phoenix-adapter/docs/support-matrix.md`, `packages/phoenix-adapter/docs/e2e-verification.md`, related CLI entry points if promoted beyond package scripts.
-- **Patterns:** Keep unsupported mappings visible, as the current Phoenix adapter already does. Do not move Phoenix-specific dataset or experiment concepts into AgentV core.
-- **Test Scenarios:** Convert a Phoenix/OTLP trace export into trace artifacts, run deterministic trace graders, report unsupported evaluator families, and emit a Phoenix experiment/report with AgentV grader results where supported.
-- **Verification:** Dry-run conversion must work offline. Live Phoenix smoke can remain a separately documented manual check.
+- **Goal:** Superseded for this plan by the 2026-06-21 Phoenix boundary ADR. Phoenix can be an external trace reference when spans were emitted independently, but it is not an AgentV trace, dataset, experiment, transcript, or index backend.
+- **Files:** Future read-through belongs outside core and should use Phoenix GraphQL/API plus safe `external_trace` metadata.
+- **Patterns:** Keep AgentV artifacts canonical. Do not add AgentV-to-Phoenix export/projection, direct Phoenix database access, `px` runtime requirements, or Phoenix-owned indexes.
+- **Test Scenarios:** Future read-through should prove missing Phoenix state degrades cleanly and that secrets are not surfaced from `external_trace` metadata.
+- **Verification:** Dashboard and AgentV result inspection must continue to work without Phoenix installed or running.
 
 ### U5. Pi Session Importer
 
@@ -338,7 +345,7 @@ Outside this product's identity:
 - **Lossy imports:** Some sources lack tool timing, outputs, status, or branch data. Mitigation: record provenance and warning metadata instead of fabricating precision.
 - **Artifact size:** Full trace artifacts can be large. Mitigation: keep compact summaries as default result metadata and store full trace artifacts as optional sidecar artifacts.
 - **Privacy mistakes:** Tool args/results may contain secrets or PII. Mitigation: default to redacted content and centralize capture policy.
-- **Phoenix scope creep:** It is tempting to mirror Phoenix concepts in core. Mitigation: keep Phoenix-specific dataset and experiment behavior in `packages/phoenix-adapter/`.
+- **Phoenix scope creep:** It is tempting to mirror Phoenix concepts in core. Mitigation: keep Phoenix read-through outside core, read-only, and driven by safe `external_trace` metadata; do not add Phoenix dataset or experiment projection.
 
 ---
 

--- a/docs/plans/trace-evaluation-architecture.md
+++ b/docs/plans/trace-evaluation-architecture.md
@@ -1,33 +1,36 @@
 ---
 title: Trace Evaluation Architecture
 type: feat
-status: active
+status: superseded
 date: 2026-06-04
+superseded_by: docs/adr/2026-06-21-phoenix-read-only-correlation-boundary.md
 ---
 
 # Trace Evaluation Architecture
 
 ## Summary
 
-Build AgentV's trace evaluation architecture around a versioned, provider-neutral trace artifact contract. AgentV should ingest traces from AgentV runs, OTLP/OpenInference/Phoenix exports, Pi sessions, and transcript-style agent logs; normalize them into one trace artifact model; and run existing and future graders against that model without becoming a hosted observability platform.
+Build AgentV's trace evaluation architecture around a versioned, provider-neutral trace artifact contract. AgentV should ingest traces from AgentV runs, OTLP/OpenInference exports, Pi sessions, and transcript-style agent logs; normalize them into one trace artifact model; and run existing and future graders against that model without becoming a hosted observability platform.
 
 Update, 2026-06-18: `agentv.trace.v1` is the only AgentV trace artifact
 namespace for persisted trace sidecars. The trace read-model contract in
 this older plan is a derived internal projection over that artifact, not a
 separate versioned document that users produce.
 
-Update, 2026-06-21: Phoenix-specific parts of this older plan are superseded by
+Update, 2026-06-21: This plan is no longer active. Phoenix-specific parts are superseded by
 the read-only Phoenix correlation boundary in
 [docs/adr/2026-06-21-phoenix-read-only-correlation-boundary.md](../adr/2026-06-21-phoenix-read-only-correlation-boundary.md).
-Do not use U4 or the Phoenix dataset/experiment notes below as current product
-scope. AgentV does not export or project completed runs, traces, transcripts,
-datasets, experiments, or indexes into Phoenix.
+Do not use this plan as current Phoenix product scope. AgentV does not export,
+import, or project completed runs, traces, transcripts, datasets, experiments,
+or indexes into Phoenix. Phoenix is optional read-only GraphQL/API
+correlation/read-through only when safe `external_trace` metadata points to
+spans already emitted independently by Codex, Arize, or another hook.
 
 ---
 
 ## Problem Frame
 
-AgentV already captures tool calls in provider `Message.toolCalls`, persists compact `TraceSummary` data, exports AgentV OTLP spans, and has early post-hoc trace commands. That is enough for local AgentV result inspection, but it is not enough to evaluate production traces, Phoenix traces, or third-party agent sessions with the same grader contract.
+AgentV already captures tool calls in provider `Message.toolCalls`, persists compact `TraceSummary` data, exports AgentV OTLP spans, and has early post-hoc trace commands. That is enough for local AgentV result inspection, but it is not enough to evaluate production traces or third-party agent sessions with the same grader contract.
 
 The best-practice direction is clear: larger players own trace stores, dashboards, datasets, and experiment UIs. AgentV's niche is the repo-local, declarative evaluation harness for coding agents and tool-using agents. To connect those worlds, AgentV needs a durable trace artifact contract between raw trace sources and graders.
 
@@ -53,7 +56,7 @@ The best-practice direction is clear: larger players own trace stores, dashboard
 **Post-Hoc Trace And Transcript Evaluation**
 
 - R10. Existing deterministic trace graders, including `tool-trajectory` and `execution-metrics`, must run against trace artifacts, not only live provider output messages or compact summaries.
-- R11. Post-hoc evaluation must accept AgentV run artifacts, AgentV OTLP files, Phoenix/Langfuse/OTLP exports, imported coding-agent transcripts, Pi session JSONL, and compact transcript JSONL through source-specific adapters.
+- R11. Post-hoc evaluation must accept AgentV run artifacts, AgentV OTLP files, Langfuse/OTLP exports, imported coding-agent transcripts, Pi session JSONL, and compact transcript JSONL through source-specific adapters.
 - R12. Grader output must cite trace artifact evidence, such as matched tool call IDs, positions, timing, or source event IDs.
 - R13. Trace evaluation must preserve current lightweight result output by deriving compact summaries from trace artifacts.
 
@@ -76,14 +79,14 @@ The best-practice direction is clear: larger players own trace stores, dashboard
 
 - R23. Content capture must remain opt-in. Tool arguments, tool results, message text, screenshots, and thinking blocks must be gated by a single redaction/capture policy.
 - R24. Local offline trace persistence must be supported for CI artifacts and PR review.
-- R25. Trace import must not require live access to Phoenix, Hugging Face, VS Code, or provider services when a local exported artifact is available.
+- R25. Trace import must not require live access to Hugging Face, VS Code, or provider services when a local exported artifact is available.
 
 ---
 
 ## Key Technical Decisions
 
 - **Start from realistic characterization evals:** The first implementation phase should collect a small set of real trace fixtures and write evals that answer useful agent-quality questions. The trace artifact contract should be pressure-tested by those evals before broad schema or adapter work expands.
-- **Normalize first, grade second:** Graders should consume AgentV's trace artifact contract. Importers translate raw sources into the contract; exporters translate the contract into backend-neutral OTLP/OpenInference shapes. This avoids coupling graders to Phoenix, Pi, VS Code, or provider-specific logs.
+- **Normalize first, grade second:** Graders should consume AgentV's trace artifact contract. Importers translate raw sources into the contract; exporters translate the contract into backend-neutral OTLP/OpenInference shapes. This avoids coupling graders to Pi, VS Code, or provider-specific logs.
 - **OTel is an interchange layer, not the canonical model:** VS Code and industry tooling make OTLP/HTTP and GenAI span semantics important, but entireio-style logs and Pi sessions prove valuable traces are often transcript or lifecycle JSON. AgentV should support OTel strongly without making it mandatory.
 - **Tool sequence grading is turn-centric, not span-centric:** The trace artifact should model sessions, turns, messages, tool calls, tool results, and selected branches as a projection over the canonical trace artifact.
 - **Coding-agent transcripts are trace sources:** `agentv import claude`, `agentv import codex`, `agentv import copilot`, and `agentv eval --transcript` already establish transcript import as offline grading infrastructure. The architecture should extend that path into trace artifact normalization instead of creating a separate trace-only mechanism.
@@ -106,7 +109,6 @@ AgentV should introduce a trace artifact layer between raw sources and evaluatio
 flowchart TB
   A[AgentV run output] --> N[Trace artifact]
   B[OTLP / OpenInference export] --> N
-  C[Phoenix trace export] --> N
   D[Pi session JSONL] --> N
   E[Compact transcript JSONL] --> N
   F[Imported coding-agent transcript] --> N
@@ -115,7 +117,6 @@ flowchart TB
   N --> G[Trace graders]
   N --> Q[Transcript replay provider]
   N --> O[OTLP / OpenInference export]
-  N --> P[Phoenix adapter]
 
   S --> R[AgentV result artifacts]
   G --> R
@@ -132,7 +133,7 @@ Directional internal projection shape:
 
 ```yaml
 source:
-  kind: pi_session | agentv_run | otlp | phoenix | langfuse | imported_transcript | compact_transcript
+  kind: pi_session | agentv_run | otlp | langfuse | imported_transcript | compact_transcript
   path: traces/session.jsonl
   url: https://...
 session:
@@ -238,14 +239,14 @@ The exact schema belongs in implementation, but these concepts should be stable:
 - **Files:** `apps/cli/src/commands/import/`, `packages/core/src/import/`, `packages/core/src/import/transcript-provider.ts`, `apps/cli/src/commands/eval/run-eval.ts`.
 - **Patterns:** Reuse `TranscriptEntry`, `TranscriptJsonLine`, and `TranscriptProvider` instead of inventing a parallel transcript format. Preserve `agentv eval --transcript` compatibility while adding trace artifact derivation.
 - **Test Scenarios:** Import one Claude, Codex, and Copilot fixture; replay each through `--transcript`; derive trace artifacts; run `tool-trajectory`; verify tool IDs, order, tool outputs, source provider metadata, duration, cost, token usage, and redaction state where available.
-- **Verification:** Existing transcript-provider tests keep passing, and new trace-evaluation tests prove imported transcripts and OTLP/Phoenix exports feed the same grader path.
+- **Verification:** Existing transcript-provider tests keep passing, and new trace-evaluation tests prove imported transcripts and OTLP exports feed the same grader path.
 
 ### U6c. Replay From Trace Artifact
 
 - **Goal:** Let trace artifacts act as replay sources, not only grader inputs.
 - **Files:** `packages/core/src/import/transcript-provider.ts`, `packages/core/src/import/types.ts`, trace artifact model files from U1, `apps/cli/src/commands/eval/run-eval.ts`.
 - **Patterns:** Treat replay as a projection from a trace artifact to provider `Message[]`. Do not duplicate storage by keeping one trace file for graders and a separate transcript file for replay when the trace artifact can serve both.
-- **Test Scenarios:** Replay a trace artifact generated from AgentV output, an imported transcript, and an OTLP/Phoenix-style trace. Verify each produces the expected provider output messages and identical compact summaries where data is representable.
+- **Test Scenarios:** Replay a trace artifact generated from AgentV output, an imported transcript, and an OTLP-style trace. Verify each produces the expected provider output messages and identical compact summaries where data is representable.
 - **Verification:** Existing `agentv eval --transcript` behavior remains compatible, with a migration path to replay trace artifacts directly.
 
 ### U6d. Replay Target Database Loop
@@ -283,10 +284,10 @@ The exact schema belongs in implementation, but these concepts should be stable:
 ### U9. Documentation and Best-Practice Recipes
 
 - **Goal:** Document the contract and the integration posture so AgentV's scope stays clear.
-- **Files:** `apps/web/src/content/docs/` if public docs exist for this area, package READMEs, `packages/phoenix-adapter/docs/support-matrix.md`, showcase material under `examples/showcase/trace-evaluation/`.
+- **Files:** `apps/web/src/content/docs/` if public docs exist for this area, package READMEs, boundary ADRs, showcase material under `examples/showcase/trace-evaluation/`.
 - **Patterns:** Document patterns instead of adding core primitives when composition is enough.
 - **Test Scenarios:** Validate example eval YAML and include at least one trace-import fixture for post-hoc scoring.
-- **Verification:** Docs should show recipes for local trace scoring, Phoenix trace evaluation, Pi session scoring, and OTLP export.
+- **Verification:** Docs should show recipes for local trace scoring, read-only Phoenix correlation boundaries, Pi session scoring, and OTLP export.
 
 ---
 
@@ -295,10 +296,10 @@ The exact schema belongs in implementation, but these concepts should be stable:
 - AE1. **Covers R1, R10, R13.** Given an AgentV run with ordered tool calls, when the run is converted to a trace artifact, then `tool-trajectory` can grade the order and the result still has the same compact summary counts.
 - AE2. **Covers R2, R7, R11.** Given an OTLP trace export with `execute_tool` spans, when `agentv trace score` runs, then AgentV imports the spans into a trace artifact and grades tool usage without requiring a Phoenix server.
 - AE3. **Covers R3, R11.** Given a branchable Pi session, when a selected leaf is provided or inferred, then only the selected branch path is graded and omitted branch IDs are recorded.
-- AE4. **Covers R8, R9.** Given a Phoenix trace export containing unsupported evaluator semantics, when the Phoenix adapter runs, then the report lists unsupported mappings instead of treating them as successful conversions.
+- AE4. **Covers R8, R9.** Given an AgentV artifact has safe `external_trace` metadata for an independently emitted Phoenix session, when AgentV surfaces that reference, then it treats Phoenix as read-only external context and keeps AgentV artifacts canonical.
 - AE5. **Covers R23.** Given content capture is disabled, when a trace with tool arguments and results is exported, then the trace artifact preserves IDs, names, timing, and redaction state but does not persist raw content.
 - AE6. **Covers R12.** Given a failed tool sequence expectation, when AgentV reports the grader result, then the assertion cites the actual matched or missing tool call positions and source event IDs.
-- AE7. **Covers R10, R11.** Given a transcript imported with `agentv import codex`, `agentv import claude`, or `agentv import copilot`, when the transcript is evaluated post-hoc, then the same trace graders used for OTLP/Phoenix traces can score it.
+- AE7. **Covers R10, R11.** Given a transcript imported with `agentv import codex`, `agentv import claude`, or `agentv import copilot`, when the transcript is evaluated post-hoc, then the same trace graders used for OTLP traces can score it.
 - AE8. **Covers R14, R15, R16.** Given the same derived artifact, when AgentV uses it for replay and for grading, then replayed provider output and grader evidence come from the same ordered messages and tool calls.
 - AE9. **Covers R17, R18, R19.** Given a live target run has been recorded into replay JSONL, when the same eval runs with a replay target alias and shuffled fixture records, then AgentV selects the exact matching record, makes no live LLM call, and runs graders fresh.
 - AE10. **Covers R18.** Given a replay database has no matching record or has multiple matching records for the current test and target, when replay runs, then AgentV fails with an actionable error instead of falling back to a near match.
@@ -312,7 +313,7 @@ The exact schema belongs in implementation, but these concepts should be stable:
 Deferred for later:
 
 - Hosted trace storage or a managed observability service.
-- Phoenix dataset and experiment UI replacement.
+- Any Phoenix-owned AgentV storage, transcript, index, export, projection, dataset, or experiment path.
 - Langfuse or Braintrust prompt registry replacement.
 - Broad RAGAS metric reimplementation inside core.
 - Automatic trace mining into new eval cases, beyond import and post-hoc scoring.
@@ -334,7 +335,7 @@ Outside this product's identity:
 - **Graders:** Trace-aware graders move from output-message parsing toward trace artifact parsing while keeping compatibility with current eval results.
 - **CLI:** Post-hoc trace commands become a real evaluation path, not just inspection of AgentV-generated artifacts.
 - **Observability:** OTel export remains standards-aligned and becomes round-trippable enough for offline scoring.
-- **Adapters:** Phoenix, Pi, and transcript importers stay outside primitive grader logic, preserving AgentV's lightweight core.
+- **Adapters:** Pi and transcript importers stay outside primitive grader logic, preserving AgentV's lightweight core. Phoenix remains read-only external correlation when safe `external_trace` metadata exists.
 - **Privacy:** Redaction and content capture become an explicit boundary concern across import, persistence, export, and grading.
 
 ---
@@ -360,10 +361,8 @@ Outside this product's identity:
 - `packages/core/src/evaluation/cache/response-cache.ts` implements the existing opt-in response cache and safety behavior.
 - `packages/core/src/evaluation/config.ts` exposes TS config `cache.enabled` and `cache.path`, while `apps/cli/src/commands/eval/run-eval.ts` currently uses CLI flags and YAML cache config when constructing `ResponseCache`.
 - `packages/core/src/observability/otel-exporter.ts` already emits `agentv.eval`, `chat`, and `execute_tool` spans with GenAI attributes and optional content capture.
-- `packages/phoenix-adapter/README.md` and `packages/phoenix-adapter/docs/support-matrix.md` show the current adapter boundary and explicit unsupported-mapping posture.
 - Microsoft VS Code at `ebb335fad028ca0f3582e822d14a1bb9109725e7` uses OTLP/HTTP, optional local JSONL/SQLite persistence, `invoke_agent`, `chat`, and `execute_tool` spans, W3C trace context propagation, and privacy-gated content capture.
 - entireio/cli at `b98014a60b474ddf139a91231cdc4640eac62e5f` does not expose agent traces through OTel; its useful trace sources are compact transcript JSONL and lifecycle events with tool-use/file metadata.
 - Pi public session format and `badlogicgames/pi-mono` show branchable JSONL sessions with session headers, message entries, embedded assistant tool calls, separate tool results, model metadata, token usage, and optional inline images/thinking blocks.
 - DeepEval's cache and tracing features are adjacent but distinct: AgentV replay should cache target output/transcripts for fresh grader runs, not primarily replay cached metric judgments.
 - OpenTelemetry GenAI semantic conventions document `execute_tool` spans and tool attributes such as `gen_ai.tool.name` and `gen_ai.tool.call.id`.
-- Phoenix/OpenInference conventions favor span-kind mappings such as agent, LLM, tool, and evaluator spans, which should be adapter mappings rather than AgentV's internal model.

--- a/packages/phoenix-adapter/README.md
+++ b/packages/phoenix-adapter/README.md
@@ -1,13 +1,23 @@
 # @agentv/phoenix-adapter
 
-Converts AgentV eval YAML suites into Phoenix datasets and can run Phoenix experiments while keeping AgentV eval files as the source of truth.
+Internal Phoenix boundary fixtures for AgentV. This package is not the supported
+product path for completed AgentV run artifacts.
 
-Current adapter support is intentionally small: deterministic `contains`, `regex`, `equals`, and `is-json` assertions run through a Phoenix CODE evaluator. LLM, code, trace, composite, metric, and custom evaluator families are reported as unsupported instead of being silently mapped.
+After the 2026-06-20 product decision, AgentV does not export or project
+completed runs, traces, transcripts, datasets, experiments, or indexes into
+Phoenix. AgentV-owned local/Git-backed artifacts and Dashboard remain the
+zero-infra inspection path. Phoenix is optional read-only correlation for
+external traces that were emitted independently and are referenced through safe
+`external_trace` metadata.
+
+The deterministic YAML-to-Phoenix dataset code in this package is retained as an
+internal legacy fixture only. Do not promote it as a public integration path, and
+do not make Dashboard or the zero-infra local path depend on it.
 
 The package also exports `phoenixOtelBackend`, a backend resolver for AgentV's
 local `.agentv/otel-backends/phoenix.mjs` hook. It resolves Phoenix collector
 endpoint, auth headers, and `PHOENIX_PROJECT_NAME` resource routing outside
-`@agentv/core`.
+`@agentv/core`. This remains outside core and must not be required by Dashboard.
 
 ```bash
 bun --filter @agentv/phoenix-adapter phoenix:assert-smoke

--- a/packages/phoenix-adapter/docs/e2e-verification.md
+++ b/packages/phoenix-adapter/docs/e2e-verification.md
@@ -1,8 +1,15 @@
 # E2E Verification
 
+This file documents internal legacy fixture checks only. It is not a supported
+AgentV-to-Phoenix export path. AgentV does not export or project completed runs,
+traces, transcripts, datasets, experiments, or indexes into Phoenix.
+
 ## Dry-Run Conversion
 
-Dry-run mode discovers AgentV example evals, normalizes cases through `@agentv/core`, creates Phoenix dataset payloads in memory, and compares test IDs against AgentV baselines where present.
+Dry-run mode discovers AgentV example evals, normalizes cases through
+`@agentv/core`, builds legacy Phoenix-shaped payloads in memory, and compares
+test IDs against AgentV baselines where present. It does not contact Phoenix and
+does not write AgentV artifacts into Phoenix.
 
 ```bash
 bun run phoenix:assert-smoke
@@ -32,7 +39,11 @@ The failing suites are currently source/baseline or source-reference mismatches,
 
 ## Live Phoenix Smoke
 
-Live mode creates or updates a Phoenix dataset and records a Phoenix experiment. It currently uses the deterministic adapter path, so the best smoke target is `examples/features/assert/evals/dataset.eval.yaml`.
+Live Phoenix dataset/experiment creation is no longer part of the supported
+AgentV product boundary. Do not use live mode as Dashboard verification, a
+zero-infra path, or a public integration promise.
+
+Historical command retained for maintainers investigating the legacy fixture:
 
 ```bash
 (cd packages/phoenix-adapter && bun src/cli.ts run \
@@ -42,7 +53,8 @@ Live mode creates or updates a Phoenix dataset and records a Phoenix experiment.
   --namespace agentv-phoenix-e2e-final)
 ```
 
-The source harness was verified locally against Phoenix at `http://localhost:6006`:
+The source harness was historically verified locally against Phoenix at
+`http://localhost:6006`:
 
 - 4 Phoenix task runs
 - 4 Phoenix evaluator runs

--- a/packages/phoenix-adapter/docs/support-matrix.md
+++ b/packages/phoenix-adapter/docs/support-matrix.md
@@ -1,6 +1,16 @@
 # Phoenix Adapter Support Matrix
 
-This workspace converts AgentV example evals into Phoenix dataset and experiment payloads.
+This is an internal legacy support matrix for the earlier deterministic
+YAML-to-Phoenix adapter fixture. It is not the supported AgentV product path:
+AgentV does not export or project completed runs, traces, transcripts, datasets,
+experiments, or indexes into Phoenix.
+
+The current supported Phoenix boundary is read-only correlation/read-through
+from safe `external_trace` metadata when Codex, Arize, or another hook already
+emitted spans independently.
+
+If the legacy fixture is run for internal parity checks, its deterministic
+coverage is:
 
 | AgentV family | Phoenix status |
 | --- | --- |
@@ -20,4 +30,6 @@ This workspace converts AgentV example evals into Phoenix dataset and experiment
 | `trial-output-consistency` | Reported as unsupported in first pass |
 | Other custom families | Reported as unsupported with the family name |
 
-Unsupported does not block conversion unless `--fail-on-unsupported` is set. The report keeps unsupported families visible so parity gaps are explicit.
+Unsupported does not block legacy fixture conversion unless
+`--fail-on-unsupported` is set. The report keeps unsupported families visible so
+parity gaps are explicit.

--- a/packages/phoenix-adapter/src/agentv/load-spec.ts
+++ b/packages/phoenix-adapter/src/agentv/load-spec.ts
@@ -73,9 +73,10 @@ function collectUnsupported(
  *
  * AgentV eval YAML remains the source of truth: this adapter delegates case expansion,
  * external case files, assertion parsing, Agent Skills `evals.json`, interpolation, and
- * metadata handling to `@agentv/core`'s loader, then projects the result into Phoenix
- * dataset examples. Add Phoenix-specific behavior after this boundary rather than
- * duplicating AgentV YAML semantics in the adapter.
+ * metadata handling to `@agentv/core`'s loader, then normalizes the result for
+ * the legacy Phoenix mapping fixture. This is not an AgentV-to-Phoenix completed
+ * run export path; keep production Phoenix work read-only through external_trace
+ * correlation.
  */
 export async function loadAgentVEvalSuite(source: AgentVSource): Promise<NormalizedSuite> {
   if (!existsSync(source.path)) {

--- a/packages/phoenix-adapter/src/cli.ts
+++ b/packages/phoenix-adapter/src/cli.ts
@@ -9,13 +9,18 @@ function usage(): string {
   return `Usage:
   bun src/cli.ts run --dry-run [--agentv-root ../agentv] [--filter features/assert] [--eval-file path] [--out reports/dry-run.json]
 
+Boundary note:
+  Internal legacy fixture only. AgentV does not export/project completed runs,
+  traces, transcripts, datasets, experiments, or indexes into Phoenix.
+  Dashboard does not depend on Phoenix, px, or Phoenix database tables.
+
 Options:
   --agentv-root <path>       Source AgentV checkout. Defaults to AGENTV_ROOT or ../agentv.
   --eval-file <path>         Run one eval source.
   --filter <text>            Run sources whose repo-relative path contains text.
-  --dry-run                  Convert and verify without contacting Phoenix.
+  --dry-run                  Build and verify a legacy in-memory report without contacting Phoenix.
   --out <path>               JSON report path. Defaults to reports/phoenix-report.json.
-  --namespace <name>         Phoenix dataset name prefix.
+  --namespace <name>         Legacy Phoenix dataset name prefix for internal fixture runs.
   --fail-on-unsupported      Treat unsupported features as failures.
 `;
 }


### PR DESCRIPTION
## Summary

AgentV's Phoenix docs now describe Phoenix as optional read-only external trace context, not a shared UI or projection target for AgentV-owned artifacts. The local Dashboard and Git-backed run bundles remain the supported zero-infra path for runs, traces, sessions, transcripts, comparisons, and result inspection.

This codifies the June 20 Phoenix boundary in strategy, roadmap, agent guidance, a new ADR, and the public Phoenix/Dashboard/results docs. The legacy Phoenix adapter copy is demoted to internal fixture language, and the relevant CLI help now steers users away from Phoenix runtime, `px`, direct database access, or AgentV-to-Phoenix export/projection.

## Verification

- `git diff --check`
- `bun install`
- `bunx biome check apps/cli/src/commands/results/export.ts apps/cli/src/commands/results/serve.ts packages/phoenix-adapter/src/cli.ts packages/phoenix-adapter/src/agentv/load-spec.ts packages/phoenix-adapter/package.json`
- `bun --filter @agentv/web build`
- `bun --filter agentv typecheck` (rerun after core build completed; passed)
- `bun --filter @agentv/phoenix-adapter typecheck`
- `bun apps/cli/src/cli.ts dashboard --help`
- `bun apps/cli/src/cli.ts results export --help`
- `bun packages/phoenix-adapter/src/cli.ts --help`
- `bun --filter @agentv/phoenix-adapter test`

Code review: skipped dedicated review; no Tier 1 tool is available and Tier 2 criteria are not met after keeping the change docs/help-copy scoped.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is docs and help-copy only with no runtime behavior, schema, dependency, or service changes.

CI should validate the docs build and repository checks on the PR. Healthy signal: the docs build passes and the Phoenix docs render under `/docs/integrations/phoenix/`. Failure signal: docs build/link failures or stale copy that still promises Phoenix projection/export; mitigation is a focused docs follow-up or revert of the affected copy.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
