### PR TITLE
fix(results): push same-repo results to project origin, not a synthesized URL

### DIFF
--- a/packages/core/src/evaluation/results-repo.ts
+++ b/packages/core/src/evaluation/results-repo.ts
@@ -252,11 +252,27 @@ export function normalizeResultsConfig(
   };
 }
 
+// GitHub `owner/repo` shorthand: exactly two non-empty path segments and no
+// scheme, host, or extra slashes. A bare local path like `.` does not match
+// (no `/`), so it is never expanded into a clone URL.
+const GITHUB_OWNER_REPO_SHORTHAND = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+function isExplicitRemoteUrl(value: string): boolean {
+  return value.includes('://') || value.startsWith('git@');
+}
+
 export function resolveResultsRepoUrl(repo: string): string {
-  if (repo.includes('://') || repo.startsWith('git@')) {
-    return repo;
+  const trimmed = repo.trim();
+  if (isExplicitRemoteUrl(trimmed)) {
+    return trimmed;
   }
-  return `https://github.com/${repo}.git`;
+  // Only genuine GitHub `owner/repo` shorthand is expanded to a clone URL.
+  // Local paths (including `.`) and other non-URL values are returned unchanged
+  // so we never synthesize a bogus URL such as `https://github.com/..git`.
+  if (GITHUB_OWNER_REPO_SHORTHAND.test(trimmed)) {
+    return `https://github.com/${trimmed}.git`;
+  }
+  return trimmed;
 }
 
 export function getResultsRepoLocalPaths(repo: string): ResultsRepoLocalPaths {
@@ -606,6 +622,13 @@ async function ensureResultsRepoRemote(
   }
 
   const remoteUrl = resolveResultsRepoUrl(config.repo_url);
+  // Same-repo results push to the project's existing remote (typically
+  // `origin`). Never rewrite that remote to a value that is not a real Git
+  // remote URL (e.g. a local results path or `.`), which would otherwise
+  // clobber a correct origin with a synthesized URL.
+  if (!isExplicitRemoteUrl(remoteUrl)) {
+    return;
+  }
   const { stdout } = await runGit(['remote', 'get-url', config.remote], {
     cwd: repoDir,
     check: false,

--- a/packages/core/test/evaluation/results-repo.test.ts
+++ b/packages/core/test/evaluation/results-repo.test.ts
@@ -29,6 +29,7 @@ import {
   normalizeResultsConfig,
   pushWipCheckpoint,
   readGitResultArtifact,
+  resolveResultsRepoUrl,
   setupWipWorktree,
   syncResultsRepo,
   syncResultsRepoForProject,
@@ -529,6 +530,32 @@ describe('listGitRuns', () => {
 
     await materializeGitRun(repoDir, 'branch-only/2026-06-12T10-00-00-000Z', 'agentv-results');
     expect(readFileSync(path.join(runDir, 'attachments.txt'), 'utf8')).toBe('from branch\n');
+  });
+});
+
+describe('resolveResultsRepoUrl', () => {
+  it('expands genuine GitHub owner/repo shorthand to a clone URL', () => {
+    expect(resolveResultsRepoUrl('EntityProcess/agentv')).toBe(
+      'https://github.com/EntityProcess/agentv.git',
+    );
+  });
+
+  it('returns explicit remote URLs unchanged', () => {
+    expect(resolveResultsRepoUrl('https://github.com/example/source.git')).toBe(
+      'https://github.com/example/source.git',
+    );
+    expect(resolveResultsRepoUrl('git@github.com:example/source.git')).toBe(
+      'git@github.com:example/source.git',
+    );
+    expect(resolveResultsRepoUrl('file:///tmp/results.git')).toBe('file:///tmp/results.git');
+  });
+
+  it('never synthesizes a GitHub URL from a local path like "."', () => {
+    // Regression: same-repo results (`repo_path: .`) previously produced the
+    // malformed remote `https://github.com/..git` and overrode the project's
+    // correct origin. A local path must be returned unchanged.
+    expect(resolveResultsRepoUrl('.')).toBe('.');
+    expect(resolveResultsRepoUrl('/data/repos/WTG.AI.Prompts')).toBe('/data/repos/WTG.AI.Prompts');
   });
 });
 


### PR DESCRIPTION
## Problem
For a project whose results live in the same repo (`results.repo_path: .`, `remote: origin`), clicking **Push results** (or auto-push) fails:
```
git push --porcelain origin refs/heads/agentv/results/v1:...
remote: Not Found
fatal: repository 'https://github.com/..git/' not found
```
Even after `git remote set-url origin <correct>`, the push still targets `https://github.com/..git` — AgentV re-derives and rewrites the remote itself.

## Root cause
`resolveResultsRepoUrl()` synthesized a GitHub URL from **any** non-URL string:
`return \`https://github.com/${repo}.git\`` (`packages/core/src/evaluation/results-repo.ts`). With `repo_path: .`, `normalizeResultsConfig` sets `repo = '.'`, so `resolveResultsRepoUrl('.')` → `https://github.com/` + `.` + `.git` = `https://github.com/..git`. That value is then written via `ensureResultsRepoRemote()` (`git remote set-url`), clobbering the correct `origin`.

## Fix (`packages/core/src/evaluation/results-repo.ts`)
- `resolveResultsRepoUrl()` only expands genuine GitHub `owner/repo` shorthand (`/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/`); explicit URLs pass through; local paths (incl. `.`) are returned unchanged.
- `ensureResultsRepoRemote()` refuses to rewrite an existing remote to a non-URL value, so same-repo results keep using the project's real `origin`. Separate-repo (`repo_url`) behaviour is preserved.

## Validation
- `bun run --filter @agentv/core typecheck` → ✓
- `bun test packages/core/test/evaluation/results-repo.test.ts` → 56 pass, 0 fail (3 new regression tests)