### PR TITLE
feat(dashboard): identify result rows by eval path

### DIFF
--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -1203,6 +1203,7 @@ function attachRunDetailReadModelFields<T extends Record<string, unknown>>(
     return {
       ...result,
       ...(record.aggregation && { aggregation: record.aggregation }),
+      ...(record.eval_path && { eval_path: record.eval_path }),
       ...(record.result_dir && { result_dir: record.result_dir }),
       ...(record.summary_path && { summary_path: record.summary_path }),
       ...(record.grading_path && { grading_path: record.grading_path }),

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -2581,18 +2581,30 @@ describe('serve app', () => {
       const filename = '2026-03-25T10-00-00-000Z';
       const runDir = path.join(runsDir, filename);
       mkdirSync(runDir, { recursive: true });
-      writeFileSync(path.join(runDir, 'index.jsonl'), toJsonl(RESULT_A, RESULT_B));
+      writeFileSync(
+        path.join(runDir, 'index.jsonl'),
+        toJsonl(
+          {
+            ...RESULT_A,
+            eval_path: 'evals/demo.eval.yaml',
+            result_dir: 'demo/test-greeting',
+          },
+          RESULT_B,
+        ),
+      );
 
       const app = createApp([], tempDir, tempDir, undefined, { studioDir });
       const res = await app.request(`/api/runs/${filename}`);
       expect(res.status).toBe(200);
       const data = (await res.json()) as {
-        results: { testId: string }[];
+        results: { testId: string; eval_path?: string; result_dir?: string }[];
         source: 'local' | 'remote';
         source_label: string;
       };
       expect(data.results).toHaveLength(2);
       expect(data.results[0].testId).toBe('test-greeting');
+      expect(data.results[0].eval_path).toBe('evals/demo.eval.yaml');
+      expect(data.results[0].result_dir).toBe('demo/test-greeting');
       expect(data.source).toBe('local');
       expect(data.source_label).toBe(filename);
     });

--- a/apps/dashboard/src/components/EvalDetail.tsx
+++ b/apps/dashboard/src/components/EvalDetail.tsx
@@ -335,8 +335,9 @@ function SourceTab({ result }: { result: EvalResult }) {
         <h4 className="mb-3 text-sm font-medium text-gray-300">Traceability</h4>
         <dl className="grid gap-3 md:grid-cols-2">
           <SourceMetaRow label="Eval file" value={traceability.eval_file?.display_path} />
+          <SourceMetaRow label="Eval" value={result.eval_path} />
           <SourceMetaRow label="Test ID" value={traceability.test_id ?? result.testId} />
-          <SourceMetaRow label="Suite" value={result.suite} />
+          <SourceMetaRow label="Legacy suite" value={result.suite} />
           <SourceMetaRow label="Category" value={result.category} />
           <SourceMetaRow label="Target" value={result.target} />
         </dl>

--- a/apps/dashboard/src/components/EvalSourceLabel.tsx
+++ b/apps/dashboard/src/components/EvalSourceLabel.tsx
@@ -1,0 +1,18 @@
+import { formatEvalSourceDisplay } from '~/lib/run-detail-context';
+import type { EvalResult } from '~/lib/types';
+
+interface EvalSourceLabelProps {
+  result: Pick<EvalResult, 'eval_path' | 'suite'>;
+  className?: string;
+}
+
+export function EvalSourceLabel({ result, className = '' }: EvalSourceLabelProps) {
+  const display = formatEvalSourceDisplay(result);
+  if (!display) return null;
+
+  return (
+    <span className={`block truncate text-gray-500 ${className}`} title={display.title}>
+      {display.label}
+    </span>
+  );
+}

--- a/apps/dashboard/src/components/ResultTable.tsx
+++ b/apps/dashboard/src/components/ResultTable.tsx
@@ -10,6 +10,7 @@ import type React from 'react';
 import { Fragment, useEffect, useMemo, useState } from 'react';
 
 import { useFeedback } from '~/lib/api';
+import { evalResultPath } from '~/lib/navigation';
 import {
   RESULT_TABLE_VIEW_PRESETS,
   type RepeatRunGroup,
@@ -651,8 +652,8 @@ function TrialResultCell({
       return <TargetCell target={row.targetLabel} tone="text-gray-500" />;
     case 'score':
       return <PassRatePill rate={trial.score ?? 0} />;
-    case 'suite':
-      return <TruncatedMuted value={row.suiteLabel} tone="text-gray-500" />;
+    case 'eval':
+      return <TruncatedMuted value={row.evalLabel} tone="text-gray-500" />;
     case 'category':
       return <TruncatedMuted value={row.categoryLabel} tone="text-gray-500" />;
     case 'duration':
@@ -833,8 +834,8 @@ function ResultCell({
       ) : (
         <PassRatePill rate={row.result.score} />
       );
-    case 'suite':
-      return <TruncatedMuted value={row.suiteLabel} />;
+    case 'eval':
+      return <TruncatedMuted value={row.evalLabel} />;
     case 'category':
       return <TruncatedMuted value={row.categoryLabel} />;
     case 'duration':
@@ -910,11 +911,10 @@ function ResultDetailPanel({
   onOpenTrialDetail: (trial: EvalCaseTrial, initialTab?: DetailTab) => void;
   onClose: () => void;
 }) {
-  const evalDetailHref = buildEvalDetailHref({
+  const evalDetailHref = evalResultPath(runId, row.testId, {
     projectId,
-    runId,
-    evalId: row.testId,
     resultDir: row.result.result_dir,
+    evalPath: row.result.eval_path,
   });
   const title = selectedTrialPath ? `${row.testId} · ${selectedTrialPath}` : row.testId;
   const showAggregateRepeatDetail = repeatGroup && !selectedTrial;
@@ -934,7 +934,7 @@ function ResultDetailPanel({
           </h4>
           <p className="mt-1 truncate text-xs text-gray-500" title={row.targetLabel}>
             {row.targetLabel}
-            {row.suiteLabel ? ` · ${row.suiteLabel}` : ''}
+            {row.evalLabel ? ` · ${row.evalLabel}` : ''}
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-2">
@@ -1001,19 +1001,6 @@ function ExpanderCell({
       {repeatCollapsed ? '+' : '-'}
     </button>
   );
-}
-
-function buildEvalDetailHref(options: {
-  projectId?: string;
-  runId: string;
-  evalId: string;
-  resultDir?: string;
-}): string {
-  const base = options.projectId
-    ? `/projects/${encodeURIComponent(options.projectId)}/evals/${encodeURIComponent(options.runId)}/${encodeURIComponent(options.evalId)}`
-    : `/evals/${encodeURIComponent(options.runId)}/${encodeURIComponent(options.evalId)}`;
-  if (!options.resultDir) return base;
-  return `${base}?result_dir=${encodeURIComponent(options.resultDir)}`;
 }
 
 function scrollPanelIntoView(panel: HTMLElement | null) {

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -33,13 +33,18 @@ import {
   useRunList,
   useStudioConfig,
 } from '~/lib/api';
-import { shouldShowSuiteLabels } from '~/lib/run-detail-context';
+import {
+  evalResultIdentityKey,
+  evalResultSearchParams,
+  matchesEvalResultIdentity,
+} from '~/lib/navigation';
+import { shouldShowEvalSourceLabels } from '~/lib/run-detail-context';
 import { formatRunDisplay } from '~/lib/run-label';
 import { useSidebarContext } from '~/lib/sidebar-context';
 import type { EvalResult } from '~/lib/types';
 
 import { BrandName } from './BrandName';
-import { EvalSuiteLabel } from './EvalSuiteLabel';
+import { EvalSourceLabel } from './EvalSourceLabel';
 
 /** Responsive <aside> wrapper. Handles mobile overlay and desktop static placement. */
 function SidebarShell({ children }: { children: ReactNode }) {
@@ -104,11 +109,11 @@ function SidebarRunText({ display }: { display: ReturnType<typeof formatRunDispl
 function EvalSidebarItemContent({
   result,
   passThreshold,
-  showSuiteLabel,
+  showEvalSourceLabel,
 }: {
   result: EvalResult;
   passThreshold: number;
-  showSuiteLabel: boolean;
+  showEvalSourceLabel: boolean;
 }) {
   const passed = isPassing(result.score, passThreshold);
 
@@ -119,12 +124,21 @@ function EvalSidebarItemContent({
       </span>
       <span className="min-w-0 flex-1">
         <span className="block truncate">{result.testId}</span>
-        {showSuiteLabel ? (
-          <EvalSuiteLabel suite={result.suite} className="mt-1 max-w-full text-[11px] leading-4" />
+        {showEvalSourceLabel ? (
+          <EvalSourceLabel result={result} className="mt-1 max-w-full text-[11px] leading-4" />
         ) : null}
       </span>
     </>
   );
+}
+
+function useCurrentEvalIdentitySearch() {
+  const location = useLocation();
+  const search = location.search as Record<string, string | undefined>;
+  return {
+    resultDir: search.result_dir,
+    evalPath: search.eval_path,
+  };
 }
 
 type ProjectTabId = 'runs' | 'experiments' | 'analytics' | 'targets';
@@ -409,8 +423,9 @@ function RunDetailSidebar({ currentRunId }: { currentRunId: string }) {
 function EvalSidebar({ runId, currentEvalId }: { runId: string; currentEvalId: string }) {
   const { data } = useRunDetail(runId);
   const { data: config } = useStudioConfig();
+  const currentIdentity = useCurrentEvalIdentitySearch();
   const passThreshold = config?.threshold ?? config?.pass_threshold ?? 0.8;
-  const showSuiteLabels = shouldShowSuiteLabels(data?.results ?? []);
+  const showEvalSourceLabels = shouldShowEvalSourceLabels(data?.results ?? []);
 
   return (
     <SidebarShell>
@@ -434,13 +449,18 @@ function EvalSidebar({ runId, currentEvalId }: { runId: string; currentEvalId: s
         </div>
 
         {data?.results.map((result) => {
-          const isActive = result.testId === currentEvalId;
+          const search = evalResultSearchParams({
+            resultDir: result.result_dir,
+            evalPath: result.eval_path,
+          });
+          const isActive = matchesEvalResultIdentity(result, currentEvalId, currentIdentity);
 
           return (
             <Link
-              key={result.testId}
+              key={evalResultIdentityKey(result)}
               to="/evals/$runId/$evalId"
               params={{ runId, evalId: result.testId }}
+              search={search}
               className={`mb-0.5 flex items-start gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${
                 isActive
                   ? 'bg-gray-800 text-cyan-400'
@@ -450,7 +470,7 @@ function EvalSidebar({ runId, currentEvalId }: { runId: string; currentEvalId: s
               <EvalSidebarItemContent
                 result={result}
                 passThreshold={passThreshold}
-                showSuiteLabel={showSuiteLabels}
+                showEvalSourceLabel={showEvalSourceLabels}
               />
             </Link>
           );
@@ -490,12 +510,17 @@ function SuiteSidebar({ runId, suite }: { runId: string; suite: string }) {
 
         {suiteResults.map((result) => {
           const passed = isPassing(result.score, passThreshold);
+          const search = evalResultSearchParams({
+            resultDir: result.result_dir,
+            evalPath: result.eval_path,
+          });
 
           return (
             <Link
-              key={result.testId}
+              key={evalResultIdentityKey(result)}
               to="/evals/$runId/$evalId"
               params={{ runId, evalId: result.testId }}
+              search={search}
               className="mb-0.5 flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-gray-400 transition-colors hover:bg-gray-800/50 hover:text-gray-200"
             >
               <span className={`text-xs ${passed ? 'text-emerald-400' : 'text-red-400'}`}>
@@ -609,8 +634,9 @@ function ProjectEvalSidebar({
 }) {
   const { data } = useProjectRunDetail(projectId, runId);
   const { data: config } = useStudioConfig(projectId);
+  const currentIdentity = useCurrentEvalIdentitySearch();
   const passThreshold = config?.threshold ?? config?.pass_threshold ?? 0.8;
-  const showSuiteLabels = shouldShowSuiteLabels(data?.results ?? []);
+  const showEvalSourceLabels = shouldShowEvalSourceLabels(data?.results ?? []);
 
   return (
     <SidebarShell>
@@ -632,12 +658,17 @@ function ProjectEvalSidebar({
           Evaluations
         </div>
         {data?.results.map((result) => {
-          const isActive = result.testId === currentEvalId;
+          const search = evalResultSearchParams({
+            resultDir: result.result_dir,
+            evalPath: result.eval_path,
+          });
+          const isActive = matchesEvalResultIdentity(result, currentEvalId, currentIdentity);
           return (
             <Link
-              key={result.testId}
+              key={evalResultIdentityKey(result)}
               to="/projects/$projectId/evals/$runId/$evalId"
               params={{ projectId, runId, evalId: result.testId }}
+              search={search}
               className={`mb-0.5 flex items-start gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${
                 isActive
                   ? 'bg-gray-800 text-cyan-400'
@@ -647,7 +678,7 @@ function ProjectEvalSidebar({
               <EvalSidebarItemContent
                 result={result}
                 passThreshold={passThreshold}
-                showSuiteLabel={showSuiteLabels}
+                showEvalSourceLabel={showEvalSourceLabels}
               />
             </Link>
           );
@@ -693,11 +724,16 @@ function ProjectSuiteSidebar({
         </div>
         {suiteResults.map((result) => {
           const passed = isPassing(result.score, passThreshold);
+          const search = evalResultSearchParams({
+            resultDir: result.result_dir,
+            evalPath: result.eval_path,
+          });
           return (
             <Link
-              key={result.testId}
+              key={evalResultIdentityKey(result)}
               to="/projects/$projectId/evals/$runId/$evalId"
               params={{ projectId, runId, evalId: result.testId }}
+              search={search}
               className="mb-0.5 flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-gray-400 transition-colors hover:bg-gray-800/50 hover:text-gray-200"
             >
               <span className={`text-xs ${passed ? 'text-emerald-400' : 'text-red-400'}`}>

--- a/apps/dashboard/src/lib/navigation.test.ts
+++ b/apps/dashboard/src/lib/navigation.test.ts
@@ -3,9 +3,13 @@ import { describe, expect, it } from 'bun:test';
 import {
   categoryPath,
   evalPath,
+  evalResultIdentityKey,
+  evalResultPath,
+  evalResultSearchParams,
   experimentPath,
   initialProjectRedirectStorageKey,
   jobPath,
+  matchesEvalResultIdentity,
   resolveIndexRoute,
   resolveInitialProjectRedirect,
   runPath,
@@ -58,6 +62,15 @@ describe('route path helpers', () => {
     expect(evalPath('run::1', 'case/a', 'demo project')).toBe(
       '/projects/demo%20project/evals/run%3A%3A1/case%2Fa',
     );
+    expect(
+      evalResultPath('run::1', 'case/a', {
+        projectId: 'demo project',
+        resultDir: 'evals/auth.eval.yaml/case-a',
+        evalPath: 'evals/auth.eval.yaml',
+      }),
+    ).toBe(
+      '/projects/demo%20project/evals/run%3A%3A1/case%2Fa?result_dir=evals%2Fauth.eval.yaml%2Fcase-a',
+    );
     expect(jobPath('job/1', 'demo project')).toBe('/projects/demo%20project/jobs/job%2F1');
     expect(categoryPath('run::1', 'Safety > PII', 'demo project')).toBe(
       '/projects/demo%20project/runs/run%3A%3A1/category/Safety%20%3E%20PII',
@@ -74,11 +87,42 @@ describe('route path helpers', () => {
   it('keeps unscoped paths for legacy single-project routes', () => {
     expect(runPath('run::1')).toBe('/runs/run%3A%3A1');
     expect(evalPath('run::1', 'case/a')).toBe('/evals/run%3A%3A1/case%2Fa');
+    expect(evalResultPath('run::1', 'case/a', { evalPath: 'evals/smoke.eval.yaml' })).toBe(
+      '/evals/run%3A%3A1/case%2Fa?eval_path=evals%2Fsmoke.eval.yaml',
+    );
     expect(jobPath('job/1')).toBe('/jobs/job%2F1');
     expect(categoryPath('run::1', 'Safety')).toBe('/runs/run%3A%3A1/category/Safety');
     expect(suitePath('run::1', 'evals/smoke.eval.yaml')).toBe(
       '/runs/run%3A%3A1/suite/evals%2Fsmoke.eval.yaml',
     );
     expect(runsHomePath()).toBe('/?tab=runs');
+  });
+
+  it('prefers result_dir over eval_path for eval result query identity', () => {
+    expect(
+      evalResultSearchParams({
+        resultDir: 'opaque/case',
+        evalPath: 'evals/smoke.eval.yaml',
+      }),
+    ).toEqual({ result_dir: 'opaque/case' });
+    expect(evalResultSearchParams({ evalPath: 'evals/smoke.eval.yaml' })).toEqual({
+      eval_path: 'evals/smoke.eval.yaml',
+    });
+  });
+
+  it('matches and keys eval results by result_dir before eval_path', () => {
+    const result = {
+      testId: 'shared',
+      target: 'codex',
+      result_dir: 'opaque/shared',
+      eval_path: 'evals/auth.eval.yaml',
+    };
+
+    expect(evalResultIdentityKey(result)).toBe('opaque/shared');
+    expect(matchesEvalResultIdentity(result, 'shared', { resultDir: 'opaque/shared' })).toBe(true);
+    expect(matchesEvalResultIdentity(result, 'shared', { resultDir: 'other/shared' })).toBe(false);
+    expect(matchesEvalResultIdentity(result, 'shared', { evalPath: 'evals/auth.eval.yaml' })).toBe(
+      true,
+    );
   });
 });

--- a/apps/dashboard/src/lib/navigation.ts
+++ b/apps/dashboard/src/lib/navigation.ts
@@ -33,6 +33,58 @@ export function evalPath(runId: string, evalId: string, projectId?: string): str
     : `/evals/${encodeURIComponent(runId)}/${encodeURIComponent(evalId)}`;
 }
 
+export interface EvalResultPathOptions {
+  projectId?: string;
+  resultDir?: string;
+  evalPath?: string;
+}
+
+export interface EvalResultIdentity {
+  testId: string;
+  target?: string;
+  result_dir?: string;
+  eval_path?: string;
+  suite?: string;
+}
+
+export function evalResultSearchParams(options: EvalResultPathOptions): Record<string, string> {
+  if (options.resultDir) {
+    return { result_dir: options.resultDir };
+  }
+  if (options.evalPath) {
+    return { eval_path: options.evalPath };
+  }
+  return {};
+}
+
+export function evalResultPath(
+  runId: string,
+  evalId: string,
+  options: EvalResultPathOptions = {},
+): string {
+  const base = evalPath(runId, evalId, options.projectId);
+  const params = new URLSearchParams(evalResultSearchParams(options));
+  const query = params.toString();
+  return query ? `${base}?${query}` : base;
+}
+
+export function evalResultIdentityKey(result: EvalResultIdentity): string {
+  if (result.result_dir) return result.result_dir;
+  return [result.eval_path ?? result.suite ?? '', result.testId, result.target ?? ''].join(':');
+}
+
+export function matchesEvalResultIdentity(
+  result: Pick<EvalResultIdentity, 'testId' | 'result_dir' | 'eval_path'>,
+  evalId: string,
+  options: Pick<EvalResultPathOptions, 'resultDir' | 'evalPath'> = {},
+): boolean {
+  return (
+    result.testId === evalId &&
+    (!options.resultDir || result.result_dir === options.resultDir) &&
+    (!options.evalPath || result.eval_path === options.evalPath)
+  );
+}
+
 export function experimentPath(experimentName: string, projectId?: string): string {
   return projectId
     ? `/projects/${encodeURIComponent(projectId)}/experiments/${encodeURIComponent(experimentName)}`

--- a/apps/dashboard/src/lib/result-table.test.ts
+++ b/apps/dashboard/src/lib/result-table.test.ts
@@ -90,7 +90,7 @@ describe('result-table model', () => {
       results: [
         result({
           testId: 'metric-case',
-          suite: 'dataset.eval.yaml',
+          eval_path: 'evals/dataset.eval.yaml',
           category: 'smoke',
           target: 'azure',
           durationMs: 1234,
@@ -105,7 +105,7 @@ describe('result-table model', () => {
       'status',
       'test',
       'target',
-      'suite',
+      'eval',
       'score',
       'category',
       'duration',
@@ -114,15 +114,17 @@ describe('result-table model', () => {
       'grader:correctness',
     ]);
     expect(model.visibleColumns.map((column) => column.id)).toContain('grader:correctness');
+    expect(model.columns.find((column) => column.id === 'eval')?.label).toBe('Eval');
+    expect(model.rows[0].evalLabel).toBe('evals/dataset.eval.yaml');
   });
 
-  it('orders repeat-run columns with target before suite before score', () => {
+  it('orders repeat-run columns with target before eval before score', () => {
     const model = buildResultTableModel({
       passThreshold: 0.8,
       results: [
         result({
           testId: 'repeat-case',
-          suite: 'strict-layout',
+          eval_path: 'evals/strict-layout.eval.yaml',
           target: 'openai',
           trials: [
             { attempt: 0, run_path: 'run-1', score: 1, verdict: 'pass' },
@@ -137,7 +139,7 @@ describe('result-table model', () => {
       'expander',
       'test',
       'target',
-      'suite',
+      'eval',
       'score',
     ]);
     expect(model.repeatGroups).toHaveLength(1);
@@ -167,5 +169,45 @@ describe('result-table model', () => {
     expect(model.state.view).toBe('grader_errors');
     expect(model.state.grader).toBe('rubric');
     expect(model.visibleColumns.map((column) => column.id)).toEqual(['grader:rubric']);
+  });
+
+  it('uses eval_path and result_dir to distinguish duplicate test IDs', () => {
+    const model = buildResultTableModel({
+      passThreshold: 0.8,
+      results: [
+        result({
+          testId: 'shared-case',
+          eval_path: 'evals/auth/login.eval.yaml',
+          result_dir: 'auth-login/shared-case',
+          target: 'codex',
+        }),
+        result({
+          testId: 'shared-case',
+          eval_path: 'evals/billing/login.eval.yaml',
+          result_dir: 'billing-login/shared-case',
+          target: 'codex',
+        }),
+      ],
+    });
+
+    expect(model.rows.map((row) => row.evalLabel)).toEqual([
+      'evals/auth/login.eval.yaml',
+      'evals/billing/login.eval.yaml',
+    ]);
+    expect(model.rows.map((row) => row.key)).toEqual([
+      'result_dir:auth-login/shared-case',
+      'result_dir:billing-login/shared-case',
+    ]);
+    expect(new Set(model.rows.map((row) => row.key)).size).toBe(2);
+  });
+
+  it('falls back to legacy suite labels for old runs without eval_path', () => {
+    const model = buildResultTableModel({
+      passThreshold: 0.8,
+      results: [result({ testId: 'legacy-case', suite: 'legacy-suite' })],
+    });
+
+    expect(model.columns.find((column) => column.id === 'eval')?.label).toBe('Eval');
+    expect(model.rows[0].evalLabel).toBe('legacy-suite');
   });
 });

--- a/apps/dashboard/src/lib/result-table.ts
+++ b/apps/dashboard/src/lib/result-table.ts
@@ -68,7 +68,7 @@ export interface ResultTableRow {
   readonly reviewed: boolean;
   readonly targetLabel: string;
   readonly modelLabel?: string;
-  readonly suiteLabel?: string;
+  readonly evalLabel?: string;
   readonly categoryLabel?: string;
   readonly tokenTotal?: number;
   readonly graderNames: readonly string[];
@@ -235,6 +235,25 @@ function targetLabel(result: EvalResult): string {
   return targetUsed && targetUsed !== target ? `${target} -> ${targetUsed}` : target;
 }
 
+function evalLabel(result: EvalResult): string | undefined {
+  return cleanString(result.eval_path) ?? cleanString(result.suite);
+}
+
+function rowKey(result: EvalResult, index: number): string {
+  const resultDir = cleanString(result.result_dir);
+  if (resultDir) return `result_dir:${resultDir}`;
+
+  return [
+    'result',
+    cleanString(result.eval_path) ?? cleanString(result.suite) ?? '',
+    result.testId,
+    cleanString(result.target) ?? '',
+    cleanString(result.targetUsed) ?? '',
+    cleanString(result.timestamp) ?? '',
+    String(index),
+  ].join(':');
+}
+
 function buildRow(
   result: EvalResult,
   index: number,
@@ -250,6 +269,7 @@ function buildRow(
     result.scores?.some((score) => scoreHasFailure(score, passThreshold)) ?? false;
   const model = modelLabel(result);
   const target = targetLabel(result);
+  const evalSource = evalLabel(result);
   const suite = cleanString(result.suite);
   const category = cleanString(result.category);
   const tokenTotal = totalTokens(result);
@@ -257,6 +277,7 @@ function buildRow(
     result.testId,
     target,
     model ?? '',
+    evalSource ?? '',
     suite ?? '',
     category ?? '',
     result.executionStatus ?? '',
@@ -266,7 +287,7 @@ function buildRow(
   ];
 
   return {
-    key: `${result.testId}:${result.target ?? ''}:${result.timestamp ?? ''}:${index}`,
+    key: rowKey(result, index),
     result,
     index,
     testId: result.testId,
@@ -278,7 +299,7 @@ function buildRow(
     reviewed: reviewedTestIds.has(result.testId),
     targetLabel: target,
     ...(model && { modelLabel: model }),
-    ...(suite && { suiteLabel: suite }),
+    ...(evalSource && { evalLabel: evalSource }),
     ...(category && { categoryLabel: category }),
     ...(tokenTotal !== undefined && { tokenTotal }),
     graderNames,
@@ -329,7 +350,7 @@ function buildRepeatGroup(row: ResultTableRow, passThreshold: number): RepeatRun
 
 function buildColumns(rows: readonly ResultTableRow[], graderOptions: readonly string[]) {
   const hasRepeatRows = rows.some((row) => caseTrials(row.result).length > 1);
-  const hasSuite = rows.some((row) => row.suiteLabel);
+  const hasEval = rows.some((row) => row.evalLabel);
   const hasCategory = rows.some((row) => row.categoryLabel);
   const hasDuration = rows.some(
     (row) =>
@@ -354,8 +375,8 @@ function buildColumns(rows: readonly ResultTableRow[], graderOptions: readonly s
       : []),
     { id: 'test', label: 'Test ID', kind: 'base', defaultVisible: true },
     { id: 'target', label: 'Target', kind: 'base', defaultVisible: true },
-    ...(hasSuite
-      ? [{ id: 'suite', label: 'Suite', kind: 'base' as const, defaultVisible: true }]
+    ...(hasEval
+      ? [{ id: 'eval', label: 'Eval', kind: 'base' as const, defaultVisible: true }]
       : []),
     { id: 'score', label: 'Score', kind: 'base', defaultVisible: true },
     ...(hasCategory

--- a/apps/dashboard/src/lib/run-detail-context.test.ts
+++ b/apps/dashboard/src/lib/run-detail-context.test.ts
@@ -4,8 +4,11 @@ import type { EvalResult } from './types';
 
 import {
   buildRunDetailHeader,
+  evalSourceValue,
   formatCategoryDisplay,
+  formatEvalSourceDisplay,
   formatSuiteDisplay,
+  shouldShowEvalSourceLabels,
   shouldShowSuiteLabels,
 } from './run-detail-context';
 
@@ -97,6 +100,28 @@ describe('formatSuiteDisplay', () => {
   });
 });
 
+describe('eval source labels', () => {
+  it('prefers eval_path over legacy suite metadata', () => {
+    const result = {
+      eval_path: 'evals/auth/login.eval.yaml',
+      suite: 'legacy-suite',
+    };
+
+    expect(evalSourceValue(result)).toBe('evals/auth/login.eval.yaml');
+    expect(formatEvalSourceDisplay(result)).toEqual({
+      label: 'login',
+      title: 'evals/auth/login.eval.yaml',
+    });
+  });
+
+  it('falls back to suite for old result rows', () => {
+    expect(formatEvalSourceDisplay({ suite: 'legacy-suite' })).toEqual({
+      label: 'legacy-suite',
+      title: 'legacy-suite',
+    });
+  });
+});
+
 describe('shouldShowSuiteLabels', () => {
   it('shows labels for mixed-suite runs', () => {
     expect(
@@ -107,6 +132,26 @@ describe('shouldShowSuiteLabels', () => {
   it('suppresses repeated labels for single-suite runs', () => {
     expect(
       shouldShowSuiteLabels([{ suite: 'evals/a.eval.yaml' }, { suite: 'evals/a.eval.yaml' }]),
+    ).toBe(false);
+  });
+});
+
+describe('shouldShowEvalSourceLabels', () => {
+  it('shows labels for mixed eval paths even when test IDs overlap', () => {
+    expect(
+      shouldShowEvalSourceLabels([
+        { eval_path: 'evals/a.eval.yaml', suite: 'legacy' },
+        { eval_path: 'evals/b.eval.yaml', suite: 'legacy' },
+      ]),
+    ).toBe(true);
+  });
+
+  it('suppresses repeated labels for a single eval path', () => {
+    expect(
+      shouldShowEvalSourceLabels([
+        { eval_path: 'evals/a.eval.yaml' },
+        { eval_path: 'evals/a.eval.yaml' },
+      ]),
     ).toBe(false);
   });
 });

--- a/apps/dashboard/src/lib/run-detail-context.ts
+++ b/apps/dashboard/src/lib/run-detail-context.ts
@@ -6,9 +6,9 @@
  * presentation logic here so route components stay thin and tests can pin
  * the remote-context contract without rendering React.
  *
- * Suite labels are displayed only when a run mixes suites or has partial suite
- * metadata. Keep the table/sidebar dense by suppressing repeated labels for
- * single-suite runs.
+ * Eval source labels are displayed only when a run mixes eval files or has
+ * partial legacy suite metadata. Keep the table/sidebar dense by suppressing
+ * repeated labels for single-eval runs.
  */
 
 import type { EvalResult, RunDetailResponse } from './types';
@@ -17,6 +17,7 @@ type RunSource = RunDetailResponse['source'];
 
 type HeaderResult = Pick<EvalResult, 'experiment' | 'target' | 'timestamp'>;
 type SuiteLabelResult = Pick<EvalResult, 'suite'>;
+type EvalSourceLabelResult = Pick<EvalResult, 'eval_path' | 'suite'>;
 
 export interface RunDetailHeaderInput {
   runId: string;
@@ -162,9 +163,26 @@ export function formatSuiteDisplay(suite: string | undefined): SuiteDisplay | un
   };
 }
 
+export function evalSourceValue(result: EvalSourceLabelResult): string | undefined {
+  return cleanOptional(result.eval_path) ?? cleanOptional(result.suite);
+}
+
+export function formatEvalSourceDisplay(result: EvalSourceLabelResult): SuiteDisplay | undefined {
+  return formatSuiteDisplay(evalSourceValue(result));
+}
+
 export function shouldShowSuiteLabels(results: readonly SuiteLabelResult[]): boolean {
   const normalizedSuites = results.map((result) => cleanOptional(result.suite) ?? '');
   const meaningfulSuites = normalizedSuites.filter((suite) => suite && suite !== 'Uncategorized');
 
   return meaningfulSuites.length > 0 && new Set(normalizedSuites).size > 1;
+}
+
+export function shouldShowEvalSourceLabels(results: readonly EvalSourceLabelResult[]): boolean {
+  const normalizedSources = results.map((result) => evalSourceValue(result) ?? '');
+  const meaningfulSources = normalizedSources.filter(
+    (source) => source && source !== 'Uncategorized',
+  );
+
+  return meaningfulSources.length > 0 && new Set(normalizedSources).size > 1;
 }

--- a/apps/dashboard/src/lib/types.ts
+++ b/apps/dashboard/src/lib/types.ts
@@ -226,6 +226,7 @@ export type TraceSessionResponse = CoreTraceSessionResponse;
 export interface EvalResult {
   testId: string;
   timestamp?: string;
+  eval_path?: string;
   suite?: string;
   category?: string;
   target?: string;

--- a/apps/dashboard/src/routes/evals/$runId.$evalId.tsx
+++ b/apps/dashboard/src/routes/evals/$runId.$evalId.tsx
@@ -12,6 +12,7 @@ import { useState } from 'react';
 import { EvalDetail } from '~/components/EvalDetail';
 import { RunEvalModal } from '~/components/RunEvalModal';
 import { isPassing, useRunDetail, useStudioConfig } from '~/lib/api';
+import { matchesEvalResultIdentity } from '~/lib/navigation';
 
 export const Route = createFileRoute('/evals/$runId/$evalId')({
   component: EvalDetailPage,
@@ -23,6 +24,10 @@ function EvalDetailPage() {
     typeof window === 'undefined'
       ? undefined
       : (new URLSearchParams(window.location.search).get('result_dir') ?? undefined);
+  const evalPath =
+    typeof window === 'undefined'
+      ? undefined
+      : (new URLSearchParams(window.location.search).get('eval_path') ?? undefined);
   const { data, isLoading, error } = useRunDetail(runId);
   const { data: config } = useStudioConfig();
   const [showRunEval, setShowRunEval] = useState(false);
@@ -45,8 +50,8 @@ function EvalDetailPage() {
     );
   }
 
-  const result = data?.results.find(
-    (r) => r.testId === evalId && (!resultDir || r.result_dir === resultDir),
+  const result = data?.results.find((r) =>
+    matchesEvalResultIdentity(r, evalId, { resultDir, evalPath }),
   );
 
   if (!result) {
@@ -71,7 +76,7 @@ function EvalDetailPage() {
       <div className="flex items-center justify-between">
         <div>
           <p className="text-sm text-gray-400">
-            Run: {runId} / Eval: {evalId}
+            Run: {runId} / Eval: {result.eval_path ?? evalId}
           </p>
           <h1 className="flex items-center gap-2 text-2xl font-semibold text-white">
             <span

--- a/apps/dashboard/src/routes/projects/$projectId_/evals/$runId.$evalId.tsx
+++ b/apps/dashboard/src/routes/projects/$projectId_/evals/$runId.$evalId.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 import { EvalDetail } from '~/components/EvalDetail';
 import { RunEvalModal } from '~/components/RunEvalModal';
 import { isPassing, useProjectRunDetail, useStudioConfig } from '~/lib/api';
+import { matchesEvalResultIdentity } from '~/lib/navigation';
 
 export const Route = createFileRoute('/projects/$projectId_/evals/$runId/$evalId')({
   component: ProjectEvalDetailPage,
@@ -19,6 +20,10 @@ function ProjectEvalDetailPage() {
     typeof window === 'undefined'
       ? undefined
       : (new URLSearchParams(window.location.search).get('result_dir') ?? undefined);
+  const evalPath =
+    typeof window === 'undefined'
+      ? undefined
+      : (new URLSearchParams(window.location.search).get('eval_path') ?? undefined);
   const { data, isLoading, error } = useProjectRunDetail(projectId, runId);
   const { data: config } = useStudioConfig(projectId);
   const [showRunEval, setShowRunEval] = useState(false);
@@ -41,8 +46,8 @@ function ProjectEvalDetailPage() {
     );
   }
 
-  const result = data?.results.find(
-    (r) => r.testId === evalId && (!resultDir || r.result_dir === resultDir),
+  const result = data?.results.find((r) =>
+    matchesEvalResultIdentity(r, evalId, { resultDir, evalPath }),
   );
 
   if (!result) {
@@ -67,7 +72,7 @@ function ProjectEvalDetailPage() {
       <div className="flex items-center justify-between">
         <div>
           <p className="text-sm text-gray-400">
-            Run: {runId} / Eval: {evalId}
+            Run: {runId} / Eval: {result.eval_path ?? evalId}
           </p>
           <h1 className="flex items-center gap-2 text-2xl font-semibold text-white">
             <span


### PR DESCRIPTION
## Summary

Dashboard run tables now use repo-relative `eval_path` as the visible Eval identity while preserving `suite` only as a legacy fallback for old run artifacts. Result drill-down links carry `result_dir` when available, falling back to eval-path-scoped identity so duplicate `test_id` rows from different eval files continue to open the correct artifact.

This keeps Experiments and Recent Runs centered on eval source identity without renaming unrelated benchmark concepts or the existing compatibility suite routes.

## Validation

- `bun test apps/dashboard/src/lib/result-table.test.ts apps/dashboard/src/lib/navigation.test.ts apps/dashboard/src/lib/run-detail-context.test.ts`
- `cd apps/dashboard && bun run build`
- `bun test apps/cli/test/commands/results/serve.test.ts`
- `bun --filter agentv typecheck`
- `bunx biome check ...touched dashboard/CLI files...`
- `git diff --check`

## Review Notes

- Spawned a code-review subagent before PR. It found duplicate-test-id sidebar active/link issues; this PR includes the follow-up fix so sidebar links and active states use `result_dir`/`eval_path` identity instead of bare `test_id`.

## Post-Deploy Monitoring & Validation

- No runtime migration or service monitoring required. This is local Dashboard read-model/navigation behavior with legacy `suite` fallback retained for old artifacts.

Refs EntityProcess/agentv-beads#16 and bead `av-504.4`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
