### PR TITLE
fix(results): keep dashboard status read-only for repo paths

### DIFF
--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -3497,12 +3497,20 @@ describe('serve app', () => {
         autoPush: false,
       });
 
+      git(`git -C "${cloneDir}" fetch --quiet origin ${resultsBranch}`, tempDir);
+      const metadataRemoteRef = `refs/remotes/origin/${resultsBranch}`;
       const artifactRemoteRef = `refs/remotes/origin/${AGENTV_RESULTS_ARTIFACTS_REF}`;
+      const metadataRefLookup = () =>
+        git(
+          `git -C "${cloneDir}" show-ref --verify --quiet ${metadataRemoteRef} && echo present || true`,
+          tempDir,
+        );
       const artifactRefLookup = () =>
         git(
           `git -C "${cloneDir}" show-ref --verify --quiet ${artifactRemoteRef} && echo present || true`,
           tempDir,
         );
+      expect(metadataRefLookup()).toBe('present');
       expect(artifactRefLookup()).toBe('');
 
       const app = createApp([], tempDir, tempDir, undefined, { studioDir });

--- a/packages/core/src/evaluation/results-repo.ts
+++ b/packages/core/src/evaluation/results-repo.ts
@@ -2095,9 +2095,7 @@ export async function getResultsRepoSyncStatus(config?: ResultsConfig): Promise<
 
   try {
     if (usesStorageBranchWorktree(normalized)) {
-      await fetchResultsRepo(normalized.path, normalized.remote, normalized.branch).catch(
-        () => undefined,
-      );
+      // Dashboard status is read-only; explicit sync paths do the fetch.
       return withGitInspection(
         baseStatus,
         await inspectResultsStorageBranchGit(normalized.path, normalized),

--- a/packages/core/test/evaluation/results-repo.test.ts
+++ b/packages/core/test/evaluation/results-repo.test.ts
@@ -1001,6 +1001,38 @@ describe('results repo write path', () => {
     expect(remoteFiles).not.toContain('README.md');
   }, 20000);
 
+  it('does not fetch a repo_path storage branch during status inspection', async () => {
+    const { remoteDir, seedDir } = initializeRemoteRepo(rootDir);
+    const projectDir = path.join(rootDir, 'source-project-status-readonly');
+    git(`git clone --quiet "${remoteDir}" "${projectDir}"`, rootDir);
+    const originalOrigin = git('git remote get-url origin', projectDir);
+    const storageBranch = initializeRemoteStorageBranch(seedDir, DEFAULT_RESULTS_BRANCH);
+    const remoteRef = `refs/remotes/origin/${storageBranch}`;
+
+    expect(
+      git(`git show-ref --verify --quiet "${remoteRef}" && echo present || true`, projectDir),
+    ).toBe('');
+
+    const status = await getResultsRepoSyncStatus({
+      repo_path: projectDir,
+      branch: storageBranch,
+      remote: 'origin',
+      sync: { auto_push: false },
+    });
+
+    expect(status).toMatchObject({
+      configured: true,
+      available: true,
+      repo: projectDir,
+      repo_path: projectDir,
+      branch: storageBranch,
+    });
+    expect(git('git remote get-url origin', projectDir)).toBe(originalOrigin);
+    expect(
+      git(`git show-ref --verify --quiet "${remoteRef}" && echo present || true`, projectDir),
+    ).toBe('');
+  }, 20000);
+
   it('commits repo_path metadata overlays to the configured storage branch during sync', async () => {
     const { remoteDir, seedDir } = initializeRemoteRepo(rootDir);
     const storageBranch = initializeRemoteStorageBranch(seedDir, DEFAULT_RESULTS_BRANCH);


### PR DESCRIPTION
## Summary
- Prevent `getResultsRepoSyncStatus()` from fetching configured storage branches for `repo_path`/same-checkout results configs.
- Add a regression proving status inspection leaves both the existing `origin` URL and missing `refs/remotes/origin/agentv/results/v1` untouched.

## Root cause / investigation
- Current Dashboard startup, `/api/config`, `/api/remote/status`, and `/api/projects/:id/remote/status` did not rewrite a disposable repo origin to `https://github.com/..git`.
- The historical `https://github.com/..git` corruption path was PR #1502-era results sync code: `resolveResultsRepoUrl('.')` synthesized the placeholder URL and `ensureResultsRepoRemote()` ran `git remote set-url`. That path is already removed on current main.
- A remaining Dashboard read path was still not read-only: remote status for `results.repo.path: .` fetched the storage branch into the source checkout on page-load status polling. This did not rewrite `origin`, but it did mutate source checkout Git refs from a read-only Dashboard status request.

## Red / green evidence
- Red regression before fix: `bun test ./packages/core/test/evaluation/results-repo.test.ts --test-name-pattern "does not fetch a repo_path storage branch during status inspection"` failed because `refs/remotes/origin/agentv/results/v1` became `present`.
- Green after fix: the same regression passes.
- Disposable Dashboard UAT after rebuild:
  - Before startup: origin URL correct, remote results ref absent.
  - After startup and `GET /api/remote/status`: origin URL unchanged, remote results ref still absent, run_count 0.
  - After explicit `POST /api/remote/sync`: origin URL unchanged, remote results ref present, run_count 1.

## Verification
- `bun test ./packages/core/test/evaluation/results-repo.test.ts --test-name-pattern "does not fetch a repo_path storage branch during status inspection"`
- `bun test ./packages/core/test/evaluation/results-repo.test.ts`
- `bun test ./apps/cli/test/commands/results/serve.test.ts --test-name-pattern "remote/status|remote/sync|project-scoped remote status"`
- `bun --filter @agentv/core typecheck`
- `bun --filter @agentv/core lint`
- `bun run build`
- Verified `git remote -v` in both worker and primary checkout remained `https://github.com/EntityProcess/agentv.git` for fetch/push.

Bead: av-0p9