### PR TITLE
fix(beads): guard worktree tracker state

### DIFF
--- a/.agents/workflow.md
+++ b/.agents/workflow.md
@@ -19,7 +19,7 @@ This file expands [AGENTS.md](../AGENTS.md) for day-to-day repo work: tracker ha
 - When working in the primary checkout, stage explicit paths only. Do not commit another agent's files, project-local coordination config, generated evidence, or unrelated tracker or doc state.
 - Use a dedicated git worktree based on the latest `origin/main` for non-trivial, risky, cross-cutting, long-running, or parallel implementation, or whenever the primary checkout is stale or dirty in paths you need.
 - Before starting implementation in a dedicated worktree, verify its `HEAD` is based on the current `origin/main` commit.
-- Before Beads bootstrap, copy `.beads/config.yaml.example` to `.beads/config.yaml` and run `bun run beads:check`. Keep `.beads/metadata.json` tracked; it preserves AgentV's `av` embedded Dolt identity. See [docs/runbooks/beads-worktree-recovery.md](../docs/runbooks/beads-worktree-recovery.md).
+- In worktrees, use plain `bd` commands and let Beads share the primary checkout database through native worktree discovery. Do not use `--db .beads/embeddeddolt` or bootstrap a worktree-local Beads database unless the primary checkout has no hydrated database. Keep `.beads/metadata.json` tracked; it preserves AgentV's `av` embedded Dolt identity. See [docs/runbooks/beads-worktree-recovery.md](../docs/runbooks/beads-worktree-recovery.md).
 
 Manual setup:
 
@@ -35,9 +35,13 @@ cd ../agentv.worktrees/<type>-<short-desc>
 ```bash
 bun install
 cp "$(git worktree list --porcelain | head -1 | sed 's/worktree //')/.env" .env
+bun run beads:check
+bd worktree info
+bd where
 ```
 
-- Both steps are required before running builds, tests, or evals in the worktree.
+- These setup steps are required before running builds, tests, evals, or tracker
+  updates in the worktree.
 - If you discover you are on a stale base or have uncoordinated dirty files, stop and fix that before changing code.
 - Whenever you `git checkout`, `gh pr checkout`, `git pull`, or otherwise switch to a ref that may have changed `package.json` or `bun.lock`, run `bun install` before building or testing.
 

--- a/docs/runbooks/beads-worktree-recovery.md
+++ b/docs/runbooks/beads-worktree-recovery.md
@@ -13,6 +13,11 @@ database `av` and project `a7aea826-0087-45fc-93f5-9084e9924e8b`.
 before running `bd bootstrap`; the example pins both `sync.remote` and
 `federation.remote` to `EntityProcess/agentv-beads`.
 
+Beads supports Git worktrees natively. AgentV worktrees should normally use
+plain `bd` commands and share the primary checkout's hydrated Beads database.
+Do not bootstrap a second worktree-local embedded Dolt database when the
+primary checkout already has `.beads/embeddeddolt`.
+
 ## Preflight
 
 Run the guard before `bd bootstrap`, `bd dolt push`, or `bd federation sync`:
@@ -44,23 +49,51 @@ After creating an AgentV worktree:
 ```bash
 bun install
 cp "$(git worktree list --porcelain | head -1 | sed 's/worktree //')/.env" .env
-cp .beads/config.yaml.example .beads/config.yaml
 bun run beads:check
-bd bootstrap --dry-run
-bd bootstrap
+bd worktree info
+bd where
 ```
 
