### PR TITLE
fix(results): omit missing trace sidecar from metrics

### DIFF
--- a/packages/core/src/evaluation/metrics.ts
+++ b/packages/core/src/evaluation/metrics.ts
@@ -882,7 +882,7 @@ export function buildMetricsArtifact(
         path: tracePath ?? CANONICAL_TRACE_ARTIFACT_PATH,
       },
       source_artifacts: dropUndefined({
-        trace_path: tracePath,
+        trace_path: options.tracePath,
         transcript_path: options.transcriptPath,
         grading_path: options.gradingPath,
         timing_path: options.timingPath,


### PR DESCRIPTION
## Summary

- Bead: av-wrf.1
- Follow-up to PR #1521 after it was merged before the final review fix could attach to the PR head.
- Stop advertising `source_artifacts.trace_path` in per-run `metrics.json` unless a trace sidecar path was explicitly provided. This keeps `metrics.json` from pointing at `trace.json` for run bundles that do not write that file.

## Notes

- The other two requested review items from PR #1521 were already present on the merged implementation branch after fast-forward: `normalizedToolResult` emits `tool_use.result` for status/duration/output presence, and `.agents/verification.md` documents the ADR 0008 artifact layout.

## Verification

- `bun --filter @agentv/core build`
- `bun test apps/cli/test/commands/eval/artifact-writer.test.ts packages/core/test/evaluation/providers/pi-cli-tool-extraction.test.ts apps/cli/test/commands/results/shared.test.ts` (73 pass)
- `bun run lint`
- `bun run typecheck`
