### PR TITLE
fix(results): nest artifacts by suite and target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,9 @@ Read the full rationale and examples in [.agents/product-boundary.md](.agents/pr
 - For browser or screenshot UAT, keep evidence out of the public repo and publish reviewable artifacts to an `agentv-private` evidence branch. See [.agents/verification.md](.agents/verification.md).
 - Wire formats are `snake_case`; internal TypeScript is `camelCase`. Translate only at the boundary.
 - In AgentV, a `project` holds runs, traces, and experiments; a `benchmark` is a curated eval suite. Do not collapse those terms.
+- Treat experiments as persisted run profiles, eval suites as task contracts with optional fallback targets, and cases files as reusable case data. Do not collapse those layers.
 - Treat run-root `index.jsonl` as the stable manifest and discovery anchor. Dashboard and other readers should follow explicit manifest paths such as `artifact_dir`, `metrics_path`, and `grading_path` instead of deriving meaning from folder depth, so future physical layout changes do not break readers.
+- Prefer human-readable result artifact directories under `<suite>/<case-id>/run-N`, adding `<target>` between case and run only for multi-target runs. Keep `index.jsonl` path fields authoritative.
 - `artifact_pointers` are an offload indirection for large detached payload bytes, such as trace and transcript artifacts. Do not use them as the discovery path for ordinary per-case sidecars; expose those with explicit index/manifest path fields such as `metrics_path`.
 
 ## Repo Map

--- a/apps/cli/test/commands/eval/artifact-writer.test.ts
+++ b/apps/cli/test/commands/eval/artifact-writer.test.ts
@@ -1568,7 +1568,7 @@ describe('writeArtifactsFromResults', () => {
     expect(grading.assertions[0].text).toBe('baseline-check');
   });
 
-  it('writes case artifacts at the run root when suite is present', async () => {
+  it('nests case artifacts under the suite when suite is present', async () => {
     const paths = await writeArtifactsFromResults(
       [makeResult({ suite: 'eval-top-months-chart', testId: 'shared-id', target: 'baseline' })],
       testDir,
@@ -1579,11 +1579,11 @@ describe('writeArtifactsFromResults', () => {
       .split('\n')
       .map(JSON.parse);
     expect(indexLine.suite).toBe('eval-top-months-chart');
-    expect(indexLine.artifact_dir).toBe('shared-id');
-    expect(indexLine.grading_path).toBe('shared-id/run-1/grading.json');
+    expect(indexLine.artifact_dir).toBe('eval-top-months-chart/shared-id');
+    expect(indexLine.grading_path).toBe('eval-top-months-chart/shared-id/run-1/grading.json');
   });
 
-  it('disambiguates duplicate case artifact directories without changing test ids', async () => {
+  it('uses suite namespaces for duplicate test ids in different suites', async () => {
     const firstEval = path.join(testDir, 'suite-a.eval.yaml');
     const secondEval = path.join(testDir, 'suite-b.eval.yaml');
     const sourceTests = [
@@ -1628,7 +1628,7 @@ describe('writeArtifactsFromResults', () => {
     const paths = await writeArtifactsFromResults(
       [
         makeResult({ suite: 'suite-a', testId: 'shared-id', target: 'baseline' }),
-        makeResult({ suite: 'suite-b', testId: 'shared-id', target: 'candidate' }),
+        makeResult({ suite: 'suite-b', testId: 'shared-id', target: 'baseline' }),
       ],
       testDir,
       { sourceTests },
@@ -1638,26 +1638,42 @@ describe('writeArtifactsFromResults', () => {
       .trim()
       .split('\n')
       .map((line) => JSON.parse(line) as IndexArtifactEntry);
-    const firstSuffix = createHash('sha256')
-      .update('evals/suite-a.eval.yaml')
-      .digest('hex')
-      .slice(0, 8);
-    const secondSuffix = createHash('sha256')
-      .update('evals/suite-b.eval.yaml')
-      .digest('hex')
-      .slice(0, 8);
 
     expect(indexLines.map((line) => line.test_id)).toEqual(['shared-id', 'shared-id']);
     expect(indexLines.map((line) => line.artifact_dir)).toEqual([
-      `shared-id__${firstSuffix}`,
-      `shared-id__${secondSuffix}`,
+      'suite-a/shared-id',
+      'suite-b/shared-id',
     ]);
     expect(indexLines.map((line) => line.grading_path)).toEqual([
-      `shared-id__${firstSuffix}/run-1/grading.json`,
-      `shared-id__${secondSuffix}/run-1/grading.json`,
+      'suite-a/shared-id/run-1/grading.json',
+      'suite-b/shared-id/run-1/grading.json',
     ]);
-    expect(await readdir(path.join(testDir, `shared-id__${firstSuffix}`))).toContain('run-1');
-    expect(await readdir(path.join(testDir, `shared-id__${secondSuffix}`))).toContain('run-1');
+    expect(await readdir(path.join(testDir, 'suite-a', 'shared-id'))).toContain('run-1');
+    expect(await readdir(path.join(testDir, 'suite-b', 'shared-id'))).toContain('run-1');
+  });
+
+  it('adds a target segment when a run contains multiple targets', async () => {
+    const paths = await writeArtifactsFromResults(
+      [
+        makeResult({ suite: 'suite-a', testId: 'shared-id', target: 'baseline' }),
+        makeResult({ suite: 'suite-a', testId: 'shared-id', target: 'candidate' }),
+      ],
+      testDir,
+    );
+
+    const indexLines = (await readFile(paths.indexPath, 'utf8'))
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as IndexArtifactEntry);
+
+    expect(indexLines.map((line) => line.artifact_dir)).toEqual([
+      'suite-a/shared-id/baseline',
+      'suite-a/shared-id/candidate',
+    ]);
+    expect(indexLines.map((line) => line.grading_path)).toEqual([
+      'suite-a/shared-id/baseline/run-1/grading.json',
+      'suite-a/shared-id/candidate/run-1/grading.json',
+    ]);
   });
 
   it('writes task bundle artifacts with local source paths when source metadata is provided', async () => {

--- a/apps/cli/test/commands/results/export.test.ts
+++ b/apps/cli/test/commands/results/export.test.ts
@@ -162,13 +162,26 @@ function toJsonl(...records: object[]): string {
   return `${records.map((r) => JSON.stringify(r)).join('\n')}\n`;
 }
 
-function artifactDir(outputDir: string, record: { suite?: string; test_id?: string }): string {
+function artifactDir(
+  outputDir: string,
+  record: { suite?: string; test_id?: string; target?: string },
+  options: { includeTargetSegment?: boolean } = {},
+): string {
   const testId = record.test_id ?? 'unknown';
-  return path.join(outputDir, ...(record.suite ? [record.suite] : []), testId);
+  return path.join(
+    outputDir,
+    ...(record.suite ? [record.suite] : []),
+    testId,
+    ...(options.includeTargetSegment ? [record.target ?? 'unknown'] : []),
+  );
 }
 
-function runDir(outputDir: string, record: { suite?: string; test_id?: string }): string {
-  return path.join(artifactDir(outputDir, record), 'run-1');
+function runDir(
+  outputDir: string,
+  record: { suite?: string; test_id?: string; target?: string },
+  options: { includeTargetSegment?: boolean } = {},
+): string {
+  return path.join(artifactDir(outputDir, record, options), 'run-1');
 }
 
 function readIndex(outputDir: string): IndexArtifactEntry[] {
@@ -655,10 +668,35 @@ describe('results export', () => {
 
     expect(existsSync(path.join(outputDir, 'summary.json'))).toBe(true);
     expect(existsSync(path.join(outputDir, 'index.jsonl'))).toBe(true);
-    expect(existsSync(path.join(artifactDir(outputDir, RESULT_FULL), 'summary.json'))).toBe(true);
-    expect(existsSync(path.join(runDir(outputDir, RESULT_FULL), 'grading.json'))).toBe(true);
-    expect(existsSync(path.join(runDir(outputDir, RESULT_PARTIAL), 'grading.json'))).toBe(true);
-    expect(existsSync(path.join(runDir(outputDir, RESULT_NO_TRACE), 'grading.json'))).toBe(true);
+    expect(
+      existsSync(
+        path.join(
+          artifactDir(outputDir, RESULT_FULL, { includeTargetSegment: true }),
+          'summary.json',
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      existsSync(
+        path.join(runDir(outputDir, RESULT_FULL, { includeTargetSegment: true }), 'grading.json'),
+      ),
+    ).toBe(true);
+    expect(
+      existsSync(
+        path.join(
+          runDir(outputDir, RESULT_PARTIAL, { includeTargetSegment: true }),
+          'grading.json',
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      existsSync(
+        path.join(
+          runDir(outputDir, RESULT_NO_TRACE, { includeTargetSegment: true }),
+          'grading.json',
+        ),
+      ),
+    ).toBe(true);
   });
 
   it('should include per-grader summary in summary when scores present', async () => {

--- a/apps/cli/test/eval.integration.test.ts
+++ b/apps/cli/test/eval.integration.test.ts
@@ -343,15 +343,18 @@ describe('agentv eval CLI', () => {
 
       const results = await readJsonLines(path.join(outputDir, 'index.jsonl'));
       expect(results).toHaveLength(2);
+      const [alpha, beta] = results as Array<{ artifact_dir: string }>;
       await expectFileExists(path.join(outputDir, 'summary.json'));
-      await expectFileExists(path.join(outputDir, 'case-alpha', 'summary.json'));
-      await expectFileExists(path.join(outputDir, 'case-alpha', 'run-1', 'metrics.json'));
-      await expectFileExists(path.join(outputDir, 'case-alpha', 'run-1', 'timing.json'));
-      await expectFileExists(path.join(outputDir, 'case-alpha', 'run-1', 'grading.json'));
-      await expectFileExists(path.join(outputDir, 'case-beta', 'summary.json'));
-      await expectFileExists(path.join(outputDir, 'case-beta', 'run-1', 'metrics.json'));
-      await expectFileExists(path.join(outputDir, 'case-beta', 'run-1', 'timing.json'));
-      await expectFileExists(path.join(outputDir, 'case-beta', 'run-1', 'grading.json'));
+      expect(alpha.artifact_dir).toBe('sample.test/case-alpha');
+      expect(beta.artifact_dir).toBe('sample.test/case-beta');
+      await expectFileExists(path.join(outputDir, alpha.artifact_dir, 'summary.json'));
+      await expectFileExists(path.join(outputDir, alpha.artifact_dir, 'run-1', 'metrics.json'));
+      await expectFileExists(path.join(outputDir, alpha.artifact_dir, 'run-1', 'timing.json'));
+      await expectFileExists(path.join(outputDir, alpha.artifact_dir, 'run-1', 'grading.json'));
+      await expectFileExists(path.join(outputDir, beta.artifact_dir, 'summary.json'));
+      await expectFileExists(path.join(outputDir, beta.artifact_dir, 'run-1', 'metrics.json'));
+      await expectFileExists(path.join(outputDir, beta.artifact_dir, 'run-1', 'timing.json'));
+      await expectFileExists(path.join(outputDir, beta.artifact_dir, 'run-1', 'grading.json'));
     } finally {
       await rm(fixture.baseDir, { recursive: true, force: true });
     }
@@ -369,8 +372,12 @@ describe('agentv eval CLI', () => {
       expect(extractOutputPath(stdout)).toBe(path.join(outputDir, 'index.jsonl'));
       await expectFileExists(path.join(outputDir, 'index.jsonl'));
       await expectFileExists(path.join(outputDir, 'summary.json'));
-      await expectFileExists(path.join(outputDir, 'case-alpha', 'summary.json'));
-      await expectFileExists(path.join(outputDir, 'case-alpha', 'run-1', 'grading.json'));
+      const [alpha] = (await readJsonLines(path.join(outputDir, 'index.jsonl'))) as Array<{
+        artifact_dir: string;
+      }>;
+      expect(alpha.artifact_dir).toBe('sample.test/case-alpha');
+      await expectFileExists(path.join(outputDir, alpha.artifact_dir, 'summary.json'));
+      await expectFileExists(path.join(outputDir, alpha.artifact_dir, 'run-1', 'grading.json'));
     } finally {
       await rm(fixture.baseDir, { recursive: true, force: true });
     }

--- a/apps/dashboard/src/components/ResultTable.tsx
+++ b/apps/dashboard/src/components/ResultTable.tsx
@@ -18,6 +18,7 @@ import {
   type ResultTableState,
   type ResultTableStateInput,
   buildResultTableModel,
+  buildScoreEntryMap,
 } from '~/lib/result-table';
 import type { EvalCaseRun, EvalResult, ScoreEntry } from '~/lib/types';
 
@@ -636,6 +637,16 @@ function RunResultCell({
   const status = isExecutionError ? 'error' : passed ? 'passing' : 'failing';
   const statusLabel = isExecutionError ? 'Error' : passed ? 'Passing' : 'Failing';
   const label = caseRunPath(caseRun, index);
+  if (column.id.startsWith('grader:')) {
+    const graderName = column.id.slice('grader:'.length);
+    return (
+      <GraderScoreCell
+        score={buildScoreEntryMap(caseRun.scores).get(graderName)}
+        passThreshold={passThreshold}
+      />
+    );
+  }
+
   switch (column.id) {
     case 'status':
       return <ResultStatusSymbol status={status} label={statusLabel} />;

--- a/apps/dashboard/src/components/RunList.tsx
+++ b/apps/dashboard/src/components/RunList.tsx
@@ -66,6 +66,8 @@ interface RunListItemView {
   ts: { date: string; full: string };
   isActive: boolean;
   label: string;
+  experimentName: string;
+  targetName: string;
   display: RunDisplay;
   errors: number;
   qualityCount: number;
@@ -73,6 +75,14 @@ interface RunListItemView {
   passedCount: number;
   failedCount: number;
   metadataDirty: boolean;
+}
+
+function runExperimentName(run: RunMeta): string {
+  return run.experiment?.trim() || 'default';
+}
+
+function runTargetName(run: RunMeta): string {
+  return run.target?.trim() || '-';
 }
 
 function formatDate(ts: string | undefined | null): { date: string; full: string } {
@@ -100,6 +110,8 @@ export function buildRunListItemView(run: RunMeta, passThreshold: number): RunLi
   const isActive = run.status === 'starting' || run.status === 'running';
   const display = formatRunDisplay(run, { includePassRate: false });
   const label = display.label;
+  const experimentName = runExperimentName(run);
+  const targetName = runTargetName(run);
   const errors = executionErrorCount(run);
   const qualityCount = Math.max(0, run.test_count - errors);
   const passing = qualityCount > 0 ? run.pass_rate >= passThreshold : errors === 0;
@@ -112,6 +124,8 @@ export function buildRunListItemView(run: RunMeta, passThreshold: number): RunLi
     ts,
     isActive,
     label,
+    experimentName,
+    targetName,
     display,
     errors,
     qualityCount,
@@ -414,6 +428,8 @@ export function RunList({
             run,
             ts,
             label,
+            experimentName,
+            targetName,
             display,
             errors,
             qualityCount,
@@ -450,15 +466,13 @@ export function RunList({
                   <RunNameLink
                     projectId={projectId}
                     runId={run.filename}
-                    label={display.primary}
+                    label={experimentName}
                     title={display.title}
                     className="block truncate text-sm font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
                   />
-                  {display.secondary ? (
-                    <p className="mt-0.5 truncate text-xs text-gray-500" title={display.title}>
-                      {display.secondary}
-                    </p>
-                  ) : null}
+                  <p className="mt-0.5 truncate text-xs text-gray-500" title={targetName}>
+                    {targetName}
+                  </p>
                   <div className="mt-2 flex flex-wrap items-center gap-2">
                     <RemoteIndicator onRemote={run.on_remote === true} branch={remoteBranch} />
                     {metadataDirty ? <PendingSyncBadge /> : null}
@@ -507,8 +521,8 @@ export function RunList({
           <thead className="border-b border-gray-800 bg-gray-900/50">
             <tr>
               {enableCombine && <th className="w-10 px-4 py-3" />}
-              <th className="w-8 px-4 py-3" />
-              <th className="w-[22rem] px-4 py-3 font-medium text-gray-400">Run</th>
+              <th className="w-[16rem] px-4 py-3 font-medium text-gray-400">Experiment</th>
+              <th className="w-[14rem] px-4 py-3 font-medium text-gray-400">Target</th>
               <th className="px-4 py-3 font-medium text-gray-400">Remote</th>
               <th className="px-4 py-3 text-right font-medium text-gray-400">Passed</th>
               <th className="px-4 py-3 text-right font-medium text-gray-400">Failures</th>
@@ -524,6 +538,8 @@ export function RunList({
                 run,
                 ts,
                 label,
+                experimentName,
+                targetName,
                 display,
                 errors,
                 qualityCount,
@@ -553,33 +569,31 @@ export function RunList({
                       />
                     </td>
                   )}
-                  {/* Status dot — spinner for active runs, otherwise quality pass/fail. */}
-                  <td className="px-4 py-3 text-center">
-                    <RunStatusMark view={view} />
-                  </td>
-
-                  {/* Run name */}
-                  <td className="w-[22rem] max-w-[22rem] px-4 py-3">
-                    <div className="min-w-0">
-                      <div className="flex min-w-0 items-center gap-2">
+                  {/* Experiment */}
+                  <td className="w-[16rem] max-w-[16rem] px-4 py-3">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <RunStatusMark view={view} className="shrink-0" />
+                      <div className="min-w-0">
                         <RunNameLink
                           projectId={projectId}
                           runId={run.filename}
-                          label={display.primary}
+                          label={experimentName}
                           title={display.title}
                           className="block min-w-0 truncate font-medium text-cyan-400 hover:text-cyan-300 hover:underline"
                         />
-                        {metadataDirty ? <PendingSyncBadge /> : null}
                       </div>
-                      {display.secondary ? (
-                        <div
-                          className="mt-0.5 truncate text-xs text-gray-500"
-                          title={display.title}
-                        >
-                          {display.secondary}
-                        </div>
-                      ) : null}
+                      {metadataDirty ? <PendingSyncBadge /> : null}
                     </div>
+                  </td>
+
+                  {/* Target */}
+                  <td
+                    className={`w-[14rem] max-w-[14rem] truncate px-4 py-3 ${
+                      targetName === '-' ? 'text-gray-600' : 'text-gray-300'
+                    }`}
+                    title={targetName}
+                  >
+                    {targetName}
                   </td>
 
                   {/* Remote presence */}

--- a/apps/dashboard/src/lib/result-table.test.ts
+++ b/apps/dashboard/src/lib/result-table.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { buildResultTableModel } from './result-table';
+import { buildResultTableModel, buildScoreEntryMap } from './result-table';
 import type { EvalResult } from './types';
 
 function result(overrides: Partial<EvalResult>): EvalResult {
@@ -104,9 +104,9 @@ describe('result-table model', () => {
     expect(model.columns.map((column) => column.id)).toEqual([
       'status',
       'test',
+      'suite',
       'target',
       'score',
-      'suite',
       'category',
       'duration',
       'cost_tokens',
@@ -194,6 +194,45 @@ describe('result-table model', () => {
     expect(model.visibleColumns.map((column) => column.id)).toContain('duration');
     expect(model.visibleColumns.map((column) => column.id)).toContain('cost_tokens');
     expect(model.filteredRepeatGroups.map((group) => group.row.testId)).toEqual(['repeat-case']);
+  });
+
+  it('resolves dynamic grader scores from repeated run attempts', () => {
+    const model = buildResultTableModel({
+      passThreshold: 0.8,
+      results: [
+        result({
+          testId: 'repeat-case',
+          score: 0.75,
+          scores: [{ name: 'contains-smoke output', type: 'contains', score: 0.75 }],
+          runs: [
+            {
+              run: 1,
+              run_path: 'run-1',
+              score: 0.5,
+              verdict: 'fail',
+              scores: [{ name: 'contains-smoke output', type: 'contains', score: 0.5 }],
+            },
+            {
+              run: 2,
+              run_path: 'run-2',
+              score: 1,
+              verdict: 'pass',
+              scores: [{ name: 'contains-smoke output', type: 'contains', score: 1 }],
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(model.visibleColumns.map((column) => column.id)).toContain(
+      'grader:contains-smoke output',
+    );
+    const group = model.repeatGroups[0];
+    expect(group?.meanScore).toBe(0.75);
+    expect(buildScoreEntryMap(group?.runs[0]?.scores).get('contains-smoke output')?.score).toBe(
+      0.5,
+    );
+    expect(buildScoreEntryMap(group?.runs[1]?.scores).get('contains-smoke output')?.score).toBe(1);
   });
 
   it('keeps the repeat expander visible for saved result table column URLs', () => {

--- a/apps/dashboard/src/lib/result-table.ts
+++ b/apps/dashboard/src/lib/result-table.ts
@@ -167,7 +167,7 @@ function uniqueAssertions(assertions: readonly AssertionEntry[]): AssertionEntry
   });
 }
 
-function buildGraderMap(
+export function buildScoreEntryMap(
   scores: readonly ScoreEntry[] | undefined,
 ): ReadonlyMap<string, ScoreEntry> {
   const map = new Map<string, ScoreEntry>();
@@ -241,7 +241,7 @@ function buildRow(
   const executionError = isExecutionError(result);
   const passing = !executionError && result.score >= passThreshold;
   const status: ResultTableRowStatus = executionError ? 'error' : passing ? 'passing' : 'failing';
-  const graderScores = buildGraderMap(result.scores);
+  const graderScores = buildScoreEntryMap(result.scores);
   const graderNames = [...graderScores.keys()];
   const graderError =
     result.scores?.some((score) => scoreHasFailure(score, passThreshold)) ?? false;
@@ -349,11 +349,11 @@ function buildColumns(rows: readonly ResultTableRow[], graderOptions: readonly s
       ? [{ id: 'expander', label: 'Expand', kind: 'base' as const, defaultVisible: true }]
       : []),
     { id: 'test', label: 'Test ID', kind: 'base', defaultVisible: true },
-    { id: 'target', label: 'Target', kind: 'base', defaultVisible: true },
-    { id: 'score', label: 'Score', kind: 'base', defaultVisible: true },
     ...(hasSuite
       ? [{ id: 'suite', label: 'Suite', kind: 'base' as const, defaultVisible: true }]
       : []),
+    { id: 'target', label: 'Target', kind: 'base', defaultVisible: true },
+    { id: 'score', label: 'Score', kind: 'base', defaultVisible: true },
     ...(hasCategory
       ? [{ id: 'category', label: 'Category', kind: 'base' as const, defaultVisible: false }]
       : []),

--- a/apps/web/src/content/docs/docs/tools/results.mdx
+++ b/apps/web/src/content/docs/docs/tools/results.mdx
@@ -112,6 +112,16 @@ Duplicate policy is explicit:
 
 ### Run observability
 
+AgentV writes readable per-case artifact directories under the run workspace.
+When suite metadata is available, single-target runs use
+`<suite>/<case-id>/run-N/`. Runs with multiple selected targets insert the target
+axis: `<suite>/<case-id>/<target>/run-N/`. If a result has no suite metadata,
+AgentV may keep the compatibility layout `<case-id>/run-N/`.
+
+The folder tree is for human inspection. Tooling should follow `index.jsonl`
+rows and their explicit paths, including `artifact_dir`, `summary_path`,
+`grading_path`, `metrics_path`, and `timing_path`.
+
 Each `run-N/` directory includes `metrics.json` and `timing.json`. `metrics.json`
 is the flattened executor behavior summary for dashboards, comparison exports,
 and metric-style graders. `timing.json` carries the run's duration, token,

--- a/docs/adr/2026-06-25-experiments-as-persisted-run-profiles.md
+++ b/docs/adr/2026-06-25-experiments-as-persisted-run-profiles.md
@@ -1,0 +1,160 @@
+# ADR: Treat experiments as persisted run profiles
+
+Date: 2026-06-25
+
+Status: Proposed
+
+## Context
+
+AgentV needs a coherent target-selection contract now that experiment files can
+carry runtime settings. The immediate question is whether introducing
+experiments means AgentV should stop allowing targets in eval YAML.
+
+It should not. `EVAL.yaml` is the eval suite contract: task shape, prompts,
+datasets, assertions, fixtures, case references, and any suite-local defaults
+needed for the eval to run by itself. `cases.yaml` or JSONL case files are case
+data. `.agentv/targets.yaml` is the target provider registry. Experiments are
+persisted run profiles: a reviewable YAML form of the CLI choices used for a
+run, including which target or targets were selected.
+
+The reason to introduce experiments is not to replace `EVAL.yaml`. It is to
+avoid hiding material run settings in an ephemeral CLI invocation or local
+operator state. A run should record the selected target, repeat strategy,
+timeout, setup, filters, and other runtime knobs so results can be reproduced,
+compared, reviewed, and audited.
+
+This decision narrows and clarifies
+[ADR 2026-06-23](./2026-06-23-experiments-vs-eval-separation.md): experiments
+are first-class run profiles, but eval-local defaults remain part of the suite
+contract.
+
+## Vocabulary
+
+- Target provider registry: `.agentv/targets.yaml`, which defines reusable LLM,
+  agent harness, or adapter targets.
+- Eval suite: `EVAL.yaml`, `*.eval.yaml`, or equivalent suite files. A suite may
+  reference external case data and may define fallback target selection needed
+  for local self-running.
+- Cases file: `cases.yaml`, JSONL, or another dataset file containing reusable
+  cases. Cases should not define provider details.
+- Experiment: a named, committed or generated run profile that persists CLI-like
+  runtime settings for one or more eval suites.
+- Run artifact: the portable result bundle. It is discovered through manifests
+  such as `summary.json` and run-root `index.jsonl`, not by inferring semantics
+  from physical folder depth.
+
+## Decision
+
+AgentV will keep target selection in `EVAL.yaml` as a fallback default. It will
+not disable or remove eval-local targets.
+
+The target-resolution precedence is:
+
+1. CLI override, such as `--target`.
+2. Experiment `target` or `targets`.
+3. Eval suite fallback target selection, such as `execution.target` or
+   `execution.targets`.
+4. The target named `default`.
+
+The higher-precedence source wins for the selected run. Lower-precedence sources
+remain valid defaults but do not merge into the selected target set unless the
+runtime explicitly defines a matrix behavior.
+
+Case-level `execution.targets` is an applicability filter over the resolved
+target set. It decides which selected targets a case should run against. It is
+not a new target provider definition surface and should not override the
+experiment or CLI target selection.
+
+Experiments are optional. A simple eval suite should remain runnable with no
+experiment file by using eval-local defaults or the target named `default`.
+When a user supplies CLI flags without an experiment file, AgentV should still
+persist the resolved run configuration in the run bundle so the material choices
+are not lost.
+
+Run artifacts should model results as rows across the stable axes:
+
+- experiment or run profile name
+- eval suite
+- case id
+- resolved target
+- attempt or repeat index, when applicable
+
+Within a run workspace, AgentV should also use a human-readable physical layout
+that matches those axes where it helps inspection:
+
+- Single-target run: `<suite>/<case-id>/run-N/`
+- Multi-target run: `<suite>/<case-id>/<target>/run-N/`
+
+The `target` segment appears only when the same run selected multiple targets.
+`run-1` is written even for a single execution so the layout does not fork
+between normal and repeated cases. When no suite metadata exists, the artifact
+writer may fall back to the historical `<case-id>/run-N/` layout for
+compatibility.
+
+This physical layout is not a discovery API. Dashboard and other readers must
+continue to follow explicit manifest fields such as `artifact_dir`,
+`summary_path`, `grading_path`, `metrics_path`, and `timing_path` instead of
+deriving meaning from folder depth.
+
+## Consequences
+
+Positive:
+
+- Evals stay self-runnable and easy to author.
+- Experiments make CLI choices explicit, reviewable, and reproducible.
+- Existing eval files and examples that define suite-level targets remain valid.
+- A suite can default to an LLM target while another defaults to an agent harness
+  target, and a shared experiment or CLI override can still select a different
+  target when needed.
+- AgentV avoids duplicating task definitions just to compare targets.
+
+Negative:
+
+- AgentV keeps more than one valid target source, so diagnostics must report
+  which source won.
+- The schemas and docs need to be precise about `target` versus `targets` and
+  about suite-level defaults versus case-level filters.
+- Existing code paths that treat CLI `--target default` as "no override" or
+  that cannot select eval-local target aliases from CLI need cleanup.
+- Artifact metadata needs a resolved run configuration even when no experiment
+  file was supplied.
+
+## Implementation Notes
+
+Likely implementation follow-ups:
+
+- Validate mutually exclusive `target` and `targets` where both would be
+  ambiguous, especially in experiment files.
+- Keep legacy top-level eval `target` as a compatibility alias, but document
+  `execution.target` and `execution.targets` as the suite-level defaults.
+- Treat CLI `--target default` as an explicit override to the target named
+  `default`, not as an omitted override.
+- Resolve target aliases and hook variants consistently when CLI or experiment
+  selection references eval-local target entries.
+- Persist resolved run settings in run bundle metadata or a `run_config`
+  artifact even for raw CLI runs.
+- Fix documentation that implies runtime choices belong only in experiments.
+- Store artifacts under suite namespaces when suite metadata is available, and
+  add the target namespace only for multi-target runs.
+- Clarify that case-level `execution.targets` is a filter; if singular
+  case-level `execution.target` is documented, either implement it or remove the
+  documentation.
+
+Suggested follow-up bead title:
+
+`Clarify target precedence across CLI experiments and eval defaults`
+
+## Non-Goals
+
+- Do not remove `EVAL.yaml` target defaults.
+- Do not make experiment files mandatory for local eval runs.
+- Do not move provider definitions from `.agentv/targets.yaml` into experiments
+  or eval suites.
+- Do not make readers discover results by walking the physical artifact tree.
+- Do not use experiments as a replacement for reusable case data files.
+
+## References
+
+- [ADR 2026-06-23: Separate experiments from eval definitions](./2026-06-23-experiments-vs-eval-separation.md)
+- [STRATEGY.md](../../STRATEGY.md)
+- [ROADMAP.md](../../ROADMAP.md)

--- a/packages/core/src/evaluation/run-artifacts.ts
+++ b/packages/core/src/evaluation/run-artifacts.ts
@@ -1126,12 +1126,30 @@ function safeTestId(testId: string | undefined): string {
   return safeArtifactPathSegment(testId, 'unknown');
 }
 
+function safeTarget(target: string | undefined): string {
+  return safeArtifactPathSegment(target, 'unknown');
+}
+
 function getSuite(result: EvaluationResult): string | undefined {
   return result.suite;
 }
 
-function buildArtifactSubdir(result: EvaluationResult): string {
-  return safeTestId(result.testId);
+function sourceSuite(sourceTest: EvalTest | undefined): string | undefined {
+  return sourceTest?.suite;
+}
+
+function buildArtifactSubdir(
+  result: EvaluationResult,
+  sourceTest: EvalTest | undefined,
+  includeTargetSegment: boolean,
+): string {
+  const suite = getSuite(result) ?? sourceSuite(sourceTest);
+  const segments = [
+    ...(suite ? [safeArtifactPathSegment(suite, 'suite')] : []),
+    safeTestId(result.testId ?? sourceTest?.id),
+    ...(includeTargetSegment ? [safeTarget(result.target)] : []),
+  ];
+  return path.posix.join(...segments);
 }
 
 function sourceTestsByTestId(sourceTests: readonly EvalTest[] | undefined) {
@@ -1219,7 +1237,11 @@ function allocateArtifactSubdirs(
   results: readonly EvaluationResult[],
   sourceTests: readonly (EvalTest | undefined)[],
 ): readonly string[] {
-  const baseDirs = results.map((result) => buildArtifactSubdir(result));
+  const targetNames = new Set(results.map((result) => safeTarget(result.target)));
+  const includeTargetSegment = targetNames.size > 1;
+  const baseDirs = results.map((result, index) =>
+    buildArtifactSubdir(result, sourceTests[index], includeTargetSegment),
+  );
   const baseCounts = new Map<string, number>();
   for (const baseDir of baseDirs) {
     baseCounts.set(baseDir, (baseCounts.get(baseDir) ?? 0) + 1);
@@ -1237,14 +1259,12 @@ function allocateArtifactSubdirs(
     }
 
     const suffix = artifactDisambiguationSuffix(results[index], sourceTests[index], nextOccurrence);
-    let candidate = safeArtifactPathSegment(
-      `${baseDir}__${suffix}`,
-      `${baseDir}_${nextOccurrence}`,
-    );
+    let candidate = appendArtifactSubdirSuffix(baseDir, suffix, `${baseDir}_${nextOccurrence}`);
     let collision = 2;
     while (used.has(candidate)) {
-      candidate = safeArtifactPathSegment(
-        `${baseDir}__${suffix}_${collision}`,
+      candidate = appendArtifactSubdirSuffix(
+        baseDir,
+        `${suffix}_${collision}`,
         `${baseDir}_${nextOccurrence}_${collision}`,
       );
       collision += 1;
@@ -1252,6 +1272,19 @@ function allocateArtifactSubdirs(
     used.add(candidate);
     return candidate;
   });
+}
+
+function appendArtifactSubdirSuffix(baseDir: string, suffix: string, fallback: string): string {
+  const segments = baseDir.split('/').filter(Boolean);
+  if (segments.length === 0) {
+    return safeArtifactPathSegment(`${fallback}__${suffix}`, fallback);
+  }
+
+  const last = segments[segments.length - 1] ?? fallback;
+  return path.posix.join(
+    ...segments.slice(0, -1),
+    safeArtifactPathSegment(`${last}__${suffix}`, fallback),
+  );
 }
 
 function toRelativeArtifactPath(outputDir: string, filePath: string): string {
@@ -1503,7 +1536,7 @@ export function buildResultIndexArtifact(
     artifactPointers?: ResultArtifactPointersWire;
   },
 ): ResultIndexArtifact {
-  const artifactSubdir = buildArtifactSubdir(result);
+  const artifactSubdir = buildArtifactSubdir(result, undefined, false);
   const hasAnswer = result.output.length > 0;
   const hasTranscript = resultHasExecutionTraceTranscript(result);
   const isSingleRun = !hasPersistedCaseRuns(result);


### PR DESCRIPTION
## Summary

AgentV result bundles now use a readable suite/test/run layout, with an extra target segment only when a run selects multiple targets. This makes duplicate case IDs across suites understandable without opaque suffixes while preserving `index.jsonl` as the discovery contract for Dashboard and other readers.

This is a stacked PR against `dashboard-pr1500-full-stack`; the intended review diff is the artifact-layout commit on top of that stack.

## Design Notes

- Single-target run artifacts resolve to `<suite>/<case-id>/run-N/` when suite metadata is available.
- Multi-target runs resolve to `<suite>/<case-id>/<target>/run-N/` so each target has a stable namespace.
- Consumers still follow manifest paths such as `artifact_dir`, `grading_path`, `metrics_path`, and `timing_path`; folder depth remains a human-readable layout, not an API.
- The ADR keeps eval-local target defaults, experiment defaults, and CLI overrides as separate layers.

## Validation

- `bun test apps/cli/test/commands/eval/artifact-writer.test.ts`
- `bun test apps/cli/test/commands/eval/aggregate.test.ts`
- `bun test apps/cli/test/commands/results/export.test.ts`
- `bun test apps/cli/test/commands/results/report.test.ts`
- `bun test apps/cli/test/commands/results/validate.test.ts`
- `bun test apps/cli/test/eval.integration.test.ts`
- `bun test packages/core/test/evaluation/evaluate-programmatic-api.test.ts`
- `bun test packages/core/test/evaluation/orchestrator.test.ts`
- `bunx biome check AGENTS.md docs/adr/2026-06-25-experiments-as-persisted-run-profiles.md apps/web/src/content/docs/docs/tools/results.mdx packages/core/src/evaluation/run-artifacts.ts apps/cli/test/commands/eval/artifact-writer.test.ts apps/cli/test/commands/results/export.test.ts apps/cli/test/eval.integration.test.ts`
- `bun --filter @agentv/core typecheck`
- `bun --filter agentv typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
