### PR TITLE
feat(config): support local config overlays

### DIFF
--- a/.agentv/.gitignore
+++ b/.agentv/.gitignore
@@ -3,3 +3,5 @@ results/
 logs/
 cache/
 cache.json
+config.local.yaml
+config.local.yml

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ examples/**/*.results.jsonl
 **/.agentv/cache/
 **/.agentv/cache.json
 **/.agentv/version-check.json
+**/.agentv/config.local.yaml
+**/.agentv/config.local.yml
+!examples/**/.agentv/config.local.yaml
+!examples/**/.agentv/config.local.yml
 
 # Local agent orchestrator config (may contain secrets)
 agent-orchestrator.yaml

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ AGENTV_RESULTS_REPO=EntityProcess/agentv-evalresults \
 ```
 
 The script clones AgentV examples into `~/agentv-dashboard`, clones the results
-repo, writes the Dashboard project registry under `$AGENTV_HOME/config.yaml`,
-builds the Docker image, and starts Dashboard at `http://localhost:3117`.
+repo, writes the Dashboard project registry under the `$AGENTV_HOME` config
+pair, builds the Docker image, and starts Dashboard at `http://localhost:3117`.
 
 ## License
 

--- a/apps/cli/src/commands/results/studio-config.ts
+++ b/apps/cli/src/commands/results/studio-config.ts
@@ -1,11 +1,13 @@
 /**
  * Dashboard configuration loader.
  *
- * Reads dashboard-specific settings from the `dashboard:` section of config.yaml.
- * Project-local `.agentv/config.yaml` takes precedence over the global
- * `${AGENTV_HOME:-~/.agentv}/config.yaml`, with legacy `studio:` and root-level
- * threshold keys still accepted for compatibility. Saving writes only to the
- * project-local file and preserves unrelated fields.
+ * Reads dashboard-specific settings from the `dashboard:` section of
+ * config.yaml plus optional config.local.yaml overlays. Project-local
+ * `.agentv/config.yaml` / `.agentv/config.local.yaml` takes precedence over the
+ * global `${AGENTV_HOME:-~/.agentv}/config.yaml` pair, with legacy `studio:`
+ * and root-level threshold keys still accepted for compatibility. Saving
+ * writes only to the project-local config.yaml file and preserves unrelated
+ * fields.
  *
  * config.yaml format:
  *   required_version: ">=4.2.0"
@@ -23,7 +25,13 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
-import { DEFAULT_THRESHOLD, getAgentvConfigDir, parseYamlValue } from '@agentv/core';
+import {
+  DEFAULT_THRESHOLD,
+  getAgentvConfigDir,
+  getLocalConfigPath,
+  mergeConfigObjects,
+  parseYamlValue,
+} from '@agentv/core';
 import { stringify as stringifyYaml } from 'yaml';
 
 export interface StudioConfig {
@@ -37,7 +45,8 @@ const DEFAULTS: StudioConfig = {
 };
 
 /**
- * Load dashboard config from `config.yaml` in the given `.agentv/` directory.
+ * Load dashboard config from `config.yaml` in the given `.agentv/` directory,
+ * overlaid by sibling `config.local.yaml` when present.
  * Reads from `dashboard.threshold`, falling back to `dashboard.pass_threshold`,
  * `studio.threshold`, `studio.pass_threshold`, then root-level `pass_threshold`
  * for backward compatibility.
@@ -47,11 +56,11 @@ const DEFAULTS: StudioConfig = {
 export function loadStudioConfig(agentvDir: string): StudioConfig {
   const localConfigPath = path.join(agentvDir, 'config.yaml');
   const globalConfigPath = path.join(getAgentvConfigDir(), 'config.yaml');
-  const localConfig = loadParsedConfig(localConfigPath);
+  const localConfig = loadParsedConfigPair(localConfigPath);
   const globalConfig =
-    path.resolve(globalConfigPath) === path.resolve(localConfigPath)
+    path.resolve(path.dirname(globalConfigPath)) === path.resolve(path.dirname(localConfigPath))
       ? undefined
-      : loadParsedConfig(globalConfigPath);
+      : loadParsedConfigPair(globalConfigPath);
 
   const threshold = [
     readThreshold(localConfig?.dashboard),
@@ -79,6 +88,13 @@ function loadParsedConfig(configPath: string): Record<string, unknown> | undefin
   const parsed = parseYamlValue(raw);
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
   return parsed as Record<string, unknown>;
+}
+
+function loadParsedConfigPair(configPath: string): Record<string, unknown> | undefined {
+  const base = loadParsedConfig(configPath);
+  const local = loadParsedConfig(getLocalConfigPath(configPath));
+  if (base && local) return mergeConfigObjects(base, local);
+  return local ?? base;
 }
 
 function readThreshold(section: unknown): number | undefined {

--- a/apps/cli/test/commands/results/studio-config.test.ts
+++ b/apps/cli/test/commands/results/studio-config.test.ts
@@ -104,6 +104,19 @@ describe('loadStudioConfig', () => {
     expect(config.threshold).toBe(0.9);
   });
 
+  it('overlays config.local.yaml on config.yaml for dashboard settings', () => {
+    writeFileSync(
+      path.join(tempDir, 'config.yaml'),
+      'dashboard:\n  app_name: base evals\n  threshold: 0.6\n',
+    );
+    writeFileSync(path.join(tempDir, 'config.local.yaml'), 'dashboard:\n  threshold: 0.9\n');
+
+    const config = loadStudioConfig(tempDir);
+
+    expect(config.appName).toBe('base evals');
+    expect(config.threshold).toBe(0.9);
+  });
+
   it('falls back to legacy studio section when dashboard has no threshold', () => {
     writeFileSync(
       path.join(tempDir, 'config.yaml'),

--- a/apps/web/src/content/docs/docs/evaluation/running-evals.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/running-evals.mdx
@@ -528,17 +528,30 @@ agentv eval --strict evals/my-eval.yaml
 
 ## Config File Defaults
 
-Set default execution options so you don't have to pass them on every CLI invocation. Project-local `.agentv/config.yaml`, home/global `$AGENTV_HOME/config.yaml` (or `~/.agentv/config.yaml`), and `agentv.config.ts` are supported.
+Set default execution options so you don't have to pass them on every CLI invocation. Project-local `.agentv/config.yaml`, project-local `.agentv/config.local.yaml`, home/global `$AGENTV_HOME/config.yaml` plus `$AGENTV_HOME/config.local.yaml` (or `~/.agentv/...`), and `agentv.config.ts` are supported.
 
-Project-local YAML config takes precedence over home/global YAML config. AgentV uses the first config file it finds; it does not merge project and global YAML files.
+Project-local YAML config takes precedence over home/global YAML config. AgentV uses the first config directory it finds; it does not merge project and global YAML directories.
 
-### YAML config (`.agentv/config.yaml` or `$AGENTV_HOME/config.yaml`)
+Within one config directory, AgentV reads `config.yaml` first and `config.local.yaml` second. The local overlay wins: plain objects deep-merge, arrays replace, and scalar values from `config.local.yaml` override `config.yaml`.
+
+Use `config.yaml` for portable defaults that can be committed with the eval project. Use `config.local.yaml` for machine-local overrides such as private paths, local result remotes, Dashboard project registry entries, or temporary execution defaults. Project-local `config.local.yaml` is gitignored by default.
+
+### YAML config (`config.yaml` plus optional `config.local.yaml`)
 
 ```yaml
 execution:
   verbose: true
   keep_workspaces: false
   otel_file: .agentv/results/otel-{timestamp}.json
+```
+
+Example local overlay:
+
+```yaml
+execution:
+  keep_workspaces: true
+eval_patterns:
+  - "local-evals/**/*.eval.yaml"
 ```
 
 | Field | CLI equivalent | Type | Default | Description |
@@ -563,7 +576,7 @@ export default defineConfig({
 
 The `{timestamp}` placeholder is replaced with an ISO-like timestamp (e.g., `2026-03-05T14-30-00-000Z`) at execution time.
 
-**Precedence:** CLI flags > project-local `.agentv/config.yaml` > home/global `$AGENTV_HOME/config.yaml` (or `~/.agentv/config.yaml`) > `agentv.config.ts` > built-in defaults.
+**Precedence:** CLI flags > project-local `.agentv/config.local.yaml` over `.agentv/config.yaml` > home/global `$AGENTV_HOME/config.local.yaml` over `$AGENTV_HOME/config.yaml` (or `~/.agentv/...`) > `agentv.config.ts` > built-in defaults.
 
 ## Response Cache
 
@@ -641,7 +654,7 @@ The replay provider never invokes the live target. It only returns the recorded 
 
 ### AGENTV_HOME
 
-Override AgentV's lightweight home/config directory. This directory stores files such as `config.yaml`, `version-check.json`, `last-config.json`, and managed helper binaries. Registered Dashboard projects live under `projects:` in this home `config.yaml`.
+Override AgentV's lightweight home/config directory. This directory stores files such as `config.yaml`, `config.local.yaml`, `version-check.json`, `last-config.json`, and managed helper binaries. Registered Dashboard projects live under `projects:` in the home config pair.
 
 ```bash
 # Linux/macOS
