### PR TITLE
chore(entire): use manual commit strategy

### DIFF
--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,7 +1,5 @@
 {
   "enabled": true,
   "telemetry": false,
-  "strategy_options": {
-    "push_sessions": false
-  }
+  "strategy": "manual-commit"
 }


### PR DESCRIPTION
Switch Entire CLI to the explicit manual commit strategy so local session capture remains enabled without automatic session pushes.

Validation: config-only change; no runtime tests run.
