### PR TITLE
Support flatter eval imports

### DIFF
--- a/apps/web/src/content/docs/docs/evaluation/eval-files.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/eval-files.mdx
@@ -17,15 +17,15 @@ other suites. Raw case files are reusable data inputs, not a second runnable
 experiment format.
 
 - A **task suite** is eval YAML that owns task context: `workspace`, shared
-  `input`, shared `assertions`, and test cases. It can run directly or be
-  imported with `type: suite`.
+  `input`, shared `assertions`, fixtures, graders, and test cases. It can run
+  directly or be imported through `imports.suites`.
 - A **raw case file** is a YAML/JSONL array, directory, or glob of cases. Import
-  it with `tests: ./cases.yaml`, string shorthand, or `type: tests`; parent
+  it with `imports.tests`, `tests: ./cases.yaml`, or string shorthand; parent
   suite context applies because raw cases do not carry their own suite context.
 - A **wrapper eval** is eval YAML that imports one or more suites with
-  `type: suite` and binds runtime policy in its inline `experiment:` block.
+  `imports.suites` and binds runtime policy in its inline `experiment:` block.
   Wrapper evals can live anywhere in the repo. A wrapper that imports suites
-  with `type: suite` must not define parent `workspace`; imported suites own
+  with `imports.suites` must not define parent `workspace`; imported suites own
   task environment. Machine-local existing workspace paths belong in CLI flags
   or `config.local.yaml`, not eval YAML.
 
@@ -61,17 +61,21 @@ A wrapper eval stays ordinary eval YAML while choosing runtime policy:
 ```yaml
 # experiments/refunds-codex.eval.yaml
 experiment:
-  name: refunds-codex
   target: codex-gpt5
   repeat:
     count: 2
     strategy: pass_all
 
+imports:
+  suites:
+    - path: ../evals/suites/refunds.eval.yaml
+  tests:
+    - path: ../evals/cases/refund-smoke.cases.yaml
+
 tests:
-  - include: ../evals/suites/refunds.eval.yaml
-    type: suite
-  - include: ../evals/cases/refund-smoke.cases.yaml
-    type: tests
+  - id: local-edge-case
+    input: Can a final-sale item be refunded after damage in transit?
+    expected_output: Explain the final-sale exception for damaged transit.
 ```
 
 The `experiments/` directory in that example is optional and user-owned. AgentV
@@ -79,7 +83,7 @@ does not infer behavior from the path; the wrapper runs because it is eval YAML
 with an inline `experiment:` block. The wrapper owns runtime policy only. Put
 workspace setup in imported child suites. Parent workspace-affecting fields,
 including top-level `workspace`, are for parent-owned raw cases, including
-cases imported with `type: tests`. Runtime workspace path overrides belong in
+cases imported with `imports.tests`. Runtime workspace path overrides belong in
 CLI flags or `.agentv/config.local.yaml`; repos, hooks, templates, Docker
 config, env checks, and isolation belong in top-level or case-level
 `workspace`.
