### PR TITLE
test(eval): guard workspace path override compatibility

### DIFF
--- a/apps/cli/test/eval.integration.test.ts
+++ b/apps/cli/test/eval.integration.test.ts
@@ -505,6 +505,31 @@ describe('agentv eval CLI', () => {
     }
   }, 30_000);
 
+  it('keeps --workspace-path as a static workspace override for existing workspaces', async () => {
+    const fixture = await createFixture();
+    try {
+      const workspacePath = path.join(fixture.baseDir, 'prepared-workspace');
+      await mkdir(workspacePath, { recursive: true });
+
+      const result = await runCli(fixture, [
+        'eval',
+        fixture.testFilePath,
+        '--workspace-path',
+        workspacePath,
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const diagnostics = await readDiagnostics(fixture);
+      expect(diagnostics).toMatchObject({
+        workspaceMode: 'static',
+        workspacePath,
+        resultCount: 2,
+      });
+    } finally {
+      await rm(fixture.baseDir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
   it('passes run-level budget tracking through to the evaluator', async () => {
     const fixture = await createFixture();
     try {

--- a/apps/cli/test/fixtures/mock-run-evaluation.ts
+++ b/apps/cli/test/fixtures/mock-run-evaluation.ts
@@ -19,6 +19,8 @@ interface RunEvaluationOptionsLike {
   readonly evalCases?: ReadonlyArray<unknown>;
   readonly verbose?: boolean;
   readonly maxConcurrency?: number;
+  readonly workspaceMode?: string;
+  readonly workspacePath?: string;
   readonly trials?: {
     readonly count: number;
     readonly strategy: string;
@@ -181,6 +183,8 @@ async function maybeWriteDiagnostics(
     envLocalOnly: process.env.CLI_ENV_LOCAL_ONLY ?? null,
     budgetUsd: options.budgetUsd ?? null,
     maxConcurrency: options.maxConcurrency ?? null,
+    workspaceMode: options.workspaceMode ?? null,
+    workspacePath: options.workspacePath ?? null,
     trials: options.trials ?? null,
     threshold: options.threshold ?? null,
     hasRunBudgetTracker: options.runBudgetTracker !== undefined,

--- a/packages/core/test/evaluation/workspace/setup.test.ts
+++ b/packages/core/test/evaluation/workspace/setup.test.ts
@@ -113,4 +113,40 @@ describe('prepareSharedWorkspaceSetup', () => {
     expect(readFileSync(path.join(repoDir, 'tracked.txt'), 'utf8')).toBe('clean\n');
     expect(existsSync(path.join(repoDir, 'stale.txt'))).toBe(false);
   }, 30_000);
+
+  it('uses CLI workspacePath as an existing static workspace without materializing repos', async () => {
+    const existingWorkspace = path.join(tmpDir, 'existing-workspace');
+    mkdirSync(existingWorkspace, { recursive: true });
+    writeFileSync(path.join(existingWorkspace, 'marker.txt'), 'already prepared\n', 'utf8');
+
+    const evalCase: EvalTest = {
+      id: 'case-1',
+      question: 'test',
+      criteria: 'ok',
+      workspace: {
+        repos: [
+          {
+            path: './repo-a',
+            repo: 'https://example.com/repo-a.git',
+            commit: 'main',
+          },
+        ],
+      },
+    };
+
+    setup = await prepareSharedWorkspaceSetup({
+      evalRunId: 'test-cli-workspace-path',
+      evalCases: [evalCase],
+      evalDir: tmpDir,
+      workspacePath: existingWorkspace,
+      workers: 1,
+    });
+
+    expect(setup.sharedWorkspacePath).toBe(existingWorkspace);
+    expect(setup.repoManager).toBeUndefined();
+    expect(readFileSync(path.join(existingWorkspace, 'marker.txt'), 'utf8')).toBe(
+      'already prepared\n',
+    );
+    expect(existsSync(path.join(existingWorkspace, 'repo-a'))).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

`--workspace-path` remains a supported way to point AgentV at an already prepared workspace and skip AgentV-owned materialization. This PR adds regression coverage for both the public CLI shorthand (`agentv eval <file> --workspace-path <dir>`) and the core setup path that must reuse the supplied directory without cloning repos into it.

## Validation

- `bun --filter @agentv/core build && bun --filter @agentv/sdk build`
- `bun test apps/cli/test/eval.integration.test.ts`
- `bun test packages/core/test/evaluation/workspace/setup.test.ts`
- `bun apps/cli/src/cli.ts eval run --help | rg -- '--workspace-path|--workspace-mode'`
- `bun run typecheck`
- `bun run lint`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