@@ -655,6 +668,28 @@ set AGENTV_HOME=D:\agentv-config
 ```
 
 When unset, AgentV uses `~/.agentv`.
+
+For local workspaces, put portable registry defaults in `$AGENTV_HOME/config.yaml` and machine-local project paths or result remotes in `$AGENTV_HOME/config.local.yaml`:
+
+```yaml
+projects:
+  - id: agentv
+    name: AgentV
+    repo:
+      path: /home/user/projects/agentv
+    results:
+      repo:
+        path: /home/user/agentv-results
+        branch: agentv/results/v1
+```
+
+When running AgentV from a worktree that needs environment from a primary checkout, load the primary `.env` through the runtime instead of shell-sourcing it:
+
+```bash
+bun --env-file /home/user/projects/agentv/.env apps/cli/src/cli.ts eval evals/smoke.eval.yaml
+```
+
+This keeps `.env` parsing in Bun's dotenv loader and avoids executing shell syntax from an environment file.
 
 ### AGENTV_DATA_DIR
 

--- a/packages/core/src/config-overlays.ts
+++ b/packages/core/src/config-overlays.ts
@@ -1,0 +1,47 @@
+import path from 'node:path';
+
+export const AGENTV_CONFIG_FILE_NAME = 'config.yaml';
+export const AGENTV_CONFIG_YML_FILE_NAME = 'config.yml';
+export const AGENTV_LOCAL_CONFIG_FILE_NAME = 'config.local.yaml';
+export const AGENTV_LOCAL_CONFIG_YML_FILE_NAME = 'config.local.yml';
+
+export function getLocalConfigPath(configPath: string): string {
+  const basename = path.basename(configPath);
+  const localName =
+    basename === AGENTV_CONFIG_YML_FILE_NAME
+      ? AGENTV_LOCAL_CONFIG_YML_FILE_NAME
+      : AGENTV_LOCAL_CONFIG_FILE_NAME;
+  return path.join(path.dirname(configPath), localName);
+}
+
+export function isAgentVConfigFileName(basename: string): boolean {
+  return (
+    basename === AGENTV_CONFIG_FILE_NAME ||
+    basename === AGENTV_CONFIG_YML_FILE_NAME ||
+    basename === AGENTV_LOCAL_CONFIG_FILE_NAME ||
+    basename === AGENTV_LOCAL_CONFIG_YML_FILE_NAME
+  );
+}
+
+export function isPlainConfigObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+export function mergeConfigObjects(
+  base: Record<string, unknown>,
+  overlay: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...base };
+  for (const [key, overlayValue] of Object.entries(overlay)) {
+    const baseValue = merged[key];
+    merged[key] =
+      isPlainConfigObject(baseValue) && isPlainConfigObject(overlayValue)
+        ? mergeConfigObjects(baseValue, overlayValue)
+        : overlayValue;
+  }
+  return merged;
+}

--- a/packages/core/src/evaluation/loaders/config-loader.ts
+++ b/packages/core/src/evaluation/loaders/config-loader.ts
@@ -1,6 +1,12 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import {
+  AGENTV_CONFIG_FILE_NAME,
+  getLocalConfigPath,
+  isPlainConfigObject,
+  mergeConfigObjects,
+} from '../../config-overlays.js';
 import { getAgentvConfigDir } from '../../paths.js';
 import { interpolateEnv } from '../interpolation.js';
 import type {
@@ -83,43 +89,82 @@ export type AgentVConfig = {
 /**
  * Load optional AgentV YAML configuration.
  *
- * Project-local `.agentv/config.yaml` files are searched from the eval file
- * directory up to the repo root. If no project-local config is found, AgentV
- * falls back to the home/global config at `${AGENTV_HOME:-~/.agentv}/config.yaml`.
- * The first valid project-local file wins for normal settings. Registered
- * project bindings such as result repos live in the home config `projects:`
- * registry and are resolved by Dashboard/remote-results code separately.
+ * Project-local `.agentv/config.yaml` and `.agentv/config.local.yaml` files
+ * are searched from the eval file directory up to the repo root. The first
+ * directory with either file is the project-local config source. If no
+ * project-local config is found, AgentV falls back to the home/global pair at
+ * `${AGENTV_HOME:-~/.agentv}/config.yaml` plus `config.local.yaml`.
+ *
+ * Within a pair, `config.yaml` loads first and `config.local.yaml` overlays it:
+ * plain objects deep-merge, arrays replace, and scalar overlay values win.
+ * Registered project bindings such as result repos live in the home config
+ * `projects:` registry and are resolved by Dashboard/remote-results code
+ * separately.
  */
 export async function loadConfig(
   evalFilePath: string,
   repoRoot: string,
 ): Promise<AgentVConfig | null> {
   const directories = buildDirectoryChain(evalFilePath, repoRoot);
-  const globalConfigPath = path.join(getAgentvConfigDir(), 'config.yaml');
+  const globalConfigPath = path.join(getAgentvConfigDir(), AGENTV_CONFIG_FILE_NAME);
 
   for (const directory of directories) {
-    const configPath = path.join(directory, '.agentv', 'config.yaml');
+    const configPath = path.join(directory, '.agentv', AGENTV_CONFIG_FILE_NAME);
 
-    if (!(await fileExists(configPath))) {
+    if (!(await configPairExists(configPath))) {
       continue;
     }
 
-    const config = await readConfigFile(configPath);
-    if (config) {
-      return config;
-    }
+    return readConfigFilePair(configPath);
   }
 
-  return (await fileExists(globalConfigPath)) ? readConfigFile(globalConfigPath) : null;
+  return (await configPairExists(globalConfigPath)) ? readConfigFilePair(globalConfigPath) : null;
 }
 
-async function readConfigFile(configPath: string): Promise<AgentVConfig | null> {
+async function configPairExists(configPath: string): Promise<boolean> {
+  return (await fileExists(configPath)) || (await fileExists(getLocalConfigPath(configPath)));
+}
+
+async function readConfigObjectFile(
+  configPath: string,
+): Promise<Record<string, unknown> | undefined> {
+  if (!(await fileExists(configPath))) {
+    return undefined;
+  }
   try {
     const rawConfig = await readFile(configPath, 'utf8');
-    const parsed = interpolateEnv(parseYamlValue(rawConfig), process.env) as unknown;
+    const parsed = parseYamlValue(rawConfig) as unknown;
+
+    if (!isPlainConfigObject(parsed)) {
+      logWarning(`Invalid AgentV config format at ${configPath}`);
+      return undefined;
+    }
+    return parsed;
+  } catch (error) {
+    logWarning(`Could not read AgentV config at ${configPath}: ${(error as Error).message}`);
+    return undefined;
+  }
+}
+
+async function readConfigFilePair(configPath: string): Promise<AgentVConfig | null> {
+  const base = await readConfigObjectFile(configPath);
+  const local = await readConfigObjectFile(getLocalConfigPath(configPath));
+  const rawMerged = base && local ? mergeConfigObjects(base, local) : (local ?? base);
+  if (!rawMerged) {
+    return null;
+  }
+  return parseConfigObject(rawMerged, local ? getLocalConfigPath(configPath) : configPath);
+}
+
+function parseConfigObject(
+  rawConfig: Record<string, unknown>,
+  configPath: string,
+): AgentVConfig | null {
+  try {
+    const parsed = interpolateEnv(rawConfig, process.env) as unknown;
 
     if (!isJsonObject(parsed)) {
-      logWarning(`Invalid config.yaml format at ${configPath}`);
+      logWarning(`Invalid AgentV config format at ${configPath}`);
       return null;
     }
 
@@ -167,7 +212,7 @@ async function readConfigFile(configPath: string): Promise<AgentVConfig | null> 
       ...(hooks && { hooks }),
     };
   } catch (error) {
-    logWarning(`Could not read config.yaml at ${configPath}: ${(error as Error).message}`);
+    logWarning(`Could not parse AgentV config at ${configPath}: ${(error as Error).message}`);
     return null;
   }
 }

--- a/packages/core/src/evaluation/validation/config-validator.ts
+++ b/packages/core/src/evaluation/validation/config-validator.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import { getLocalConfigPath } from '../../config-overlays.js';
 import { getAgentvConfigDir } from '../../paths.js';
 import { interpolateEnv } from '../interpolation.js';
 import { parseYamlValue } from '../yaml-loader.js';
@@ -146,7 +147,9 @@ export async function validateConfigFile(
 
 function inferConfigScope(filePath: string): 'project' | 'global' {
   const globalConfigPath = path.resolve(getAgentvConfigDir(), 'config.yaml');
-  if (path.resolve(filePath) === globalConfigPath) {
+  const globalLocalConfigPath = path.resolve(getLocalConfigPath(globalConfigPath));
+  const resolvedPath = path.resolve(filePath);
+  if (resolvedPath === globalConfigPath || resolvedPath === globalLocalConfigPath) {
     return 'global';
   }
   return filePath.split(/[\\/]/).includes('.agentv') ? 'project' : 'global';

--- a/packages/core/src/evaluation/validation/file-type.ts
+++ b/packages/core/src/evaluation/validation/file-type.ts
@@ -1,6 +1,11 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import {
+  AGENTV_LOCAL_CONFIG_FILE_NAME,
+  AGENTV_LOCAL_CONFIG_YML_FILE_NAME,
+  isAgentVConfigFileName,
+} from '../../config-overlays.js';
 import { parseYamlValue } from '../yaml-loader.js';
 import type { FileType } from './types.js';
 
@@ -11,7 +16,7 @@ const SCHEMA_CONFIG_V2 = 'agentv-config-v2';
 /**
  * Detect file type by reading $schema field from YAML file.
  * If $schema is missing, infers type from filename/path:
- * - config.yaml under .agentv folder → 'config'
+ * - config.yaml/config.local.yaml under .agentv folder → 'config'
  * - targets.yaml under .agentv folder → 'targets'
  * - All other YAML files → 'eval' (default)
  */
@@ -60,9 +65,16 @@ function inferFileTypeFromPath(filePath: string): FileType {
   const normalized = path.normalize(filePath).replace(/\\/g, '/');
   const basename = path.basename(filePath);
 
+  if (
+    basename === AGENTV_LOCAL_CONFIG_FILE_NAME ||
+    basename === AGENTV_LOCAL_CONFIG_YML_FILE_NAME
+  ) {
+    return 'config';
+  }
+
   // Check if file is under .agentv folder
   if (normalized.includes('/.agentv/')) {
-    if (basename === 'config.yaml' || basename === 'config.yml') {
+    if (isAgentVConfigFileName(basename)) {
       return 'config';
     }
     if (basename === 'targets.yaml' || basename === 'targets.yml') {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -147,6 +147,16 @@ export {
   type WipWorktreeHandle,
 } from './evaluation/results-repo.js';
 export {
+  AGENTV_CONFIG_FILE_NAME,
+  AGENTV_CONFIG_YML_FILE_NAME,
+  AGENTV_LOCAL_CONFIG_FILE_NAME,
+  AGENTV_LOCAL_CONFIG_YML_FILE_NAME,
+  getLocalConfigPath,
+  isAgentVConfigFileName,
+  isPlainConfigObject,
+  mergeConfigObjects,
+} from './config-overlays.js';
+export {
   getAgentvConfigDir,
   getAgentvHome,
   getAgentvDataDir,

--- a/packages/core/src/projects.ts
+++ b/packages/core/src/projects.ts
@@ -6,11 +6,12 @@
  * matching the "project" terminology used by Arize Phoenix, Langfuse,
  * Braintrust, W&B Weave, and LangSmith.
  *
- * The registry lives under `projects:` in `~/.agentv/config.yaml` and is the
- * single source of truth for which projects Dashboard shows. Dashboard re-reads
- * the file on every `/api/projects` request, so edits (direct, via
- * POST /api/projects, via the CLI's --add/--remove, or via a Kubernetes
- * ConfigMap mount) are reflected without restarting `agentv serve`.
+ * The registry lives under `projects:` in `~/.agentv/config.yaml`, optionally
+ * overlaid by `~/.agentv/config.local.yaml`, and is the single source of truth
+ * for which projects Dashboard shows. Dashboard re-reads the files on every
+ * `/api/projects` request, so edits (direct, via POST /api/projects, via the
+ * CLI's --add/--remove, or via a Kubernetes ConfigMap mount) are reflected
+ * without restarting `agentv serve`.
  *
  * YAML format (all keys snake_case per AGENTS.md §"Wire Format Convention"):
  *   projects:
@@ -36,9 +37,11 @@
  *   subsequent runs — git pull --ff-only
  *
  * Concurrency: the registry assumes a single writer. All mutating calls
- * (add/remove/touchProject) do read-modify-write on config.yaml without a
- * lock, preserving unrelated top-level config keys. Dashboard's HTTP handlers
- * are serialized by Node's
+ * (add/remove/touchProject) do read-modify-write on the owning registry file
+ * without a lock, preserving unrelated top-level config keys. If
+ * `config.local.yaml` already has a top-level `projects:` key, mutations stay
+ * there so local-only paths and result remotes are not silently moved into
+ * portable `config.yaml`. Dashboard's HTTP handlers are serialized by Node's
  * single-threaded event loop, which satisfies the 24/7 deployment case.
  * Run only one `agentv` process against a given home at a time.
  *
@@ -54,6 +57,11 @@ import path from 'node:path';
 
 import { stringify as stringifyYaml } from 'yaml';
 
+import {
+  AGENTV_CONFIG_FILE_NAME,
+  getLocalConfigPath,
+  mergeConfigObjects,
+} from './config-overlays.js';
 import { interpolateEnv } from './evaluation/interpolation.js';
 import { parseYamlValue } from './evaluation/yaml-loader.js';
 import { getAgentvConfigDir } from './paths.js';
@@ -94,7 +102,7 @@ export interface ProjectRegistry {
 // ── Registry path ───────────────────────────────────────────────────────
 
 export function getProjectsRegistryPath(): string {
-  return path.join(getAgentvConfigDir(), 'config.yaml');
+  return path.join(getAgentvConfigDir(), AGENTV_CONFIG_FILE_NAME);
 }
 
 // ── Load / Save ─────────────────────────────────────────────────────────
@@ -306,12 +314,12 @@ function toYaml(entry: ProjectEntry): ProjectEntryYaml {
 
 export function loadProjectRegistry(): ProjectRegistry {
   const registryPath = getProjectsRegistryPath();
-  if (!existsSync(registryPath)) {
+  const localRegistryPath = getLocalConfigPath(registryPath);
+  if (!existsSync(registryPath) && !existsSync(localRegistryPath)) {
     return { projects: [] };
   }
   try {
-    const raw = readFileSync(registryPath, 'utf-8');
-    const parsed = parseYamlValue(raw) as { projects?: unknown } | null | undefined;
+    const parsed = readMergedHomeConfig(registryPath) as { projects?: unknown } | null | undefined;
     if (!parsed || typeof parsed !== 'object') {
       return { projects: [] };
     }
@@ -328,7 +336,7 @@ export function loadProjectRegistry(): ProjectRegistry {
 }
 
 export function saveProjectRegistry(registry: ProjectRegistry): void {
-  const registryPath = getProjectsRegistryPath();
+  const registryPath = getProjectsRegistryWritePath();
   const dir = path.dirname(registryPath);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
@@ -347,6 +355,25 @@ function readHomeConfig(configPath: string): Record<string, unknown> {
   } catch {
     return {};
   }
+}
+
+function readMergedHomeConfig(configPath: string): Record<string, unknown> {
+  const base = readHomeConfig(configPath);
+  const local = readHomeConfig(getLocalConfigPath(configPath));
+  return Object.keys(base).length > 0 && Object.keys(local).length > 0
+    ? mergeConfigObjects(base, local)
+    : Object.keys(local).length > 0
+      ? local
+      : base;
+}
+
+function getProjectsRegistryWritePath(): string {
+  const registryPath = getProjectsRegistryPath();
+  const localRegistryPath = getLocalConfigPath(registryPath);
+  const localConfig = readHomeConfig(localRegistryPath);
+  return Object.prototype.hasOwnProperty.call(localConfig, 'projects')
+    ? localRegistryPath
+    : registryPath;
 }
 
 // ── CRUD operations ─────────────────────────────────────────────────────

--- a/packages/core/test/evaluation/loaders/config-loader.test.ts
+++ b/packages/core/test/evaluation/loaders/config-loader.test.ts
@@ -94,6 +94,121 @@ describe('loadConfig', () => {
     }
   });
 
+  it('overlays project-local .agentv/config.local.yaml on .agentv/config.yaml', async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'agentv-local-config-overlay-'));
+    try {
+      const projectDir = path.join(tempDir, 'project');
+      const evalDir = path.join(projectDir, 'evals');
+      const localConfigDir = path.join(projectDir, '.agentv');
+      mkdirSync(evalDir, { recursive: true });
+      mkdirSync(localConfigDir, { recursive: true });
+      writeFileSync(
+        path.join(localConfigDir, 'config.yaml'),
+        [
+          'eval_patterns:',
+          '  - "**/*.base.eval.yaml"',
+          'execution:',
+          '  verbose: true',
+          '  pool_slots: 2',
+          'results:',
+          '  repo:',
+          '    path: .',
+          '    branch: base-results',
+          '',
+        ].join('\n'),
+      );
+      writeFileSync(
+        path.join(localConfigDir, 'config.local.yaml'),
+        [
+          'eval_patterns:',
+          '  - "**/*.local.eval.yaml"',
+          'execution:',
+          '  keep_workspaces: true',
+          'results:',
+          '  repo:',
+          '    branch: local-results',
+          '',
+        ].join('\n'),
+      );
+
+      const config = await loadConfig(path.join(evalDir, 'suite.eval.yaml'), projectDir);
+
+      expect(config?.eval_patterns).toEqual(['**/*.local.eval.yaml']);
+      expect(config?.execution).toEqual({
+        verbose: true,
+        keep_workspaces: true,
+        pool_slots: 2,
+      });
+      expect(config?.results).toEqual({
+        mode: 'github',
+        repo_path: '.',
+        branch: 'local-results',
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('treats project-local config.local.yaml alone as configured and does not fall back global', async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'agentv-local-only-overlay-'));
+    try {
+      const projectDir = path.join(tempDir, 'project');
+      const evalDir = path.join(projectDir, 'evals');
+      const localConfigDir = path.join(projectDir, '.agentv');
+      const homeDir = path.join(tempDir, 'home');
+      mkdirSync(evalDir, { recursive: true });
+      mkdirSync(localConfigDir, { recursive: true });
+      mkdirSync(homeDir, { recursive: true });
+      writeFileSync(
+        path.join(homeDir, 'config.yaml'),
+        'eval_patterns:\n  - "**/*.global.eval.yaml"\n',
+      );
+      writeFileSync(
+        path.join(localConfigDir, 'config.local.yaml'),
+        'execution:\n  keep_workspaces: true\n',
+      );
+
+      await withOptionalEnv('AGENTV_HOME', homeDir, async () => {
+        const config = await loadConfig(path.join(evalDir, 'suite.eval.yaml'), projectDir);
+        expect(config?.eval_patterns).toBeUndefined();
+        expect(config?.execution).toEqual({ keep_workspaces: true });
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('overlays AGENTV_HOME/config.local.yaml on AGENTV_HOME/config.yaml', async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'agentv-global-config-overlay-'));
+    try {
+      const projectDir = path.join(tempDir, 'project');
+      const evalDir = path.join(projectDir, 'evals');
+      const homeDir = path.join(tempDir, 'home');
+      mkdirSync(evalDir, { recursive: true });
+      mkdirSync(homeDir, { recursive: true });
+      writeFileSync(
+        path.join(homeDir, 'config.yaml'),
+        'execution:\n  verbose: true\n  pool_slots: 4\neval_patterns:\n  - "**/*.base.eval.yaml"\n',
+      );
+      writeFileSync(
+        path.join(homeDir, 'config.local.yaml'),
+        'execution:\n  keep_workspaces: true\neval_patterns:\n  - "**/*.local.eval.yaml"\n',
+      );
+
+      await withOptionalEnv('AGENTV_HOME', homeDir, async () => {
+        const config = await loadConfig(path.join(evalDir, 'suite.eval.yaml'), projectDir);
+        expect(config?.eval_patterns).toEqual(['**/*.local.eval.yaml']);
+        expect(config?.execution).toEqual({
+          verbose: true,
+          keep_workspaces: true,
+          pool_slots: 4,
+        });
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('does not merge global results into project-local config', async () => {
     const tempDir = mkdtempSync(path.join(os.tmpdir(), 'agentv-local-results-isolated-'));
     try {

--- a/packages/core/test/evaluation/validation/config-validator.test.ts
+++ b/packages/core/test/evaluation/validation/config-validator.test.ts
@@ -110,6 +110,34 @@ describe('validateConfigFile', () => {
     expect(result.errors).toHaveLength(0);
   });
 
+  it('infers AGENTV_HOME config.local.yaml as global', async () => {
+    const previousAgentvHome = process.env.AGENTV_HOME;
+    const homeDir = path.join(tempDir, 'agentv-home-local');
+    const filePath = path.join(homeDir, 'config.local.yaml');
+    await mkdir(homeDir, { recursive: true });
+    await writeFile(
+      filePath,
+      `projects:
+  - id: agentv
+    name: AgentV
+    repo:
+      path: /srv/agentv
+    added_at: "2026-01-01T00:00:00Z"
+    last_opened_at: "2026-01-01T00:00:00Z"
+`,
+    );
+
+    try {
+      process.env.AGENTV_HOME = homeDir;
+      const result = await validateConfigFile(filePath);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    } finally {
+      if (previousAgentvHome === undefined) process.env.AGENTV_HOME = undefined;
+      else process.env.AGENTV_HOME = previousAgentvHome;
+    }
+  });
+
   it('accepts URL-backed source storage branch results in global project config', async () => {
     const filePath = path.join(tempDir, 'global-config-repo-path.yaml');
     await writeFile(

--- a/packages/core/test/evaluation/validation/file-type.test.ts
+++ b/packages/core/test/evaluation/validation/file-type.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { detectFileType } from '../../../src/evaluation/validation/file-type.js';
+
+describe('detectFileType', () => {
+  it('treats .agentv/config.local.yaml as AgentV config', async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'agentv-file-type-'));
+    try {
+      const agentvDir = path.join(tempDir, 'project', '.agentv');
+      mkdirSync(agentvDir, { recursive: true });
+      const configPath = path.join(agentvDir, 'config.local.yaml');
+      writeFileSync(configPath, 'execution:\n  verbose: true\n');
+
+      await expect(detectFileType(configPath)).resolves.toBe('config');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('treats config.local.yaml outside .agentv as AgentV config', async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'agentv-file-type-home-'));
+    try {
+      const configPath = path.join(tempDir, 'agentv-home', 'config.local.yaml');
+      mkdirSync(path.dirname(configPath), { recursive: true });
+      writeFileSync(configPath, 'projects: []\n');
+
+      await expect(detectFileType(configPath)).resolves.toBe('config');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/test/projects.test.ts
+++ b/packages/core/test/projects.test.ts
@@ -323,6 +323,72 @@ dashboard:
     expect(yamlOnDisk).toContain('projects:');
   });
 
+  it('loads project registry entries from AGENTV_HOME config.local.yaml', () => {
+    const registryPath = getProjectsRegistryPath();
+    const localRegistryPath = path.join(path.dirname(registryPath), 'config.local.yaml');
+    mkdirSync(path.dirname(registryPath), { recursive: true });
+    writeFileSync(
+      localRegistryPath,
+      `projects:
+  - id: local-results
+    name: Local Results
+    repo:
+      path: /srv/agentv/source
+    results:
+      repo:
+        path: /srv/agentv/results/local-results
+        branch: agentv/results/v1
+      sync:
+        require_push: true
+    added_at: "2026-01-01T00:00:00Z"
+    last_opened_at: "2026-01-01T00:00:00Z"
+`,
+      'utf-8',
+    );
+
+    const registry = loadProjectRegistry();
+
+    expect(registry.projects).toHaveLength(1);
+    expect(registry.projects[0]).toMatchObject({
+      id: 'local-results',
+      path: '/srv/agentv/source',
+      results: {
+        repoPath: '/srv/agentv/results/local-results',
+        branch: 'agentv/results/v1',
+        sync: { requirePush: true },
+      },
+    });
+  });
+
+  it('keeps registry mutations in config.local.yaml when the overlay owns projects', () => {
+    const registryPath = getProjectsRegistryPath();
+    const localRegistryPath = path.join(path.dirname(registryPath), 'config.local.yaml');
+    mkdirSync(path.dirname(registryPath), { recursive: true });
+    writeFileSync(registryPath, 'dashboard:\n  app_name: AgentV\n', 'utf-8');
+    writeFileSync(
+      localRegistryPath,
+      `projects:
+  - id: local-only
+    name: Local Only
+    repo:
+      path: /srv/agentv/source
+    added_at: "2026-01-01T00:00:00Z"
+    last_opened_at: "2026-01-01T00:00:00Z"
+`,
+      'utf-8',
+    );
+
+    touchProject('local-only');
+
+    const baseYaml = readFileSync(registryPath, 'utf-8');
+    const localYaml = readFileSync(localRegistryPath, 'utf-8');
+    expect(baseYaml).toContain('dashboard:');
+    expect(baseYaml).not.toContain('projects:');
+    expect(localYaml).toContain('projects:');
+    expect(localYaml).toContain('id: local-only');
+    expect(localYaml).not.toContain('dashboard:');
+  });
+
   it('interpolates env vars in repo_url', () => {
     const registryPath = getProjectsRegistryPath();
     mkdirSync(path.dirname(registryPath), { recursive: true });


### PR DESCRIPTION
## Summary

AgentV config now supports gitignored local overlays, so operators can keep machine-specific project paths, result remotes, and worktree defaults out of committed `config.yaml` while preserving portable defaults for shared setup.

The overlay contract applies to project-local `.agentv` config, `$AGENTV_HOME` config, Dashboard settings, and project registry loading. Registry mutations continue writing `$AGENTV_HOME/config.yaml` for existing non-local setups, but stay in `$AGENTV_HOME/config.local.yaml` when that overlay already owns `projects:`.

## Validation

- `bun test packages/core/test/evaluation/validation/file-type.test.ts packages/core/test/evaluation/validation/config-validator.test.ts packages/core/test/evaluation/loaders/config-loader.test.ts packages/core/test/projects.test.ts`
- `bun test apps/cli/test/commands/results/studio-config.test.ts`
- `bun --filter @agentv/core build`
- `bun --filter @agentv/core typecheck`
- `bun --filter agentv typecheck`
- `bunx biome check packages/core/src/config-overlays.ts packages/core/src/evaluation/loaders/config-loader.ts packages/core/src/projects.ts packages/core/src/evaluation/validation/config-validator.ts packages/core/src/evaluation/validation/file-type.ts packages/core/test/evaluation/loaders/config-loader.test.ts packages/core/test/projects.test.ts packages/core/test/evaluation/validation/config-validator.test.ts packages/core/test/evaluation/validation/file-type.test.ts apps/cli/src/commands/results/studio-config.ts apps/cli/test/commands/results/studio-config.test.ts`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
