### PR TITLE
fix(dashboard): show file contents inline in run Files tab

### DIFF
--- a/apps/dashboard/src/components/EvalDetail.tsx
+++ b/apps/dashboard/src/components/EvalDetail.tsx
@@ -76,7 +76,7 @@ export function EvalDetail({ eval: result, runId, projectId }: EvalDetailProps) 
   };
 
   return (
-    <div className="flex min-h-full flex-col">
+    <div className="flex h-full min-h-full flex-col">
       {/* Tab navigation — at the top so Files tab editor fills maximum height */}
       <div className="border-b border-gray-800">
         <div className="flex gap-1 px-4">


### PR DESCRIPTION
## Problem
On the run/results detail view, selecting the **Files** tab shows the file list but the file content pane renders **blank**. The content only appears via **Full Page**.

## Root cause
The inline run-detail panel renders `EvalDetail` inside a fixed-height block container (`h-[36rem] … overflow-hidden`), but `EvalDetail`'s root used only `min-h-full` (min-height; `height: auto` → indefinite). Percentage heights cascade only from a definite-height ancestor, so every `h-full` descendant down to the Monaco viewer (`height="100%"`) collapsed to 0px. Full Page works because there `EvalDetail` is a flex item of a `flex flex-col` parent, giving it a definite height.

## Fix
`apps/dashboard/src/components/EvalDetail.tsx` root: `flex min-h-full flex-col` → `flex h-full min-h-full flex-col`. `h-full` makes the height definite regardless of parent type; `min-h-full` kept so Full Page is unchanged.

## Validation
- `apps/dashboard` `tsc -b && vite build` → ✓
- `apps/dashboard` `bun test` → 122 pass, 0 fail