-Stop if `bd bootstrap --dry-run` plans to sync from
+`bd where` should report the primary checkout's `.beads` path. If it reports
+the worktree's own `.beads/embeddeddolt`, do not run `bd bootstrap` or
+`bd dolt pull` against that local database. Prefer creating future worktrees
+with `bd worktree create`; for an existing manually-created worktree, add a
+checkout-local redirect:
+
+```bash
+primary="$(git worktree list --porcelain | head -1 | sed 's/worktree //')"
+realpath --relative-to=. "$primary/.beads" > .beads/redirect
+bd where
+```
+
+If the primary checkout does not have a hydrated Beads database yet, copy
+`.beads/config.yaml.example` to `.beads/config.yaml` in the primary checkout,
+run `bun run beads:check`, then use `bd bootstrap --dry-run` and `bd bootstrap`.
+Stop if the dry run plans to sync from
 `git+https://github.com/EntityProcess/agentv.git` or database `beads`.
 
 ## Recovery
 
 If `bd --readonly context --json` reports database `beads`, no project ID, or a
 project ID other than `a7aea826-0087-45fc-93f5-9084e9924e8b`, restore the tracked
-identity and local config first:
+identity first:
 
 ```bash
 git restore -- .beads/metadata.json
+```
+
+If this is a linked worktree and `bd where` points at the worktree's own
+`.beads/embeddeddolt`, redirect it to the primary checkout:
+
+```bash
+primary="$(git worktree list --porcelain | head -1 | sed 's/worktree //')"
+realpath --relative-to=. "$primary/.beads" > .beads/redirect
+bun run beads:check
+```
+
+If this is the primary checkout rather than a linked worktree, use local config:
+
+```bash
 cp .beads/config.yaml.example .beads/config.yaml
 bun run beads:check
 ```

--- a/scripts/check-beads-context.ts
+++ b/scripts/check-beads-context.ts
@@ -18,7 +18,7 @@ import {
   rmSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join, relative, resolve } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 
 const root = resolve(import.meta.dirname, '..');
@@ -61,6 +61,8 @@ interface BdContext {
   readonly project_id?: string;
   readonly repo_root?: string;
   readonly beads_dir?: string;
+  readonly is_redirected?: boolean;
+  readonly is_worktree?: boolean;
 }
 
 interface BootstrapPlan {
@@ -339,12 +341,31 @@ function checkBdCurrent(): void {
   );
   if (context) checkContextIdentity(context, 'current bd context');
 
+  const contextBeadsDir = context?.beads_dir ? resolve(context.beads_dir) : undefined;
+  const worktreeBeadsDir = resolve(root, '.beads');
+
+  if (
+    context?.is_worktree &&
+    !context.is_redirected &&
+    context.repo_root &&
+    contextBeadsDir === worktreeBeadsDir
+  ) {
+    const primaryBeadsDir = resolve(context.repo_root, '.beads');
+    const redirectTarget = relative(root, primaryBeadsDir) || '.';
+    record(
+      'ERROR',
+      'worktree Beads is using local tracker state instead of the primary checkout',
+      `repo_root: ${context.repo_root}\nbeads_dir: ${context.beads_dir ?? 'unknown'}`,
+      `Use plain bd commands from a Beads-native worktree, or recover this manual worktree with: printf '%s\\n' "${redirectTarget}" > .beads/redirect`,
+    );
+    return;
+  }
+
   if (context?.repo_root && resolve(context.repo_root) !== root) {
     record(
-      'WARN',
-      'bd context is using a Beads directory outside this checkout',
+      'OK',
+      'bd context uses the primary checkout Beads directory',
       `repo_root: ${context.repo_root}\nbeads_dir: ${context.beads_dir ?? 'unknown'}`,
-      `Use --fixture to verify this branch template. If operating on the shared Beads directory, copy ${configExamplePath} to that checkout's ${configPath}.`,
     );
     return;
   }


### PR DESCRIPTION
## Summary
AgentV worktrees now fail fast when Beads resolves to an empty worktree-local tracker database instead of the primary checkout's hydrated tracker state. The workflow and recovery docs now align with Beads' native worktree support: use plain `bd`, verify `bd worktree info` / `bd where`, and reserve `.beads/redirect` for manual recovery instead of bootstrapping per-worktree Dolt databases.

## Verification
- `bun run beads:check`
- Temporarily moved `.beads/redirect` aside and confirmed `bun run beads:check` fails with the new local-tracker-state diagnostic, then restored the redirect and reran successfully.
