### PR TITLE
feat(experiments): support eval suite selection

### DIFF
--- a/apps/cli/src/commands/eval/discover.ts
+++ b/apps/cli/src/commands/eval/discover.ts
@@ -17,8 +17,8 @@ export interface DiscoveredEvalFile {
  * Discover eval files by glob pattern matching.
  *
  * Uses `eval_patterns` from `.agentv/config.yaml` if configured,
- * otherwise falls back to default patterns that match `suite*.yaml`,
- * `eval.yaml`, and `dataset*.yaml` files under `evals/` directories.
+ * otherwise falls back to default patterns that match `*.eval.yaml`,
+ * `EVAL.yaml`, `eval.yaml`, and `*.eval.ts` files under `evals/` directories.
  */
 export async function discoverEvalFiles(cwd: string): Promise<readonly DiscoveredEvalFile[]> {
   const repoRoot = await findRepoRoot(cwd);

--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -617,8 +617,23 @@ function resolveExperimentFilePath(cwd: string, experimentRef: string): string |
     return existsSync(experimentPath) ? experimentPath : undefined;
   }
 
-  for (const ext of ['yaml', 'yml', 'ts', 'js', 'mts', 'mjs']) {
-    const candidate = path.resolve(cwd, 'experiments', `${experimentRef}.${ext}`);
+  for (const fileName of [
+    `${experimentRef}.exp.yaml`,
+    `${experimentRef}.exp.yml`,
+    `${experimentRef}.experiment.yaml`,
+    `${experimentRef}.experiment.yml`,
+    `${experimentRef}.yaml`,
+    `${experimentRef}.yml`,
+    `${experimentRef}.experiment.ts`,
+    `${experimentRef}.experiment.js`,
+    `${experimentRef}.experiment.mts`,
+    `${experimentRef}.experiment.mjs`,
+    `${experimentRef}.ts`,
+    `${experimentRef}.js`,
+    `${experimentRef}.mts`,
+    `${experimentRef}.mjs`,
+  ]) {
+    const candidate = path.resolve(cwd, 'experiments', fileName);
     if (existsSync(candidate)) {
       return candidate;
     }
@@ -650,7 +665,7 @@ function applyExperimentOptions(
   const workspaceMode =
     options.workspaceMode ?? readExperimentWorkspaceMode(experiment.workspace?.mode);
   const workspacePath = options.workspacePath ?? readExperimentWorkspacePath(experiment.workspace);
-  const experimentFilter = normalizeExperimentCaseFilter(experiment.evals);
+  const experimentFilter = normalizeExperimentCaseFilter(experiment.evalCases);
 
   return {
     ...options,
@@ -725,15 +740,27 @@ function readExperimentWorkspacePath(
 }
 
 function normalizeExperimentCaseFilter(
-  evals: ExperimentConfig['evals'] | undefined,
+  evalCases: ExperimentConfig['evalCases'] | undefined,
 ): NormalizedOptions['filter'] {
-  if (typeof evals === 'string') {
-    return evals;
+  if (typeof evalCases === 'string') {
+    return evalCases;
   }
-  if (!Array.isArray(evals)) {
+  if (!Array.isArray(evalCases)) {
     return undefined;
   }
-  return evals.length === 1 ? evals[0] : [...evals];
+  return evalCases.length === 1 ? evalCases[0] : [...evalCases];
+}
+
+function normalizeExperimentEvalSuiteInputs(
+  evalSuites: ExperimentConfig['evalSuites'] | undefined,
+): readonly string[] {
+  if (typeof evalSuites === 'string') {
+    return [evalSuites];
+  }
+  if (!Array.isArray(evalSuites)) {
+    return [];
+  }
+  return [...evalSuites];
 }
 
 async function runExperimentSteps(params: {
@@ -1529,12 +1556,17 @@ export async function runEvalCommand(
     experiment: resolvedExperiment.name,
   };
 
+  const experimentEvalSuiteInputs = normalizeExperimentEvalSuiteInputs(
+    options.experimentConfig?.evalSuites,
+  );
   const evalPathInputs =
     input.testFiles.length > 0
       ? [...input.testFiles]
-      : options.experimentConfig?.evals !== undefined
-        ? [...(yamlConfig?.eval_patterns ?? DEFAULT_EVAL_PATTERNS)]
-        : [];
+      : experimentEvalSuiteInputs.length > 0
+        ? [...experimentEvalSuiteInputs]
+        : options.experimentConfig?.evalCases !== undefined
+          ? [...(yamlConfig?.eval_patterns ?? DEFAULT_EVAL_PATTERNS)]
+          : [];
   if (evalPathInputs.length === 0 && process.stdin.isTTY) {
     const { launchInteractiveWizard } = await import('./interactive.js');
     await launchInteractiveWizard();

--- a/apps/cli/src/commands/eval/shared.ts
+++ b/apps/cli/src/commands/eval/shared.ts
@@ -42,7 +42,7 @@ export async function resolveEvalPaths(evalPaths: string[], cwd: string): Promis
         // Auto-expand directory to recursive eval file glob
         const dirGlob = path.posix.join(
           candidatePath.replace(/\\/g, '/'),
-          '**/{*.eval.yaml,*.eval.yml,eval.yaml,eval.yml,*.eval.ts,*.eval.mts}',
+          '**/{*.eval.yaml,*.eval.yml,EVAL.yaml,EVAL.yml,eval.yaml,eval.yml,*.eval.ts,*.eval.mts}',
         );
         const dirMatches = await fg(dirGlob, {
           absolute: true,
@@ -99,7 +99,7 @@ export async function resolveEvalPaths(evalPaths: string[], cwd: string): Promis
     throw new Error(
       `No eval files matched any provided paths or globs: ${includePatterns.join(
         ', ',
-      )}. Provide YAML, JSONL, JSON, or TypeScript paths or globs (e.g., "evals/**/eval.yaml", "evals/**/*.eval.ts").`,
+      )}. Provide YAML, JSONL, JSON, or TypeScript paths or globs (e.g., "evals/**/*.eval.yaml", "evals/**/EVAL.yaml", "evals/**/*.eval.ts").`,
     );
   }
 

--- a/apps/cli/test/commands/eval/shared.test.ts
+++ b/apps/cli/test/commands/eval/shared.test.ts
@@ -77,6 +77,18 @@ describe('resolveEvalPaths', () => {
     expect(resolved).toEqual([path.normalize(tsFile)]);
   });
 
+  it('discovers EVAL.yaml files from directory auto-expansion', async () => {
+    const evalDir = path.join(tempDir, 'evals');
+    mkdirSync(evalDir, { recursive: true });
+
+    const evalFile = path.join(evalDir, 'EVAL.yaml');
+    writeFileSync(evalFile, 'tests:\n  - id: sample\n    input: test\n');
+
+    const resolved = await resolveEvalPaths([tempDir], tempDir);
+
+    expect(resolved).toEqual([path.normalize(evalFile)]);
+  });
+
   it('accepts a direct .mts file path', async () => {
     const tsFile = path.join(tempDir, 'custom.eval.mts');
     writeFileSync(tsFile, 'export default { tests: [] }');

--- a/apps/cli/test/eval.integration.test.ts
+++ b/apps/cli/test/eval.integration.test.ts
@@ -533,7 +533,168 @@ describe('agentv eval CLI', () => {
     }
   }, 30_000);
 
-  it('runs a native experiment file with eval selection and run knobs', async () => {
+  it('uses experiment eval_suites without positional eval paths', async () => {
+    const fixture = await createFixture();
+    try {
+      const experimentsDir = path.join(fixture.suiteDir, 'experiments');
+      await mkdir(experimentsDir, { recursive: true });
+      await writeFile(
+        path.join(fixture.suiteDir, '.agentv', 'config.yaml'),
+        'eval_patterns:\n  - unused.test.yaml\n',
+        'utf8',
+      );
+      await writeFile(
+        path.join(fixture.suiteDir, 'unused.test.yaml'),
+        [
+          'description: config discovery should not win over experiment eval_suites',
+          'target: missing-target',
+          'tests:',
+          '  - id: case-unused',
+          '    criteria: System responds with unused',
+          '    input: unused',
+          '    expected_output: unused',
+          '',
+        ].join('\n'),
+        'utf8',
+      );
+      const experimentPath = path.join(experimentsDir, 'repeat-matrix.exp.yaml');
+      await writeFile(
+        experimentPath,
+        [
+          'name: repeat-matrix',
+          'targets:',
+          '  - file-target',
+          '  - cli-target',
+          'eval_suites:',
+          '  - sample.test.yaml',
+          'eval_cases: case-alpha',
+          'repeat:',
+          '  count: 2',
+          '  strategy: mean',
+          'early_exit: false',
+          'workers: 1',
+          '',
+        ].join('\n'),
+        'utf8',
+      );
+
+      const timestamp = '2026-06-25T06-49-34-908Z';
+      const { stdout, exitCode } = await runCli(
+        fixture,
+        ['eval', '--experiment', 'experiments/repeat-matrix.exp.yaml'],
+        { AGENTV_RUN_TIMESTAMP: timestamp },
+      );
+
+      expect(exitCode).toBe(0);
+      const outputPath = extractOutputPath(stdout);
+      expect(outputPath).toBe(
+        path.join(
+          fixture.suiteDir,
+          '.agentv',
+          'results',
+          'repeat-matrix',
+          timestamp,
+          'index.jsonl',
+        ),
+      );
+
+      const diagnostics = await readDiagnostics(fixture);
+      expect(diagnostics).toMatchObject({
+        filter: 'case-alpha',
+        evalCaseIds: ['case-alpha'],
+        maxConcurrency: 1,
+        runs: {
+          count: 2,
+          strategy: 'mean',
+          earlyExit: false,
+        },
+        resultCount: 1,
+      });
+
+      const results = (await readJsonLines(outputPath)) as Array<Record<string, unknown>>;
+      expect(results).toHaveLength(2);
+      expect(results.map((result) => result.test_id)).toEqual(['case-alpha', 'case-alpha']);
+      expect(new Set(results.map((result) => result.target))).toEqual(
+        new Set(['file-target', 'cli-target']),
+      );
+
+      const summary = JSON.parse(
+        await readFile(path.join(path.dirname(outputPath), 'summary.json'), 'utf8'),
+      ) as { metadata?: Record<string, unknown> };
+      expect(summary.metadata?.experiment).toBe('repeat-matrix');
+      expect(summary.metadata?.experiment_config).toMatchObject({
+        name: 'repeat-matrix',
+        source_path: experimentPath,
+        targets: ['file-target', 'cli-target'],
+        eval_suites: ['sample.test.yaml'],
+        eval_cases: 'case-alpha',
+      });
+    } finally {
+      await rm(fixture.baseDir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it('lets positional eval paths override experiment eval_suites', async () => {
+    const fixture = await createFixture();
+    try {
+      const experimentsDir = path.join(fixture.suiteDir, 'experiments');
+      await mkdir(experimentsDir, { recursive: true });
+      await writeFile(
+        path.join(fixture.suiteDir, 'unused.test.yaml'),
+        [
+          'description: experiment eval_suites should be ignored when CLI paths are present',
+          'target: missing-target',
+          'tests:',
+          '  - id: case-unused',
+          '    criteria: System responds with unused',
+          '    input: unused',
+          '    expected_output: unused',
+          '',
+        ].join('\n'),
+        'utf8',
+      );
+      await writeFile(
+        path.join(experimentsDir, 'override.exp.yaml'),
+        [
+          'name: override-exp',
+          'target: cli-target',
+          'eval_suites:',
+          '  - unused.test.yaml',
+          'eval_cases: case-alpha',
+          '',
+        ].join('\n'),
+        'utf8',
+      );
+
+      const { stdout, exitCode } = await runCli(fixture, [
+        'eval',
+        fixture.testFilePath,
+        '--experiment',
+        'experiments/override.exp.yaml',
+      ]);
+
+      expect(exitCode).toBe(0);
+      const outputPath = extractOutputPath(stdout);
+      const results = (await readJsonLines(outputPath)) as Array<Record<string, unknown>>;
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        test_id: 'case-alpha',
+        target: 'cli-target',
+      });
+
+      const diagnostics = await readDiagnostics(fixture);
+      expect(diagnostics).toMatchObject({
+        target: 'cli-target',
+        filter: 'case-alpha',
+        evalCaseIds: ['case-alpha'],
+        resultCount: 1,
+      });
+    } finally {
+      await rm(fixture.baseDir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it('runs a native experiment file with legacy case filtering, discovery, and run knobs', async () => {
     const fixture = await createFixture();
     try {
       const experimentsDir = path.join(fixture.suiteDir, 'experiments');
@@ -557,7 +718,7 @@ describe('agentv eval CLI', () => {
         ].join('\n'),
         'utf8',
       );
-      const experimentPath = path.join(experimentsDir, 'default.yaml');
+      const experimentPath = path.join(experimentsDir, 'default.exp.yaml');
       await writeFile(
         experimentPath,
         [
@@ -580,11 +741,7 @@ describe('agentv eval CLI', () => {
         'utf8',
       );
 
-      const { stdout, exitCode } = await runCli(fixture, [
-        'eval',
-        '--experiment',
-        'experiments/default.yaml',
-      ]);
+      const { stdout, exitCode } = await runCli(fixture, ['eval', '--experiment', 'default']);
 
       expect(exitCode).toBe(0);
       const outputPath = extractOutputPath(stdout);
@@ -614,7 +771,7 @@ describe('agentv eval CLI', () => {
         name: 'native-exp',
         source_path: experimentPath,
         target: 'cli-target',
-        evals: 'case-alpha',
+        eval_cases: 'case-alpha',
         repeat: {
           count: 2,
           strategy: 'mean',

--- a/apps/web/src/content/docs/docs/evaluation/batch-cli.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/batch-cli.mdx
@@ -97,7 +97,7 @@ The batch runner reads the eval YAML directly and processes all tests in one inv
 The runner receives the eval file path via `--eval` and an output path via `--output`:
 
 ```bash
-bun run batch-runner.ts --eval ./my-eval.yaml --output ./output.jsonl
+bun run batch-runner.ts --eval ./my-eval.eval.yaml --output ./output.jsonl
 ```
 
 ### Output

--- a/apps/web/src/content/docs/docs/evaluation/experiments.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/experiments.mdx
@@ -6,17 +6,23 @@ sidebar:
 ---
 
 Experiments define **how** eval cases run: target or target matrix, setup,
-scripts, timeout, sandbox, case filters, and repeat-run policy. Eval files stay
-focused on **what** is tested: prompts, datasets, assertions, and task fixtures.
+scripts, timeout, sandbox, eval file selection, case filters, and repeat-run
+policy. Eval files stay focused on **what** is tested: prompts, datasets,
+assertions, and task fixtures.
 
 ## Experiment YAML
+
+Experiment files use the `*.exp.yaml` convention. Eval suites use
+`*.eval.yaml` or `EVAL.yaml`.
 
 Committed experiments conventionally live under `experiments/`:
 
 ```yaml
 name: baseline
 target: codex-gpt5
-evals: "agent-*"
+eval_suites:
+  - evals/**/*.eval.yaml
+eval_cases: "agent-*"
 timeout_seconds: 720
 repeat:
   count: 4
@@ -30,6 +36,13 @@ scripts:
 
 Wire fields use `snake_case`. AgentV translates to internal `camelCase` when it
 loads the file.
+
+Use `eval_suites` for eval suite file paths or globs. The syntax matches
+positional CLI eval paths, including directories, globs, and `!` negation
+patterns, and is resolved from the project root/current working directory. Use
+`eval_cases` for case or test-id filtering inside the selected suites. Existing
+experiments that use `evals` as a case filter keep working as a legacy alias for
+`eval_cases`; do not use `evals` in new experiment files.
 
 ## Repeat runs
 
@@ -140,14 +153,18 @@ scripts:
 Run a specific experiment:
 
 ```bash
-bun agentv eval evals/suite.eval.yaml --experiment experiments/default.yaml
+bun agentv eval --experiment experiments/default.exp.yaml
 ```
+
+When the experiment defines `eval_suites`, positional eval paths are optional.
+If positional eval paths are provided, they override `eval_suites` for that ad
+hoc run; `eval_cases` still applies as a case filter.
 
 If no experiment is passed, AgentV checks `.agentv/config.yaml` for a default:
 
 ```yaml
 experiments:
-  default: experiments/default.yaml
+  default: experiments/default.exp.yaml
 ```
 
 If no default is configured, AgentV keeps the old behavior and uses the

--- a/apps/web/src/content/docs/docs/evaluation/running-evals.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/running-evals.mdx
@@ -8,10 +8,32 @@ sidebar:
 ## Run an Evaluation
 
 ```bash
-agentv eval evals/my-eval.yaml
+agentv eval evals/my-eval.eval.yaml
 ```
 
 Results are written to `.agentv/results/<experiment>/<timestamp>/index.jsonl`. When no experiment is defined, AgentV uses `.agentv/results/default/<timestamp>/index.jsonl`. Each line is a JSON object with one result per test case, and the run workspace also stores the manifest and related artifacts. Use this generated run folder as the portable audit surface: copy or sync the run directory, not a hand-authored parallel bundle.
+
+An experiment can also select eval files directly:
+
+```yaml
+# experiments/repeat-matrix.exp.yaml
+name: repeat-matrix
+eval_suites:
+  - evals/dashboard-repeat.eval.yaml
+targets:
+  - baseline
+  - candidate
+repeat:
+  count: 2
+  strategy: mean
+```
+
+```bash
+agentv eval --experiment experiments/repeat-matrix.exp.yaml
+```
+
+CLI positional eval paths override `eval_suites` for one-off runs. Experiment
+`eval_cases` filters case/test IDs over whichever suites were selected.
 
 Each `scores[]` entry includes per-grader timing:
 
@@ -44,7 +66,7 @@ The `duration_ms`, `started_at`, and `ended_at` fields are present on every grad
 Run against a different target than specified in the eval file:
 
 ```bash
-agentv eval --target my-target evals/**/*.yaml
+agentv eval --target my-target evals/**/*.eval.yaml
 ```
 
 ### Experiment Label
@@ -52,8 +74,8 @@ agentv eval --target my-target evals/**/*.yaml
 Tag a pipeline run with an experiment name to track different conditions (e.g. with vs without skills):
 
 ```bash
-agentv pipeline run evals/my-eval.yaml --experiment with_skills
-agentv pipeline run evals/my-eval.yaml --experiment without_skills
+agentv pipeline run evals/my-eval.eval.yaml --experiment with_skills
+agentv pipeline run evals/my-eval.eval.yaml --experiment without_skills
 ```
 
 The experiment label is written to `manifest.json` and propagated to each entry in `index.jsonl` by `pipeline bench`. The eval file stays the same across experiments — what changes is the environment. Dashboards can filter and compare results by experiment.
@@ -63,7 +85,7 @@ The experiment label is written to `manifest.json` and propagated to each entry 
 Run a single test by ID:
 
 ```bash
-agentv eval --test-id case-123 evals/my-eval.yaml
+agentv eval --test-id case-123 evals/my-eval.eval.yaml
 ```
 
 ### Dry Run
@@ -71,7 +93,7 @@ agentv eval --test-id case-123 evals/my-eval.yaml
 Test the harness flow with mock responses (does not call real providers):
 
 ```bash
-agentv eval --dry-run evals/my-eval.yaml
+agentv eval --dry-run evals/my-eval.eval.yaml
 ```
 
 :::note
@@ -84,7 +106,7 @@ Write all artifacts (`index.jsonl`, `summary.json`, per-case summaries, and
 `run-N` details) to a specific directory:
 
 ```bash
-agentv eval evals/my-eval.yaml --output ./my-results
+agentv eval evals/my-eval.eval.yaml --output ./my-results
 ```
 
 `--output` is a run directory, not a file path. The canonical manifest is always
@@ -95,7 +117,7 @@ agentv eval evals/my-eval.yaml --output ./my-results
 The run directory is the complete artifact boundary. Use `<output>/index.jsonl` for scripts, CI summaries, and downstream tools:
 
 ```bash
-agentv eval evals/my-eval.yaml --output ./my-results
+agentv eval evals/my-eval.eval.yaml --output ./my-results
 cat ./my-results/index.jsonl
 ```
 
@@ -170,7 +192,7 @@ result-oriented workflows. For full-fidelity span inspection, export OTLP JSON e
 agentv inspect stats .agentv/results/default/<timestamp>/index.jsonl
 
 # Full-fidelity OTLP JSON trace (importable by OTel backends like Jaeger, Grafana)
-agentv eval evals/my-eval.yaml --otel-file traces/eval.otlp.json
+agentv eval evals/my-eval.eval.yaml --otel-file traces/eval.otlp.json
 
 # Inspect the OTLP export
 agentv inspect show traces/eval.otlp.json --tree
@@ -188,13 +210,13 @@ Stream traces directly to an observability backend during evaluation using `--ex
 
 ```bash
 # Use a built-in CLI backend resolver (braintrust, langfuse, confident)
-agentv eval evals/my-eval.yaml --export-otel --otel-backend braintrust
+agentv eval evals/my-eval.eval.yaml --export-otel --otel-backend braintrust
 
 # Include message content and tool I/O in spans (disabled by default for privacy)
-agentv eval evals/my-eval.yaml --export-otel --otel-backend braintrust --otel-capture-content
+agentv eval evals/my-eval.eval.yaml --export-otel --otel-backend braintrust --otel-capture-content
 
 # Group messages into turn spans for multi-turn evaluations
-agentv eval evals/my-eval.yaml --export-otel --otel-backend braintrust --otel-group-turns
+agentv eval evals/my-eval.eval.yaml --export-otel --otel-backend braintrust --otel-group-turns
 ```
 
 #### Braintrust
@@ -209,7 +231,7 @@ export BRAINTRUST_PROJECT=my-project    # associates traces with a Braintrust pr
 Run an eval with traces sent to Braintrust:
 
 ```bash
-agentv eval evals/my-eval.yaml --export-otel --otel-backend braintrust --otel-capture-content
+agentv eval evals/my-eval.eval.yaml --export-otel --otel-backend braintrust --otel-capture-content
 ```
 
 The following environment variables control project association (at least one is required):
@@ -238,7 +260,7 @@ export LANGFUSE_PUBLIC_KEY=pk-...
 export LANGFUSE_SECRET_KEY=sk-...
 # Optional: export LANGFUSE_HOST=https://cloud.langfuse.com
 
-agentv eval evals/my-eval.yaml --export-otel --otel-backend langfuse --otel-capture-content
+agentv eval evals/my-eval.eval.yaml --export-otel --otel-backend langfuse --otel-capture-content
 ```
 
 #### Local Backend Resolvers
@@ -257,7 +279,7 @@ export default {
 ```
 
 ```bash
-agentv eval evals/my-eval.yaml --export-otel --otel-backend my-backend
+agentv eval evals/my-eval.eval.yaml --export-otel --otel-backend my-backend
 ```
 
 Backend resolvers keep platform-specific endpoint, header, and project-routing logic outside
@@ -272,7 +294,7 @@ For generic OTLP export without a backend resolver, configure via environment va
 export OTEL_EXPORTER_OTLP_ENDPOINT=https://your-backend/v1/traces
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer token"
 
-agentv eval evals/my-eval.yaml --export-otel
+agentv eval evals/my-eval.eval.yaml --export-otel
 ```
 
 ### Parallelism
@@ -280,10 +302,10 @@ agentv eval evals/my-eval.yaml --export-otel
 The `--workers N` flag controls how many **test cases run in parallel within each eval file** (default: 3). Eval files always run sequentially — one file completes before the next starts.
 
 ```bash
-agentv eval evals/my-eval.yaml --workers 4
+agentv eval evals/my-eval.eval.yaml --workers 4
 # Up to 4 test cases from the file run concurrently
 
-agentv eval evals/file1.yaml evals/file2.yaml evals/file3.yaml --workers 3
+agentv eval evals/file1.eval.yaml evals/file2.eval.yaml evals/file3.eval.yaml --workers 3
 # Files run one at a time; within each file, up to 3 test cases run in parallel
 ```
 
@@ -295,16 +317,16 @@ Use workspace mode and finish policies instead of multiple conflicting booleans:
 
 ```bash
 # Mode: pooled | temp | static
-agentv eval evals/my-eval.yaml --workspace-mode pooled
+agentv eval evals/my-eval.eval.yaml --workspace-mode pooled
 
 # Static mode path
-agentv eval evals/my-eval.yaml --workspace-mode static --workspace-path /path/to/workspace
+agentv eval evals/my-eval.eval.yaml --workspace-mode static --workspace-path /path/to/workspace
 
 # Pooled reset policy override: standard | full (CLI override)
-agentv eval evals/my-eval.yaml --workspace-clean full
+agentv eval evals/my-eval.eval.yaml --workspace-clean full
 
 # Finish policy overrides: keep | cleanup (CLI)
-agentv eval evals/my-eval.yaml --retain-on-success cleanup --retain-on-failure keep
+agentv eval evals/my-eval.eval.yaml --retain-on-success cleanup --retain-on-failure keep
 ```
 
 Equivalent eval YAML:
@@ -340,16 +362,16 @@ AgentV ships three flags for picking up a partial run. They differ only in **whi
 
 ```bash
 # Resume the last run — no args needed; AgentV finds it from .agentv/cache.json
-agentv eval evals/my-eval.yaml --resume
+agentv eval evals/my-eval.eval.yaml --resume
 
 # Or target a specific run dir explicitly
-agentv eval evals/my-eval.yaml --output .agentv/results/default/<timestamp> --resume
+agentv eval evals/my-eval.eval.yaml --output .agentv/results/default/<timestamp> --resume
 
 # Re-run errors AND failed cases against the last run dir
-agentv eval evals/my-eval.yaml --rerun-failed
+agentv eval evals/my-eval.eval.yaml --rerun-failed
 
 # Re-run only execution errors from any prior run by path
-agentv eval evals/my-eval.yaml --retry-errors .agentv/results/default/<timestamp>/index.jsonl
+agentv eval evals/my-eval.eval.yaml --retry-errors .agentv/results/default/<timestamp>/index.jsonl
 ```
 
 After any failing run, the CLI prints the exact `--rerun-failed` command for the run dir that just completed — copy/paste it. If the process or pod disappeared before you could access the local run directory and results auto-push was enabled, recover the partial run from [WIP checkpoints](/docs/tools/wip-checkpoints/) first, then use the same `--resume` flow.
@@ -405,7 +427,7 @@ The threshold also controls JUnit XML pass/fail: tests with scores below the thr
 Check eval files for schema errors without executing:
 
 ```bash
-agentv validate evals/my-eval.yaml
+agentv validate evals/my-eval.eval.yaml
 ```
 
 ## Run a Single Assertion
@@ -444,7 +466,7 @@ agentv import claude --list
 agentv import claude --session-id <uuid>
 
 # Run graders against the imported transcript
-agentv eval evals/my-eval.yaml --transcript .agentv/transcripts/claude-<id>.jsonl
+agentv eval evals/my-eval.eval.yaml --transcript .agentv/transcripts/claude-<id>.jsonl
 ```
 
 See the [Import tool docs](/docs/tools/import/) for all providers and options.
@@ -533,7 +555,7 @@ includes a note that the version mismatch may be the cause.
 Use `--strict` in CI pipelines to enforce version requirements:
 
 ```bash
-agentv eval --strict evals/my-eval.yaml
+agentv eval --strict evals/my-eval.eval.yaml
 ```
 
 ## Config File Defaults

--- a/apps/web/src/content/docs/docs/guides/skill-improvement-workflow.mdx
+++ b/apps/web/src/content/docs/docs/guides/skill-improvement-workflow.mdx
@@ -268,10 +268,10 @@ The `--experiment` flag provides a structured way to label baseline and candidat
 
 ```bash
 # Baseline: run without skills installed
-agentv pipeline run evals/my-eval.yaml --experiment without_skills
+agentv pipeline run evals/my-eval.eval.yaml --experiment without_skills
 
 # Candidate: run with skills installed
-agentv pipeline run evals/my-eval.yaml --experiment with_skills
+agentv pipeline run evals/my-eval.eval.yaml --experiment with_skills
 ```
 
 Both runs use the same eval file and produce separate run directories. The experiment label is recorded in `manifest.json` and `index.jsonl`, making it easy to filter and compare in dashboards.

--- a/apps/web/src/content/docs/docs/guides/workspace-architecture.mdx
+++ b/apps/web/src/content/docs/docs/guides/workspace-architecture.mdx
@@ -198,7 +198,7 @@ To relocate the agentv home directory, set `HOME` or `USERPROFILE` to point to t
 
 ```powershell
 $env:USERPROFILE = "D:\Users\$env:USERNAME"
-agentv eval evals/my-eval.yaml
+agentv eval evals/my-eval.eval.yaml
 ```
 
 ### Long-path support for relocated home directories
@@ -235,7 +235,7 @@ tree is checked out, but the active phase should be visible in the terminal.
 ### Enable verbose logging
 
 ```bash
-agentv eval evals/my-eval.yaml --verbose
+agentv eval evals/my-eval.eval.yaml --verbose
 ```
 
 Verbose mode logs each setup phase with timestamps. Look for:
@@ -286,7 +286,7 @@ Workspace pooling is **enabled by default** for shared workspaces with repos. Th
 To disable pooling for a run:
 
 ```bash
-agentv eval evals/my-eval.yaml --no-pool
+agentv eval evals/my-eval.eval.yaml --no-pool
 ```
 
 See the [Workspace Pool](/docs/guides/workspace-pool/) guide for details on pool configuration, clean modes, concurrency, and drift detection.

--- a/apps/web/src/content/docs/docs/guides/workspace-pool.mdx
+++ b/apps/web/src/content/docs/docs/guides/workspace-pool.mdx
@@ -40,7 +40,7 @@ Pooling is on by default. To disable it:
 ### CLI mode
 
 ```bash
-agentv eval evals/my-eval.yaml --workspace-mode temp
+agentv eval evals/my-eval.eval.yaml --workspace-mode temp
 ```
 
 ### YAML workspace mode
@@ -63,7 +63,7 @@ By default, pool reset uses `git clean -fd` which **preserves `.gitignore`d file
 For strict reset that also removes `.gitignore`d files, use the `--workspace-clean full` CLI flag:
 
 ```bash
-agentv eval evals/my-eval.yaml --workspace-clean full
+agentv eval evals/my-eval.eval.yaml --workspace-clean full
 ```
 
 | Mode | Git command | `.gitignore`d files | Use case |
@@ -126,7 +126,7 @@ Two configs produce different fingerprints if **any** of these fields differ. Fo
 Pool slots support concurrent eval workers. When running with multiple workers (`-w N`), each worker acquires its own slot from the pool:
 
 ```bash
-agentv eval evals/my-eval.yaml -w 4
+agentv eval evals/my-eval.eval.yaml -w 4
 ```
 
 This creates up to 4 slots (`slot-0` through `slot-3`). PID-based lock files prevent two workers from using the same slot simultaneously. If a lock file references a dead process, it's automatically cleaned up as a stale lock.
@@ -178,7 +178,7 @@ This pattern is especially valuable with pooling: a single `workspace.yaml` guar
 For workspaces you manage outside AgentV, use static mode:
 
 ```bash
-agentv eval evals/my-eval.yaml --workspace-mode static --workspace-path /path/to/my-workspace
+agentv eval evals/my-eval.eval.yaml --workspace-mode static --workspace-path /path/to/my-workspace
 ```
 
 **Auto-materialisation:** When `workspace.path` points to an empty or missing directory, AgentV automatically copies the template and clones repos into it. If the directory already exists and is populated, AgentV checks each repo individually — existing repos are reused as-is, and only missing repos are cloned. This makes static mode convenient for both first-run bootstrap and incremental setup.

--- a/apps/web/src/content/docs/docs/integrations/langfuse.mdx
+++ b/apps/web/src/content/docs/docs/integrations/langfuse.mdx
@@ -19,7 +19,7 @@ export LANGFUSE_SECRET_KEY=sk-lf-...
 Run an eval with Langfuse export enabled:
 
 ```bash
-agentv eval evals/my-eval.yaml --export-otel --otel-backend langfuse
+agentv eval evals/my-eval.eval.yaml --export-otel --otel-backend langfuse
 ```
 
 Traces appear in your Langfuse dashboard within seconds.

--- a/apps/web/src/content/docs/docs/tools/compare.mdx
+++ b/apps/web/src/content/docs/docs/tools/compare.mdx
@@ -12,9 +12,9 @@ The `compare` command computes deltas between two evaluation runs for A/B testin
 Run two evaluations and compare them:
 
 ```bash
-agentv eval evals/my-eval.yaml --output .agentv/results/default/before
+agentv eval evals/my-eval.eval.yaml --output .agentv/results/default/before
 # ... make changes to your agent ...
-agentv eval evals/my-eval.yaml --output .agentv/results/default/after
+agentv eval evals/my-eval.eval.yaml --output .agentv/results/default/after
 agentv compare .agentv/results/default/before/index.jsonl .agentv/results/default/after/index.jsonl
 ```
 

--- a/apps/web/src/content/docs/docs/tools/import.mdx
+++ b/apps/web/src/content/docs/docs/tools/import.mdx
@@ -206,7 +206,7 @@ agentv import claude --list
 agentv import claude --session-id 4c4f9e4e-e6f1-490b-a1b1-9aef543ebf22
 
 # 3. Run graders against the imported transcript
-agentv eval evals/my-eval.yaml --transcript .agentv/transcripts/claude-4c4f9e4e.jsonl
+agentv eval evals/my-eval.eval.yaml --transcript .agentv/transcripts/claude-4c4f9e4e.jsonl
 ```
 
 See `examples/features/import-claude/` for a complete working example.

--- a/apps/web/src/content/docs/docs/tools/validate.mdx
+++ b/apps/web/src/content/docs/docs/tools/validate.mdx
@@ -10,13 +10,13 @@ The `validate` command checks evaluation files for schema errors without running
 ## Usage
 
 ```bash
-agentv validate evals/my-eval.yaml
+agentv validate evals/my-eval.eval.yaml
 ```
 
 Validate multiple files:
 
 ```bash
-agentv validate evals/**/*.yaml
+agentv validate evals/**/*.eval.yaml
 ```
 
 ## What It Checks

--- a/docs/adr/2026-06-23-experiments-vs-eval-separation.md
+++ b/docs/adr/2026-06-23-experiments-vs-eval-separation.md
@@ -70,7 +70,8 @@ as the power-user escape hatch:
 name: copilot-gpt55-withskill
 target: copilot-gpt55
 model: openai/gpt-5.5
-evals: "agent-042-*"
+eval_suites: "evals/**/*.eval.yaml"
+eval_cases: "agent-042-*"
 scripts:
   - build
 repeat:
@@ -90,7 +91,7 @@ usage keeps working:
 
 ```yaml
 experiments:
-  default: experiments/default.yaml
+  default: experiments/default.exp.yaml
 ```
 
 If no default experiment is configured, AgentV keeps the current behavior and

--- a/docs/adr/2026-06-25-experiments-as-persisted-run-profiles.md
+++ b/docs/adr/2026-06-25-experiments-as-persisted-run-profiles.md
@@ -71,6 +71,24 @@ When a user supplies CLI flags without an experiment file, AgentV should still
 persist the resolved run configuration in the run bundle so the material choices
 are not lost.
 
+Experiments may also persist eval suite file selection with `eval_suites`. This
+field uses the same path, glob, directory, and negation syntax as positional
+`agentv eval` arguments, and paths are resolved from the project root/current
+working directory just like CLI arguments. Experiment `eval_cases` is the
+case/test-id filter over the selected suites. Existing experiment `evals`
+remains a legacy alias for `eval_cases`.
+
+The eval-file selection precedence is:
+
+1. CLI positional eval paths.
+2. Experiment `eval_suites`.
+3. Config/default discovery only for compatibility paths that already rely on
+   experiment `evals` as a case filter.
+
+The higher-precedence source chooses the eval files for the run. The lower
+source does not merge in extra suites. Experiment `eval_cases` can still narrow
+cases after either CLI paths or `eval_suites` select the files.
+
 Run artifacts should model results as rows across the stable axes:
 
 - experiment or run profile name

--- a/docs/plans/2026-06-23-002-experiments-separation-plan.md
+++ b/docs/plans/2026-06-23-002-experiments-separation-plan.md
@@ -107,7 +107,8 @@ agent: codex
 model: openai/gpt-5.5
 agent_options:
   reasoning_effort: high
-evals: "agent-042-*"
+eval_suites: "evals/**/*.eval.yaml"
+eval_cases: "agent-042-*"
 scripts:
   - build
   - script: bun test
@@ -173,10 +174,10 @@ otherwise AgentV derives the name from the file basename.
 
 Later CLI phases should add:
 
-- `agentv eval --experiment experiments/baseline.yaml`.
-- `agentv eval --experiment baseline` resolving `experiments/baseline.yaml`
+- `agentv eval --experiment experiments/baseline.exp.yaml`.
+- `agentv eval --experiment baseline` resolving `experiments/baseline.exp.yaml`
   before falling back to a label.
-- `agentv eval --experiments "experiments/*.yaml"` for matrices.
+- `agentv eval --experiments "experiments/*.exp.yaml"` for matrices.
 - Experiment `evals` filters AgentV case IDs. When no eval paths are provided,
   file discovery uses `.agentv/config.yaml eval_patterns` or AgentV's default
   eval patterns.
@@ -187,7 +188,7 @@ Phase 1 is additive. It introduces experiment config loading and default
 resolution without changing how eval execution applies targets or workspace
 settings.
 
-Phase 2 moves examples to committed `experiments/default.yaml` files while
+Phase 2 moves examples to committed `experiments/default.exp.yaml` files while
 leaving existing `eval.yaml execution` fields in place.
 
 Phase 3 applies experiment runtime fields in the runner: target selection, eval
@@ -277,10 +278,10 @@ Test Scenarios:
 
 - `agentv eval evals/foo/eval.yaml` still writes under
   `.agentv/results/default/<timestamp>/`.
-- Configured `experiments.default: experiments/default.yaml` with `name:
+- Configured `experiments.default: experiments/default.exp.yaml` with `name:
   baseline` writes under `.agentv/results/baseline/<timestamp>/`.
 - `--experiment smoke` writes under `.agentv/results/smoke/<timestamp>/`.
-- `--experiment experiments/smoke.yaml` uses the file's `name` when present.
+- `--experiment experiments/smoke.exp.yaml` uses the file's `name` when present.
 - Missing path-like experiment values fail clearly.
 
 ### U4. Runner Field Application
@@ -345,7 +346,7 @@ Files:
 Approach:
 
 Document eval versus experiment authoring. Add at least one example with
-`eval.yaml` plus `experiments/default.yaml`, and one A/B pair such as baseline
+`*.eval.yaml` plus `experiments/default.exp.yaml`, and one A/B pair such as baseline
 versus with-skill.
 
 Test Scenarios:
@@ -384,7 +385,7 @@ Phase 1 targeted checks:
 - `bun test packages/core/test/evaluation` for loader and config coverage once
   tests exist.
 - CLI-level test for default experiment run layout.
-- A dry-run fixture using `experiments/default.yaml` to prove the resolved
+- A dry-run fixture using `experiments/default.exp.yaml` to prove the resolved
   experiment name reaches artifacts.
 - Existing eval-only dry-run fixture to prove fallback stays `default`.
 

--- a/examples/features/benchmark-tooling/README.md
+++ b/examples/features/benchmark-tooling/README.md
@@ -127,7 +127,7 @@ Use `agentv compare` directly on the canonical run manifest for pairwise or matr
 
 ```bash
 # 1. Run a matrix evaluation that produces a canonical run workspace
-bun agentv eval my-eval.yaml
+bun agentv eval my-eval.eval.yaml
 
 # 2. Compare any two targets from the same run
 bun agentv compare .agentv/results/default/<timestamp>/index.jsonl \
@@ -282,7 +282,7 @@ bun examples/features/benchmark-tooling/scripts/benchmark-report.ts ./by-target/
 
 ```bash
 # 1. Run multi-model evaluation
-bun agentv eval my-eval.yaml
+bun agentv eval my-eval.eval.yaml
 
 # 2. Compare two targets from the run manifest
 bun agentv compare .agentv/results/default/<timestamp>/index.jsonl \

--- a/examples/features/runs/README.md
+++ b/examples/features/runs/README.md
@@ -6,16 +6,15 @@ behavior in committed experiment files.
 ## Files
 
 - `evals/dataset.eval.yaml` defines the two task cases.
-- `experiments/default.yaml` runs the cases with `pass_at_k`.
-- `experiments/mean.yaml` aggregates repeated scores with `mean`.
-- `experiments/confidence-interval.yaml` aggregates repeated scores with a 95%
+- `experiments/default.exp.yaml` runs the cases with `pass_at_k`.
+- `experiments/mean.exp.yaml` aggregates repeated scores with `mean`.
+- `experiments/confidence-interval.exp.yaml` aggregates repeated scores with a 95%
   confidence interval lower bound.
 
 ## Run
 
 ```bash
-bun agentv eval examples/features/runs/evals/dataset.eval.yaml \
-  --experiment examples/features/runs/experiments/default.yaml
+bun agentv eval --experiment examples/features/runs/experiments/default.exp.yaml
 ```
 
 Swap the experiment path to try the other strategies.
@@ -25,6 +24,9 @@ Swap the experiment path to try the other strategies.
 The repeat block now lives on the experiment, not in `eval.yaml`:
 
 ```yaml
+eval_suites:
+  - examples/features/runs/evals/dataset.eval.yaml
+eval_cases: "*"
 repeat:
   count: 2
   strategy: pass_at_k

--- a/examples/features/runs/experiments/confidence-interval.exp.yaml
+++ b/examples/features/runs/experiments/confidence-interval.exp.yaml
@@ -1,8 +1,8 @@
 name: repeat-runs-confidence-interval
 target: llm
-evals:
-  - math-basics
-  - capital-knowledge
+eval_suites:
+  - examples/features/runs/evals/dataset.eval.yaml
+eval_cases: "*"
 repeat:
   count: 5
   strategy: confidence_interval

--- a/examples/features/runs/experiments/default.exp.yaml
+++ b/examples/features/runs/experiments/default.exp.yaml
@@ -1,8 +1,8 @@
 name: repeat-runs
 target: llm
-evals:
-  - math-basics
-  - capital-knowledge
+eval_suites:
+  - examples/features/runs/evals/dataset.eval.yaml
+eval_cases: "*"
 repeat:
   count: 2
   strategy: pass_at_k

--- a/examples/features/runs/experiments/mean.exp.yaml
+++ b/examples/features/runs/experiments/mean.exp.yaml
@@ -1,8 +1,8 @@
 name: repeat-runs-mean
 target: llm
-evals:
-  - math-basics
-  - capital-knowledge
+eval_suites:
+  - examples/features/runs/evals/dataset.eval.yaml
+eval_cases: "*"
 repeat:
   count: 3
   strategy: mean

--- a/examples/showcase/multi-model-benchmark/README.md
+++ b/examples/showcase/multi-model-benchmark/README.md
@@ -19,7 +19,7 @@ multi-model-benchmark/
 ├── evals/
 │   └── benchmark.eval.yaml          # Eval definition (task cases + metrics)
 ├── experiments/
-│   └── default.yaml                 # Targets, repeat policy, and run knobs
+│   └── default.exp.yaml             # Targets, repeat policy, and run knobs
 └── prompts/
     ├── accuracy-rubric.md           # Factual correctness grader (weight 3.0)
     ├── completeness-rubric.md       # Coverage grader (weight 2.0)
@@ -37,8 +37,7 @@ From the repository root:
 
 ```bash
 # Run the full matrix (all targets × all tests × 2 repeat attempts)
-bun agentv eval examples/showcase/multi-model-benchmark/evals/benchmark.eval.yaml \
-  --experiment examples/showcase/multi-model-benchmark/experiments/default.yaml
+bun agentv eval --experiment examples/showcase/multi-model-benchmark/experiments/default.exp.yaml
 ```
 
 ### Cost & Safety
@@ -49,8 +48,7 @@ To run against a single target first:
 
 ```bash
 # Test with just one model before running the full matrix
-bun agentv eval examples/showcase/multi-model-benchmark/evals/benchmark.eval.yaml \
-  --experiment examples/showcase/multi-model-benchmark/experiments/default.yaml \
+bun agentv eval --experiment examples/showcase/multi-model-benchmark/experiments/default.exp.yaml \
   --target copilot
 ```
 
@@ -132,11 +130,9 @@ targets:
   - copilot
   - claude
   - gemini-llm
-evals:
-  - factual-*
-  - analytical-comparison
-  - creative-explanation
-  - structured-list
+eval_suites:
+  - examples/showcase/multi-model-benchmark/evals/benchmark.eval.yaml
+eval_cases: "*"
 repeat:
   count: 2
   strategy: pass_at_k

--- a/examples/showcase/multi-model-benchmark/evals/benchmark.eval.yaml
+++ b/examples/showcase/multi-model-benchmark/evals/benchmark.eval.yaml
@@ -10,7 +10,7 @@
 #
 # Usage:
 #   agentv eval examples/showcase/multi-model-benchmark/evals/benchmark.eval.yaml \
-#     --experiment examples/showcase/multi-model-benchmark/experiments/default.yaml
+#     --experiment examples/showcase/multi-model-benchmark/experiments/default.exp.yaml
 
 description: Multi-model benchmark — accuracy, completeness, and clarity across models
 tags: [multi-provider]

--- a/examples/showcase/multi-model-benchmark/experiments/default.exp.yaml
+++ b/examples/showcase/multi-model-benchmark/experiments/default.exp.yaml
@@ -3,12 +3,9 @@ targets:
   - copilot
   - claude
   - gemini-llm
-evals:
-  - factual-geography
-  - factual-science
-  - analytical-comparison
-  - creative-explanation
-  - structured-list
+eval_suites:
+  - examples/showcase/multi-model-benchmark/evals/benchmark.eval.yaml
+eval_cases: "*"
 repeat:
   count: 2
   strategy: pass_at_k

--- a/packages/core/scripts/generate-eval-schema.ts
+++ b/packages/core/scripts/generate-eval-schema.ts
@@ -52,6 +52,6 @@ await writeSchema({
   schema: ExperimentFileSchema,
   name: 'ExperimentFile',
   title: 'AgentV Experiment File',
-  description: 'Schema for AgentV experiment YAML files (experiments/*.yaml)',
+  description: 'Schema for AgentV experiment YAML files (experiments/*.exp.yaml)',
   outputFile: 'experiment-schema.json',
 });

--- a/packages/core/src/evaluation/evaluate.ts
+++ b/packages/core/src/evaluation/evaluate.ts
@@ -287,7 +287,7 @@ export interface EvalRunArtifacts {
  * @example Load from YAML
  * ```typescript
  * const { summary } = await evaluate({
- *   specFile: './evals/my-eval.yaml',
+ *   specFile: './evals/my-eval.eval.yaml',
  *   filter: 'greeting-*',
  * });
  * ```

--- a/packages/core/src/evaluation/experiment.ts
+++ b/packages/core/src/evaluation/experiment.ts
@@ -65,6 +65,8 @@ export type ExperimentConfigWire = {
   readonly targets?: readonly ExperimentTargetRefWire[];
   readonly model?: string;
   readonly agent_options?: Record<string, unknown>;
+  readonly eval_suites?: string | readonly string[];
+  readonly eval_cases?: string | readonly string[];
   readonly evals?: string | readonly string[];
   readonly scripts?: readonly ExperimentScriptWire[];
   readonly repeat?: ExperimentRepeatWire;
@@ -85,7 +87,8 @@ export type ExperimentConfig = {
   readonly targets?: readonly ExperimentTargetRef[];
   readonly model?: string;
   readonly agentOptions?: Record<string, unknown>;
-  readonly evals?: string | readonly string[];
+  readonly evalSuites?: string | readonly string[];
+  readonly evalCases?: string | readonly string[];
   readonly scripts?: readonly ExperimentScript[];
   readonly repeat?: ExperimentRepeat;
   readonly runs?: number;
@@ -108,7 +111,8 @@ export type ExperimentArtifactMetadata = {
   readonly target?: string;
   readonly targets?: readonly string[];
   readonly model?: string;
-  readonly evals?: string | readonly string[];
+  readonly eval_suites?: string | readonly string[];
+  readonly eval_cases?: string | readonly string[];
   readonly repeat?: {
     readonly count: number;
     readonly strategy: RunStrategy;
@@ -149,6 +153,7 @@ export function isExperimentFileReference(value: string): boolean {
 export function deriveExperimentNameFromPath(filePath: string): string {
   return path
     .basename(filePath)
+    .replace(/\.exp\.(ya?ml)$/i, '')
     .replace(/\.experiment\.(ya?ml|[cm]?[jt]s)$/i, '')
     .replace(/\.(ya?ml|[cm]?[jt]s)$/i, '');
 }
@@ -187,7 +192,11 @@ export function normalizeExperimentConfig(
   const targets = readTargets(rawConfig.targets);
   const model = readOptionalString(rawConfig.model, 'model');
   const agentOptions = readOptionalRecord(rawConfig.agent_options ?? rawConfig.agentOptions);
-  const evals = readOptionalStringOrStringArray(rawConfig.evals, 'evals');
+  const evalSuites = readOptionalStringOrStringArray(
+    rawConfig.eval_suites ?? rawConfig.evalSuites,
+    'eval_suites',
+  );
+  const evalCases = readExperimentEvalCases(rawConfig);
   const scripts = readScriptArray(rawConfig.scripts, 'scripts');
   const repeat = readRepeat(rawConfig.repeat);
   const runs = readOptionalPositiveInteger(rawConfig.runs, 'runs');
@@ -215,7 +224,8 @@ export function normalizeExperimentConfig(
     ...(targets !== undefined && { targets }),
     ...(model !== undefined && { model }),
     ...(agentOptions !== undefined && { agentOptions }),
-    ...(evals !== undefined && { evals }),
+    ...(evalSuites !== undefined && { evalSuites }),
+    ...(evalCases !== undefined && { evalCases }),
     ...(scripts !== undefined && { scripts }),
     ...(repeat !== undefined && { repeat }),
     ...(runs !== undefined && { runs }),
@@ -257,7 +267,8 @@ export function buildExperimentArtifactMetadata(
     ...(config.target !== undefined && { target: config.target }),
     ...(targets && targets.length > 0 && { targets }),
     ...(config.model !== undefined && { model: config.model }),
-    ...(config.evals !== undefined && { evals: config.evals }),
+    ...(config.evalSuites !== undefined && { eval_suites: config.evalSuites }),
+    ...(config.evalCases !== undefined && { eval_cases: config.evalCases }),
     ...(config.repeat !== undefined && {
       repeat: {
         count: config.repeat.count,
@@ -323,6 +334,19 @@ function readTargets(raw: unknown): readonly ExperimentTargetRef[] | undefined {
       ...(hooks !== undefined && { hooks }),
     };
   });
+}
+
+function readExperimentEvalCases(
+  rawConfig: Record<string, unknown>,
+): string | readonly string[] | undefined {
+  const canonical = rawConfig.eval_cases ?? rawConfig.evalCases;
+  const legacy = rawConfig.evals;
+  if (canonical !== undefined && legacy !== undefined) {
+    throw new Error(
+      'Experiment eval_cases and evals cannot both be set. Use eval_cases for case/test-id filters.',
+    );
+  }
+  return readOptionalStringOrStringArray(canonical ?? legacy, 'eval_cases');
 }
 
 function readScriptArray(raw: unknown, location: string): readonly ExperimentScript[] | undefined {

--- a/packages/core/src/evaluation/loaders/config-loader.ts
+++ b/packages/core/src/evaluation/loaders/config-loader.ts
@@ -19,6 +19,7 @@ const ANSI_RESET = '\u001b[0m';
 
 export const DEFAULT_EVAL_PATTERNS: readonly string[] = [
   '**/evals/**/*.eval.yaml',
+  '**/evals/**/EVAL.yaml',
   '**/evals/**/eval.yaml',
   '**/evals/**/*.eval.ts',
 ];

--- a/packages/core/src/evaluation/validation/experiment-file.schema.ts
+++ b/packages/core/src/evaluation/validation/experiment-file.schema.ts
@@ -56,6 +56,8 @@ export const ExperimentFileSchema = z
     targets: z.array(ExperimentTargetRefSchema).min(1).optional(),
     model: z.string().min(1).optional(),
     agent_options: JsonObjectSchema.optional(),
+    eval_suites: StringOrStringArraySchema.optional(),
+    eval_cases: StringOrStringArraySchema.optional(),
     evals: StringOrStringArraySchema.optional(),
     scripts: z.array(ExperimentScriptSchema).optional(),
     repeat: ExperimentRepeatSchema.optional(),
@@ -71,4 +73,7 @@ export const ExperimentFileSchema = z
   .strict()
   .refine((value) => value.repeat === undefined || value.runs === undefined, {
     message: 'Use repeat or runs, not both.',
+  })
+  .refine((value) => value.eval_cases === undefined || value.evals === undefined, {
+    message: 'Use eval_cases or legacy evals, not both.',
   });

--- a/packages/core/test/evaluation/config.test.ts
+++ b/packages/core/test/evaluation/config.test.ts
@@ -44,10 +44,10 @@ describe('defineConfig execution defaults', () => {
   it('accepts typed experiment defaults', () => {
     const config = defineConfig({
       defaultExperiment: 'smoke',
-      experiments: { default: 'experiments/default.yaml' },
+      experiments: { default: 'experiments/default.exp.yaml' },
     });
     expect(config.defaultExperiment).toBe('smoke');
-    expect(config.experiments?.default).toBe('experiments/default.yaml');
+    expect(config.experiments?.default).toBe('experiments/default.exp.yaml');
   });
 
   it('rejects non-boolean verbose', () => {

--- a/packages/core/test/evaluation/experiment.test.ts
+++ b/packages/core/test/evaluation/experiment.test.ts
@@ -19,7 +19,8 @@ describe('experiment config', () => {
       agent: 'codex',
       model: 'openai/gpt-5.5',
       agent_options: { reasoning_effort: 'high' },
-      evals: 'evals/**/*.eval.yaml',
+      eval_suites: 'evals/**/*.eval.yaml',
+      eval_cases: 'case-*',
       scripts: ['build', { script: 'bun test', timeout_seconds: 120 }],
       runs: 3,
       early_exit: false,
@@ -36,7 +37,8 @@ describe('experiment config', () => {
       agent: 'codex',
       model: 'openai/gpt-5.5',
       agentOptions: { reasoning_effort: 'high' },
-      evals: 'evals/**/*.eval.yaml',
+      evalSuites: 'evals/**/*.eval.yaml',
+      evalCases: 'case-*',
       scripts: [{ script: 'build' }, { script: 'bun test', timeoutSeconds: 120 }],
       runs: 3,
       earlyExit: false,
@@ -47,6 +49,14 @@ describe('experiment config', () => {
       setup: [{ script: 'bun install' }],
     });
     expect(config.fingerprint).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('treats legacy evals as an eval_cases alias', () => {
+    const config = normalizeExperimentConfig({
+      evals: ['case-alpha', 'case-beta'],
+    });
+
+    expect(config.evalCases).toEqual(['case-alpha', 'case-beta']);
   });
 
   it('normalizes experiment-level repeat config with legacy trial strategy parity', () => {
@@ -83,7 +93,7 @@ describe('experiment config', () => {
   it('loads a YAML experiment file', async () => {
     const tempDir = mkdtempSync(path.join(os.tmpdir(), 'agentv-experiment-'));
     try {
-      const experimentPath = path.join(tempDir, 'default.yaml');
+      const experimentPath = path.join(tempDir, 'default.exp.yaml');
       writeFileSync(
         experimentPath,
         [
@@ -123,12 +133,17 @@ describe('experiment config', () => {
       /repeat and runs/,
     );
     expect(() => normalizeExperimentConfig({ sandbox: 'host' })).toThrow(/sandbox/);
+    expect(() => normalizeExperimentConfig({ eval_cases: 'case-a', evals: 'case-b' })).toThrow(
+      /eval_cases and evals/,
+    );
   });
 
   it('builds safe snake_case artifact metadata', () => {
     const config = normalizeExperimentConfig({
       name: 'baseline',
       target: 'codex',
+      eval_suites: ['evals/**/*.eval.yaml'],
+      eval_cases: ['case-alpha'],
       agent_options: { secret: 'not persisted' },
       setup: [{ script: 'bun install' }],
       scripts: [{ script: 'bun test' }],
@@ -143,6 +158,8 @@ describe('experiment config', () => {
     expect(metadata).toMatchObject({
       name: 'baseline',
       target: 'codex',
+      eval_suites: ['evals/**/*.eval.yaml'],
+      eval_cases: ['case-alpha'],
       repeat: {
         count: 2,
         strategy: 'mean',
@@ -158,7 +175,7 @@ describe('experiment config', () => {
   });
 
   it('detects experiment file references separately from labels', () => {
-    expect(isExperimentFileReference('experiments/default.yaml')).toBe(true);
+    expect(isExperimentFileReference('experiments/default.exp.yaml')).toBe(true);
     expect(isExperimentFileReference('default.yaml')).toBe(true);
     expect(isExperimentFileReference('baseline')).toBe(false);
   });
@@ -166,6 +183,9 @@ describe('experiment config', () => {
   it('derives experiment names from file paths', () => {
     expect(deriveExperimentNameFromPath('/repo/experiments/baseline.experiment.ts')).toBe(
       'baseline',
+    );
+    expect(deriveExperimentNameFromPath('/repo/experiments/with-skill.exp.yaml')).toBe(
+      'with-skill',
     );
     expect(deriveExperimentNameFromPath('/repo/experiments/with-skill.yaml')).toBe('with-skill');
   });

--- a/packages/core/test/evaluation/loaders/config-loader.test.ts
+++ b/packages/core/test/evaluation/loaders/config-loader.test.ts
@@ -136,13 +136,13 @@ describe('loadConfig', () => {
       mkdirSync(localConfigDir, { recursive: true });
       writeFileSync(
         path.join(localConfigDir, 'config.yaml'),
-        'experiments:\n  default: experiments/default.yaml\n',
+        'experiments:\n  default: experiments/default.exp.yaml\n',
       );
 
       const config = await loadConfig(path.join(evalDir, 'suite.eval.yaml'), projectDir);
 
-      expect(config?.experiments?.default).toBe('experiments/default.yaml');
-      expect(resolveDefaultExperimentReference(config)).toBe('experiments/default.yaml');
+      expect(config?.experiments?.default).toBe('experiments/default.exp.yaml');
+      expect(resolveDefaultExperimentReference(config)).toBe('experiments/default.exp.yaml');
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -170,8 +170,10 @@ describe('loadConfig', () => {
 
 describe('parseExperimentsConfig', () => {
   it('parses experiments.default', () => {
-    expect(parseExperimentsConfig({ default: 'experiments/default.yaml' }, 'config.yaml')).toEqual({
-      default: 'experiments/default.yaml',
+    expect(
+      parseExperimentsConfig({ default: 'experiments/default.exp.yaml' }, 'config.yaml'),
+    ).toEqual({
+      default: 'experiments/default.exp.yaml',
     });
   });
 });

--- a/packages/core/test/evaluation/validation/eval-schema-sync.test.ts
+++ b/packages/core/test/evaluation/validation/eval-schema-sync.test.ts
@@ -51,7 +51,7 @@ describe('generated schema sync', () => {
     const expected = {
       $schema: 'https://json-schema.org/draft/2019-09/schema',
       title: 'AgentV Experiment File',
-      description: 'Schema for AgentV experiment YAML files (experiments/*.yaml)',
+      description: 'Schema for AgentV experiment YAML files (experiments/*.exp.yaml)',
       ...generated,
     };
 

--- a/skills-data/agentv-eval-writer/SKILL.md
+++ b/skills-data/agentv-eval-writer/SKILL.md
@@ -19,9 +19,11 @@ Comprehensive docs: https://agentv.dev
 Treat YAML as the canonical portable model. Prefer authoring `.eval.yaml` / `EVAL.yaml` first, then use TypeScript helpers, Python scripts, or executable graders only when they lower to the same fields or when the evaluation logic must actually run code.
 
 Eval files define what is tested: prompts, datasets, assertions, and task fixtures.
-Experiment files define how those evals run: targets, setup, scripts, timeout,
-sandbox, and repeat-run policy. Use `experiments/*.yaml` for committed run
-configurations.
+Experiment files define how those evals run: eval suite paths/globs
+(`eval_suites`), target selection, setup, scripts, timeout, sandbox, case
+filters (`eval_cases`), and repeat-run policy. Use `experiments/*.exp.yaml` for
+committed run configurations that can be replayed with
+`agentv eval --experiment <path>`.
 
 Use `@agentv/sdk` for TypeScript helper imports. Do not use `@agentv/eval` for new evals, examples, scaffolds, or skill guidance; it was a deprecated compatibility package and has been removed from this repository.
 

--- a/skills-data/agentv-eval-writer/references/config-schema.json
+++ b/skills-data/agentv-eval-writer/references/config-schema.json
@@ -16,12 +16,12 @@
     },
     "eval_patterns": {
       "type": "array",
-      "description": "Glob patterns for discovering eval files during interactive mode (`agentv eval` with no args). Defaults to ['**/evals/**/dataset*.yaml', '**/evals/**/eval.yaml'] if not specified.",
+      "description": "Glob patterns for discovering eval files during interactive mode (`agentv eval` with no args). Defaults to ['**/evals/**/*.eval.yaml', '**/evals/**/EVAL.yaml', '**/evals/**/eval.yaml', '**/evals/**/*.eval.ts'] if not specified.",
       "items": {
         "type": "string",
-        "description": "Glob pattern (e.g., '**/evals/**/dataset*.yaml', '**/evals/**/eval.yaml')"
+        "description": "Glob pattern (e.g., '**/evals/**/*.eval.yaml', '**/evals/**/EVAL.yaml')"
       },
-      "examples": [["**/evals/**/dataset*.yaml", "**/evals/**/eval.yaml"], ["**/evals/**/*.yaml"]]
+      "examples": [["**/evals/**/*.eval.yaml", "**/evals/**/EVAL.yaml"], ["**/evals/**/*.yaml"]]
     },
     "execution": {
       "type": "object",

--- a/skills-data/agentv-eval-writer/references/experiment-schema.json
+++ b/skills-data/agentv-eval-writer/references/experiment-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema#",
   "title": "AgentV Experiment File",
-  "description": "Schema for AgentV experiment YAML files (experiments/*.yaml)",
+  "description": "Schema for AgentV experiment YAML files (experiments/*.exp.yaml)",
   "$ref": "#/definitions/ExperimentFile",
   "definitions": {
     "ExperimentFile": {
@@ -59,6 +59,38 @@
           "type": "object",
           "properties": {},
           "additionalProperties": {}
+        },
+        "eval_suites": {
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            }
+          ]
+        },
+        "eval_cases": {
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            }
+          ]
         },
         "evals": {
           "anyOf": [


### PR DESCRIPTION
## Summary

Experiments can now be replayed without positional eval paths by declaring `eval_suites` in the experiment YAML. Case filtering is explicit as `eval_cases`, while legacy `evals` remains accepted as a compatibility alias for case/test-id filters only.

CLI positional eval paths still win for one-off runs, and experiment case filters continue to apply after the suite source is chosen. The default output layout remains timestamped under `.agentv/results/<experiment>/<timestamp>/`.

## Contract

| Field | Purpose |
| --- | --- |
| `eval_suites` | Eval suite file paths, directories, or globs such as `evals/**/*.eval.yaml` |
| `eval_cases` | Case/test-id filter patterns within the selected suites |
| `evals` | Legacy alias for `eval_cases`; rejected if combined with `eval_cases` |

## Validation

- `bun test test/evaluation/experiment.test.ts test/evaluation/validation/eval-schema-sync.test.ts`
- `bun --filter @agentv/core build`
- `bun --filter @agentv/sdk build`
- `bun test apps/cli/test/eval.integration.test.ts`
- `bun run validate:examples`
- `bun run typecheck`
- `bun run lint`
- Manual temp-project smoke: `AGENTV_RUN_TIMESTAMP=2026-06-25T06-49-34-908Z bun /home/entity/projects/EntityProcess/agentv__worktrees/experiment-eval-paths/apps/cli/src/cli.ts eval --experiment experiments/repeat-matrix.yaml`

The manual smoke produced `.agentv/results/repeat-matrix/2026-06-25T06-49-34-908Z/index.jsonl` from an experiment-only invocation with two mock targets and repeat config. Live agent + live grader dogfood has not been run yet, so this PR is opened as draft.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
