### PR TITLE
fix(pi-cli): route endpoint overrides through azure provider

### DIFF
--- a/packages/core/src/evaluation/providers/pi-provider-aliases.ts
+++ b/packages/core/src/evaluation/providers/pi-provider-aliases.ts
@@ -9,8 +9,10 @@
  * (openai-responses) since v1 endpoints don't accept api-version params.
  * Without base_url, uses the native azure-openai-responses provider.
  *
- * **pi CLI:** Always uses azure-openai-responses with AZURE_OPENAI_RESOURCE_NAME.
- * The CLI's azure provider builds the correct URL internally.
+ * **pi CLI:** Uses azure-openai-responses for Azure and OpenAI-compatible
+ * endpoint overrides. The CLI's Azure provider accepts full endpoint URLs via
+ * AZURE_OPENAI_BASE_URL, while its OpenAI provider treats --api-key as the
+ * hosted OpenAI path.
  */
 
 /** Short alias → pi-ai SDK provider name (when no base_url override). */

--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -1940,6 +1940,7 @@ function resolvePiCliConfig(
     allowLiteral: true,
     optionalEnv: true,
   });
+  const piCliSubprovider = normalizePiCliSubprovider(subprovider, baseUrl);
 
   const tools = resolveOptionalString(toolsSource, env, `${target.name} pi-cli tools`, {
     allowLiteral: true,
@@ -1976,7 +1977,7 @@ function resolvePiCliConfig(
 
   return {
     executable,
-    subprovider,
+    subprovider: piCliSubprovider,
     model,
     apiKey,
     baseUrl,
@@ -1990,6 +1991,20 @@ function resolvePiCliConfig(
     streamLog: streamLogResult.streamLog,
     systemPrompt,
   };
+}
+
+function normalizePiCliSubprovider(
+  subprovider: string | undefined,
+  baseUrl: string | undefined,
+): string | undefined {
+  if (!baseUrl) return subprovider;
+  if (!subprovider || subprovider.toLowerCase() === 'openai') {
+    // PI CLI's OpenAI provider treats --api-key as a real OpenAI key path.
+    // OpenAI-compatible endpoints work reliably through its Azure provider,
+    // which accepts full endpoint URLs via AZURE_OPENAI_BASE_URL.
+    return 'azure';
+  }
+  return subprovider;
 }
 
 function resolveClaudeConfig(

--- a/packages/core/test/evaluation/providers/targets.test.ts
+++ b/packages/core/test/evaluation/providers/targets.test.ts
@@ -1406,6 +1406,65 @@ describe('createProvider', () => {
     expect(resolved.config.apiKey).toBe('azure-secret');
   });
 
+  it('normalizes pi-cli openai base_url targets to azure for PI CLI compatibility', () => {
+    const resolved = resolveTargetDefinition(
+      {
+        name: 'pi-cli-openai-compatible',
+        provider: 'pi-cli',
+        subprovider: 'openai',
+        base_url: 'http://127.0.0.1:10531/v1',
+        api_key: '${{ OPENAI_API_KEY }}',
+        model: 'gpt-5.3-codex-spark',
+      },
+      { OPENAI_API_KEY: 'local-key' },
+    );
+
+    expect(resolved.kind).toBe('pi-cli');
+    if (resolved.kind !== 'pi-cli') throw new Error('expected pi-cli');
+    expect(resolved.config.subprovider).toBe('azure');
+    expect(resolved.config.baseUrl).toBe('http://127.0.0.1:10531/v1');
+    expect(resolved.config.apiKey).toBe('local-key');
+  });
+
+  it('defaults pi-cli base_url targets to azure when subprovider is omitted', () => {
+    const resolved = resolveTargetDefinition(
+      {
+        name: 'pi-cli-local-endpoint',
+        provider: 'pi-cli',
+        base_url: '${{ AGENTV_OPENAI_BASE_URL }}',
+        api_key: '${{ AGENTV_OPENAI_API_KEY }}',
+        model: 'gpt-5.3-codex-spark',
+      },
+      {
+        AGENTV_OPENAI_BASE_URL: 'http://127.0.0.1:10531/v1',
+        AGENTV_OPENAI_API_KEY: 'local-key',
+      },
+    );
+
+    expect(resolved.kind).toBe('pi-cli');
+    if (resolved.kind !== 'pi-cli') throw new Error('expected pi-cli');
+    expect(resolved.config.subprovider).toBe('azure');
+    expect(resolved.config.baseUrl).toBe('http://127.0.0.1:10531/v1');
+  });
+
+  it('keeps pi-cli openai targets on openai when no base_url is configured', () => {
+    const resolved = resolveTargetDefinition(
+      {
+        name: 'pi-cli-openai',
+        provider: 'pi-cli',
+        subprovider: 'openai',
+        api_key: '${{ OPENAI_API_KEY }}',
+        model: 'gpt-4o',
+      },
+      { OPENAI_API_KEY: 'real-openai-key' },
+    );
+
+    expect(resolved.kind).toBe('pi-cli');
+    if (resolved.kind !== 'pi-cli') throw new Error('expected pi-cli');
+    expect(resolved.config.subprovider).toBe('openai');
+    expect(resolved.config.baseUrl).toBeUndefined();
+  });
+
   it('resolves pi-cli thinking level from env-backed config', () => {
     const resolved = resolveTargetDefinition(
       {


### PR DESCRIPTION
## Summary
- Normalize pi-cli targets that use a base_url with no subprovider or subprovider: openai to the PI CLI Azure provider path.
- Preserve real OpenAI pi-cli targets when no base_url is configured.
- Document why PI CLI endpoint overrides use Azure env wiring and add resolver coverage.

## Validation
- bun node_modules/.bin/biome check --write packages/core/src/evaluation/providers/pi-provider-aliases.ts packages/core/src/evaluation/providers/targets.ts packages/core/test/evaluation/providers/targets.test.ts
- bun test packages/core/test/evaluation/providers/targets.test.ts
- bun --filter @agentv/core build