### PR TITLE
fix(results): ignore missing WIP branch cleanup

### DIFF
--- a/packages/core/src/evaluation/results-repo.ts
+++ b/packages/core/src/evaluation/results-repo.ts
@@ -4124,7 +4124,19 @@ export async function deleteWipBranch(params: {
 }): Promise<void> {
   const normalized = normalizeResultsConfig(params.config);
   const cloneDir = await ensureResultsRepoClone(normalized);
-  await runGit(['push', normalized.remote, '--delete', params.wipBranch], { cwd: cloneDir });
+  const result = await runGit(['push', normalized.remote, '--delete', params.wipBranch], {
+    cwd: cloneDir,
+    check: false,
+  });
+  if (result.exitCode === 0 || isMissingRemoteRefDelete(result)) {
+    return;
+  }
+  throw new Error(result.stderr.trim() || result.stdout.trim() || 'Failed to delete WIP branch');
+}
+
+function isMissingRemoteRefDelete(result: { stdout: string; stderr: string }): boolean {
+  const text = `${result.stderr}\n${result.stdout}`.toLowerCase();
+  return text.includes('remote ref does not exist') || text.includes('unable to delete');
 }
 
 // git exits non-zero with one of these messages when the requested ref/object

--- a/packages/core/src/evaluation/results-repo.ts
+++ b/packages/core/src/evaluation/results-repo.ts
@@ -4136,7 +4136,7 @@ export async function deleteWipBranch(params: {
 
 function isMissingRemoteRefDelete(result: { stdout: string; stderr: string }): boolean {
   const text = `${result.stderr}\n${result.stdout}`.toLowerCase();
-  return text.includes('remote ref does not exist') || text.includes('unable to delete');
+  return text.includes('remote ref does not exist');
 }
 
 // git exits non-zero with one of these messages when the requested ref/object

--- a/packages/core/test/evaluation/results-repo.test.ts
+++ b/packages/core/test/evaluation/results-repo.test.ts
@@ -2808,4 +2808,10 @@ describe('WIP branch helpers', () => {
     const branchesAfter = git('git branch -r', cloneDir);
     expect(branchesAfter).not.toContain(`origin/${wipBranch}`);
   }, 30000);
+
+  it('deleteWipBranch ignores a missing remote WIP branch', async () => {
+    await expect(
+      deleteWipBranch({ config, wipBranch: 'agentv/wip/test-host/missing-run' }),
+    ).resolves.toBeUndefined();
+  }, 30000);
 });

--- a/packages/core/test/evaluation/results-repo.test.ts
+++ b/packages/core/test/evaluation/results-repo.test.ts
@@ -2814,4 +2814,40 @@ describe('WIP branch helpers', () => {
       deleteWipBranch({ config, wipBranch: 'agentv/wip/test-host/missing-run' }),
     ).resolves.toBeUndefined();
   }, 30000);
+
+  it('deleteWipBranch surfaces non-missing remote delete failures', async () => {
+    const wipBranch = 'agentv/wip/test-host/rejected-delete';
+    const handle = await setupWipWorktree({ config, wipBranch });
+    const runDir = path.join(rootDir, 'run-rejected-delete-test');
+    writeRunArtifacts(runDir, 'default', '2026-01-15T13-00-00');
+
+    try {
+      await pushWipCheckpoint({
+        handle,
+        sourceDir: runDir,
+        destinationPath: 'default/2026-01-15T13-00-00',
+      });
+    } finally {
+      await handle.cleanup();
+    }
+
+    const hookPath = path.join(remoteDir, 'hooks', 'update');
+    writeFileSync(
+      hookPath,
+      [
+        '#!/usr/bin/env sh',
+        'if [ "$3" = "0000000000000000000000000000000000000000" ]; then',
+        '  echo "unable to delete protected WIP branch" >&2',
+        '  exit 1',
+        'fi',
+        'exit 0',
+        '',
+      ].join('\n'),
+    );
+    chmodSync(hookPath, 0o755);
+
+    await expect(deleteWipBranch({ config, wipBranch })).rejects.toThrow(
+      /unable to delete protected WIP branch|hook declined/,
+    );
+  }, 30000);
 });


### PR DESCRIPTION
## Summary
- make WIP branch cleanup idempotent when the remote branch was never pushed
- keep other WIP branch deletion failures visible
- add regression coverage for deleting a missing WIP branch

## Test
- bun test packages/core/test/evaluation/results-repo.test.ts --test-name-pattern "WIP branch helpers"

## Context
Found while dogfooding WTG.AI.Prompts cw-refvessel smoke eval with copilot-sdk-openai against the local OpenAI proxy; successful eval runs could still print a noisy cleanup warning when the WIP branch did not exist.