### PR TITLE
docs: standardize contract design references

### DIFF
--- a/.agents/product-boundary.md
+++ b/.agents/product-boundary.md
@@ -73,6 +73,15 @@ If existing primitives cover the need, document the pattern instead of building 
 
 Before adding features, research how peer frameworks solve the problem. Prefer the lowest common denominator that covers most use cases. Novel features without industry precedent need strong justification and should usually start as plugins.
 
+Use public reference standards before inventing AgentV-specific contracts:
+
+- Claude Skills for assertion, expectation, grading, and skill-eval terminology.
+- Vercel agent-eval for fixture-driven agent evals, repeated attempts, hidden verifiers, and result-bundle ergonomics.
+- Hugging Face Datasets for dataset, split, record, and portable corpus conventions.
+- OpenInference for trace, span, tool-call, and model-observability semantics.
+
+Treat these as reference inputs, not dependencies. AgentV should adopt the shared lowest common denominator when it fits the repo-native artifact model, and document any intentional divergence in the relevant plan, ADR, or contract docs.
+
 ### 5. YAGNI - You Aren't Gonna Need It
 
 Do not build features until there is a concrete need. Start with the simplest version that satisfies current demand.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Design guardrails:
 - Prefer core primitives plus plugins or wrappers over new built-ins.
 - Document composition patterns before inventing a new feature.
 - Match industry-standard lowest-common-denominator contracts when possible.
+- When designing AgentV contracts, check public reference standards such as Claude Skills, Vercel agent-eval, Hugging Face Datasets, and OpenInference before inventing AgentV-specific shapes. Use their shared lowest common denominator where it fits, and document any intentional divergence.
 - Apply YAGNI aggressively and solve the current request with the smallest surface that works.
 - Keep extensions non-breaking unless a same-week unreleased surface should be hard-corrected.
 - Design for AI comprehension with self-describing modules, clear extension points, and no dead scaffolding.


### PR DESCRIPTION
## Summary

AgentV contract design guidance now points agents at public reference standards before creating new wire formats or artifact shapes.

## Changes

- Adds Claude Skills, Vercel agent-eval, Hugging Face Datasets, and OpenInference as concrete references in `AGENTS.md`.
- Expands the product-boundary standards section with how to use those references without taking runtime dependencies.

## Testing

Docs-only change. No automated tests run.
