### PR TITLE
fix(targets): use flat Copilot SDK provider config

### DIFF
--- a/.agentv/targets.yaml
+++ b/.agentv/targets.yaml
@@ -43,10 +43,9 @@ targets:
   - name: copilot-sdk-azure
     provider: copilot-sdk
     model: ${{ AZURE_DEPLOYMENT_NAME }}
-    byok:
-      type: azure
-      base_url: ${{ AZURE_OPENAI_ENDPOINT }}
-      api_key: ${{ AZURE_OPENAI_API_KEY }}
+    subprovider: azure
+    base_url: ${{ AZURE_OPENAI_ENDPOINT }}
+    api_key: ${{ AZURE_OPENAI_API_KEY }}
     grader_target: grader
     stream_log: raw
 


### PR DESCRIPTION
## Summary
- replace unsupported `byok` nesting on `copilot-sdk-azure` with flat Copilot custom-provider fields
- keep the Azure endpoint and API key wired through environment references

## Validation
- `bun -e "import { validateTargetsFile } from './packages/core/src/evaluation/validation/targets-validator.ts'; const result = await validateTargetsFile('.agentv/targets.yaml'); console.log(JSON.stringify({ valid: result.valid, warnings: result.errors.filter(e => e.severity === 'warning').map(e => e.message), errors: result.errors.filter(e => e.severity !== 'warning').map(e => e.message) }, null, 2)); process.exit(result.valid ? 0 : 1);"`
