### PR TITLE
fix(cli): avoid duplicate createRequire binding

### DIFF
--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import { constants, existsSync, mkdirSync } from 'node:fs';
 import { access, readFile } from 'node:fs/promises';
-import { createRequire } from 'node:module';
+import { createRequire as createNodeRequire } from 'node:module';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -89,8 +89,8 @@ import type { TaskBundleTargetSelection } from './task-bundle.js';
 import { WipCheckpointLoop } from './wip-checkpoint.js';
 
 const DEFAULT_WORKERS = 3;
-const require = createRequire(import.meta.url);
-const micromatch = require('micromatch') as {
+const loadCjsModule = createNodeRequire(import.meta.url);
+const micromatch = loadCjsModule('micromatch') as {
   isMatch(id: string, pattern: string): boolean;
 };
 


### PR DESCRIPTION
## Summary
- fix the Validate Evals CI failure seen after #1514 by avoiding a duplicate generated createRequire binding in the CLI bundle
- keep micromatch loaded through createRequire, but alias the source binding so Bun does not see two createRequire declarations in the same chunk

## Verification
- bunx biome check apps/cli/src/commands/eval/run-eval.ts
- bun run build && bun apps/cli/dist/cli.js validate 'examples/features/**/evals/**/*.eval.yaml' 'examples/features/**/*.EVAL.yaml'
- bun --filter agentv typecheck