### PR TITLE
feat(dashboard): set run experiment and tags

### DIFF
--- a/apps/cli/src/commands/results/eval-runner.ts
+++ b/apps/cli/src/commands/results/eval-runner.ts
@@ -27,10 +27,11 @@ import { listTargetNames, readTargetDefinitions } from '@agentv/core';
 import type { Context } from 'hono';
 import type { Hono } from 'hono';
 
-import { TARGET_FILE_CANDIDATES, discoverTargetsFile } from '../../utils/targets.js';
+import { TARGET_FILE_CANDIDATES } from '../../utils/targets.js';
 import { discoverEvalFiles } from '../eval/discover.js';
-import { buildDefaultRunDir } from '../eval/result-layout.js';
+import { buildDefaultRunDir, normalizeExperimentName } from '../eval/result-layout.js';
 import { findRepoRoot } from '../eval/shared.js';
+import { normalizeTags, writeRunTags } from './run-tags.js';
 
 // ── In-memory run tracker ────────────────────────────────────────────────
 
@@ -140,6 +141,8 @@ interface RunEvalRequest {
   suite_filter?: string;
   test_ids?: string[];
   target?: string;
+  experiment?: string;
+  tags?: string[];
   threshold?: number;
   workers?: number;
   dry_run?: boolean;
@@ -170,7 +173,27 @@ function validateResumeOptions(req: RunEvalRequest): string | undefined {
   return undefined;
 }
 
-function buildCliArgs(req: RunEvalRequest): string[] {
+function parseInitialTags(value: unknown): string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) {
+    throw new Error('tags must be an array of strings');
+  }
+  return normalizeTags(value);
+}
+
+function normalizeRunMetadata(req: RunEvalRequest): { experiment: string; tags: string[] } {
+  const experiment = normalizeExperimentName(req.experiment);
+  const tags = parseInitialTags(req.tags);
+  if ((req.resume || req.rerun_failed) && req.experiment?.trim()) {
+    throw new Error('experiment cannot be changed when resuming an existing run');
+  }
+  if ((req.resume || req.rerun_failed) && tags.length > 0) {
+    throw new Error('initial tags can only be set when creating a new run');
+  }
+  return { experiment, tags };
+}
+
+function buildCliArgs(req: RunEvalRequest, experiment?: string): string[] {
   const args: string[] = ['eval'];
 
   // Suite filter (eval paths/globs)
@@ -194,6 +217,10 @@ function buildCliArgs(req: RunEvalRequest): string[] {
   // Target override
   if (req.target?.trim()) {
     args.push('--target', req.target.trim());
+  }
+
+  if (experiment && req.experiment?.trim()) {
+    args.push('--experiment', experiment);
   }
 
   // Threshold
@@ -306,6 +333,12 @@ function openConsoleLogStream(outputDir: string): WriteStream | undefined {
   }
 }
 
+function writeInitialRunTags(outputDir: string, tags: readonly string[]): void {
+  if (tags.length === 0) return;
+  mkdirSync(outputDir, { recursive: true });
+  writeRunTags(path.join(outputDir, 'index.jsonl'), tags);
+}
+
 // ── Route registration ───────────────────────────────────────────────────
 
 // biome-ignore lint/suspicious/noExplicitAny: Hono Context generic varies by route
@@ -369,12 +402,19 @@ export function registerEvalRoutes(
       return c.json({ error: resumeError }, 400);
     }
 
+    let metadata: { experiment: string; tags: string[] };
+    try {
+      metadata = normalizeRunMetadata(body);
+    } catch (err) {
+      return c.json({ error: (err as Error).message }, 400);
+    }
+
     const cliPaths = resolveCliPath(cwd);
     if (!cliPaths) {
       return c.json({ error: 'Cannot locate agentv CLI entry point' }, 500);
     }
 
-    const args = buildCliArgs(body);
+    const args = buildCliArgs(body, metadata.experiment);
     // Determine the output directory for this run. When the caller provides
     // an explicit --output (resume/rerun), use that path. Otherwise generate
     // the default path now so we can pass it via --output and later correlate
@@ -382,7 +422,7 @@ export function registerEvalRoutes(
     // target in the sidebar before any results have been written).
     const outputDir = body.output?.trim()
       ? path.resolve(cwd, body.output.trim())
-      : buildDefaultRunDir(cwd);
+      : buildDefaultRunDir(cwd, metadata.experiment);
     if (!body.output?.trim()) {
       args.push('--output', outputDir);
     }
@@ -402,6 +442,7 @@ export function registerEvalRoutes(
     activeRuns.set(runId, run);
 
     try {
+      writeInitialRunTags(outputDir, metadata.tags);
       const child = spawn(cliPaths.binPath, [...cliPaths.args, ...args], {
         cwd,
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -537,7 +578,14 @@ export function registerEvalRoutes(
       return c.json({ error: 'Invalid JSON body' }, 400);
     }
 
-    const args = buildCliArgs(body);
+    let metadata: { experiment: string; tags: string[] };
+    try {
+      metadata = normalizeRunMetadata(body);
+    } catch (err) {
+      return c.json({ error: (err as Error).message }, 400);
+    }
+
+    const args = buildCliArgs(body, metadata.experiment);
     return c.json({ command: buildCliPreview(args) });
   });
 
@@ -590,15 +638,22 @@ export function registerEvalRoutes(
       return c.json({ error: resumeError }, 400);
     }
 
+    let metadata: { experiment: string; tags: string[] };
+    try {
+      metadata = normalizeRunMetadata(body);
+    } catch (err) {
+      return c.json({ error: (err as Error).message }, 400);
+    }
+
     const cliPaths = resolveCliPath(cwd);
     if (!cliPaths) {
       return c.json({ error: 'Cannot locate agentv CLI entry point' }, 500);
     }
 
-    const args = buildCliArgs(body);
+    const args = buildCliArgs(body, metadata.experiment);
     const outputDir = body.output?.trim()
       ? path.resolve(cwd, body.output.trim())
-      : buildDefaultRunDir(cwd);
+      : buildDefaultRunDir(cwd, metadata.experiment);
     if (!body.output?.trim()) {
       args.push('--output', outputDir);
     }
@@ -618,6 +673,7 @@ export function registerEvalRoutes(
     activeRuns.set(runId, run);
 
     try {
+      writeInitialRunTags(outputDir, metadata.tags);
       const child = spawn(cliPaths.binPath, [...cliPaths.args, ...args], {
         cwd,
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -721,7 +777,13 @@ export function registerEvalRoutes(
     } catch {
       return c.json({ error: 'Invalid JSON body' }, 400);
     }
-    const args = buildCliArgs(body);
+    let metadata: { experiment: string; tags: string[] };
+    try {
+      metadata = normalizeRunMetadata(body);
+    } catch (err) {
+      return c.json({ error: (err as Error).message }, 400);
+    }
+    const args = buildCliArgs(body, metadata.experiment);
     return c.json({ command: buildCliPreview(args) });
   });
 }

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -4041,7 +4041,7 @@ describe('serve app', () => {
       expect(res.status).toBe(202);
       const data = (await res.json()) as { command: string };
       expect(data.command).toContain('--experiment smoke');
-      expect(data.command).toContain(path.join('.agentv', 'results', 'runs', 'smoke'));
+      expect(data.command).toContain(path.join('.agentv', 'results', 'smoke'));
       const outputDir = data.command.match(/--output ([^\s]+)/)?.[1];
       expect(outputDir).toBeString();
 

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -4026,6 +4026,33 @@ describe('serve app', () => {
       expect(data.command).toContain('--output .agentv/results/default/r1');
     });
 
+    it('builds a selected experiment output path and writes initial tags beside the new run', async () => {
+      const app = makeAppForRun();
+      const res = await app.request('/api/eval/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          suite_filter: 'examples/demo.eval.yaml',
+          experiment: 'smoke',
+          tags: [' baseline ', 'baseline', 'prompt-v2'],
+        }),
+      });
+
+      expect(res.status).toBe(202);
+      const data = (await res.json()) as { command: string };
+      expect(data.command).toContain('--experiment smoke');
+      expect(data.command).toContain(path.join('.agentv', 'results', 'runs', 'smoke'));
+      const outputDir = data.command.match(/--output ([^\s]+)/)?.[1];
+      expect(outputDir).toBeString();
+
+      const tagFile = JSON.parse(
+        readFileSync(path.join(outputDir as string, 'tags.json'), 'utf8'),
+      ) as {
+        tags: string[];
+      };
+      expect(tagFile.tags).toEqual(['baseline', 'prompt-v2']);
+    });
+
     it('builds --retry-errors <path> from the request', async () => {
       const app = makeAppForRun();
       const res = await app.request('/api/eval/run', {
@@ -4071,6 +4098,23 @@ describe('serve app', () => {
         }),
       });
       expect(res.status).toBe(400);
+    });
+
+    it('rejects initial tags when resuming an existing run', async () => {
+      const app = makeAppForRun();
+      const res = await app.request('/api/eval/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          suite_filter: 'examples/demo.eval.yaml',
+          output: 'runs/r1',
+          resume: true,
+          tags: ['baseline'],
+        }),
+      });
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as { error: string };
+      expect(data.error).toContain('creating a new run');
     });
 
     it('returns 403 in read-only mode for unscoped /api/eval/run', async () => {
@@ -4204,6 +4248,44 @@ describe('serve app', () => {
       expect(res.status).toBe(200);
       const data = (await res.json()) as { command: string };
       expect(data.command).toContain('--retry-errors .agentv/results/default/r0/index.jsonl');
+    });
+
+    it('emits --experiment for selected experiment requests', async () => {
+      const app = createApp([], tempDir, undefined, undefined, { studioDir });
+      const res = await app.request('/api/eval/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          suite_filter: 'examples/demo.eval.yaml',
+          experiment: 'smoke',
+        }),
+      });
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { command: string };
+      expect(data.command).toContain('--experiment smoke');
+    });
+
+    it('rejects invalid experiment and tag values', async () => {
+      const app = createApp([], tempDir, undefined, undefined, { studioDir });
+      const badExperiment = await app.request('/api/eval/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          suite_filter: 'examples/demo.eval.yaml',
+          experiment: 'bad/name',
+        }),
+      });
+      expect(badExperiment.status).toBe(400);
+
+      const badTag = await app.request('/api/eval/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          suite_filter: 'examples/demo.eval.yaml',
+          tags: ['good', 'bad\nvalue'],
+        }),
+      });
+      expect(badTag.status).toBe(400);
     });
   });
 

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -4107,7 +4107,7 @@ describe('serve app', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           suite_filter: 'examples/demo.eval.yaml',
-          output: 'runs/r1',
+          output: '.agentv/results/default/r1',
           resume: true,
           tags: ['baseline'],
         }),

