### PR TITLE
docs(eval): clarify expected_output assertion contract

### DIFF
--- a/apps/web/src/content/docs/docs/evaluation/eval-cases.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/eval-cases.mdx
@@ -67,7 +67,13 @@ When suite-level `input` is defined in the eval file, those messages are prepend
 
 ## Expected Output
 
-Optional reference response for comparison by graders. A string expands to a single assistant message:
+Optional reference response for comparison by graders. `expected_output` is passive reference
+data: it is stored on the case and passed to graders, but it does not choose a grader by
+itself when `assertions` is present. Add an explicit `llm-grader`, `code-grader`,
+`field-accuracy`, or another reference-aware grader when you want the reference answer
+evaluated.
+
+A string expands to a single assistant message:
 
 ```yaml
 expected_output: "42"
@@ -332,13 +338,16 @@ Required gates are evaluated after all graders run. If any required grader falls
 - Suite-level `assertions` graders are appended automatically.
 - Set `execution.skip_defaults: true` on a test to skip suite-level defaults.
 
-## How `criteria` and `assertions` Interact
+## How Reference Fields and `assertions` Interact
 
-The `criteria` field is a **data field** that describes what the response should accomplish. It is not an grader itself — how it gets used depends on whether `assertions` is present.
+The `criteria` and `expected_output` fields are **data fields** that describe what the
+response should accomplish. They are not graders themselves — how they get used depends
+on whether `assertions` is present.
 
 ### No `assertions` — implicit LLM grader
 
-When a test has no `assertions` field, a default `llm-grader` grader runs automatically and uses `criteria` as the evaluation prompt:
+When a test has no `assertions` field, a default `llm-grader` grader runs automatically
+and uses the case context, including `criteria` and `expected_output` when present:
 
 ```yaml
 tests:
@@ -363,7 +372,23 @@ tests:
 
 ### `assertions` present — explicit graders only
 
-When `assertions` is defined, only the declared graders run. No implicit grader is added. Graders that are declared (such as `llm-grader`, `code-grader`, or `rubrics`) receive `criteria` as input automatically.
+When `assertions` is defined, only the declared graders run. No implicit grader is added
+because `criteria` or `expected_output` exists. Graders that are declared (such as
+`llm-grader`, `code-grader`, or `rubrics`) receive the case context, including
+`criteria` and `expected_output`, as input automatically.
+
+This means a case with `expected_output` and only deterministic assertions evaluates only
+those deterministic assertions:
+
+```yaml
+tests:
+  - id: deterministic-reference
+    input: "What is 2 + 2?"
+    expected_output: "4"        # reference data only
+    assertions:
+      - type: contains          # only this grader runs
+        value: "4"
+```
 
 If `assertions` contains only deterministic graders (like `contains` or `regex`), the `criteria` field is not evaluated and a warning is emitted:
 

--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -2608,6 +2608,9 @@ async function runEvaluatorsForCase(options: {
     dependencyResults,
   } = options;
 
+  // Declared assertions are the complete grader list for the case. Reference
+  // data such as expected_output stays on evalCase for graders that read it,
+  // but does not add an implicit llm-grader.
   if (evalCase.assertions && evalCase.assertions.length > 0) {
     return runEvaluatorList({
       evalCase,

--- a/packages/core/test/evaluation/orchestrator.test.ts
+++ b/packages/core/test/evaluation/orchestrator.test.ts
@@ -2425,6 +2425,31 @@ describe('criteria with assert runs only declared evaluators (#452)', () => {
     expect(result.score).toBeCloseTo(1.0);
   });
 
+  it('does NOT inject implicit llm-grader when expected_output is present with assert', async () => {
+    const provider = new SequenceProvider('mock', {
+      responses: [{ output: [{ role: 'assistant', content: 'hello world' }] }],
+    });
+
+    const result = await runEvalCase({
+      evalCase: {
+        ...criteriaTestCase,
+        criteria: undefined,
+        expected_output: [{ role: 'assistant', content: 'hello world' }],
+        assertions: [{ name: 'has-hello', type: 'contains' as const, value: 'hello' }],
+      },
+      provider,
+      target: {
+        ...baseTarget,
+        graderTarget: 'grader-target',
+      },
+      evaluators: evaluatorRegistry,
+    });
+
+    expect(result.scores).toHaveLength(1);
+    expect(result.scores?.[0].type).toBe('contains');
+    expect(result.score).toBe(1);
+  });
+
   it('criteria is available as evalCase data for evaluators that consume it', async () => {
     const provider = new SequenceProvider('mock', {
       responses: [{ output: [{ role: 'assistant', content: 'hello world' }] }],

--- a/skills-data/agentv-bench/references/eval-yaml-spec.md
+++ b/skills-data/agentv-bench/references/eval-yaml-spec.md
@@ -18,13 +18,23 @@ The grader agent uses this to evaluate assertions without the CLI.
 
 - `id` (string, required) — unique test identifier
 - `input` (string | object | Message | Message[], required) — task input. String shorthand expands to `[{role: user, content: "..."}]`; object shorthand preserves structured user content when the object has no top-level `role`. Top-level `role` is reserved for message objects.
-- `expected_output` (string | Message[], optional) — reference answer. String shorthand expands to `[{role: assistant, content: "..."}]`
+- `expected_output` (string | Message[], optional) — passive reference answer. String shorthand expands to `[{role: assistant, content: "..."}]`. It is available to declared graders, but does not add an implicit grader when `assertions` is present.
 - `criteria` (string, optional) — human-readable success criteria
 - `assertions` (array, optional) — grader assertions
 - `conversation_id` (string, optional) — groups related tests
 - `execution` (object, optional) — per-test execution override
 
 ## 2. Assertion Types and Grading Recipes
+
+### Default grader contract
+
+When a test has no `assertions`, AgentV uses the default `llm-grader` with the case context,
+including `criteria` and `expected_output` when present.
+
+When `assertions` is present, the list is explicit: run only the declared
+assertions/graders. `expected_output` remains reference data for graders that consume it,
+such as `llm-grader`, `code-grader`, or `field-accuracy`; it does not trigger an additional
+default `llm-grader`.
 
 For each assertion type: YAML config fields, grading recipe (exact pseudocode for deterministic types), and PASS/FAIL conditions.
 


### PR DESCRIPTION
## Summary

AgentV now documents and tests the contract that `expected_output` is reference data when `assertions` are declared. Cases with explicit assertions continue to run only those graders; reference-aware graders can still consume `expected_output` when users declare them.

## Validation

- `bun --filter @agentv/core test ./test/evaluation/orchestrator.test.ts`
- `bun run typecheck`
- `bun run lint`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