@@ -112,7 +116,8 @@ tests:
 | `category` | Optional slash-delimited analytics taxonomy path. Overrides the category derived from the eval file path. |
 | `experiment` | Runtime policy (`target`, `targets`, `workers`, `repeat`, `threshold`, `timeout_seconds`, `budget_usd`, etc.) |
 | `workspace` | Suite-level task environment — inline object or string path to an [external workspace file](/docs/guides/workspace-pool/#external-workspace-config). Repo entries declare identity and checkout pins; acquisition is covered in [Workspace Architecture](/docs/guides/workspace-architecture/#repo-provenance-vs-acquisition). |
-| `tests` | Array of individual tests, include entries, or a string path to an external file or directory. Tests and include entries may use scoped `run:` overrides for `threshold`, `repeat`, `timeout_seconds`, and `budget_usd`. |
+| `imports` | Optional import groups. `imports.suites` imports full child eval suites with their task context. `imports.tests` imports raw test rows into this file's context. Import entries may use scoped `run:` overrides for `threshold`, `repeat`, `timeout_seconds`, and `budget_usd`. |
+| `tests` | Inline raw tests or a string path to an external raw-case file or directory. Legacy `tests[].include` entries still load with a migration warning; prefer `imports.suites` or `imports.tests`. |
 | `assertions` | Suite-level graders appended to each test unless `execution.skip_defaults: true` is set on the test |
 | `input` | Suite-level input messages prepended to each test's input unless `execution.skip_defaults: true` is set on the test |
 
@@ -332,13 +337,26 @@ use direct paths, directories, or globs:
 ```yaml
 tests:
   - ./cases/*.cases.yaml
-  - include: ./suites/*.eval.yaml
-    type: suite
 ```
 
-String shorthand is raw-case-only. Import reusable task suites with object
-entries using `include:` and `type: suite`; use `type: tests` when you want to
-drop suite context and import only raw cases.
+String shorthand is raw-case-only. Import reusable task suites through
+`imports.suites`; use `imports.tests` when you want to drop suite context and
+import only raw cases into the parent context:
+
+```yaml
+imports:
+  suites:
+    - path: ./suites/*.eval.yaml
+  tests:
+    - path: ./cases/regression.jsonl
+
+tests:
+  - id: local-edge-case
+    input: ...
+```
+
+Legacy `tests[].include` entries still load with a migration warning for older
+eval files, but new evals should use `imports.suites` or `imports.tests`.
 
 ### Raw Cases as Directory Paths
 

--- a/apps/web/src/content/docs/docs/evaluation/experiments.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/experiments.mdx
@@ -64,75 +64,81 @@ experiment:
   workers: 2
 
 tests:
-  - include: ../evals/suites/refunds.eval.yaml
-    type: suite
-  - include: ../evals/cases/refund-smoke.cases.yaml
-    type: tests
+  - id: local-edge-case
+    input: Check a damaged final-sale refund.
+
+imports:
+  suites:
+    - path: ../evals/suites/refunds.eval.yaml
+  tests:
+    - path: ../evals/cases/refund-smoke.cases.yaml
 ```
 
 The `experiments/` folder is optional and user-owned. AgentV does not scan it
 for special files or infer runtime behavior from the path; the same wrapper eval
 could live under `evals/wrappers/`, `benchmarks/`, or beside the suite it runs.
 
-## Tests Imports
+## Suite And Test Imports
 
-Use `tests[]` for composition, imports, and selection.
+Use `imports.suites` for full child suites and `imports.tests` for raw test
+rows. Inline `tests` remain raw cases owned by the current file.
 
 ```yaml
+imports:
+  suites:
+    - path: evals/support/*.eval.yaml
+      select:
+        test_ids:
+          - refund-*
+          - missing-order-date
+        tags: regression
+        metadata:
+          priority: high
+      run:
+        threshold: 1.0
+        repeat:
+          count: 2
+          strategy: pass_all
+  tests:
+    - path: cases/*.cases.yaml
+    - path: cases/regression.jsonl
+
 tests:
-  - include: evals/support/*.eval.yaml
-    type: suite
-    select:
-      test_ids:
-        - refund-*
-        - missing-order-date
-      tags: regression
-      metadata:
-        priority: high
-    run:
-      threshold: 1.0
-      repeat:
-        count: 2
-        strategy: pass_all
-  - include: cases/*.cases.yaml
-    type: tests
-  - include: cases/regression.jsonl
-    type: tests
   - cases/smoke/*.cases.yaml
 ```
 
-`type: suite` preserves the imported suite's task contract: metadata,
+`imports.suites` preserves the imported suite's task contract: metadata,
 `workspace`, shared `input`, shared `assertions`, and tests. The parent eval
 still owns the single run bundle and runtime policy. Child suite
 `experiment:` blocks are ignored when imported; use parent `experiment:` for
-run policy and `tests[].run` for scoped threshold, repeat, timeout, or budget
+run policy and import `run:` for scoped threshold, repeat, timeout, or budget
 overrides.
 
-A parent eval that imports any `type: suite` entry must not define top-level
+A parent eval that imports any `imports.suites` entry must not define top-level
 `workspace`. Imported suites own task environment. If the parent should provide
-workspace context, import raw cases with `type: tests` or shorthand paths
+workspace context, import raw cases with `imports.tests` or shorthand paths
 instead of importing an eval suite.
 
-`type: tests` imports only raw test entries. It intentionally drops shared
+`imports.tests` imports only raw test entries. It intentionally drops shared
 context from an imported eval suite, so parent suite fields apply to those raw
 cases.
 
-`tests[].select.test_ids` filters imported test IDs with glob patterns.
-`tests[].select.tags` filters each imported case's effective `metadata.tags`.
+Import `select.test_ids` filters imported test IDs with glob patterns.
+Import `select.tags` filters each imported case's effective `metadata.tags`.
 Effective case tags are suite-first and deduped:
 `suite.tags + suite.metadata.tags + test.metadata.tags`. Top-level suite `tags`
 still remain suite identity metadata for discovery and reporting; selection reads
-the merged case metadata view. `tests[].select.metadata` filters case metadata by
+the merged case metadata view. Import `select.metadata` filters case metadata by
 key/value, where selector values may be scalars or lists. Globbed include paths
 are resolved in deterministic path order, then test order.
 
 String-valued `tests` and string entries inside `tests[]` are raw-case import
-shorthand. They are equivalent to `include` with `type: tests` and may point at
+shorthand. They are equivalent to `imports.tests` and may point at
 raw case files, directories, or globs. Importing another eval suite must use
-object form with `include:` and `type: suite`.
+`imports.suites`.
 
-Suite imports are resolved as a deterministic include graph. Circular `type:
-suite` imports fail validation with the import chain; raw-case shorthand does
+Suite imports are resolved as a deterministic include graph. Circular
+`imports.suites` imports fail validation with the import chain; raw-case shorthand does
 not recursively load suite runtime blocks.
 
 Imported suite rows keep their source suite metadata in `run_manifest.jsonl`. Use each
@@ -145,7 +151,7 @@ Use scoped `run:` blocks for result interpretation and scheduling policies that
 vary by include group or test case. Precedence is:
 
 ```text
-test.run > tests[].run > parent experiment
+test.run > import run > parent experiment
 ```
 
 ```yaml
@@ -156,26 +162,26 @@ experiment:
     count: 3
     strategy: pass_at_k
 
+imports:
+  suites:
+    - path: ./evals/flaky-agentic/**/*.eval.yaml
+      select:
+        tags: [agentic]
+      run:
+        repeat:
+          count: 3
+          strategy: pass_at_k
+
+    - path: ./evals/regression/**/*.eval.yaml
+      select:
+        tags: [must-pass]
+      run:
+        threshold: 1.0
+        repeat:
+          count: 2
+          strategy: pass_all
+
 tests:
-  - include: ./evals/flaky-agentic/**/*.eval.yaml
-    type: suite
-    select:
-      tags: [agentic]
-    run:
-      repeat:
-        count: 3
-        strategy: pass_at_k
-
-  - include: ./evals/regression/**/*.eval.yaml
-    type: suite
-    select:
-      tags: [must-pass]
-    run:
-      threshold: 1.0
-      repeat:
-        count: 2
-        strategy: pass_all
-
   - id: critical-case
     input: "..."
     criteria: Must pass exactly

--- a/docs/adr/0006-separate-experiments-from-eval-definitions.md
+++ b/docs/adr/0006-separate-experiments-from-eval-definitions.md
@@ -159,17 +159,22 @@ multi-file command such as `agentv eval a.eval.yaml b.eval.yaml` remains a batch
 of independent eval-suite runs, rather than one implicit wrapper experiment with
 shared mutable setup.
 
-## Tests Import Surface
+## Suite And Test Import Surface
 
-`tests:` is the only composition, import, and selection surface.
+`imports.suites`, `imports.tests`, and inline `tests` are the authored
+composition surfaces.
 
-`include:` accepts direct paths and glob patterns. Include entries are
-structurally identified by the `include` field, so their `type:` field can use
-the ordinary AgentV wire-format discriminator without ambiguity:
+`imports.suites` imports full child eval suites. `imports.tests` imports raw
+case rows into the parent file's task context. Inline `tests` are raw cases
+owned by the current file. Legacy `tests[].include` entries remain a migration
+path for existing eval files, but new evals should use the flatter import
+groups.
 
-- `include: **/*.eval.yaml` imports eval suites.
-- `include: **/*.cases.yaml` imports raw cases.
-- `include: **/*.jsonl` imports raw cases.
+`path:` accepts direct paths and glob patterns:
+
+- `imports.suites[].path: **/*.eval.yaml` imports eval suites.
+- `imports.tests[].path: **/*.cases.yaml` imports raw cases.
+- `imports.tests[].path: **/*.jsonl` imports raw cases.
 
 `select:` filters imported cases with the same general selection shape used by
 old experiment suite selection. `select.test_ids` filters by test id and maps
@@ -216,29 +221,29 @@ In that example, `case-1` matches `select.tags: cargowise`.
 Imported tests run in deterministic order: resolved path first, then the test
 order inside each resolved source.
 
-`type: suite` preserves the imported suite task contract. That includes suite
+`imports.suites` preserves the imported suite task contract. That includes suite
 metadata, `workspace`, shared `input`, shared `assertions`, and tests. The
 parent eval still owns one run bundle and one runtime policy. Child suite
-`experiment:` blocks are ignored when imported with `type: suite`; they do not
+`experiment:` blocks are ignored when imported through `imports.suites`; they do not
 fall back into the parent run. Scoped runtime overrides that the parent wants
-to apply to imported tests live in `tests[].run`.
+to apply to imported tests live on the import entry's `run:` block.
 
-A parent eval that imports any child eval suite with `type: suite` must not
+A parent eval that imports any child eval suite with `imports.suites` must not
 define parent `workspace`. The wrapper owns runtime policy, not task
 environment. Imported child suites keep their own `workspace`, including
 `workspace.repos[]`, templates, hooks, and isolation. Existing local workspace
 paths are machine-local bindings supplied through CLI flags or
 `config.local.yaml`. If the parent should own workspace context, import raw cases
-with `type: tests` or shorthand paths instead of importing an eval suite.
+with `imports.tests` or shorthand paths instead of importing an eval suite.
 
-`type: tests` imports only raw test entries. It intentionally drops shared
+`imports.tests` imports only raw test entries. It intentionally drops shared
 suite context such as workspace, shared input, and shared assertions. Use this
 mode only when the imported file is a case corpus or when dropping suite context
 is the desired behavior.
 
 Suite files still support raw-case shorthand imports. A string-valued `tests`
-field or a string entry inside the `tests` list is equivalent to an include
-entry with `type: tests`:
+field or a string entry inside the `tests` list is equivalent to an
+`imports.tests` entry:
 
 ```yaml
 tests: ./cases.yaml
@@ -247,16 +252,13 @@ tests: ./cases.yaml
 ```yaml
 tests:
   - ./cases/*.cases.yaml
-  - include: ./suites/*.eval.yaml
-    type: suite
 ```
 
 The shorthand is only for raw case files or directories. Importing another eval
-suite must use object form with `include:` and `type: suite`, so authors cannot
-accidentally drop or preserve suite context without saying which behavior they
-want.
+suite must use `imports.suites`, so authors cannot accidentally drop or
+preserve suite context without saying which behavior they want.
 
-Do not use `import:` or `kind:` for `tests:` include entries.
+Do not use `import:` or `kind:` for import entries.
 
 Parent suite-level task fields should not silently override imported suite task
 fields. Explicit override syntax can be considered later if a concrete use case

--- a/examples/features/external-datasets/README.md
+++ b/examples/features/external-datasets/README.md
@@ -1,13 +1,13 @@
 # External Datasets Example
 
-Demonstrates loading test cases from external files using `file://` references.
+Demonstrates loading raw test cases from external files using `imports.tests`.
 
 ## What This Shows
 
-- Loading tests from external YAML files (`file://cases/accuracy.yaml`)
-- Loading tests from external JSONL files (`file://cases/regression.jsonl`)
-- Mixing inline test definitions with external file references
-- Glob patterns for loading multiple files (`file://cases/**/*.yaml`)
+- Loading tests from external YAML files (`imports.tests[].path: cases/accuracy.yaml`)
+- Loading tests from external JSONL files (`imports.tests[].path: cases/regression.jsonl`)
+- Mixing inline `tests` with imported raw test rows
+- Glob patterns for loading multiple files (`imports.tests[].path: cases/**/*.yaml`)
 
 ## Running
 
@@ -18,7 +18,7 @@ bun agentv eval examples/features/external-datasets/evals/dataset.eval.yaml
 
 ## Key Files
 
-- `evals/dataset.eval.yaml` — Main eval with inline tests and `file://` references
+- `evals/dataset.eval.yaml` — Main eval with inline tests and `imports.tests` references
 - `evals/cases/accuracy.yaml` — YAML array of test cases
 - `evals/cases/regression.jsonl` — JSONL test data (one test per line)
 
@@ -46,7 +46,8 @@ One JSON test object per line:
 
 Use glob patterns to load from multiple files:
 ```yaml
-tests:
-  - file://cases/**/*.yaml    # All YAML files recursively
-  - file://cases/*.jsonl      # All JSONL files in cases/
+imports:
+  tests:
+    - path: cases/**/*.yaml    # All YAML files recursively
+    - path: cases/*.jsonl      # All JSONL files in cases/
 ```

--- a/examples/features/external-datasets/evals/dataset.eval.yaml
+++ b/examples/features/external-datasets/evals/dataset.eval.yaml
@@ -1,13 +1,15 @@
 name: external-datasets-demo
 version: "1.0"
 
-execution:
+experiment:
   target: llm
+
+imports:
+  tests:
+    - path: cases/accuracy.yaml
+    - path: cases/regression.jsonl
 
 tests:
   - id: inline-test
     criteria: "The agent should greet the user politely"
     input: "Hello, how are you?"
-
-  - file://cases/accuracy.yaml
-  - file://cases/regression.jsonl

--- a/packages/core/src/evaluation/validation/eval-file.schema.ts
+++ b/packages/core/src/evaluation/validation/eval-file.schema.ts
@@ -484,6 +484,27 @@ const TestIncludeSchema = z
   })
   .strict();
 