--- a/apps/dashboard/src/components/RunEvalModal.tsx
+++ b/apps/dashboard/src/components/RunEvalModal.tsx
@@ -36,6 +36,8 @@ import {
   getThresholdFieldValue,
 } from './run-eval-threshold';
 
+const DEFAULT_EXPERIMENT = 'default';
+
 // ── Props ────────────────────────────────────────────────────────────────
 
 export interface RunEvalModalProps {
@@ -60,6 +62,9 @@ export function RunEvalModal({ open, onClose, projectId, prefill }: RunEvalModal
   const [testIdInput, setTestIdInput] = useState('');
   const [testIds, setTestIds] = useState<string[]>(prefill?.testIds ?? []);
   const [target, setTarget] = useState(prefill?.target ?? '');
+  const [experiment, setExperiment] = useState(DEFAULT_EXPERIMENT);
+  const [tagInput, setTagInput] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
   const [threshold, setThreshold] = useState('');
   const [thresholdEdited, setThresholdEdited] = useState(false);
   const [workers, setWorkers] = useState('');
@@ -102,6 +107,9 @@ export function RunEvalModal({ open, onClose, projectId, prefill }: RunEvalModal
       setSuiteFilter(prefill?.suiteFilter ?? '');
       setTestIds(prefill?.testIds ?? []);
       setTarget(prefill?.target ?? '');
+      setExperiment(DEFAULT_EXPERIMENT);
+      setTagInput('');
+      setTags([]);
       setTestIdInput('');
       setThreshold('');
       setThresholdEdited(false);
@@ -125,16 +133,30 @@ export function RunEvalModal({ open, onClose, projectId, prefill }: RunEvalModal
 
   // Build request body from form state
   const buildRequest = useCallback((): RunEvalRequest => {
+    const effectiveTags = mergeUniqueTags(tags, parseTagsInput(tagInput));
     return buildRunEvalRequest({
       suiteFilter,
       testIds,
       target,
+      experiment,
+      tags: effectiveTags,
       thresholdInput: threshold,
       studioThreshold: studioConfig?.threshold,
       workers,
       dryRun,
     });
-  }, [dryRun, studioConfig?.threshold, suiteFilter, target, testIds, threshold, workers]);
+  }, [
+    dryRun,
+    experiment,
+    studioConfig?.threshold,
+    suiteFilter,
+    tagInput,
+    tags,
+    target,
+    testIds,
+    threshold,
+    workers,
+  ]);
 
   // Update CLI preview when form changes
   useEffect(() => {
@@ -159,6 +181,18 @@ export function RunEvalModal({ open, onClose, projectId, prefill }: RunEvalModal
 
   function removeTestId(id: string) {
     setTestIds(testIds.filter((t) => t !== id));
+  }
+
+  function addTagsFromInput() {
+    const nextTags = parseTagsInput(tagInput);
+    if (nextTags.length > 0) {
+      setTags(mergeUniqueTags(tags, nextTags));
+    }
+    setTagInput('');
+  }
+
+  function removeTag(tag: string) {
+    setTags(tags.filter((t) => t !== tag));
   }
 
   // Launch
@@ -312,6 +346,81 @@ export function RunEvalModal({ open, onClose, projectId, prefill }: RunEvalModal
           </select>
         </div>
 
+        {/* Run metadata */}
+        <div className="rounded-md border border-gray-800 bg-gray-950/40 p-3">
+          <div className="grid gap-3 sm:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+            <div>
+              <label
+                htmlFor="experiment-input"
+                className="mb-1 block text-xs font-medium text-gray-400"
+              >
+                Experiment
+              </label>
+              <input
+                id="experiment-input"
+                type="text"
+                value={experiment}
+                onChange={(e) => setExperiment(e.target.value)}
+                placeholder={DEFAULT_EXPERIMENT}
+                className="w-full rounded-md border border-gray-700 bg-gray-800 px-3 py-1.5 text-sm text-white placeholder-gray-500 focus:border-cyan-600 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label htmlFor="tags-input" className="mb-1 block text-xs font-medium text-gray-400">
+                Tags
+              </label>
+              <div className="flex gap-2">
+                <input
+                  id="tags-input"
+                  type="text"
+                  value={tagInput}
+                  onChange={(e) => setTagInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ',') {
+                      e.preventDefault();
+                      addTagsFromInput();
+                    }
+                  }}
+                  onBlur={addTagsFromInput}
+                  placeholder="baseline, prompt-v2"
+                  className="min-w-0 flex-1 rounded-md border border-gray-700 bg-gray-800 px-3 py-1.5 text-sm text-white placeholder-gray-500 focus:border-cyan-600 focus:outline-none"
+                />
+                <button
+                  type="button"
+                  onClick={addTagsFromInput}
+                  disabled={!tagInput.trim()}
+                  className="rounded-md bg-gray-700 px-3 py-1.5 text-sm text-white hover:bg-gray-600 disabled:opacity-50"
+                >
+                  Add
+                </button>
+              </div>
+            </div>
+          </div>
+          {tags.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-1">
+              {tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="inline-flex items-center gap-1 rounded-md border border-cyan-900/60 bg-cyan-950/30 px-2 py-0.5 text-xs font-medium text-cyan-300"
+                >
+                  {tag}
+                  <button
+                    type="button"
+                    onClick={() => removeTag(tag)}
+                    className="text-cyan-400 hover:text-white"
+                    aria-label={`Remove tag ${tag}`}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+          <p className="mt-2 text-xs text-gray-500">
+            Saved with the new run only; existing runs stay unchanged.
+          </p>
+        </div>
+
         {/* Advanced options */}
         <div>
           <button
@@ -412,6 +521,24 @@ export function RunEvalModal({ open, onClose, projectId, prefill }: RunEvalModal
 
 // ── Sub-components ───────────────────────────────────────────────────────
 
+function parseTagsInput(value: string): string[] {
+  return value
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0);
+}
+
+function mergeUniqueTags(existing: string[], incoming: string[]): string[] {
+  const seen = new Set(existing);
+  const merged = [...existing];
+  for (const tag of incoming) {
+    if (seen.has(tag)) continue;
+    seen.add(tag);
+    merged.push(tag);
+  }
+  return merged;
+}
+
 function ModalShell({
   children,
   onClose,
@@ -423,7 +550,7 @@ function ModalShell({
 }) {
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 pt-[10vh]">
-      <div className="w-full max-w-lg rounded-lg border border-gray-700 bg-gray-900 shadow-xl">
+      <div className="max-h-[80vh] w-full max-w-lg overflow-y-auto rounded-lg border border-gray-700 bg-gray-900 shadow-xl">
         <div className="flex items-center justify-between border-b border-gray-800 px-5 py-3">
           <h2 className="text-lg font-semibold text-white">{title}</h2>
           <button type="button" onClick={onClose} className="text-gray-400 hover:text-white">

--- a/apps/dashboard/src/components/run-eval-threshold.test.ts
+++ b/apps/dashboard/src/components/run-eval-threshold.test.ts
@@ -27,6 +27,8 @@ describe('buildRunEvalRequest', () => {
         suiteFilter: 'evals/**/*.eval.yaml',
         testIds: [],
         target: '',
+        experiment: '',
+        tags: [],
         thresholdInput: '',
         studioThreshold: 0.75,
         workers: '',
@@ -44,6 +46,8 @@ describe('buildRunEvalRequest', () => {
         suiteFilter: 'evals/**/*.eval.yaml',
         testIds: [],
         target: '',
+        experiment: '',
+        tags: [],
         thresholdInput: '0.9',
         studioThreshold: 0.75,
         workers: '',
@@ -52,6 +56,27 @@ describe('buildRunEvalRequest', () => {
     ).toEqual({
       suite_filter: 'evals/**/*.eval.yaml',
       threshold: 0.9,
+    });
+  });
+
+  it('submits launch metadata when experiment and tags are set', () => {
+    expect(
+      buildRunEvalRequest({
+        suiteFilter: 'evals/**/*.eval.yaml',
+        testIds: [],
+        target: '',
+        experiment: 'smoke',
+        tags: ['baseline', 'prompt-v2'],
+        thresholdInput: '',
+        studioThreshold: 0.75,
+        workers: '',
+        dryRun: false,
+      }),
+    ).toEqual({
+      suite_filter: 'evals/**/*.eval.yaml',
+      experiment: 'smoke',
+      tags: ['baseline', 'prompt-v2'],
+      threshold: 0.75,
     });
   });
 });

--- a/apps/dashboard/src/components/run-eval-threshold.ts
+++ b/apps/dashboard/src/components/run-eval-threshold.ts
@@ -5,6 +5,8 @@ interface BuildRunEvalRequestOptions {
   suiteFilter: string;
   testIds: string[];
   target: string;
+  experiment: string;
+  tags: string[];
   thresholdInput: string;
   studioThreshold?: number;
   workers: string;
@@ -38,6 +40,8 @@ export function buildRunEvalRequest({
   suiteFilter,
   testIds,
   target,
+  experiment,
+  tags,
   thresholdInput,
   studioThreshold,
   workers,
@@ -48,6 +52,8 @@ export function buildRunEvalRequest({
   if (suiteFilter.trim()) req.suite_filter = suiteFilter.trim();
   if (testIds.length > 0) req.test_ids = testIds;
   if (target) req.target = target;
+  if (experiment.trim()) req.experiment = experiment.trim();
+  if (tags.length > 0) req.tags = tags;
 
   const resolvedThreshold = getDefaultThresholdInputValue(thresholdInput, studioThreshold);
   if (resolvedThreshold) req.threshold = Number.parseFloat(resolvedThreshold);

--- a/apps/dashboard/src/lib/types.ts
+++ b/apps/dashboard/src/lib/types.ts
@@ -564,6 +564,8 @@ export interface RunEvalRequest {
   suite_filter?: string;
   test_ids?: string[];
   target?: string;
+  experiment?: string;
+  tags?: string[];
   threshold?: number;
   workers?: number;
   dry_run?: boolean;

--- a/apps/web/src/content/docs/docs/tools/dashboard.mdx
+++ b/apps/web/src/content/docs/docs/tools/dashboard.mdx
@@ -111,6 +111,8 @@ In the per-test results table, click a test ID to open its checks, transcript, s
 
 In Recent Runs, select local completed runs to combine partial runs or delete stale run workspaces. Combine creates a new local run workspace and leaves the source runs in place. If all selected runs are from one experiment, the combined run inherits that experiment, including `default`; if selected runs span experiments, Dashboard asks for a new experiment name before creating the combined run. Delete removes the selected local run workspace directory, including sidecars such as `tags.json`; remote runs are read-only.
 
+When you launch an eval from Dashboard, set the experiment and initial tags before the run starts. The selected experiment is recorded with the new run, and tags are written to that run workspace's `tags.json` sidecar; existing runs are not changed.
+
 The same deletion primitive is available from the CLI:
 
 ```bash


### PR DESCRIPTION
## Summary

- Add Experiment and Tags controls to the Dashboard Run Eval modal.
- Send `experiment` and `tags` in the run-launch API request using the existing snake_case wire contract.
- Validate experiment names and tags server-side before spawning the eval process.
- Pass `--experiment` to the CLI and write initial tags to the new run workspace's `tags.json` sidecar.
- Keep resume/rerun flows from changing experiment or setting initial tags on existing runs.

## Notes

This branch was rebased after PR #1489, so new Dashboard-created runs now follow `.agentv/results/<experiment>/<timestamp>/` through `buildDefaultRunDir()`.

No dogfood screenshots or browser evidence are committed to this public repo. Any future UAT evidence should be stored on an `agentv-private` evidence branch.

## Worker validation

The worker reported these checks on the original branch before the artifact-layout rebase:

- `bun test apps/dashboard/src/components/run-eval-threshold.test.ts`
- `bun --filter @agentv/sdk build`
- `bun test apps/cli/test/commands/results/serve.test.ts -t "POST /api/eval"`
- `bunx biome check ...changed TS files...`
- `bun --filter agentv typecheck`
- `bun --filter @agentv/dashboard build`
- Browser UAT with agent-browser on desktop/mobile modal flows

GitHub Actions is the merge gate for the rebased branch.
