### PR TITLE
fix(docker): drop COPY of removed phoenix-adapter package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /app
 COPY package.json bun.lock ./
 COPY packages/core/package.json packages/core/
 COPY packages/sdk/package.json packages/sdk/
-COPY packages/phoenix-adapter/package.json packages/phoenix-adapter/
 COPY apps/cli/package.json apps/cli/
 COPY apps/dashboard/package.json apps/dashboard/
 COPY apps/web/package.json apps/web/
@@ -60,8 +59,6 @@ COPY --from=build /app/packages/core/dist ./packages/core/dist
 COPY --from=build /app/packages/core/package.json ./packages/core/
 COPY --from=build /app/packages/sdk/dist ./packages/sdk/dist
 COPY --from=build /app/packages/sdk/package.json ./packages/sdk/
-COPY --from=build /app/packages/phoenix-adapter/dist ./packages/phoenix-adapter/dist
-COPY --from=build /app/packages/phoenix-adapter/package.json ./packages/phoenix-adapter/
 COPY --from=build /app/apps/cli/dist ./apps/cli/dist
 COPY --from=build /app/apps/cli/package.json ./apps/cli/
 COPY --from=build /app/apps/cli/node_modules ./apps/cli/node_modules


### PR DESCRIPTION
## Problem

A fresh `docker build` on `main` fails:

```
Step 6/39 : COPY packages/phoenix-adapter/package.json packages/phoenix-adapter/
COPY failed: file not found in build context or excluded by .dockerignore:
stat packages/phoenix-adapter/package.json: file does not exist
```

Commit `93fc317e` ("refactor: remove private Phoenix adapter package") deleted
`packages/phoenix-adapter` from the tree but left three `COPY` lines referencing
it in the `Dockerfile` (one in the build stage, two in the runtime stage).

## Fix

Remove the three dead `COPY packages/phoenix-adapter/...` lines. `bun.lock` no
longer references the package and `git ls-tree main packages/` shows only `core`
and `sdk`, so nothing else needs to change. The image builds and runs again.

## Verification

- `docker build .` succeeds end to end (36 steps) and the resulting image serves
  the dashboard normally.