+const ImportEntrySchema = z
+  .object({
+    path: z.string().min(1),
+    select: z.union([SelectPatternSchema, TestIncludeSelectSchema]).optional(),
+    run: RunOverrideSchema.optional(),
+  })
+  .strict();
+
+const ImportGroupSchema = z.union([
+  z.array(z.union([ImportEntrySchema, z.string().min(1)])),
+  z.string().min(1),
+  ImportEntrySchema,
+]);
+
+const ImportsSchema = z
+  .object({
+    suites: ImportGroupSchema.optional(),
+    tests: ImportGroupSchema.optional(),
+  })
+  .strict();
+
 const TestsSchema = z.union([
   z.array(z.union([EvalTestSchema, TestIncludeSchema, z.string().min(1)])),
   z.string().min(1),
@@ -512,8 +533,10 @@ export const EvalFileSchema = z
     input: InputSchema.optional(),
     // Suite-level input_files shorthand
     input_files: z.array(z.string()).optional(),
-    // Tests (array, include entries, or external file path)
-    tests: TestsSchema,
+    // Imports: suites preserve child context; tests import raw rows into parent context
+    imports: ImportsSchema.optional(),
+    // Tests (inline raw cases, legacy include entries, or external raw-case path)
+    tests: TestsSchema.optional(),
     // Deprecated aliases
     eval_cases: TestsSchema.optional(),
     // Target
@@ -530,4 +553,9 @@ export const EvalFileSchema = z
   })
   .refine((value) => value.experiment === undefined || value.execution === undefined, {
     message: "Use either top-level 'experiment' or legacy 'execution', not both.",
-  });
+  })
+  .refine(
+    (value) =>
+      value.tests !== undefined || value.eval_cases !== undefined || value.imports !== undefined,
+    { message: "Eval files must define 'tests' or 'imports'." },
+  );

--- a/packages/core/src/evaluation/validation/eval-validator.ts
+++ b/packages/core/src/evaluation/validation/eval-validator.ts
@@ -18,6 +18,15 @@ type SuiteImportStackEntry = {
   readonly displayPath: string;
   readonly filePath: string;
 };
+type ImportEntryType = 'suite' | 'tests';
+type NormalizedImportEntry = {
+  readonly path: string;
+  readonly type: ImportEntryType;
+  readonly location: string;
+  readonly select?: JsonValue;
+  readonly run?: JsonValue;
+  readonly legacy?: boolean;
+};
 
 /** Assertion grader types that require a string `value` field. */
 const ASSERTION_TYPES_WITH_STRING_VALUE = new Set([
@@ -52,6 +61,7 @@ const KNOWN_TOP_LEVEL_FIELDS = new Set([
   'requires',
   'input',
   'input_files',
+  'imports',
   'tests',
   'target',
   'experiment',
@@ -64,8 +74,9 @@ const KNOWN_TOP_LEVEL_FIELDS = new Set([
   'governance',
 ]);
 
-/** Known fields on tests[] include entries. */
+/** Known fields on legacy tests[] include entries. */
 const KNOWN_INCLUDE_FIELDS = new Set(['include', 'type', 'select', 'run']);
+const KNOWN_IMPORT_FIELDS = new Set(['path', 'select', 'run']);
 const KNOWN_RUN_OVERRIDE_FIELDS = new Set(['threshold', 'repeat', 'timeout_seconds', 'budget_usd']);
 const KNOWN_REPEAT_STRATEGIES = new Set(['pass_at_k', 'pass_all', 'mean', 'confidence_interval']);
 const KNOWN_TEST_EXECUTION_FIELDS = new Set([
@@ -285,13 +296,28 @@ export async function validateEvalFile(filePath: string): Promise<ValidationResu
   validateInputField(parsed.input, 'input', absolutePath, errors);
 
   await validateSuiteWorkspaceConfigs(parsed, absolutePath, errors);
+  await validateImportsField(parsed.imports, absolutePath, errors);
 
   const cases: JsonValue | undefined = parsed.tests;
+  const hasImports = collectImportEntries(parsed).length > 0;
 
   // tests can be a string path (external file/directory reference) or an array
   if (typeof cases === 'string') {
     await validateRawCaseImportPath(cases, absolutePath, 'tests', errors);
+    await validateCompositionDiagnostics(absolutePath, parsed, errors);
+    await validateSuiteImportCycles(absolutePath, parsed, errors);
 
+    return {
+      valid: errors.filter((e) => e.severity === 'error').length === 0,
+      filePath: absolutePath,
+      fileType: 'eval',
+      errors,
+    };
+  }
+
+  if (cases === undefined && hasImports) {
+    await validateCompositionDiagnostics(absolutePath, parsed, errors);
+    await validateSuiteImportCycles(absolutePath, parsed, errors);
     return {
       valid: errors.filter((e) => e.severity === 'error').length === 0,
       filePath: absolutePath,
@@ -305,7 +331,8 @@ export async function validateEvalFile(filePath: string): Promise<ValidationResu
       severity: 'error',
       filePath: absolutePath,
       location: 'tests',
-      message: "Missing or invalid 'tests' field (must be an array or a file path string)",
+      message:
+        "Missing or invalid 'tests' field (must be an array or a file path string, unless imports are provided)",
     });
     return {
       valid: errors.length === 0,
@@ -531,20 +558,161 @@ function rejectRuntimeWorkspaceConfig(
   });
 }
 
+function importEntryPath(value: JsonValue): string | undefined {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+  if (!isObject(value)) {
+    return undefined;
+  }
+  return typeof value.path === 'string' && value.path.trim().length > 0
+    ? value.path.trim()
+    : undefined;
+}
+
+async function validateImportsField(
+  imports: JsonValue | undefined,
+  filePath: string,
+  errors: ValidationError[],
+): Promise<void> {
+  if (imports === undefined) {
+    return;
+  }
+  if (!isObject(imports)) {
+    errors.push({
+      severity: 'error',
+      filePath,
+      location: 'imports',
+      message: "Invalid 'imports' field. Use imports.suites and/or imports.tests.",
+    });
+    return;
+  }
+
+  for (const key of Object.keys(imports)) {
+    if (key !== 'suites' && key !== 'tests') {
+      errors.push({
+        severity: 'warning',
+        filePath,
+        location: `imports.${key}`,
+        message: `Unknown imports field '${key}'. Use imports.suites or imports.tests.`,
+      });
+    }
+  }
+
+  await validateImportGroup(imports.suites, 'suite', 'imports.suites', filePath, errors);
+  await validateImportGroup(imports.tests, 'tests', 'imports.tests', filePath, errors);
+}
+
+async function validateImportGroup(
+  group: JsonValue | undefined,
+  type: ImportEntryType,
+  location: string,
+  filePath: string,
+  errors: ValidationError[],
+): Promise<void> {
+  if (group === undefined) {
+    return;
+  }
+  const entries = Array.isArray(group) ? group : [group];
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    const entryLocation = `${location}[${i}]`;
+    const entryPath = importEntryPath(entry);
+    if (!entryPath) {
+      errors.push({
+        severity: 'error',
+        filePath,
+        location: entryLocation,
+        message: "Invalid import entry. Use a path string or an object with a non-empty 'path'.",
+      });
+      continue;
+    }
+    if (type === 'tests' && !/\.eval\.ya?ml$/i.test(entryPath)) {
+      await validateRawCaseImportPath(entryPath, filePath, `${entryLocation}.path`, errors);
+    }
+    if (isObject(entry)) {
+      for (const key of Object.keys(entry)) {
+        if (!KNOWN_IMPORT_FIELDS.has(key)) {
+          errors.push({
+            severity: 'warning',
+            filePath,
+            location: `${entryLocation}.${key}`,
+            message: `Unknown field '${key}'. This field will be ignored.`,
+          });
+        }
+      }
+      validateIncludeSelect(entry.select, `${entryLocation}.select`, filePath, errors);
+      validateRunOverride(entry.run, `${entryLocation}.run`, filePath, errors);
+    }
+  }
+}
+
+function collectImportEntries(parsed: JsonObject): readonly NormalizedImportEntry[] {
+  const entries: NormalizedImportEntry[] = [];
+  if (isObject(parsed.imports)) {
+    entries.push(...collectImportGroup(parsed.imports.suites, 'suite', 'imports.suites'));
+    entries.push(...collectImportGroup(parsed.imports.tests, 'tests', 'imports.tests'));
+  }
+  const tests = parsed.tests;
+  if (Array.isArray(tests)) {
+    for (let i = 0; i < tests.length; i++) {
+      const entry = tests[i];
+      if (!isObject(entry) || !isIncludeEntry(entry)) {
+        continue;
+      }
+      if (entry.type !== 'suite' && entry.type !== 'tests') {
+        continue;
+      }
+      entries.push({
+        path: entry.include.trim(),
+        type: entry.type,
+        location: `tests[${i}].include`,
+        select: entry.select,
+        run: entry.run,
+        legacy: true,
+      });
+    }
+  }
+  return entries;
+}
+
+function collectImportGroup(
+  group: JsonValue | undefined,
+  type: ImportEntryType,
+  location: string,
+): readonly NormalizedImportEntry[] {
+  if (group === undefined) {
+    return [];
+  }
+  const entries = Array.isArray(group) ? group : [group];
+  return entries.flatMap((entry, index) => {
+    const pathValue = importEntryPath(entry);
+    return pathValue
+      ? [
+          {
+            path: pathValue,
+            type,
+            location: `${location}[${index}].path`,
+            ...(isObject(entry) && entry.select !== undefined ? { select: entry.select } : {}),
+            ...(isObject(entry) && entry.run !== undefined ? { run: entry.run } : {}),
+          },
+        ]
+      : [];
+  });
+}
+
 async function validateCompositionDiagnostics(
   filePath: string,
   parsed: JsonObject,
   errors: ValidationError[],
 ): Promise<void> {
-  const tests = parsed.tests;
-  if (!Array.isArray(tests)) {
+  const imports = collectImportEntries(parsed);
+  if (imports.length === 0) {
     return;
   }
 
   const parentHasRuntime = parsed.experiment !== undefined || parsed.execution !== undefined;
-  const hasSuiteImport = tests.some(
-    (entry) => isObject(entry) && isIncludeEntry(entry) && entry.type === 'suite',
-  );
+  const hasSuiteImport = imports.some((entry) => entry.type === 'suite');
 
   if (hasSuiteImport) {
     for (const location of parentWorkspaceLocations(parsed)) {
@@ -558,15 +726,8 @@ async function validateCompositionDiagnostics(
     }
   }
 
-  for (let i = 0; i < tests.length; i++) {
-    const entry = tests[i];
-    if (!isObject(entry) || !isIncludeEntry(entry)) {
-      continue;
-    }
-
-    const includePath = entry.include.trim();
-    const location = `tests[${i}].include`;
-    const resolvedSuites = await resolveSuiteIncludePaths(includePath, path.dirname(filePath));
+  for (const entry of imports) {
+    const resolvedSuites = await resolveSuiteIncludePaths(entry.path, path.dirname(filePath));
 
     if (entry.type === 'suite') {
       for (const resolvedSuite of resolvedSuites) {
@@ -587,10 +748,10 @@ async function validateCompositionDiagnostics(
         errors.push({
           severity: 'warning',
           filePath,
-          location,
+          location: entry.location,
           message: parentHasRuntime
-            ? `Imported suite '${resolvedSuite.displayPath}' defines ${runtimeField}, but child experiment blocks are ignored for type: suite imports. The parent experiment owns wrapper runtime; move runtime settings to the parent experiment or use tests[].run for per-case thresholds, repeats, timeouts, and budgets.`
-            : `Imported suite '${resolvedSuite.displayPath}' defines ${runtimeField}, but child experiment blocks are ignored for type: suite imports. The parent experiment owns wrapper runtime, and this parent has no experiment, so no child runtime settings are applied. Add a parent experiment or use tests[].run for per-case thresholds, repeats, timeouts, and budgets.`,
+            ? `Imported suite '${resolvedSuite.displayPath}' defines ${runtimeField}, but child experiment blocks are ignored for imports.suites. The parent experiment owns wrapper runtime; move runtime settings to the parent experiment or use import run overrides for per-case thresholds, repeats, timeouts, and budgets.`
+            : `Imported suite '${resolvedSuite.displayPath}' defines ${runtimeField}, but child experiment blocks are ignored for imports.suites. The parent experiment owns wrapper runtime, and this parent has no experiment, so no child runtime settings are applied. Add a parent experiment or use import run overrides for per-case thresholds, repeats, timeouts, and budgets.`,
         });
       }
       continue;
@@ -604,8 +765,8 @@ async function validateCompositionDiagnostics(
         errors.push({
           severity: 'warning',
           filePath,
-          location,
-          message: `type: tests imports raw cases from eval suite '${resolvedSuite.displayPath}' and drops suite context, including child workspace, input, assertions, metadata, and experiment. Parent suite context applies. Use type: suite to preserve child test and workspace semantics.`,
+          location: entry.location,
+          message: `imports.tests imports raw cases from eval suite '${resolvedSuite.displayPath}' and drops suite context, including child workspace, input, assertions, metadata, and experiment. Parent suite context applies. Use imports.suites to preserve child test and workspace semantics.`,
         });
       }
     }
@@ -641,6 +802,16 @@ function validateIncludeEntry(
   filePath: string,
   errors: ValidationError[],
 ): void {
+  const mode = entry.type === 'suite' ? 'suites' : entry.type === 'tests' ? 'tests' : undefined;
+  errors.push({
+    severity: 'warning',
+    filePath,
+    location,
+    message: mode
+      ? `tests[].include is deprecated. Use imports.${mode} entries with path instead.`
+      : 'tests[].include is deprecated. Use imports.suites or imports.tests entries with path instead.',
+  });
+
   for (const key of Object.keys(entry)) {
     if (!KNOWN_INCLUDE_FIELDS.has(key)) {
       errors.push({
@@ -1319,24 +1490,18 @@ async function validateSuiteImportCyclesFromParsed(
   stack: readonly SuiteImportStackEntry[],
   errors: ValidationError[],
 ): Promise<void> {
-  const tests = parsed.tests;
-  if (!Array.isArray(tests)) {
+  const imports = collectImportEntries(parsed);
+  if (imports.length === 0) {
     return;
   }
 
-  for (let i = 0; i < tests.length; i++) {
-    const entry = tests[i];
-    if (!isObject(entry) || !isIncludeEntry(entry)) {
-      continue;
-    }
-    const includePath = entry.include.trim();
+  for (const entry of imports) {
     if (entry.type !== 'suite') {
       continue;
     }
 
-    const location = `tests[${i}].include`;
     const resolvedSuites = await resolveSuiteIncludePaths(
-      includePath,
+      entry.path,
       path.dirname(currentFilePath),
     );
     for (const resolvedSuite of resolvedSuites) {
@@ -1344,7 +1509,7 @@ async function validateSuiteImportCyclesFromParsed(
         errors.push({
           severity: 'error',
           filePath: currentFilePath,
-          location,
+          location: entry.location,
           message: `Circular eval suite import: ${formatCircularImportChain(stack, resolvedSuite)}`,
         });
         continue;

--- a/packages/core/src/evaluation/yaml-parser.ts
+++ b/packages/core/src/evaluation/yaml-parser.ts
@@ -169,6 +169,7 @@ function formatCircularImportChain(
 }
 
 type RawTestSuite = JsonObject & {
+  readonly imports?: JsonValue;
   readonly tests?: JsonValue;
   /** @deprecated Use `tests` instead */
   readonly eval_cases?: JsonValue;
@@ -490,25 +491,40 @@ async function loadTestsFromParsedYamlValue(
     absoluteTestPath,
   );
 
-  // Parse suite-level workspace config (default for all cases)
-  const evalFileDir = path.dirname(absoluteTestPath);
-
   const importedSuiteTests: EvalTest[] = [];
-  // Resolve tests: string path to external file/directory, inline array, include entries, or error
+  const evalFileDir = path.dirname(absoluteTestPath);
+  const parentWorkspace = parentWorkspaceLocation(suite);
+  const importEntries = readImports(suite.imports);
+  const expandedImports = await expandImportEntries({
+    entries: importEntries,
+    evalFileDir,
+    repoRoot,
+    suiteMetadataPayload,
+    parentWorkspaceLocation: parentWorkspace,
+    options,
+  });
+  importedSuiteTests.push(...expandedImports.importedSuiteTests);
+
+  // Resolve tests: string path to external file/directory, inline array, legacy include entries, or error.
   let expandedTestCases: readonly JsonValue[];
   if (typeof rawTestCases === 'string') {
-    expandedTestCases = await loadRawCasesFromShorthand(rawTestCases, evalFileDir);
+    expandedTestCases = [
+      ...expandedImports.rawCases,
+      ...(await loadRawCasesFromShorthand(rawTestCases, evalFileDir)),
+    ];
   } else if (Array.isArray(rawTestCases)) {
     const expanded = await expandInlineTestEntries({
       entries: rawTestCases,
       evalFileDir,
       repoRoot,
       suiteMetadataPayload,
-      parentWorkspaceLocation: parentWorkspaceLocation(suite),
+      parentWorkspaceLocation: parentWorkspace,
       options,
     });
-    expandedTestCases = expanded.rawCases;
+    expandedTestCases = [...expandedImports.rawCases, ...expanded.rawCases];
     importedSuiteTests.push(...expanded.importedSuiteTests);
+  } else if (rawTestCases === undefined && importEntries.length > 0) {
+    expandedTestCases = expandedImports.rawCases;
   } else {
     throw new Error(`Invalid test file format: ${evalFilePath} - missing 'tests' field`);
   }
@@ -866,6 +882,15 @@ type ExpandedInlineTestEntries = {
   readonly importedSuiteTests: readonly EvalTest[];
 };
 
+type NormalizedImportEntry = {
+  readonly path: string;
+  readonly mode: IncludeEntryType;
+  readonly select?: IncludeSelect;
+  readonly run?: EvalRunOverride;
+  readonly location: string;
+  readonly legacy?: boolean;
+};
+
 type IncludeSelect = {
   readonly testIds?: string | readonly string[];
   readonly tags?: string | readonly string[];
@@ -962,6 +987,19 @@ function isIncludeEntry(value: JsonValue): value is JsonObject & { include: stri
   return (
     isJsonObject(value) && typeof value.include === 'string' && value.include.trim().length > 0
   );
+}
+
+function importEntryPath(value: JsonValue): string | undefined {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+  if (!isJsonObject(value)) {
+    return undefined;
+  }
+  const pathValue = value.path ?? value.include;
+  return typeof pathValue === 'string' && pathValue.trim().length > 0
+    ? pathValue.trim()
+    : undefined;
 }
 
 function hasGlobMagic(value: string): boolean {
@@ -1108,6 +1146,126 @@ function rawCaseMatchesSelect(
   );
 }
 
+function readImports(rawImports: JsonValue | undefined): readonly NormalizedImportEntry[] {
+  if (rawImports === undefined) {
+    return [];
+  }
+  if (!isJsonObject(rawImports)) {
+    throw new Error("Invalid 'imports' field. Use imports.suites and/or imports.tests.");
+  }
+  const entries: NormalizedImportEntry[] = [];
+  entries.push(...readImportGroup(rawImports.suites, 'suite', 'imports.suites'));
+  entries.push(...readImportGroup(rawImports.tests, 'tests', 'imports.tests'));
+  return entries;
+}
+
+function readImportGroup(
+  rawGroup: JsonValue | undefined,
+  mode: IncludeEntryType,
+  location: string,
+): readonly NormalizedImportEntry[] {
+  if (rawGroup === undefined) {
+    return [];
+  }
+  const values = Array.isArray(rawGroup) ? rawGroup : [rawGroup];
+  return values.map((entry, index) => normalizeImportEntry(entry, mode, `${location}[${index}]`));
+}
+
+function normalizeImportEntry(
+  entry: JsonValue,
+  mode: IncludeEntryType,
+  location: string,
+): NormalizedImportEntry {
+  const includePath = importEntryPath(entry);
+  if (!includePath) {
+    throw new Error(`Invalid ${location}. Use a path string or an object with a non-empty path.`);
+  }
+  const select = isJsonObject(entry)
+    ? readSelectPatterns(entry.select, `${location}.select for path '${includePath}'`)
+    : undefined;
+  const includeRun = isJsonObject(entry)
+    ? normalizeRunOverride(entry.run, `${location}.run for path '${includePath}'`)
+    : undefined;
+  return {
+    path: includePath,
+    mode,
+    ...(select !== undefined && { select }),
+    ...(includeRun !== undefined && { run: includeRun }),
+    location,
+  };
+}
+
+function normalizeLegacyIncludeEntry(
+  entry: JsonObject & { include: string },
+): NormalizedImportEntry {
+  const includePath = entry.include.trim();
+  const mode = normalizeIncludeEntryType(entry.type, includePath);
+  const select = readSelectPatterns(entry.select, `tests[].select for include '${includePath}'`);
+  const includeRun = normalizeRunOverride(entry.run, `tests[].run for include '${includePath}'`);
+  logWarning(
+    `tests[].include is deprecated. Use imports.${mode === 'suite' ? 'suites' : 'tests'} with path: ${includePath}`,
+  );
+  return {
+    path: includePath,
+    mode,
+    ...(select !== undefined && { select }),
+    ...(includeRun !== undefined && { run: includeRun }),
+    location: 'tests[].include',
+    legacy: true,
+  };
+}
+
+async function expandImportEntries(params: {
+  readonly entries: readonly NormalizedImportEntry[];
+  readonly evalFileDir: string;
+  readonly repoRoot: URL | string;
+  readonly suiteMetadataPayload?: Record<string, unknown>;
+  readonly parentWorkspaceLocation?: string;
+  readonly options?: LoadOptions;
+}): Promise<ExpandedInlineTestEntries> {
+  const rawCases: JsonValue[] = [];
+  const importedSuiteTests: EvalTest[] = [];
+
+  for (const entry of params.entries) {
+    const resolvedPaths = await resolveIncludePaths(entry.path, params.evalFileDir);
+
+    for (const resolvedPath of resolvedPaths) {
+      if (entry.mode === 'suite') {
+        if (params.parentWorkspaceLocation) {
+          throw new Error(
+            `Parent workspace is not allowed when importing eval suites (${params.parentWorkspaceLocation}): ${entry.path}. Move workspace into the child suite, or import raw cases with imports.tests when you intentionally want parent workspace context.`,
+          );
+        }
+        const suite = await loadTestSuite(resolvedPath, params.repoRoot, {
+          ...params.options,
+          filter: entry.select?.testIds,
+        });
+        const selectedTests = params.options?.filter
+          ? suite.tests.filter((test) => matchesFilter(test.id, params.options?.filter ?? ''))
+          : suite.tests;
+        importedSuiteTests.push(
+          ...selectedTests
+            .filter((test) => evalTestMatchesSelect(test, entry.select))
+            .map(markSuiteImportedTest)
+            .map((test) => applyRunOverrideToImportedTest(test, entry.run)),
+        );
+      } else {
+        const importedCases = await loadRawCasesForInclude(resolvedPath);
+        const filteredCases = entry.select
+          ? importedCases.filter((testCase) =>
+              rawCaseMatchesSelect(testCase, entry.select, params.suiteMetadataPayload),
+            )
+          : importedCases;
+        rawCases.push(
+          ...filteredCases.map((testCase) => applyRunOverrideToRawCase(testCase, entry.run)),
+        );
+      }
+    }
+  }
+
+  return { rawCases, importedSuiteTests };
+}
+
 async function resolveIncludePaths(
   includePath: string,
   evalFileDir: string,
@@ -1192,44 +1350,16 @@ async function expandInlineTestEntries(params: {
       continue;
     }
 
-    const includePath = entry.include.trim();
-    const mode = normalizeIncludeEntryType(entry.type, includePath);
-    const select = readSelectPatterns(entry.select, `tests[].select for include '${includePath}'`);
-    const includeRun = normalizeRunOverride(entry.run, `tests[].run for include '${includePath}'`);
-    const resolvedPaths = await resolveIncludePaths(includePath, params.evalFileDir);
-
-    for (const resolvedPath of resolvedPaths) {
-      if (mode === 'suite') {
-        if (params.parentWorkspaceLocation) {
-          throw new Error(
-            `Parent workspace is not allowed when importing eval suites with type: suite (${params.parentWorkspaceLocation}): ${includePath}. Move workspace into the child suite, or import raw cases with type: tests when you intentionally want parent workspace context.`,
-          );
-        }
-        const suite = await loadTestSuite(resolvedPath, params.repoRoot, {
-          ...params.options,
-          filter: select?.testIds,
-        });
-        const selectedTests = params.options?.filter
-          ? suite.tests.filter((test) => matchesFilter(test.id, params.options?.filter ?? ''))
-          : suite.tests;
-        importedSuiteTests.push(
-          ...selectedTests
-            .filter((test) => evalTestMatchesSelect(test, select))
-            .map(markSuiteImportedTest)
-            .map((test) => applyRunOverrideToImportedTest(test, includeRun)),
-        );
-      } else {
-        const importedCases = await loadRawCasesForInclude(resolvedPath);
-        const filteredCases = select
-          ? importedCases.filter((testCase) =>
-              rawCaseMatchesSelect(testCase, select, params.suiteMetadataPayload),
-            )
-          : importedCases;
-        rawCases.push(
-          ...filteredCases.map((testCase) => applyRunOverrideToRawCase(testCase, includeRun)),
-        );
-      }
-    }
+    const expanded = await expandImportEntries({
+      entries: [normalizeLegacyIncludeEntry(entry)],
+      evalFileDir: params.evalFileDir,
+      repoRoot: params.repoRoot,
+      suiteMetadataPayload: params.suiteMetadataPayload,
+      parentWorkspaceLocation: params.parentWorkspaceLocation,
+      options: params.options,
+    });
+    rawCases.push(...expanded.rawCases);
+    importedSuiteTests.push(...expanded.importedSuiteTests);
   }
 
   return { rawCases, importedSuiteTests };

--- a/packages/core/test/evaluation/eval-inline-experiment.test.ts
+++ b/packages/core/test/evaluation/eval-inline-experiment.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
+import { validateEvalFile } from '../../src/evaluation/validation/eval-validator.js';
 import { loadTestSuite } from '../../src/evaluation/yaml-parser.js';
 
 describe('eval.yaml inline experiment and tests imports', () => {
@@ -772,6 +773,263 @@ describe('eval.yaml inline experiment and tests imports', () => {
     expect(suite.experimentConfig).toBeUndefined();
     expect(suite.tests.map((test) => test.id)).toEqual(['a', 'b']);
     expect(suite.tests.every((test) => test.run === undefined)).toBe(true);
+  });
+
+  it('imports suites through imports.suites while preserving child task context', async () => {
+    await writeFile(
+      path.join(tempDir, 'child.eval.yaml'),
+      [
+        'name: child-suite',
+        'workspace:',
+        '  template: ./child-workspace',
+        'input: child shared input',
+        'assertions:',
+        '  - type: contains',
+        '    value: child',
+        'experiment:',
+        '  threshold: 0.2',
+        'tests:',
+        '  - id: child-case',
+        '    input: child case input',
+        '    criteria: ok',
+        '',
+      ].join('\n'),
+    );
+    const parentPath = path.join(tempDir, 'parent.eval.yaml');
+    await writeFile(
+      parentPath,
+      [
+        'name: parent-suite',
+        'experiment:',
+        '  target: codex-gpt5',
+        '  threshold: 0.8',
+        'imports:',
+        '  suites:',
+        '    - path: child.eval.yaml',
+        '      run:',
+        '        timeout_seconds: 60',
+        'tests:',
+        '  - id: local-edge',
+        '    input: local input',
+        '    criteria: local ok',
+        '',
+      ].join('\n'),
+    );
+
+    const suite = await loadTestSuite(parentPath, tempDir);
+    const byId = new Map(suite.tests.map((test) => [test.id, test]));
+
+    expect(suite.experimentConfig).toMatchObject({ target: 'codex-gpt5', threshold: 0.8 });
+    expect(byId.get('child-case')?.suite).toBe('child-suite');
+    expect(byId.get('child-case')?.source?.importedSuiteName).toBe('child-suite');
+    expect(byId.get('child-case')?.workspace?.template).toBe(path.join(tempDir, 'child-workspace'));
+    expect(byId.get('child-case')?.input.map((message) => message.content)).toEqual([
+      'child shared input',
+      'child case input',
+    ]);
+    expect(byId.get('child-case')?.assertions?.[0]).toMatchObject({
+      type: 'contains',
+      value: 'child',
+    });
+    expect(byId.get('child-case')?.run).toEqual({ timeoutSeconds: 60 });
+    expect(byId.get('local-edge')?.suite).toBe('parent-suite');
+  });
+
+  it('imports raw rows through imports.tests and evaluates them in parent context', async () => {
+    await writeFile(
+      path.join(tempDir, 'smoke.jsonl'),
+      '{"id":"jsonl-case","input":"jsonl input","criteria":"ok"}\n',
+    );
+    await writeFile(
+      path.join(tempDir, 'regressions.yaml'),
+      ['- id: yaml-case', '  input: yaml input', '  criteria: ok', ''].join('\n'),
+    );
+    const parentPath = path.join(tempDir, 'parent.eval.yaml');
+    await writeFile(
+      parentPath,
+      [
+        'name: parent-suite',
+        'workspace:',
+        '  template: ./parent-workspace',
+        'input: parent shared input',
+        'assertions:',
+        '  - type: contains',
+        '    value: parent',
+        'imports:',
+        '  tests:',
+        '    - path: smoke.jsonl',
+        '    - path: regressions.yaml',
+        'tests:',
+        '  - id: inline-case',
+        '    input: inline input',
+        '    criteria: ok',
+        '',
+      ].join('\n'),
+    );
+
+    const suite = await loadTestSuite(parentPath, tempDir);
+    const byId = new Map(suite.tests.map((test) => [test.id, test]));
+
+    expect(suite.tests.map((test) => test.id)).toEqual(['jsonl-case', 'yaml-case', 'inline-case']);
+    for (const id of ['jsonl-case', 'yaml-case', 'inline-case']) {
+      expect(byId.get(id)?.suite).toBe('parent-suite');
+      expect(byId.get(id)?.workspace?.template).toBe(path.join(tempDir, 'parent-workspace'));
+      expect(byId.get(id)?.assertions?.[0]).toMatchObject({ type: 'contains', value: 'parent' });
+    }
+    expect(byId.get('jsonl-case')?.input.map((message) => message.content)).toEqual([
+      'parent shared input',
+      'jsonl input',
+    ]);
+  });
+
+  it('combines imports.tests with tests path shorthand in parent context', async () => {
+    await writeFile(
+      path.join(tempDir, 'imported.jsonl'),
+      '{"id":"imported-case","input":"imported input","criteria":"ok"}\n',
+    );
+    await writeFile(
+      path.join(tempDir, 'local.yaml'),
+      ['- id: local-case', '  input: local input', '  criteria: ok', ''].join('\n'),
+    );
+    const parentPath = path.join(tempDir, 'parent.eval.yaml');
+    await writeFile(
+      parentPath,
+      [
+        'name: parent-suite',
+        'workspace:',
+        '  template: ./parent-workspace',
+        'imports:',
+        '  tests:',
+        '    - path: imported.jsonl',
+        'tests: local.yaml',
+        '',
+      ].join('\n'),
+    );
+
+    const suite = await loadTestSuite(parentPath, tempDir);
+    const byId = new Map(suite.tests.map((test) => [test.id, test]));
+
+    expect(suite.tests.map((test) => test.id)).toEqual(['imported-case', 'local-case']);
+    expect(byId.get('imported-case')?.suite).toBe('parent-suite');
+    expect(byId.get('local-case')?.suite).toBe('parent-suite');
+    expect(byId.get('imported-case')?.workspace?.template).toBe(
+      path.join(tempDir, 'parent-workspace'),
+    );
+  });
+
+  it('rejects parent workspace when imports.suites preserves child workspaces', async () => {
+    await writeFile(
+      path.join(tempDir, 'child.eval.yaml'),
+      [
+        'name: child-suite',
+        'tests:',
+        '  - id: child-case',
+        '    input: child',
+        '    criteria: ok',
+        '',
+      ].join('\n'),
+    );
+    const parentPath = path.join(tempDir, 'parent.eval.yaml');
+    await writeFile(
+      parentPath,
+      [
+        'name: parent-suite',
+        'workspace:',
+        '  template: ./parent-workspace',
+        'imports:',
+        '  suites:',
+        '    - path: child.eval.yaml',
+        '',
+      ].join('\n'),
+    );
+
+    await expect(loadTestSuite(parentPath, tempDir)).rejects.toThrow(
+      /Parent workspace is not allowed/,
+    );
+  });
+
+  it('warns but supports legacy tests include entries during migration', async () => {
+    await writeFile(
+      path.join(tempDir, 'child.eval.yaml'),
+      [
+        'name: child-suite',
+        'tests:',
+        '  - id: child-case',
+        '    input: child',
+        '    criteria: ok',
+        '',
+      ].join('\n'),
+    );
+    const parentPath = path.join(tempDir, 'parent.eval.yaml');
+    await writeFile(
+      parentPath,
+      ['name: parent-suite', 'tests:', '  - include: child.eval.yaml', '    type: suite', ''].join(
+        '\n',
+      ),
+    );
+
+    const warn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (message?: unknown) => {
+      warnings.push(String(message));
+    };
+    try {
+      const suite = await loadTestSuite(parentPath, tempDir);
+      expect(suite.tests.map((test) => test.id)).toEqual(['child-case']);
+    } finally {
+      console.warn = warn;
+    }
+
+    expect(warnings.some((message) => message.includes('tests[].include is deprecated'))).toBe(
+      true,
+    );
+  });
+
+  it('validates imports.suites and warns for legacy/confusing imports', async () => {
+    await writeFile(
+      path.join(tempDir, 'child.eval.yaml'),
+      [
+        'name: child-suite',
+        'experiment:',
+        '  target: child-target',
+        'tests:',
+        '  - id: child-case',
+        '    input: child',
+        '',
+      ].join('\n'),
+    );
+    const parentPath = path.join(tempDir, 'parent.eval.yaml');
+    await writeFile(
+      parentPath,
+      [
+        'name: parent-suite',
+        'experiment:',
+        '  target: parent-target',
+        'imports:',
+        '  suites:',
+        '    - path: child.eval.yaml',
+        '  tests:',
+        '    - path: child.eval.yaml',
+        'tests:',
+        '  - include: child.eval.yaml',
+        '    type: suite',
+        '',
+      ].join('\n'),
+    );
+
+    const result = await validateEvalFile(parentPath);
+
+    expect(result.valid).toBe(true);
+    const warnings = result.errors.filter((error) => error.severity === 'warning');
+    expect(warnings.some((error) => error.message.includes('tests[].include is deprecated'))).toBe(
+      true,
+    );
+    expect(
+      warnings.some((error) => error.message.includes('child experiment blocks are ignored')),
+    ).toBe(true);
+    expect(
+      warnings.some((error) => error.message.includes('imports.tests imports raw cases')),
+    ).toBe(true);
   });
 
   it('type: tests imports only raw cases and applies parent suite context', async () => {

--- a/packages/core/test/evaluation/validation/eval-file-schema.test.ts
+++ b/packages/core/test/evaluation/validation/eval-file-schema.test.ts
@@ -116,6 +116,47 @@ describe('EvalFileSchema input shorthand', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts flatter imports with optional inline tests', () => {
+    const result = EvalFileSchema.safeParse({
+      name: 'wrapper',
+      imports: {
+        suites: [
+          {
+            path: './evals/**/*.eval.yaml',
+            select: {
+              test_ids: ['pr50857-*'],
+              tags: ['sql-migration'],
+            },
+            run: {
+              threshold: 1,
+              repeat: { count: 2, strategy: 'pass_all' },
+              timeout_seconds: 120,
+              budget_usd: 2,
+            },
+          },
+        ],
+        tests: [{ path: './cases/**/*.cases.yaml' }, './cases/regressions.jsonl'],
+      },
+      tests: [baseTest],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts import-only wrapper evals', () => {
+    const result = EvalFileSchema.safeParse({
+      name: 'wrapper',
+      experiment: {
+        target: 'codex',
+      },
+      imports: {
+        suites: [{ path: './evals/**/*.eval.yaml' }],
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it('rejects eval files that set both experiment and legacy execution', () => {
     const result = EvalFileSchema.safeParse({
       experiment: { target: 'codex' },

--- a/packages/core/test/evaluation/validation/eval-validator.test.ts
+++ b/packages/core/test/evaluation/validation/eval-validator.test.ts
@@ -34,7 +34,7 @@ describe('validateEvalFile', () => {
     expect(result.errors).toHaveLength(0);
   });
 
-  it('validates inline experiment runtime and tests include entries', async () => {
+  it('validates inline experiment runtime and flatter import entries', async () => {
     const filePath = path.join(tempDir, 'inline-experiment-include.yaml');
     await writeFile(
       filePath,
@@ -43,23 +43,26 @@ experiment:
   targets: [codex, claude]
   workers: 2
 tests:
-  - include: ./evals/**/*.eval.yaml
-    type: suite
-    select:
-      test_ids: [pr50857-*]
-      tags: [sql-migration]
-      metadata:
-        type: [e2e, regression]
-        priority: high
-    run:
-      threshold: 1.0
-      repeat:
-        count: 2
-        strategy: pass_all
-      timeout_seconds: 120
-      budget_usd: 2
-  - include: ./cases/**/*.cases.yaml
-    type: tests
+  - id: local-case
+    input: "Hello"
+imports:
+  suites:
+    - path: ./evals/**/*.eval.yaml
+      select:
+        test_ids: [pr50857-*]
+        tags: [sql-migration]
+        metadata:
+          type: [e2e, regression]
+          priority: high
+      run:
+        threshold: 1.0
+        repeat:
+          count: 2
+          strategy: pass_all
+        timeout_seconds: 120
+        budget_usd: 2
+  tests:
+    - path: ./cases/**/*.cases.yaml
 `,
     );
 
@@ -391,7 +394,7 @@ tests:
     ).toBe(true);
   });
 
-  it('warns when type: tests imports an eval suite and drops suite context', async () => {
+  it('warns when imports.tests-style raw imports drop eval suite context', async () => {
     await writeFile(
       path.join(tempDir, 'composition-child-tests-import.eval.yaml'),
       `workspace:
@@ -425,8 +428,31 @@ tests:
         (error) =>
           error.severity === 'warning' &&
           error.location === 'tests[0].include' &&
-          error.message.includes('type: tests imports raw cases') &&
+          error.message.includes('imports.tests imports raw cases') &&
           error.message.includes('drops suite context'),
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects missing raw case files under imports.tests', async () => {
+    const filePath = path.join(tempDir, 'missing-imports-tests-path.eval.yaml');
+    await writeFile(
+      filePath,
+      `imports:
+  tests:
+    - path: ./missing-cases.yaml
+`,
+    );
+
+    const result = await validateEvalFile(filePath);
+
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some(
+        (error) =>
+          error.severity === 'error' &&
+          error.location === 'imports.tests[0].path' &&
+          error.message.includes('Cannot read external test file'),
       ),
     ).toBe(true);
   });

--- a/skills-data/agentv-eval-writer/SKILL.md
+++ b/skills-data/agentv-eval-writer/SKILL.md
@@ -19,14 +19,17 @@ Comprehensive docs: https://agentv.dev
 Treat YAML as the canonical portable model. Prefer authoring `.eval.yaml` / `EVAL.yaml` first, then use TypeScript helpers, Python scripts, or executable graders only when they lower to the same fields or when the evaluation logic must actually run code.
 
 Eval files define what is tested and how it runs: prompts, datasets, assertions,
-task fixtures, and the inline `experiment:` runtime block. Use `tests[]` include
-entries for composition. `type: suite` preserves imported suite context;
-`type: tests` imports raw cases only. String-valued `tests` and string entries
-inside `tests[]` are raw-case import shorthand for direct paths, directories, and
-globs; suite imports must use `include:` with `type: suite`. Use scoped `run:`
-on include entries or individual tests only for `threshold`, `repeat`,
-`timeout_seconds`, and `budget_usd`; keep target selection, setup, and workspace
-mutation under the parent `experiment:`.
+task fixtures, and the inline `experiment:` runtime block. Use `imports.suites`
+for full child suites that preserve their workspace, shared input, assertions,
+fixtures, and graders. Use `imports.tests` for raw case rows that should run in
+the parent file's context. Inline `tests` are also parent-owned raw cases.
+String-valued `tests` and string entries inside `tests[]` are raw-case import
+shorthand for direct paths, directories, and globs. Legacy `tests[].include`
+entries still load with a migration warning, but new evals should use
+`imports.suites` or `imports.tests`. Use scoped `run:` on import entries or
+individual tests only for `threshold`, `repeat`, `timeout_seconds`, and
+`budget_usd`; keep target selection, setup, and workspace mutation under the
+parent `experiment:`.
 
 Use `@agentv/sdk` for TypeScript helper imports. Do not use `@agentv/eval` for new evals, examples, scaffolds, or skill guidance; it was a deprecated compatibility package and has been removed from this repository.
 
@@ -121,7 +124,7 @@ tests:
 
 ## Eval File Structure
 
-**Required:** `tests` (array or string raw-case path)
+**Required:** `tests` (array or string raw-case path) or `imports`
 **Optional:** `name`, `description`, `version`, `author`, `tags`, `license`, `requires`, `experiment`, `suite`, `workspace`, `assertions`, `input`
 
 **Test fields:**

--- a/skills-data/agentv-eval-writer/references/eval-schema.json
+++ b/skills-data/agentv-eval-writer/references/eval-schema.json
@@ -149,6 +149,594 @@
             "type": "string"
           }
         },
+        "imports": {
+          "type": "object",
+          "properties": {
+            "suites": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "select": {
+                            "anyOf": [
+                              {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "minLength": 1
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "minItems": 1
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "test_ids": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "minItems": 1
+                                      }
+                                    ]
+                                  },
+                                  "tags": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "minItems": 1
+                                      }
+                                    ]
+                                  },
+                                  "metadata": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": ["string", "number", "boolean"]
+                                          },
+                                          "minItems": 1
+                                        }
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            ]
+                          },
+                          "run": {
+                            "type": "object",
+                            "properties": {
+                              "threshold": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
+                              },
+                              "repeat": {
+                                "type": "object",
+                                "properties": {
+                                  "count": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                  },
+                                  "strategy": {
+                                    "type": "string",
+                                    "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                                  },
+                                  "cost_limit_usd": {
+                                    "type": "number",
+                                    "minimum": 0
+                                  },
+                                  "costLimitUsd": {
+                                    "type": "number",
+                                    "minimum": 0
+                                  }
+                                },
+                                "required": ["count"],
+                                "additionalProperties": false
+                              },
+                              "timeout_seconds": {
+                                "type": "number",
+                                "exclusiveMinimum": true,
+                                "minimum": 0
+                              },
+                              "budget_usd": {
+                                "type": "number",
+                                "exclusiveMinimum": true,
+                                "minimum": 0
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": ["path"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "select": {
+                      "anyOf": [
+                        {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "minItems": 1
+                            }
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "test_ids": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  },
+                                  "minItems": 1
+                                }
+                              ]
+                            },
+                            "tags": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  },
+                                  "minItems": 1
+                                }
+                              ]
+                            },
+                            "metadata": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": ["string", "number", "boolean"]
+                                    },
+                                    "minItems": 1
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      ]
+                    },
+                    "run": {
+                      "type": "object",
+                      "properties": {
+                        "threshold": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
+                        },
+                        "repeat": {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "integer",
+                              "minimum": 1
+                            },
+                            "strategy": {
+                              "type": "string",
+                              "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                            },
+                            "cost_limit_usd": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "costLimitUsd": {
+                              "type": "number",
+                              "minimum": 0
+                            }
+                          },
+                          "required": ["count"],
+                          "additionalProperties": false
+                        },
+                        "timeout_seconds": {
+                          "type": "number",
+                          "exclusiveMinimum": true,
+                          "minimum": 0
+                        },
+                        "budget_usd": {
+                          "type": "number",
+                          "exclusiveMinimum": true,
+                          "minimum": 0
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["path"],
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "tests": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "select": {
+                            "anyOf": [
+                              {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "minLength": 1
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "minItems": 1
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "test_ids": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "minItems": 1
+                                      }
+                                    ]
+                                  },
+                                  "tags": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "minItems": 1
+                                      }
+                                    ]
+                                  },
+                                  "metadata": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": ["string", "number", "boolean"]
+                                          },
+                                          "minItems": 1
+                                        }
+                                      ]
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            ]
+                          },
+                          "run": {
+                            "type": "object",
+                            "properties": {
+                              "threshold": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
+                              },
+                              "repeat": {
+                                "type": "object",
+                                "properties": {
+                                  "count": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                  },
+                                  "strategy": {
+                                    "type": "string",
+                                    "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                                  },
+                                  "cost_limit_usd": {
+                                    "type": "number",
+                                    "minimum": 0
+                                  },
+                                  "costLimitUsd": {
+                                    "type": "number",
+                                    "minimum": 0
+                                  }
+                                },
+                                "required": ["count"],
+                                "additionalProperties": false
+                              },
+                              "timeout_seconds": {
+                                "type": "number",
+                                "exclusiveMinimum": true,
+                                "minimum": 0
+                              },
+                              "budget_usd": {
+                                "type": "number",
+                                "exclusiveMinimum": true,
+                                "minimum": 0
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": ["path"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "select": {
+                      "anyOf": [
+                        {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "minItems": 1
+                            }
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "test_ids": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  },
+                                  "minItems": 1
+                                }
+                              ]
+                            },
+                            "tags": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  },
+                                  "minItems": 1
+                                }
+                              ]
+                            },
+                            "metadata": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": ["string", "number", "boolean"]
+                                    },
+                                    "minItems": 1
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      ]
+                    },
+                    "run": {
+                      "type": "object",
+                      "properties": {
+                        "threshold": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
+                        },
+                        "repeat": {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "integer",
+                              "minimum": 1
+                            },
+                            "strategy": {
+                              "type": "string",
+                              "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                            },
+                            "cost_limit_usd": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "costLimitUsd": {
+                              "type": "number",
+                              "minimum": 0
+                            }
+                          },
+                          "required": ["count"],
+                          "additionalProperties": false
+                        },
+                        "timeout_seconds": {
+                          "type": "number",
+                          "exclusiveMinimum": true,
+                          "minimum": 0
+                        },
+                        "budget_usd": {
+                          "type": "number",
+                          "exclusiveMinimum": true,
+                          "minimum": 0
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["path"],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
         "tests": {
           "anyOf": [
             {
@@ -19651,7 +20239,6 @@
           ]
         }
       },
-      "required": ["tests"],
       "additionalProperties": false
     }
   }


### PR DESCRIPTION
## Summary
- add top-level imports.suites and imports.tests support in the eval loader and validator
- preserve child suite task context for suite imports while importing raw tests into parent context
- update generated schema, docs, examples, and regression coverage

## Verification
- bun install
- bun --filter @agentv/core generate:schema
- git diff --check
- bun test packages/core/test/evaluation/eval-inline-experiment.test.ts packages/core/test/evaluation/validation/eval-file-schema.test.ts packages/core/test/evaluation/validation/eval-validator.test.ts packages/core/test/evaluation/validation/eval-schema-sync.test.ts
- bun --filter @agentv/core typecheck
- bun --filter @agentv/core build
- bun run lint
- bun run validate:examples
- bun --filter @agentv/core test