### PR TITLE
feat(sdk)!: canonical `experiment` only; remove `execution` alias (breaking)

### DIFF
--- a/apps/cli/src/commands/create/commands.ts
+++ b/apps/cli/src/commands/create/commands.ts
@@ -34,7 +34,7 @@ export default defineAssertion(({ output }) => {
 
 const EVAL_TEMPLATES: Record<string, (name: string) => string> = {
   default: (name: string) => `description: ${name} evaluation suite
-execution:
+experiment:
   target: default
 
 tests:
@@ -47,7 +47,7 @@ tests:
         value: "well"
 `,
   rubric: (name: string) => `description: ${name} evaluation suite
-execution:
+experiment:
   target: default
 
 tests:

--- a/apps/cli/src/commands/eval/commands/bundle.ts
+++ b/apps/cli/src/commands/eval/commands/bundle.ts
@@ -97,7 +97,7 @@ function definitionsWithEvalTargetRefs(
   return result;
 }
 
-function buildBundleExecution(options: {
+function buildBundleExperiment(options: {
   readonly targetNames: readonly string[];
   readonly targetRefs?: readonly EvalTargetRef[];
   readonly workers?: number;
@@ -114,7 +114,7 @@ function buildBundleExecution(options: {
   const singleTargetRef = options.targetNames[0]
     ? targetRefsByName.get(options.targetNames[0])
     : undefined;
-  const execution: Record<string, unknown> =
+  const experiment: Record<string, unknown> =
     options.targetNames.length === 1 && !singleTargetRef?.hooks && !singleTargetRef?.use_target
       ? { target: options.targetNames[0] }
       : {
@@ -122,21 +122,21 @@ function buildBundleExecution(options: {
         };
 
   if (options.workers !== undefined) {
-    execution.workers = options.workers;
+    experiment.workers = options.workers;
   }
   if (options.cache !== undefined) {
-    execution.cache = options.cache;
+    experiment.cache = options.cache;
   }
   if (options.cachePath !== undefined) {
-    execution.cache_path = options.cachePath;
+    experiment.cache_path = options.cachePath;
   }
   if (options.budgetUsd !== undefined) {
-    execution.budget_usd = options.budgetUsd;
+    experiment.budget_usd = options.budgetUsd;
   }
   if (options.threshold !== undefined) {
-    execution.threshold = options.threshold;
+    experiment.threshold = options.threshold;
   }
-  return execution;
+  return experiment;
 }
 
 export const evalBundleCommand = command({
@@ -221,7 +221,7 @@ export const evalBundleCommand = command({
       outputDir: args.out,
       cwd,
       repoRoot,
-      execution: buildBundleExecution({
+      experiment: buildBundleExperiment({
         targetNames,
         targetRefs: suite.targetRefs,
         workers: suite.workers,

--- a/apps/cli/src/commands/eval/task-bundle.ts
+++ b/apps/cli/src/commands/eval/task-bundle.ts
@@ -76,7 +76,7 @@ export interface MaterializeEvalBundleOptions {
   readonly outputDir: string;
   readonly cwd?: string;
   readonly repoRoot?: string;
-  readonly execution?: Record<string, unknown>;
+  readonly experiment?: Record<string, unknown>;
   readonly now?: () => Date;
 }
 
@@ -736,8 +736,8 @@ function buildPortableEvalCase(
     testCase.conversation_id = test.conversation_id;
   }
   if (test.threshold !== undefined) {
-    const existingExecution = isRecord(testCase.execution) ? testCase.execution : {};
-    testCase.execution = { ...existingExecution, threshold: test.threshold };
+    const existingExperiment = isRecord(testCase.experiment) ? testCase.experiment : {};
+    testCase.experiment = { ...existingExperiment, threshold: test.threshold };
   }
   if (test.mode) {
     testCase.mode = test.mode;
@@ -960,7 +960,7 @@ export async function materializeTaskBundle(
   const targetsPath = path.join(taskDir, TASK_TARGETS_FILENAME);
 
   await writeYamlFile(evalPath, {
-    execution: { target: options.targetName },
+    experiment: { target: options.targetName },
     tests: [evalCase],
   });
   await writeYamlFile(targetsPath, { targets: targetDefinitions });
@@ -1026,12 +1026,12 @@ export async function materializeEvalBundle(
   const evalPath = path.join(evalsDir, bundledEvalFileName(options.evalFilePath));
   const targetsPath = path.join(outputDir, BUNDLE_TARGETS_FILENAME);
   const manifestPath = path.join(outputDir, BUNDLE_MANIFEST_FILENAME);
-  const execution =
-    options.execution ??
+  const experiment =
+    options.experiment ??
     (targetNames.length === 1 ? { target: targetNames[0] } : { targets: targetNames });
 
   await writeYamlFile(evalPath, {
-    execution,
+    experiment,
     tests: options.tests.map((test) => buildPortableEvalCase(test, rewrites)),
   });
   await writeYamlFile(targetsPath, {

--- a/apps/cli/test/commands/eval/bundle.test.ts
+++ b/apps/cli/test/commands/eval/bundle.test.ts
@@ -92,7 +92,7 @@ await Bun.write(\`\${payload.workspace_path}/hook-ran.txt\`, 'ok\\n');
 
     const evalPath = path.join(sourceDir, 'evals', 'demo.eval.yaml');
     const sourceEvalBefore = `name: portable-demo
-execution:
+experiment:
   target: inherited
 workspace:
   template: ../workspace-template
@@ -142,7 +142,7 @@ tests: ../data/cases.yaml
     const bundledEvalText = await readFile(path.join(bundleDir, 'evals', 'demo.eval.yaml'), 'utf8');
     expect(bundledEvalText).not.toContain(sourceDir);
     const bundledEval = parseYamlValue(bundledEvalText) as Record<string, unknown>;
-    expect(bundledEval.execution).toEqual({ target: 'inherited' });
+    expect(bundledEval.experiment).toEqual({ target: 'inherited' });
     const [testCase] = bundledEval.tests as Record<string, unknown>[];
     expect(testCase.id).toBe('case-alpha');
     expect(testCase.workspace).toMatchObject({

--- a/apps/cli/test/commands/prepare/prepare.test.ts
+++ b/apps/cli/test/commands/prepare/prepare.test.ts
@@ -76,7 +76,7 @@ workspace:
       command: ["bun", "../scripts/hook.ts", "workspace_before_all"]
     before_each:
       command: ["bun", "../scripts/hook.ts", "workspace_before_each"]
-execution:
+experiment:
   targets:
     - name: codex
       hooks:

--- a/apps/cli/test/commands/runs/rerun.test.ts
+++ b/apps/cli/test/commands/runs/rerun.test.ts
@@ -47,7 +47,7 @@ async function writeTaskBundle(options: {
 
   await writeFile(
     path.join(taskDir, 'EVAL.yaml'),
-    `execution:
+    `experiment:
   target: captured
 tests:
   - id: ${options.testId}

--- a/apps/cli/test/eval.integration.test.ts
+++ b/apps/cli/test/eval.integration.test.ts
@@ -235,7 +235,7 @@ async function prependYamlCacheConfig(fixture: EvalFixture, cachePath: string): 
   const original = await readFile(fixture.testFilePath, 'utf8');
   await writeFile(
     fixture.testFilePath,
-    `execution:\n  cache: true\n  cache_path: ${cachePath}\n\n${original}`,
+    `experiment:\n  cache: true\n  cache_path: ${cachePath}\n\n${original}`,
     'utf8',
   );
 }

--- a/apps/web/src/content/docs/docs/evaluation/batch-cli.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/batch-cli.mdx
@@ -27,7 +27,7 @@ Use batch CLI evaluation when:
 
 ```yaml
 description: Batch CLI demo using structured input
-execution:
+experiment:
   target: batch_cli
 
 tests:

--- a/apps/web/src/content/docs/docs/evaluation/eval-cases.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/eval-cases.mdx
@@ -27,7 +27,7 @@ tests:
 | `criteria` | Conditional | Description of what a correct response should contain. Required only when the case has no `expected_output` or `assertions` |
 | `input` | Yes | Input sent to the target (string, object, or message array) |
 | `expected_output` | No | Expected response for comparison (string, object, or message array) |
-| `execution` | No | Per-case execution overrides such as `skip_defaults` or `threshold`; target selection belongs in `experiment.target(s)` or CLI `--target` |
+| `experiment` | No | Per-case runtime overrides such as `skip_defaults` or `threshold`; target selection belongs in top-level `experiment.target(s)` or CLI `--target` |
 | `workspace` | No | Per-case workspace config (overrides suite-level) |
 | `metadata` | No | Arbitrary key-value pairs passed to graders and workspace scripts |
 | `rubrics` | No | Structured evaluation criteria |
@@ -89,7 +89,7 @@ expected_output:
     content: "42"
 ```
 
-## Per-Case Execution Overrides
+## Per-Case Experiment Overrides
 
 Override graders or local scoring settings for specific tests. Do not put
 target selection in cases; use `experiment.target(s)`, CLI `--target`, separate
@@ -107,7 +107,7 @@ tests:
         prompt: ./graders/depth.md
 ```
 
-Per-case `assertions` graders are **merged** with root-level `assertions` graders — test-specific graders run first, then root-level defaults are appended. To opt out of root-level defaults for a specific test, set `execution.skip_defaults: true`:
+Per-case `assertions` graders are **merged** with root-level `assertions` graders — test-specific graders run first, then root-level defaults are appended. To opt out of root-level defaults for a specific test, set `experiment.skip_defaults: true`:
 
 ```yaml
 assertions:
@@ -124,7 +124,7 @@ tests:
   - id: special-case
     criteria: Handles edge case
     input: Handle this edge case
-    execution:
+    experiment:
       skip_defaults: true
     assertions:
       - name: custom_eval
@@ -368,7 +368,7 @@ Required gates are evaluated after all graders run. If any required grader falls
 
 - Per-test `assertions` graders run first.
 - Suite-level `assertions` graders are appended automatically.
-- Set `execution.skip_defaults: true` on a test to skip suite-level defaults.
+- Set `experiment.skip_defaults: true` on a test to skip suite-level defaults.
 
 ## How Reference Fields and `assertions` Interact
 
@@ -497,5 +497,5 @@ tests:
 
 `metadata` is passed to workspace lifecycle hooks as `case_metadata`, preserved
 in result records, and available to in-process custom assertions. AgentV does
-not interpret arbitrary metadata keys itself; use `workspace`, `execution`,
+not interpret arbitrary metadata keys itself; use `workspace`, `experiment`,
 `input`, `expected_output`, and `assertions` for operational behavior.

--- a/apps/web/src/content/docs/docs/evaluation/eval-files.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/eval-files.mdx
@@ -118,8 +118,8 @@ tests:
 | `workspace` | Suite-level task environment — inline object or string path to an [external workspace file](/docs/guides/workspace-pool/#external-workspace-config). Repo entries declare identity and checkout pins; acquisition is covered in [Workspace Architecture](/docs/guides/workspace-architecture/#repo-provenance-vs-acquisition). |
 | `imports` | Optional import groups. `imports.suites` imports full child eval suites with their task context. `imports.tests` imports raw test rows into this file's context. Import entries may use scoped `run:` overrides for `threshold`, `repeat`, `timeout_seconds`, and `budget_usd`. |
 | `tests` | Inline raw tests or a string path to an external raw-case file or directory. Legacy `tests[].include` entries still load with a migration warning; prefer `imports.suites` or `imports.tests`. |
-| `assertions` | Suite-level graders appended to each test unless `execution.skip_defaults: true` is set on the test |
-| `input` | Suite-level input messages prepended to each test's input unless `execution.skip_defaults: true` is set on the test |
+| `assertions` | Suite-level graders appended to each test unless `experiment.skip_defaults: true` is set on the test |
+| `input` | Suite-level input messages prepended to each test's input unless `experiment.skip_defaults: true` is set on the test |
 
 `workspace` is what the agent can inspect or modify through tools, not prompt
 input. Put instructions in `input`; put repos, templates, and lifecycle setup in
@@ -169,7 +169,7 @@ category paths.
 
 ### Suite-level Assertions
 
-The `assertions` field is the canonical way to define suite-level graders. Suite-level assertions are appended to every test's graders unless a test sets `execution.skip_defaults: true`.
+The `assertions` field is the canonical way to define suite-level graders. Suite-level assertions are appended to every test's graders unless a test sets `experiment.skip_defaults: true`.
 For semantic or agent-behavior checks, prefer plain assertion strings first;
 AgentV treats them as rubric criteria. Use deterministic assertions or code
 graders when the expected output is exact or requires programmatic inspection.
@@ -212,7 +212,7 @@ Resolution rules:
 - `include: name` resolves to `.agentv/templates/{name}.yaml` with the closest matching directory winning
 - Relative paths resolve from the eval file location, so `include: ./shared/format.yaml` works as expected
 - Nested includes are allowed up to depth 3 to keep cycles and runaway recursion bounded
-- Suite-level includes follow the same merge behavior as other suite-level assertions and still respect `execution.skip_defaults: true`
+- Suite-level includes follow the same merge behavior as other suite-level assertions and still respect `experiment.skip_defaults: true`
 
 ### Suite-level Input
 
@@ -263,7 +263,7 @@ input:
         value: ./system-prompt.md
 ```
 
-To opt out for a specific test, set `execution.skip_defaults: true` (same flag that skips suite-level `assertions`).
+To opt out for a specific test, set `experiment.skip_defaults: true` (same flag that skips suite-level `assertions`).
 
 ### Suite-level Input Files
 
@@ -286,7 +286,7 @@ tests:
 
 Each test's effective input becomes a single user message with `[file blocks..., text block]`.
 
-Per-test `input_files` overrides the suite-level value (it does not merge). To opt out, set `execution.skip_defaults: true` on the test.
+Per-test `input_files` overrides the suite-level value (it does not merge). To opt out, set `experiment.skip_defaults: true` on the test.
 
 ### PROMPT.md Fallback
 
@@ -482,7 +482,7 @@ For large-scale evaluations, AgentV supports JSONL (JSON Lines) format. Each lin
 
 ### Sidecar Metadata
 
-An optional YAML sidecar file provides metadata and execution config. Place it alongside the JSONL file with the same base name:
+An optional YAML sidecar file provides metadata and experiment runtime config. Place it alongside the JSONL file with the same base name:
 
 `dataset.jsonl` + `dataset.eval.yaml`:
 

--- a/apps/web/src/content/docs/docs/evaluation/examples.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/examples.mdx
@@ -13,7 +13,7 @@ A minimal eval with a single question and expected answer:
 
 ```yaml
 description: Basic arithmetic evaluation
-execution:
+experiment:
   target: default
 
 tests:
@@ -31,7 +31,7 @@ Use multipart content to attach files alongside text prompts:
 
 ````yaml
 description: Code review with guidelines
-execution:
+experiment:
   target: azure-base
 
 tests:
@@ -75,7 +75,7 @@ Combine a code grader and an LLM grader on the same test:
 
 ```yaml
 description: JSON generation with validation
-execution:
+experiment:
   target: default
 
 tests:
@@ -114,7 +114,7 @@ preprocessors:
   - type: xlsx
     command: ["bun", "run", "../scripts/preprocessors/xlsx-to-csv.ts"]
 
-execution:
+experiment:
   target: file_output
 
 tests:
@@ -129,11 +129,11 @@ See [`examples/features/preprocessors/`](../../../../examples/features/preproces
 
 ## Tool Trajectory
 
-Validate that an agent uses specific tools during execution:
+Validate that an agent uses specific tools during experiment:
 
 ```yaml
 description: Tool usage validation
-execution:
+experiment:
   target: mock_agent
 
 tests:
@@ -168,7 +168,7 @@ Benchmark a five-model grader panel against a human-labeled export, then compare
 
 ```yaml
 description: Offline grader benchmark
-execution:
+experiment:
   target: fixture_replay
 
 tests:
@@ -203,7 +203,7 @@ Evaluate pre-existing trace files without running an agent:
 
 ```yaml
 description: Static trace evaluation
-execution:
+experiment:
   target: static_trace
 
 tests:
@@ -225,7 +225,7 @@ Test multi-turn interactions where intermediate messages set context:
 
 ````yaml
 description: Multi-turn debugging session with clarifying questions
-execution:
+experiment:
   target: default
 
 tests:
@@ -286,7 +286,7 @@ Evaluate external batch runners that process all tests in one invocation:
 
 ```yaml
 description: Batch CLI demo (AML screening)
-execution:
+experiment:
   target: batch_cli
 
 tests:
@@ -359,7 +359,7 @@ tests:
 
 ### Batch CLI Pattern Notes
 
-- `execution.target: batch_cli` -- configure CLI provider with `provider_batching: true`
+- `experiment.target: batch_cli` -- configure CLI provider with `provider_batching: true`
 - The batch runner reads the eval YAML via `--eval` flag and outputs JSONL keyed by `id`
 - Put structured data in `user.content` as objects for the runner to extract
 - Use `expected_output` with object fields for structured expected output
@@ -391,7 +391,7 @@ tests: ./cases.yaml
 - id: currency-only
   criteria: Provides direct answer about currency
   input: What currency does Thailand use?
-  execution:
+  experiment:
     skip_defaults: true   # no suite-level input
 ```
 

--- a/apps/web/src/content/docs/docs/evaluation/experiments.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/experiments.mdx
@@ -34,8 +34,8 @@ tests:
     criteria: Applies the refund policy correctly
 ```
 
-`execution:` is accepted only as a legacy top-level alias for existing eval
-files. Do not use both `experiment:` and `execution:` in the same eval.
+`experiment:` is the only accepted spelling for eval runtime policy. Existing eval
+files that used `execution:` must migrate that block to `experiment:`.
 
 ## Layout Conventions
 

--- a/apps/web/src/content/docs/docs/evaluation/running-evals.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/running-evals.mdx
@@ -377,10 +377,10 @@ The interactive wizard (`agentv eval` with no arguments) remembers the last run 
 
 ### Execution Error Tolerance
 
-Control whether the eval run halts on execution errors using `execution.fail_on_error` in the eval YAML:
+Control whether the eval run halts on execution errors using `experiment.fail_on_error` in the eval YAML:
 
 ```yaml
-execution:
+experiment:
   fail_on_error: false    # never halt on errors (default)
   # fail_on_error: true   # halt on first execution error
 ```
@@ -405,7 +405,7 @@ agentv eval evals/ --threshold 0.8
 **YAML config:**
 
 ```yaml
-execution:
+experiment:
   threshold: 0.8
 ```
 
@@ -625,7 +625,7 @@ agentv eval evals/dataset.eval.yaml --cache-path .agentv/response-cache
 Eval YAML can enable the same cache per suite:
 
 ```yaml
-execution:
+experiment:
   cache: true
   cache_path: .agentv/response-cache
 ```
@@ -643,7 +643,7 @@ export default defineConfig({
 });
 ```
 
-`--no-cache` disables response caching regardless of CLI, eval YAML, or TypeScript config. Cache path precedence is `--cache-path` > eval YAML `execution.cache_path` > TypeScript config `cache.path` > `.agentv/cache`.
+`--no-cache` disables response caching regardless of CLI, eval YAML, or TypeScript config. Cache path precedence is `--cache-path` > eval YAML `experiment.cache_path` > TypeScript config `cache.path` > `.agentv/cache`.
 
 Response cache and replay are separate concepts. The response cache is an iteration aid for repeated live provider calls. Transcript or fixture replay is target substitution from curated artifacts, and graders still run fresh against the replayed output.
 

--- a/apps/web/src/content/docs/docs/evaluation/sdk.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/sdk.mdx
@@ -95,7 +95,7 @@ import { defineEval, graders } from '@agentv/sdk';
 
 export default defineEval({
   name: 'hello-suite',
-  execution: {
+  experiment: {
     targets: ['mock-sdk'],
   },
   workspace: {

--- a/apps/web/src/content/docs/docs/graders/code-graders.mdx
+++ b/apps/web/src/content/docs/docs/graders/code-graders.mdx
@@ -422,7 +422,7 @@ console.log(JSON.stringify({
 workspace:
   template: ./workspace-template   # copied into a temp dir before each run
 
-execution:
+experiment:
   target: my_agent
 
 tests:

--- a/apps/web/src/content/docs/docs/graders/custom-assertions.mdx
+++ b/apps/web/src/content/docs/docs/graders/custom-assertions.mdx
@@ -220,7 +220,7 @@ export default defineAssertion(({ output }) => {
 name: custom-assertion-demo
 description: Demonstrates custom assertions with convention discovery
 
-execution:
+experiment:
   target: default
 
 tests:

--- a/apps/web/src/content/docs/docs/graders/python-helpers.mdx
+++ b/apps/web/src/content/docs/docs/graders/python-helpers.mdx
@@ -77,7 +77,7 @@ write_eval_yaml(
     "evals/dataset.eval.yaml",
     EvalDefinition(
         name="python-helper",
-        execution={"target": "local_cli"},
+        experiment={"target": "local_cli"},
         tests="./dataset.jsonl",
     ),
 )

--- a/apps/web/src/content/docs/docs/graders/tool-trajectory.mdx
+++ b/apps/web/src/content/docs/docs/graders/tool-trajectory.mdx
@@ -180,7 +180,7 @@ Use `--dump-traces` to inspect actual traces and understand agent behavior befor
 
 ```yaml
 description: Validate research agent tool usage
-execution:
+experiment:
   target: codex_agent
 
 tests:

--- a/apps/web/src/content/docs/docs/guides/agent-eval-layers.mdx
+++ b/apps/web/src/content/docs/docs/guides/agent-eval-layers.mdx
@@ -133,7 +133,7 @@ description: Four-layer agent evaluation starter
 sidebar:
   order: 1
 
-execution:
+experiment:
   target: default
 
 tests:

--- a/apps/web/src/content/docs/docs/guides/workspace-architecture.mdx
+++ b/apps/web/src/content/docs/docs/guides/workspace-architecture.mdx
@@ -167,7 +167,7 @@ different checkout.
 Use target hooks for per-harness setup:
 
 ```yaml
-execution:
+experiment:
   targets:
     - baseline
     - name: with-skills

--- a/apps/web/src/content/docs/docs/targets/configuration.mdx
+++ b/apps/web/src/content/docs/docs/targets/configuration.mdx
@@ -62,8 +62,7 @@ already-exported secrets into `.env`.
 ## Referencing Targets in Evals
 
 Select targets at the eval runtime level with `experiment.target`,
-`experiment.targets`, legacy suite-level `execution.target(s)`, or CLI
-`--target`. Test cases do not choose targets; split target-specific cases into
+`experiment.targets`, or CLI `--target`. Test cases do not choose targets; split target-specific cases into
 separate eval suites or select them with tags/filters.
 
 ```yaml

--- a/docs/adr/0006-separate-experiments-from-eval-definitions.md
+++ b/docs/adr/0006-separate-experiments-from-eval-definitions.md
@@ -97,10 +97,21 @@ tests:
     type: tests
 ```
 
-`experiment:` is canonical for new eval YAML. `execution:` remains a legacy
-alias only for already-existing eval files. Docs, examples, schema snapshots,
-and new fixtures should use `experiment:`. New surfaces should not teach
-`execution:` except when documenting compatibility for old eval files.
+`experiment:` is the only accepted spelling for eval runtime policy. The earlier
+plan to keep `execution:` as a legacy alias is superseded by the 2026-06-30
+amendment below.
+
+### 2026-06-30 amendment: remove `execution:` fully
+
+The product decision changed from soft canonicalization to hard convergence:
+`execution:` is fully removed from eval YAML, imported eval suites, per-test
+runtime overrides, and SDK eval authoring types. Existing eval files that used
+`execution:` must migrate the block to `experiment:`. This is intentionally
+breaking so AgentV has one runtime spelling before the surface spreads further.
+
+This amendment does not affect `defineConfig().execution` or `.agentv/config`
+runtime defaults. Those are separate run-level configuration surfaces and remain
+canonical.
 
 The old experiment runtime fields are ported into the parent eval file:
 
@@ -354,17 +365,15 @@ group.
 
 The WTG database migration eval
 `evals/cargowise/database/data-transformation-pr50857-e2e.eval.yaml` has
-suite-level `execution`, `workspace`, `input`, and `assertions`.
+suite-level `experiment`, `workspace`, `input`, and `assertions`.
 
 When a wrapper eval imports it with `type: suite`, AgentV must preserve its
 shared `workspace`, `input`, and `assertions` because those fields are part of
-the task contract. Its `execution` block is the legacy spelling for child
-runtime configuration. Under this decision, child `experiment`/legacy
-`execution` blocks are ignored in wrapper composition; scoped threshold,
-repeat, timeout, and budget overrides must be authored on the parent
-`tests[].run` include entry or on child tests themselves, while
-candidate-changing fields must be supplied by the parent wrapper eval's
-`experiment:`.
+the task contract. Under this decision, child `experiment` blocks are ignored in
+wrapper composition; scoped threshold, repeat, timeout, and budget overrides
+must be authored on the parent `tests[].run` include entry or on child tests
+themselves, while candidate-changing fields must be supplied by the parent
+wrapper eval's `experiment:`.
 
 This is the motivating distinction:
 
@@ -436,9 +445,8 @@ Negative:
 
 - A parent eval that imports suites now carries both task composition and
   runtime policy in one file, so docs must explain the boundary clearly.
-- Existing `execution:` examples need to migrate to `experiment:` over time,
-  while the loader keeps `execution:` as a legacy alias for already-existing
-  evals.
+- Existing eval files using `execution:` must migrate to `experiment:`; the
+  loader no longer accepts `execution:` as an eval runtime alias.
 - Explicit task-context override syntax is deferred, so authors who need
   overrides must create a new suite or wait for a focused override design.
 - Wrapper evals need diagnostics so authors understand that parent workspace is

--- a/examples/contract/evals/code-grader-contract.eval.yaml
+++ b/examples/contract/evals/code-grader-contract.eval.yaml
@@ -1,7 +1,7 @@
 name: code-grader-contract
 description: Release gate verifying the code-grader stdin payload contract.
 
-execution:
+experiment:
   target: github-models-contract
   workers: 1
 

--- a/examples/contract/evals/release-gate.eval.yaml
+++ b/examples/contract/evals/release-gate.eval.yaml
@@ -4,7 +4,7 @@ description: Lightweight release gate for npm latest promotion.
 workspace:
   template: ../workspace-template
 
-execution:
+experiment:
   target: github-models-contract
   workers: 1
 

--- a/examples/contract/evals/repo-materialization.eval.yaml
+++ b/examples/contract/evals/repo-materialization.eval.yaml
@@ -7,7 +7,7 @@ workspace:
       repo: EntityProcess/agentv-contract-fixture
       commit: 21a34daed7ebcfe36cbed053607622a55e5e94cb
 
-execution:
+experiment:
   target: github-models-contract
   workers: 1
 

--- a/examples/features/assert-extended/evals/dataset.eval.yaml
+++ b/examples/features/assert-extended/evals/dataset.eval.yaml
@@ -5,7 +5,7 @@
 name: assert-extended
 description: Extended deterministic assertions for natural language validation
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/assert/evals/dataset.eval.yaml
+++ b/examples/features/assert/evals/dataset.eval.yaml
@@ -3,7 +3,7 @@ description: Demonstrates eval spec v2 assert features
 version: "1.0"
 tags: [demo, assert]
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/autoresearch/EVAL.yaml
+++ b/examples/features/autoresearch/EVAL.yaml
@@ -4,7 +4,7 @@ description: |
   and reasoning quality. Used as an autoresearch demo — the prompt artifact starts
   weak and the optimization loop iteratively improves it.
 
-execution:
+experiment:
   target: llm
 
 defaults:

--- a/examples/features/basic-jsonl/evals/dataset.eval.yaml
+++ b/examples/features/basic-jsonl/evals/dataset.eval.yaml
@@ -4,7 +4,7 @@
 description: JSONL version of the basic example - demonstrates file references, multi-turn, and per-case overrides
 name: basic-jsonl
 
-execution:
+experiment:
   target: llm
 
 tests: ./dataset.jsonl

--- a/examples/features/basic/evals/dataset.eval.yaml
+++ b/examples/features/basic/evals/dataset.eval.yaml
@@ -5,7 +5,7 @@ name: basic
 description: Example showing basic features, conversation threading, multiple graders
 
 # File-level default target
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/batch-cli/evals/dataset.eval.yaml
+++ b/examples/features/batch-cli/evals/dataset.eval.yaml
@@ -9,7 +9,7 @@
 name: batch-cli
 description: Batch CLI demo (AML screening) using structured input → CSV → JSONL with trace extraction
 
-execution:
+experiment:
   target: batch_cli
 
 tags: [agent]

--- a/examples/features/benchmark-tooling/evals/benchmark.eval.yaml
+++ b/examples/features/benchmark-tooling/evals/benchmark.eval.yaml
@@ -1,7 +1,7 @@
 name: multi-model-benchmark
 description: Compare greeting, code generation, and summarization across three model targets
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/code-grader-sdk/evals/dataset.eval.yaml
+++ b/examples/features/code-grader-sdk/evals/dataset.eval.yaml
@@ -4,7 +4,7 @@
 description: Demonstrates TypeScript helpers for code_grader payloads
 
 # Uses the CLI target defined in .agentv/targets.yaml
-execution:
+experiment:
   target: local_cli
 
 tags: [agent]

--- a/examples/features/code-grader-with-llm-calls/evals/contextual-precision.eval.yaml
+++ b/examples/features/code-grader-with-llm-calls/evals/contextual-precision.eval.yaml
@@ -26,7 +26,7 @@ assertions:
     target:
       max_calls: 10
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/code-grader-with-llm-calls/evals/contextual-recall.eval.yaml
+++ b/examples/features/code-grader-with-llm-calls/evals/contextual-recall.eval.yaml
@@ -29,7 +29,7 @@ assertions:
     target:
       max_calls: 15
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/compare/evals/dataset.eval.yaml
+++ b/examples/features/compare/evals/dataset.eval.yaml
@@ -8,7 +8,7 @@
 name: compare-demo
 description: Demo eval for generating baseline and candidate results to compare
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/composite/evals/dataset.eval.yaml
+++ b/examples/features/composite/evals/dataset.eval.yaml
@@ -2,7 +2,7 @@ name: composite-grader-examples
 
 # This example demonstrates the new CompositeEvaluator feature
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/copilot-log-eval/evals/skill-trigger.EVAL.yaml
+++ b/examples/features/copilot-log-eval/evals/skill-trigger.EVAL.yaml
@@ -16,7 +16,7 @@
 
 tags: [agent]
 
-execution:
+experiment:
   target: copilot-log
 
 workspace:

--- a/examples/features/default-graders/evals/dataset.eval.yaml
+++ b/examples/features/default-graders/evals/dataset.eval.yaml
@@ -4,7 +4,7 @@
 name: default-graders-example
 description: Root-level graders that automatically apply to every test
 
-execution:
+experiment:
   target: llm
 
 assertions:
@@ -34,7 +34,7 @@ tests:
       - role: user
         content: "URGENT: System is down"
     expected_output: "I understand this is urgent. Let me help you right away. Can you tell me which system is affected so I can start troubleshooting?"
-    execution:
+    experiment:
       skip_defaults: true
     assertions:
       - name: urgency_check

--- a/examples/features/deterministic-graders/evals/dataset.eval.yaml
+++ b/examples/features/deterministic-graders/evals/dataset.eval.yaml
@@ -5,7 +5,7 @@
 name: deterministic-graders
 description: Built-in deterministic assertions — contains, regex, JSON validation, equals
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/docker-workspace/evals/docker-example.EVAL.yaml
+++ b/examples/features/docker-workspace/evals/docker-example.EVAL.yaml
@@ -18,7 +18,7 @@ workspace:
     memory: 2g
     cpus: 1
 
-execution:
+experiment:
   target: mock_agent
   workers: 1
 

--- a/examples/features/document-extraction/evals/confusion-metrics.eval.yaml
+++ b/examples/features/document-extraction/evals/confusion-metrics.eval.yaml
@@ -27,7 +27,7 @@
 
 description: Header field confusion metrics (TP/TN/FP/FN aggregation)
 
-execution:
+experiment:
   target: mock_extractor
 
 assertions:

--- a/examples/features/document-extraction/evals/field-accuracy.eval.yaml
+++ b/examples/features/document-extraction/evals/field-accuracy.eval.yaml
@@ -24,7 +24,7 @@
 #
 description: Field accuracy grader patterns (per-test-case scoring)
 
-execution:
+experiment:
   target: mock_extractor
 
 assertions:

--- a/examples/features/env-interpolation/evals/dataset.eval.yaml
+++ b/examples/features/env-interpolation/evals/dataset.eval.yaml
@@ -12,7 +12,7 @@
 
 description: Demonstrates ${{ VAR }} interpolation in eval fields
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/eval-assert-demo/evals/dataset.eval.yaml
+++ b/examples/features/eval-assert-demo/evals/dataset.eval.yaml
@@ -5,7 +5,7 @@
 
 description: Code graders with eval assert CLI integration
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/execution-metrics/evals/dataset.eval.yaml
+++ b/examples/features/execution-metrics/evals/dataset.eval.yaml
@@ -19,7 +19,7 @@ name: execution-metrics
 description: Demonstrates the built-in execution_metrics grader
 
 # Mock agent that returns realistic execution metrics
-execution:
+experiment:
   target: mock_metrics_agent
 
 tests:

--- a/examples/features/experiments/evals/coding-ability.eval.yaml
+++ b/examples/features/experiments/evals/coding-ability.eval.yaml
@@ -1,5 +1,5 @@
 name: coding-ability
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/file-changes-graders/evals/dataset.eval.yaml
+++ b/examples/features/file-changes-graders/evals/dataset.eval.yaml
@@ -13,7 +13,7 @@ description: Verify file_changes diffs are accessible to LLM grader (rubrics, bu
 workspace:
   template: ../workspace-template
 
-execution:
+experiment:
   target: mock_agent
 
 tests:

--- a/examples/features/file-changes-with-repos/evals/eval.yaml
+++ b/examples/features/file-changes-with-repos/evals/eval.yaml
@@ -34,7 +34,7 @@ workspace:
           git -c user.email=test@agentv.dev -c user.name="AgentV Test" add . &&
           git -c user.email=test@agentv.dev -c user.name="AgentV Test" commit -m "init"
 
-execution:
+experiment:
   target: mock_agent
 
 tests:

--- a/examples/features/file-changes/evals/dataset.eval.yaml
+++ b/examples/features/file-changes/evals/dataset.eval.yaml
@@ -15,7 +15,7 @@ description: Verify file_changes captures edits, creates, and deletes across mul
 workspace:
   template: ../workspace-template
 
-execution:
+experiment:
   target: mock_agent
 
 tests:

--- a/examples/features/functional-grading/evals/dataset.eval.yaml
+++ b/examples/features/functional-grading/evals/dataset.eval.yaml
@@ -16,7 +16,7 @@ description: Functional grading with workspace_path — deploy-and-test pattern
 workspace:
   template: ../workspace-template
 
-execution:
+experiment:
   target: mock_agent
 
 tests:

--- a/examples/features/import-claude/evals/transcript-check.EVAL.yaml
+++ b/examples/features/import-claude/evals/transcript-check.EVAL.yaml
@@ -1,4 +1,4 @@
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/input-files-shorthand/evals/dataset.eval.yaml
+++ b/examples/features/input-files-shorthand/evals/dataset.eval.yaml
@@ -29,7 +29,7 @@
 
 description: Demonstrates input_files shorthand for attaching files to test inputs
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/langfuse-export/evals/eval.yaml
+++ b/examples/features/langfuse-export/evals/eval.yaml
@@ -7,7 +7,7 @@
 
 description: Sample eval with Langfuse trace export
 
-execution:
+experiment:
   target: default
 
 tests:

--- a/examples/features/latency-assertions/evals/dataset.eval.yaml
+++ b/examples/features/latency-assertions/evals/dataset.eval.yaml
@@ -34,7 +34,7 @@
 name: latency-assertions
 description: Latency assertions for per-step performance validation
 
-execution:
+experiment:
   target: mock_latency_agent
 
 tests:

--- a/examples/features/local-cli/evals/dataset.eval.yaml
+++ b/examples/features/local-cli/evals/dataset.eval.yaml
@@ -3,7 +3,7 @@
 description: Minimal demo showing how to invoke a CLI target with file attachments
 
 # Use the CLI target defined in .agentv/targets.yaml
-execution:
+experiment:
   target: local_cli
 
 tags: [agent]

--- a/examples/features/multi-turn-conversation-live/evals/dataset.eval.yaml
+++ b/examples/features/multi-turn-conversation-live/evals/dataset.eval.yaml
@@ -4,7 +4,7 @@
 
 description: Live multi-turn conversation evaluation with per-turn grading
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/multi-turn-conversation/evals/dataset.eval.yaml
+++ b/examples/features/multi-turn-conversation/evals/dataset.eval.yaml
@@ -4,7 +4,7 @@
 
 description: Multi-turn conversation evaluation with per-turn score breakdown
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/nlp-metrics/evals/dataset.eval.yaml
+++ b/examples/features/nlp-metrics/evals/dataset.eval.yaml
@@ -5,7 +5,7 @@
 name: nlp-metrics
 description: NLP text-quality metrics using code_grader graders
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/prompt-template-sdk/evals/dataset.eval.yaml
+++ b/examples/features/prompt-template-sdk/evals/dataset.eval.yaml
@@ -5,7 +5,7 @@
 description: Demonstrates TypeScript prompt templates for custom LLM grader prompts
 
 # Uses the default target defined in .agentv/targets.yaml
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/repo-lifecycle/evals/pool-e2e.eval.yaml
+++ b/examples/features/repo-lifecycle/evals/pool-e2e.eval.yaml
@@ -8,7 +8,7 @@ workspace:
       repo: https://github.com/EntityProcess/agentv.git
       commit: main
 
-execution:
+experiment:
   workers: 2
 
 tags: [agent]

--- a/examples/features/rubric/evals/dataset.eval.yaml
+++ b/examples/features/rubric/evals/dataset.eval.yaml
@@ -4,7 +4,7 @@
 name: rubric
 description: "Example showing rubric grader - string shorthand and type: rubrics"
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/rubric/evals/operators.eval.yaml
+++ b/examples/features/rubric/evals/operators.eval.yaml
@@ -4,7 +4,7 @@
 name: rubric-operators
 description: "Focused example showing correctness and contradiction rubric operators"
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/sdk-config-file/evals/dataset.eval.yaml
+++ b/examples/features/sdk-config-file/evals/dataset.eval.yaml
@@ -4,7 +4,7 @@
 name: sdk-config-file
 description: Demonstrates defineConfig() for typed project configuration
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/sdk-custom-assertion/evals/dataset.eval.yaml
+++ b/examples/features/sdk-custom-assertion/evals/dataset.eval.yaml
@@ -4,7 +4,7 @@
 name: sdk-custom-assertion
 description: Demonstrates custom assertions via defineAssertion() and convention discovery
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/sdk-eval-authoring/evals/greeting.eval.ts
+++ b/examples/features/sdk-eval-authoring/evals/greeting.eval.ts
@@ -4,7 +4,7 @@ export default defineEval({
   name: 'sdk-eval-authoring',
   description: 'YAML-aligned TypeScript eval authoring with @agentv/sdk',
   inputFiles: ['../fixtures/shared-context.md'],
-  execution: {
+  experiment: {
     targets: ['mock-sdk'],
   },
   workspace: {

--- a/examples/features/sdk-python/evals/dataset.eval.yaml
+++ b/examples/features/sdk-python/evals/dataset.eval.yaml
@@ -1,6 +1,6 @@
 description: Python helper example that emits canonical AgentV YAML/JSONL.
 name: python-helper
-execution:
+experiment:
   target: local_cli
 tags:
 - python

--- a/examples/features/sdk-python/src/agentv_py/evals.py
+++ b/examples/features/sdk-python/src/agentv_py/evals.py
@@ -30,7 +30,7 @@ class EvalTest:
     expected_output: Any | None = None
     criteria: str | None = None
     assertions: list[Any] | None = None
-    execution: Mapping[str, Any] | None = None
+    experiment: Mapping[str, Any] | None = None
     metadata: Mapping[str, Any] | None = None
     extra: Mapping[str, Any] = field(default_factory=dict)
 
@@ -44,8 +44,8 @@ class EvalTest:
             wire["expected_output"] = _wire_value(self.expected_output)
         if self.assertions is not None:
             wire["assertions"] = _wire_value(self.assertions)
-        if self.execution is not None:
-            wire["execution"] = _wire_value(self.execution)
+        if self.experiment is not None:
+            wire["experiment"] = _wire_value(self.experiment)
         if self.metadata is not None:
             wire["metadata"] = _wire_value(self.metadata)
         wire.update(_wire_value(self.extra))
@@ -58,7 +58,7 @@ class JsonlCase:
     input: Any
     expected_output: Any | None = None
     criteria: str | None = None
-    execution: Mapping[str, Any] | None = None
+    experiment: Mapping[str, Any] | None = None
     metadata: Mapping[str, Any] | None = None
     extra: Mapping[str, Any] = field(default_factory=dict)
 
@@ -68,8 +68,8 @@ class JsonlCase:
             wire["criteria"] = self.criteria
         if self.expected_output is not None:
             wire["expected_output"] = _wire_value(self.expected_output)
-        if self.execution is not None:
-            wire["execution"] = _wire_value(self.execution)
+        if self.experiment is not None:
+            wire["experiment"] = _wire_value(self.experiment)
         if self.metadata is not None:
             wire["metadata"] = _wire_value(self.metadata)
         wire.update(_wire_value(self.extra))
@@ -80,7 +80,7 @@ class JsonlCase:
 class EvalDefinition:
     description: str | None = None
     name: str | None = None
-    execution: Mapping[str, Any] | None = None
+    experiment: Mapping[str, Any] | None = None
     tags: list[str] | None = None
     tests: list[EvalTest] | str | None = None
     extra: Mapping[str, Any] = field(default_factory=dict)
@@ -91,8 +91,8 @@ class EvalDefinition:
             wire["description"] = self.description
         if self.name is not None:
             wire["name"] = self.name
-        if self.execution is not None:
-            wire["execution"] = _wire_value(self.execution)
+        if self.experiment is not None:
+            wire["experiment"] = _wire_value(self.experiment)
         if self.tags is not None:
             wire["tags"] = list(self.tags)
         if self.tests is not None:

--- a/examples/features/suite-level-input-files/evals/dataset.eval.yaml
+++ b/examples/features/suite-level-input-files/evals/dataset.eval.yaml
@@ -8,7 +8,7 @@
 name: suite-level-input-files-example
 description: Suite-level input + input_files shorthands
 
-execution:
+experiment:
   target: llm
 
 # Suite-level input as a plain string — prepended as a user message to every test.
@@ -16,7 +16,7 @@ execution:
 input: "Use the attached context to answer travel questions."
 
 # Suite-level input_files: file paths prepended as type:file content blocks
-# in each test's user message. Skipped when execution.skip_defaults: true.
+# in each test's user message. Skipped when experiment.skip_defaults: true.
 input_files:
   - ./system-prompt.md
 
@@ -36,5 +36,5 @@ tests:
   - id: skip-suite-defaults
     criteria: Provides a direct answer about currency exchange
     input: What currency does Thailand use?
-    execution:
+    experiment:
       skip_defaults: true

--- a/examples/features/suite-level-input/evals/cases.yaml
+++ b/examples/features/suite-level-input/evals/cases.yaml
@@ -15,5 +15,5 @@
   input:
     - role: user
       content: What currency does Thailand use?
-  execution:
+  experiment:
     skip_defaults: true

--- a/examples/features/suite-level-input/evals/dataset.eval.yaml
+++ b/examples/features/suite-level-input/evals/dataset.eval.yaml
@@ -5,12 +5,12 @@
 name: suite-level-input-example
 description: Suite-level input prepended to all tests (like suite-level assert)
 
-execution:
+experiment:
   target: llm
 
 # Suite-level input: prepended to every test's input messages.
 # Accepts the same formats as test-level input (string, object, or message array).
-# Skipped for tests with execution.skip_defaults: true.
+# Skipped for tests with experiment.skip_defaults: true.
 input:
   - role: user
     content:

--- a/examples/features/test-vars-templating/evals/dataset.eval.yaml
+++ b/examples/features/test-vars-templating/evals/dataset.eval.yaml
@@ -8,7 +8,7 @@
 
 description: Demonstrates tests[].vars templating in eval fields
 
-execution:
+experiment:
   target: llm
 
 input:

--- a/examples/features/threshold-grader/evals/dataset.eval.yaml
+++ b/examples/features/threshold-grader/evals/dataset.eval.yaml
@@ -4,7 +4,7 @@ description: Demonstrates the threshold aggregator — pass if N% of child grade
 # Demonstrates the threshold aggregator: pass if N% of child graders pass.
 # Borderline verdicts count as passing (lenient).
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/tool-evaluation-plugins/evals/dataset.eval.yaml
+++ b/examples/features/tool-evaluation-plugins/evals/dataset.eval.yaml
@@ -13,7 +13,7 @@
 
 description: Tool-call F1 scoring examples
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/tool-trajectory-advanced/evals/trace-file-demo.eval.yaml
+++ b/examples/features/tool-trajectory-advanced/evals/trace-file-demo.eval.yaml
@@ -12,7 +12,7 @@
 description: Static trace file evaluation demo - Product Research Agent
 
 # Use static_trace target that reads from a file
-execution:
+experiment:
   target: static_trace
 
 tests:

--- a/examples/features/tool-trajectory-simple/evals/dataset.eval.yaml
+++ b/examples/features/tool-trajectory-simple/evals/dataset.eval.yaml
@@ -34,7 +34,7 @@ name: tool-trajectory-simple
 description: Tool trajectory grader examples for agent execution validation
 
 # Use mock_agent CLI target that returns trace data
-execution:
+experiment:
   target: mock_agent
 
 tests:

--- a/examples/features/trace-analysis/evals/dataset.eval.yaml
+++ b/examples/features/trace-analysis/evals/dataset.eval.yaml
@@ -5,7 +5,7 @@
 name: trace-analysis-demo
 description: Demo eval for generating execution traces to analyze
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/trace-evaluation/evals/dataset.eval.yaml
+++ b/examples/features/trace-evaluation/evals/dataset.eval.yaml
@@ -8,7 +8,7 @@
 
 description: Trace-based evaluation of agent internals using code graders
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/trial-output-consistency/evals/dataset.eval.yaml
+++ b/examples/features/trial-output-consistency/evals/dataset.eval.yaml
@@ -7,7 +7,7 @@
 
 description: Trial output consistency via embedding similarity
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/vitest-workspace-grader/evals/dataset.eval.yaml
+++ b/examples/features/vitest-workspace-grader/evals/dataset.eval.yaml
@@ -4,7 +4,7 @@ description: Deterministic workspace grading with a Vitest verifier file.
 workspace:
   template: ../workspace-template
 
-execution:
+experiment:
   target: mock_agent
 
 tests:

--- a/examples/features/weighted-graders/evals/dataset.eval.yaml
+++ b/examples/features/weighted-graders/evals/dataset.eval.yaml
@@ -2,7 +2,7 @@ name: weighted-graders-examples
 
 # This example demonstrates per-grader weights for top-level aggregation
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/features/workspace-artifact/evals/eval.yaml
+++ b/examples/features/workspace-artifact/evals/eval.yaml
@@ -25,7 +25,7 @@ description: Verify file_changes captures generated artifacts (CSV) under worksp
 workspace:
   template: ../workspace-template
 
-execution:
+experiment:
   target: mock_csv_agent
 
 tests:

--- a/examples/red-team/archetypes/coding-agent/suites/backdoor-pr.eval.yaml
+++ b/examples/red-team/archetypes/coding-agent/suites/backdoor-pr.eval.yaml
@@ -15,7 +15,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/archetypes/coding-agent/suites/benign-controls.eval.yaml
+++ b/examples/red-team/archetypes/coding-agent/suites/benign-controls.eval.yaml
@@ -13,7 +13,7 @@ governance: &gov
   risk_tier: minimal
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/archetypes/coding-agent/suites/destructive-git.eval.yaml
+++ b/examples/red-team/archetypes/coding-agent/suites/destructive-git.eval.yaml
@@ -14,7 +14,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/archetypes/coding-agent/suites/mcp-tool-description-poisoning.eval.yaml
+++ b/examples/red-team/archetypes/coding-agent/suites/mcp-tool-description-poisoning.eval.yaml
@@ -15,7 +15,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/archetypes/coding-agent/suites/readme-issue-url-injection.eval.yaml
+++ b/examples/red-team/archetypes/coding-agent/suites/readme-issue-url-injection.eval.yaml
@@ -14,7 +14,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/archetypes/coding-agent/suites/sandbox-escape.eval.yaml
+++ b/examples/red-team/archetypes/coding-agent/suites/sandbox-escape.eval.yaml
@@ -14,7 +14,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/archetypes/coding-agent/suites/screenshot-pii-upload.eval.yaml
+++ b/examples/red-team/archetypes/coding-agent/suites/screenshot-pii-upload.eval.yaml
@@ -25,7 +25,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/archetypes/coding-agent/suites/secrets-exfiltration.eval.yaml
+++ b/examples/red-team/archetypes/coding-agent/suites/secrets-exfiltration.eval.yaml
@@ -14,7 +14,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/archetypes/coding-agent/suites/supply-chain-slopsquatting.eval.yaml
+++ b/examples/red-team/archetypes/coding-agent/suites/supply-chain-slopsquatting.eval.yaml
@@ -15,7 +15,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/archetypes/customer-facing-agent/suites/benign-controls.eval.yaml
+++ b/examples/red-team/archetypes/customer-facing-agent/suites/benign-controls.eval.yaml
@@ -13,7 +13,7 @@ governance: &gov
   risk_tier: minimal
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/archetypes/customer-facing-agent/suites/bola-bfla.eval.yaml
+++ b/examples/red-team/archetypes/customer-facing-agent/suites/bola-bfla.eval.yaml
@@ -17,7 +17,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/archetypes/customer-facing-agent/suites/compliance-boundary-violation.eval.yaml
+++ b/examples/red-team/archetypes/customer-facing-agent/suites/compliance-boundary-violation.eval.yaml
@@ -15,7 +15,7 @@ governance: &gov
   risk_tier: limited
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/archetypes/customer-facing-agent/suites/cross-session-leak.eval.yaml
+++ b/examples/red-team/archetypes/customer-facing-agent/suites/cross-session-leak.eval.yaml
@@ -16,7 +16,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/archetypes/customer-facing-agent/suites/escalation-hijack.eval.yaml
+++ b/examples/red-team/archetypes/customer-facing-agent/suites/escalation-hijack.eval.yaml
@@ -13,7 +13,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/archetypes/customer-facing-agent/suites/pii-cross-customer-disclosure.eval.yaml
+++ b/examples/red-team/archetypes/customer-facing-agent/suites/pii-cross-customer-disclosure.eval.yaml
@@ -15,7 +15,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/archetypes/customer-facing-agent/suites/support-doc-indirect-injection.eval.yaml
+++ b/examples/red-team/archetypes/customer-facing-agent/suites/support-doc-indirect-injection.eval.yaml
@@ -14,7 +14,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/archetypes/customer-facing-agent/suites/unauthorized-action-social-engineering.eval.yaml
+++ b/examples/red-team/archetypes/customer-facing-agent/suites/unauthorized-action-social-engineering.eval.yaml
@@ -15,7 +15,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/suites/agentic-memory-poisoning.eval.yaml
+++ b/examples/red-team/suites/agentic-memory-poisoning.eval.yaml
@@ -15,7 +15,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/suites/agentic-tool-misuse.eval.yaml
+++ b/examples/red-team/suites/agentic-tool-misuse.eval.yaml
@@ -14,7 +14,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/suites/atlas-v5.4-agentic.eval.yaml
+++ b/examples/red-team/suites/atlas-v5.4-agentic.eval.yaml
@@ -14,7 +14,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/suites/llm01-prompt-injection.eval.yaml
+++ b/examples/red-team/suites/llm01-prompt-injection.eval.yaml
@@ -18,7 +18,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/suites/llm02-insecure-output.eval.yaml
+++ b/examples/red-team/suites/llm02-insecure-output.eval.yaml
@@ -14,7 +14,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/suites/llm06-excessive-agency.eval.yaml
+++ b/examples/red-team/suites/llm06-excessive-agency.eval.yaml
@@ -16,7 +16,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/suites/llm07-system-prompt-leakage.eval.yaml
+++ b/examples/red-team/suites/llm07-system-prompt-leakage.eval.yaml
@@ -13,7 +13,7 @@ governance: &gov
   risk_tier: limited
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/suites/llm08-vector-embedding.eval.yaml
+++ b/examples/red-team/suites/llm08-vector-embedding.eval.yaml
@@ -14,7 +14,7 @@ governance: &gov
   risk_tier: high
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/red-team/suites/llm10-unbounded-consumption.eval.yaml
+++ b/examples/red-team/suites/llm10-unbounded-consumption.eval.yaml
@@ -12,7 +12,7 @@ governance: &gov
   risk_tier: limited
   owner: security-team
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/showcase/bug-fix-benchmark/README.md
+++ b/examples/showcase/bug-fix-benchmark/README.md
@@ -68,7 +68,7 @@ base. The eval file uses **target-level hooks** to create per-variant configurat
 
 ```yaml
 # In evals/bug-fixes.eval.yaml
-execution:
+experiment:
   targets:
     - name: claude-baseline
       use_target: claude

--- a/examples/showcase/bug-fix-benchmark/evals/bug-fixes.eval.yaml
+++ b/examples/showcase/bug-fix-benchmark/evals/bug-fixes.eval.yaml
@@ -1,7 +1,7 @@
 # Bug Fix Benchmark
 # SWE-bench style evaluation: Real-world bug fixing on public GitHub repositories
 #
-# Run all variants (defined in execution.targets below):
+# Run all variants (defined in experiment.targets below):
 #   agentv eval evals/bug-fixes.eval.yaml --workers 3
 #
 # Run specific variants:
@@ -24,7 +24,7 @@ workspace:
 
 # Target-level hooks: each variant shares the base "claude" target but
 # runs a different before_each hook to install its plugin configuration.
-execution:
+experiment:
   targets:
     - name: claude-baseline
       use_target: ${{ AGENT_TARGET }}

--- a/examples/showcase/cross-repo-sync/evals/dataset.eval.yaml
+++ b/examples/showcase/cross-repo-sync/evals/dataset.eval.yaml
@@ -15,7 +15,7 @@ workspace:
       timeout_ms: 5000
       cwd: .
 
-execution:
+experiment:
   target: mock_agent
 
 tests:

--- a/examples/showcase/cw-incident-triage/evals/dataset.eval.yaml
+++ b/examples/showcase/cw-incident-triage/evals/dataset.eval.yaml
@@ -6,7 +6,7 @@
 # 3. Diverse examples covering edge cases, including ambiguities between defects and feature requests.
 
 description: CargoWise criticality rating (CR1-CR9) classification eval for support ticket triage in logistics software.
-execution:
+experiment:
   target: llm
 
 assertions:

--- a/examples/showcase/grader-conformance/EVAL.yaml
+++ b/examples/showcase/grader-conformance/EVAL.yaml
@@ -9,7 +9,7 @@
 
 description: Keyword-matching grader used for conformance testing demo
 
-execution:
+experiment:
   target: llm
 
 tests:

--- a/examples/showcase/offline-grader-benchmark/evals/setup-a.eval.yaml
+++ b/examples/showcase/offline-grader-benchmark/evals/setup-a.eval.yaml
@@ -1,5 +1,5 @@
 description: Offline grader benchmark — setup A (same dataset, three low-cost graders, majority vote)
-execution:
+experiment:
   target: fixture_replay
 
 tests:

--- a/examples/showcase/offline-grader-benchmark/evals/setup-b.eval.yaml
+++ b/examples/showcase/offline-grader-benchmark/evals/setup-b.eval.yaml
@@ -1,5 +1,5 @@
 description: Offline grader benchmark — setup B (alternate prompt on the same labeled export)
-execution:
+experiment:
   target: fixture_replay
 
 tests:

--- a/examples/showcase/psychotherapy/evals/encouragement.eval.yaml
+++ b/examples/showcase/psychotherapy/evals/encouragement.eval.yaml
@@ -3,7 +3,7 @@ description: |-
   Verifies capability to perform Validation, Resource Identification, and Reframing.
   TIER 1: Standard Reference Cases (Explicit Resources).
   TIER 2: Adversarial/Safety Cases (Complex Nuance).
-execution:
+experiment:
   target: gemini-llm
 
 assertions:

--- a/examples/showcase/psychotherapy/evals/listening.eval.yaml
+++ b/examples/showcase/psychotherapy/evals/listening.eval.yaml
@@ -2,7 +2,7 @@ description: |-
   Comprehensive Evaluation Suite for 'Three Levels of Listening'.
   TIER 1: Basic capability (Explicit Content & Emotion).
   TIER 2: Advanced capability (Implicit Process, Somatization, & Resistance).
-execution:
+experiment:
   target: gemini-llm
 
 assertions:

--- a/examples/showcase/psychotherapy/evals/routing.eval.yaml
+++ b/examples/showcase/psychotherapy/evals/routing.eval.yaml
@@ -1,7 +1,7 @@
 description: |-
   Evaluation suite for 'Psychology Router'.
   Verifies correct selection of therapeutic framework based on client needs.
-execution:
+experiment:
   target: gemini-llm
 
 assertions:

--- a/examples/showcase/tool-evaluation-plugins/tool-eval-demo.eval.yaml
+++ b/examples/showcase/tool-evaluation-plugins/tool-eval-demo.eval.yaml
@@ -10,7 +10,7 @@
 description: Showcase of tool evaluation plugin patterns
 
 # Use mock_agent target (configure in .agentv/targets.yaml)
-execution:
+experiment:
   target: mock_agent
 
 tests:

--- a/examples/showcase/trace-evaluation/evals/coding-agent-replay.eval.yaml
+++ b/examples/showcase/trace-evaluation/evals/coding-agent-replay.eval.yaml
@@ -1,6 +1,6 @@
 description: Replay-first coding-agent trace evaluation showcase
 
-execution:
+experiment:
   target: replay_coding_agent
 
 tests:

--- a/packages/core/src/evaluation/cache/response-cache.ts
+++ b/packages/core/src/evaluation/cache/response-cache.ts
@@ -48,7 +48,7 @@ export class ResponseCache implements EvaluationCache {
  * Precedence:
  *   1. --no-cache CLI flag → always disabled
  *   2. --cache CLI flag → enabled
- *   3. execution.cache YAML → enabled/disabled for that eval file
+ *   3. experiment.cache YAML → enabled/disabled for that eval file
  *   4. agentv.config.ts cache.enabled → project default
  *   5. Default → disabled (safe for variability testing)
  */

--- a/packages/core/src/evaluation/graders/scoring.ts
+++ b/packages/core/src/evaluation/graders/scoring.ts
@@ -13,8 +13,8 @@
  *   All user-configurable score thresholds use 0-1 scale.
  *   The only 0-10 values in YAML are `score_ranges` which define LLM integer output band labels.
  *
- * Default threshold is 0.8. Override via CLI `--threshold`, suite `execution.threshold`,
- * or per-test `execution.threshold`. All verdict derivation flows through scoreToVerdict().
+ * Default threshold is 0.8. Override via CLI `--threshold`, suite `experiment.threshold`,
+ * or per-test `experiment.threshold`. All verdict derivation flows through scoreToVerdict().
  */
 
 import type { EvaluationVerdict } from '../types.js';

--- a/packages/core/src/evaluation/loaders/config-loader.ts
+++ b/packages/core/src/evaluation/loaders/config-loader.ts
@@ -259,10 +259,10 @@ function stripLocalOnlyExecutionDefaults(
 }
 
 function getSuiteRuntimeBlock(suite: JsonObject): Record<string, unknown> | undefined {
-  if (suite.experiment !== undefined && suite.execution !== undefined) {
-    throw new Error("Use either top-level 'experiment' or legacy 'execution', not both.");
+  if (suite.execution !== undefined) {
+    throw new Error("'execution' has been removed from eval YAML. Use 'experiment' instead.");
   }
-  const runtime = suite.experiment ?? suite.execution;
+  const runtime = suite.experiment;
   if (!runtime || typeof runtime !== 'object' || Array.isArray(runtime)) {
     return undefined;
   }
@@ -270,10 +270,10 @@ function getSuiteRuntimeBlock(suite: JsonObject): Record<string, unknown> | unde
 }
 
 /**
- * Extract target name from parsed eval suite (checks execution.target then falls back to root-level target).
+ * Extract target name from parsed eval suite (checks experiment.target then falls back to root-level target).
  */
 export function extractTargetFromSuite(suite: JsonObject): string | undefined {
-  // Check experiment.target first, then legacy execution.target, then root-level target.
+  // Check experiment.target first, then legacy root-level target.
   const runtime = getSuiteRuntimeBlock(suite);
   const runtimeTarget = runtime?.target;
   if (typeof runtimeTarget === 'string' && runtimeTarget.trim().length > 0) {
@@ -329,7 +329,7 @@ export function extractTargetRefsFromSuite(
 
 /**
  * Extract target names from parsed eval suite (backward-compat wrapper).
- * Precedence: execution.targets (array) > execution.target (singular).
+ * Precedence: experiment.targets (array) > experiment.target (singular).
  * Returns undefined when no targets array is specified.
  */
 export function extractTargetsFromSuite(suite: JsonObject): readonly string[] | undefined {
@@ -400,7 +400,7 @@ function parseTargetHooks(raw: unknown): TargetHooksConfig | undefined {
 }
 
 /**
- * Extract workers count from suite-level execution block.
+ * Extract workers count from suite-level experiment block.
  */
 export function extractWorkersFromSuite(suite: JsonObject): number | undefined {
   const runtime = getSuiteRuntimeBlock(suite);
@@ -417,7 +417,7 @@ export function extractWorkersFromSuite(suite: JsonObject): number | undefined {
 }
 
 /**
- * Cache configuration parsed from execution block.
+ * Cache configuration parsed from experiment block.
  */
 export interface CacheConfig {
   readonly enabled: boolean;
@@ -425,31 +425,31 @@ export interface CacheConfig {
 }
 
 /**
- * Extract cache configuration from parsed eval suite's execution block.
+ * Extract cache configuration from parsed eval suite's experiment block.
  * Returns undefined when no cache config is specified.
  */
 export function extractCacheConfig(suite: JsonObject): CacheConfig | undefined {
-  const executionObj = getSuiteRuntimeBlock(suite);
-  if (!executionObj) {
+  const experimentObj = getSuiteRuntimeBlock(suite);
+  if (!experimentObj) {
     return undefined;
   }
 
-  const cache = executionObj.cache;
+  const cache = experimentObj.cache;
 
   if (cache === undefined || cache === null) {
     return undefined;
   }
 
   if (typeof cache !== 'boolean') {
-    logWarning(`Invalid execution.cache: ${cache}. Must be a boolean. Ignoring.`);
+    logWarning(`Invalid experiment.cache: ${cache}. Must be a boolean. Ignoring.`);
     return undefined;
   }
 
-  if (executionObj.cachePath !== undefined) {
-    logWarning('Invalid execution.cachePath: use snake_case execution.cache_path in YAML.');
+  if (experimentObj.cachePath !== undefined) {
+    logWarning('Invalid experiment.cachePath: use snake_case experiment.cache_path in YAML.');
   }
 
-  const cachePath = executionObj.cache_path;
+  const cachePath = experimentObj.cache_path;
   const resolvedCachePath =
     typeof cachePath === 'string' && cachePath.trim().length > 0 ? cachePath.trim() : undefined;
 
@@ -457,23 +457,23 @@ export function extractCacheConfig(suite: JsonObject): CacheConfig | undefined {
 }
 
 /**
- * Extract suite-level total budget from parsed eval suite's execution block.
+ * Extract suite-level total budget from parsed eval suite's experiment block.
  * Returns undefined when not specified.
  */
 export function extractBudgetUsd(suite: JsonObject): number | undefined {
-  const executionObj = getSuiteRuntimeBlock(suite);
-  if (!executionObj) {
+  const experimentObj = getSuiteRuntimeBlock(suite);
+  if (!experimentObj) {
     return undefined;
   }
 
   // Reject the old key with a clear error
-  if ('total_budget_usd' in executionObj || 'totalBudgetUsd' in executionObj) {
+  if ('total_budget_usd' in experimentObj || 'totalBudgetUsd' in experimentObj) {
     throw new Error(
-      'execution.total_budget_usd has been renamed to execution.budget_usd. Update your eval YAML.',
+      'experiment.total_budget_usd has been renamed to experiment.budget_usd. Update your eval YAML.',
     );
   }
 
-  const rawBudget = executionObj.budget_usd ?? executionObj.budgetUsd;
+  const rawBudget = experimentObj.budget_usd ?? experimentObj.budgetUsd;
 
   if (rawBudget === undefined || rawBudget === null) {
     return undefined;
@@ -483,22 +483,22 @@ export function extractBudgetUsd(suite: JsonObject): number | undefined {
     return rawBudget;
   }
 
-  logWarning(`Invalid execution.budget_usd: ${rawBudget}. Must be a positive number. Ignoring.`);
+  logWarning(`Invalid experiment.budget_usd: ${rawBudget}. Must be a positive number. Ignoring.`);
   return undefined;
 }
 
 /**
- * Extract `execution.fail_on_error` from parsed eval suite.
+ * Extract `experiment.fail_on_error` from parsed eval suite.
  * Accepts `true` or `false`.
  * Returns undefined when not specified.
  */
 export function extractFailOnError(suite: JsonObject): FailOnError | undefined {
-  const executionObj = getSuiteRuntimeBlock(suite);
-  if (!executionObj) {
+  const experimentObj = getSuiteRuntimeBlock(suite);
+  if (!experimentObj) {
     return undefined;
   }
 
-  const raw = executionObj.fail_on_error ?? executionObj.failOnError;
+  const raw = experimentObj.fail_on_error ?? experimentObj.failOnError;
 
   if (raw === undefined || raw === null) {
     return undefined;
@@ -508,22 +508,22 @@ export function extractFailOnError(suite: JsonObject): FailOnError | undefined {
     return raw;
   }
 
-  logWarning(`Invalid execution.fail_on_error: ${raw}. Must be true or false. Ignoring.`);
+  logWarning(`Invalid experiment.fail_on_error: ${raw}. Must be true or false. Ignoring.`);
   return undefined;
 }
 
 /**
- * Extract `execution.threshold` from parsed eval suite.
+ * Extract `experiment.threshold` from parsed eval suite.
  * Accepts a number in [0, 1] range.
  * Returns undefined when not specified.
  */
 export function extractThreshold(suite: JsonObject): number | undefined {
-  const executionObj = getSuiteRuntimeBlock(suite);
-  if (!executionObj) {
+  const experimentObj = getSuiteRuntimeBlock(suite);
+  if (!experimentObj) {
     return undefined;
   }
 
-  const raw = executionObj.threshold;
+  const raw = experimentObj.threshold;
 
   if (raw === undefined || raw === null) {
     return undefined;
@@ -533,7 +533,7 @@ export function extractThreshold(suite: JsonObject): number | undefined {
     return raw;
   }
 
-  logWarning(`Invalid execution.threshold: ${raw}. Must be a number between 0 and 1. Ignoring.`);
+  logWarning(`Invalid experiment.threshold: ${raw}. Must be a number between 0 and 1. Ignoring.`);
   return undefined;
 }
 

--- a/packages/core/src/evaluation/loaders/grader-parser.ts
+++ b/packages/core/src/evaluation/loaders/grader-parser.ts
@@ -53,6 +53,7 @@ function isDeprecatedJudgeType(type: string): boolean {
  */
 export async function parseGraders(
   rawEvalCase: JsonObject & {
+    readonly experiment?: JsonValue;
     readonly execution?: JsonValue;
     readonly assertions?: JsonValue;
     readonly evaluators?: JsonValue;
@@ -63,7 +64,7 @@ export async function parseGraders(
   evalId: string,
   defaultPreprocessors?: readonly ContentPreprocessorConfig[],
 ): Promise<readonly GraderConfig[] | undefined> {
-  const execution = rawEvalCase.execution;
+  const execution = rawEvalCase.experiment ?? rawEvalCase.execution;
   const executionObject = isJsonObject(execution) ? execution : undefined;
 
   // Case-level graders priority: assertions > assert > legacy execution/top-level assertion lists
@@ -248,6 +249,7 @@ async function expandGraderEntries(
 
 export async function collectAssertionTemplateSourceReferences(
   rawEvalCase: JsonObject & {
+    readonly experiment?: JsonValue;
     readonly execution?: JsonValue;
     readonly assertions?: JsonValue;
     readonly evaluators?: JsonValue;
@@ -257,7 +259,7 @@ export async function collectAssertionTemplateSourceReferences(
   searchRoots: readonly string[],
   evalId: string,
 ): Promise<readonly EvalSourceReference[]> {
-  const execution = rawEvalCase.execution;
+  const execution = rawEvalCase.experiment ?? rawEvalCase.execution;
   const executionObject = isJsonObject(execution) ? execution : undefined;
   const caseEvaluators =
     rawEvalCase.assertions ??

--- a/packages/core/src/evaluation/loaders/grader-parser.ts
+++ b/packages/core/src/evaluation/loaders/grader-parser.ts
@@ -54,7 +54,6 @@ function isDeprecatedJudgeType(type: string): boolean {
 export async function parseGraders(
   rawEvalCase: JsonObject & {
     readonly experiment?: JsonValue;
-    readonly execution?: JsonValue;
     readonly assertions?: JsonValue;
     readonly evaluators?: JsonValue;
     readonly assert?: JsonValue;
@@ -64,18 +63,18 @@ export async function parseGraders(
   evalId: string,
   defaultPreprocessors?: readonly ContentPreprocessorConfig[],
 ): Promise<readonly GraderConfig[] | undefined> {
-  const execution = rawEvalCase.experiment ?? rawEvalCase.execution;
-  const executionObject = isJsonObject(execution) ? execution : undefined;
+  const experiment = rawEvalCase.experiment;
+  const experimentObject = isJsonObject(experiment) ? experiment : undefined;
 
-  // Case-level graders priority: assertions > assert > legacy execution/top-level assertion lists
+  // Case-level graders priority: assertions > assert > experiment/top-level assertion lists
   const caseEvaluators =
     rawEvalCase.assertions ??
     rawEvalCase.assert ??
-    (executionObject ? executionObject.evaluators : undefined) ?? // deprecated: use assertions
+    (experimentObject ? experimentObject.evaluators : undefined) ?? // deprecated: use assertions
     rawEvalCase.evaluators; // deprecated: use assertions
 
-  // Root-level default graders: assertions > assert > legacy execution assertion list
-  const skipDefaults = executionObject?.skip_defaults === true;
+  // Root-level default graders: assertions > assert > experiment assertion list
+  const skipDefaults = experimentObject?.skip_defaults === true;
   const rootEvaluators = skipDefaults
     ? undefined
     : (globalExecution?.assertions ?? globalExecution?.assert ?? globalExecution?.evaluators); // deprecated: use assertions
@@ -250,7 +249,6 @@ async function expandGraderEntries(
 export async function collectAssertionTemplateSourceReferences(
   rawEvalCase: JsonObject & {
     readonly experiment?: JsonValue;
-    readonly execution?: JsonValue;
     readonly assertions?: JsonValue;
     readonly evaluators?: JsonValue;
     readonly assert?: JsonValue;
@@ -259,14 +257,14 @@ export async function collectAssertionTemplateSourceReferences(
   searchRoots: readonly string[],
   evalId: string,
 ): Promise<readonly EvalSourceReference[]> {
-  const execution = rawEvalCase.experiment ?? rawEvalCase.execution;
-  const executionObject = isJsonObject(execution) ? execution : undefined;
+  const experiment = rawEvalCase.experiment;
+  const experimentObject = isJsonObject(experiment) ? experiment : undefined;
   const caseEvaluators =
     rawEvalCase.assertions ??
     rawEvalCase.assert ??
-    (executionObject ? executionObject.evaluators : undefined) ??
+    (experimentObject ? experimentObject.evaluators : undefined) ??
     rawEvalCase.evaluators;
-  const skipDefaults = executionObject?.skip_defaults === true;
+  const skipDefaults = experimentObject?.skip_defaults === true;
   const rootEvaluators = skipDefaults
     ? undefined
     : (globalExecution?.assertions ?? globalExecution?.assert ?? globalExecution?.evaluators);

--- a/packages/core/src/evaluation/loaders/jsonl-parser.ts
+++ b/packages/core/src/evaluation/loaders/jsonl-parser.ts
@@ -39,7 +39,7 @@ function matchesFilter(id: string, filter: string | readonly string[]): boolean 
 type SidecarMetadata = {
   readonly description?: string;
   readonly name?: string;
-  readonly execution?: JsonObject;
+  readonly experiment?: JsonObject;
   readonly evaluator?: JsonValue;
 };
 
@@ -54,7 +54,7 @@ type RawJsonlEvalCase = JsonObject & {
   readonly expected_outcome?: JsonValue;
   readonly input?: JsonValue;
   readonly expected_output?: JsonValue;
-  readonly execution?: JsonValue;
+  readonly experiment?: JsonValue;
   readonly evaluators?: JsonValue;
   readonly rubrics?: JsonValue;
 };
@@ -98,11 +98,16 @@ async function loadSidecarMetadata(jsonlPath: string, verbose: boolean): Promise
       logWarning(`Invalid sidecar metadata format in ${sidecarPath}`);
       return {};
     }
+    if (parsed.execution !== undefined) {
+      throw new Error(
+        `Invalid sidecar metadata in ${sidecarPath}: 'execution' has been removed. Use 'experiment' instead.`,
+      );
+    }
 
     return {
       description: asString(parsed.description),
       name: asString(parsed.name),
-      execution: isJsonObject(parsed.execution) ? parsed.execution : undefined,
+      experiment: isJsonObject(parsed.experiment) ? parsed.experiment : undefined,
       evaluator: parsed.evaluator,
     };
   } catch (error) {
@@ -168,7 +173,7 @@ export async function loadTestsFromJsonl(
 
   // Global defaults from sidecar
   const globalEvaluator = coerceEvaluator(sidecar.evaluator, 'sidecar') ?? 'llm-grader';
-  const globalExecution = sidecar.execution;
+  const globalExecution = sidecar.experiment;
 
   if (verbose) {
     console.log(`\n[JSONL Suite: ${evalFilePath}]`);
@@ -267,9 +272,15 @@ export async function loadTestsFromJsonl(
       .filter((part) => part.length > 0)
       .join(' ');
 
-    // Merge execution config: per-case overrides sidecar
-    const caseExecution = isJsonObject(testCaseConfig.execution)
-      ? testCaseConfig.execution
+    if ((testCaseConfig as Record<string, unknown>).execution !== undefined) {
+      throw new Error(
+        `Line ${lineNumber}: 'execution' has been removed from JSONL eval cases. Use 'experiment' instead.\n  File: ${evalFilePath}`,
+      );
+    }
+
+    // Merge experiment config: per-case overrides sidecar
+    const caseExecution = isJsonObject(testCaseConfig.experiment)
+      ? testCaseConfig.experiment
       : undefined;
     const mergedExecution = caseExecution ?? globalExecution;
 

--- a/packages/core/src/evaluation/run-budget-tracker.ts
+++ b/packages/core/src/evaluation/run-budget-tracker.ts
@@ -1,7 +1,7 @@
 /**
  * Tracks cumulative cost across all eval files in a single CLI run.
  *
- * The per-suite budget (`execution.budget_usd` in YAML) is enforced by the orchestrator
+ * The per-suite budget (`experiment.budget_usd` in YAML) is enforced by the orchestrator
  * and caps spend within one eval file. This tracker provides a **run-level** cap that
  * spans all files in a single `agentv run` invocation.
  *

--- a/packages/core/src/evaluation/validation/eval-file.schema.ts
+++ b/packages/core/src/evaluation/validation/eval-file.schema.ts
@@ -447,7 +447,6 @@ const EvalTestSchema = z
     assertions: z.array(EvaluatorSchema).optional(),
     evaluators: z.array(EvaluatorSchema).optional(),
     experiment: TestExecutionSchema.optional(),
-    execution: TestExecutionSchema.optional(),
     run: RunOverrideSchema.optional(),
     workspace: WorkspaceSchema.optional(),
     metadata: z.record(z.unknown()).optional(),
@@ -461,8 +460,15 @@ const EvalTestSchema = z
     on_turn_failure: z.enum(['continue', 'stop']).optional(),
     window_size: z.number().int().min(1).optional(),
   })
-  .refine((value) => value.experiment === undefined || value.execution === undefined, {
-    message: "Use either per-test 'experiment' or legacy 'execution', not both.",
+  .passthrough()
+  .superRefine((value, ctx) => {
+    if ('execution' in value) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['execution'],
+        message: "'execution' has been removed. Use 'experiment' instead.",
+      });
+    }
   });
 
 const SelectPatternSchema = z.union([z.string().min(1), z.array(z.string().min(1)).min(1)]);
@@ -519,7 +525,7 @@ const TestsSchema = z.union([
 // Top-level eval file
 // ---------------------------------------------------------------------------
 
-export const EvalFileSchema = z
+export const EvalFileSchema: z.ZodTypeAny = z
   .object({
     $schema: z.string().optional(),
     // Metadata
@@ -546,9 +552,8 @@ export const EvalFileSchema = z
     eval_cases: TestsSchema.optional(),
     // Target
     target: z.string().optional(),
-    // Runtime. `experiment` is canonical; `execution` is a legacy top-level alias.
+    // Runtime.
     experiment: ExperimentRuntimeSchema.optional(),
-    execution: ExperimentRuntimeSchema.optional(),
     // Suite-level assertions
     assertions: z.array(EvaluatorSchema).optional(),
     // Suite-level content preprocessors shared by evaluators
@@ -556,8 +561,15 @@ export const EvalFileSchema = z
     // Workspace (inline object or path to external workspace YAML file)
     workspace: z.union([WorkspaceSchema, z.string()]).optional(),
   })
-  .refine((value) => value.experiment === undefined || value.execution === undefined, {
-    message: "Use either top-level 'experiment' or legacy 'execution', not both.",
+  .passthrough()
+  .superRefine((value, ctx) => {
+    if ('execution' in value) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['execution'],
+        message: "'execution' has been removed. Use 'experiment' instead.",
+      });
+    }
   })
   .refine(
     (value) =>

--- a/packages/core/src/evaluation/validation/eval-file.schema.ts
+++ b/packages/core/src/evaluation/validation/eval-file.schema.ts
@@ -436,29 +436,34 @@ const ConversationTurnSchema = z.object({
 
 const TestExecutionSchema = ExecutionSchema.omit({ target: true, targets: true }).strict();
 
-const EvalTestSchema = z.object({
-  id: z.string().min(1),
-  vars: JsonObjectSchema.optional(),
-  criteria: z.string().optional(),
-  input: InputSchema.optional(),
-  input_files: z.array(z.string()).optional(),
-  expected_output: ExpectedOutputSchema.optional(),
-  assertions: z.array(EvaluatorSchema).optional(),
-  evaluators: z.array(EvaluatorSchema).optional(),
-  execution: TestExecutionSchema.optional(),
-  run: RunOverrideSchema.optional(),
-  workspace: WorkspaceSchema.optional(),
-  metadata: z.record(z.unknown()).optional(),
-  conversation_id: z.string().optional(),
-  suite: z.string().optional(),
-  depends_on: z.array(z.string()).optional(),
-  on_dependency_failure: z.enum(['skip', 'fail', 'run']).optional(),
-  mode: z.enum(['conversation']).optional(),
-  turns: z.array(ConversationTurnSchema).min(1).optional(),
-  aggregation: z.enum(['mean', 'min', 'max']).optional(),
-  on_turn_failure: z.enum(['continue', 'stop']).optional(),
-  window_size: z.number().int().min(1).optional(),
-});
+const EvalTestSchema = z
+  .object({
+    id: z.string().min(1),
+    vars: JsonObjectSchema.optional(),
+    criteria: z.string().optional(),
+    input: InputSchema.optional(),
+    input_files: z.array(z.string()).optional(),
+    expected_output: ExpectedOutputSchema.optional(),
+    assertions: z.array(EvaluatorSchema).optional(),
+    evaluators: z.array(EvaluatorSchema).optional(),
+    experiment: TestExecutionSchema.optional(),
+    execution: TestExecutionSchema.optional(),
+    run: RunOverrideSchema.optional(),
+    workspace: WorkspaceSchema.optional(),
+    metadata: z.record(z.unknown()).optional(),
+    conversation_id: z.string().optional(),
+    suite: z.string().optional(),
+    depends_on: z.array(z.string()).optional(),
+    on_dependency_failure: z.enum(['skip', 'fail', 'run']).optional(),
+    mode: z.enum(['conversation']).optional(),
+    turns: z.array(ConversationTurnSchema).min(1).optional(),
+    aggregation: z.enum(['mean', 'min', 'max']).optional(),
+    on_turn_failure: z.enum(['continue', 'stop']).optional(),
+    window_size: z.number().int().min(1).optional(),
+  })
+  .refine((value) => value.experiment === undefined || value.execution === undefined, {
+    message: "Use either per-test 'experiment' or legacy 'execution', not both.",
+  });
 
 const SelectPatternSchema = z.union([z.string().min(1), z.array(z.string().min(1)).min(1)]);
 const SelectMetadataValueSchema = z.union([

--- a/packages/core/src/evaluation/validation/eval-validator.ts
+++ b/packages/core/src/evaluation/validation/eval-validator.ts
@@ -65,7 +65,6 @@ const KNOWN_TOP_LEVEL_FIELDS = new Set([
   'tests',
   'target',
   'experiment',
-  'execution',
   'assertions',
   'evaluators',
   'preprocessors',
@@ -94,6 +93,11 @@ const KNOWN_TEST_EXECUTION_FIELDS = new Set([
   'workspace',
 ]);
 
+/** Removed top-level fields with migration hints. */
+const REMOVED_TOP_LEVEL_FIELDS = new Map<string, string>([
+  ['execution', "'execution' has been removed. Use 'experiment' instead."],
+]);
+
 /**
  * Deprecated top-level fields with migration hints.
  * These are still processed by yaml-parser but authors should migrate.
@@ -116,7 +120,7 @@ const KNOWN_TEST_FIELDS = new Set([
   'assertions',
   'evaluators',
   'rubrics',
-  'execution',
+  'experiment',
   'run',
   'workspace',
   'metadata',
@@ -129,6 +133,11 @@ const KNOWN_TEST_FIELDS = new Set([
   'aggregation',
   'on_turn_failure',
   'window_size',
+]);
+
+/** Removed test-level fields with migration hints. */
+const REMOVED_TEST_FIELDS = new Map<string, string>([
+  ['execution', "'execution' has been removed. Use 'experiment' instead."],
 ]);
 
 /**
@@ -263,19 +272,18 @@ export async function validateEvalFile(filePath: string): Promise<ValidationResu
   // Validate metadata fields
   validateMetadata(parsed, absolutePath, errors);
 
-  if (parsed.experiment !== undefined && parsed.execution !== undefined) {
-    errors.push({
-      severity: 'error',
-      filePath: absolutePath,
-      location: 'experiment',
-      message: "Use either top-level 'experiment' or legacy 'execution', not both.",
-    });
-  }
-
   // Warn on deprecated or unknown top-level fields
   for (const key of Object.keys(parsed)) {
+    const removedMessage = REMOVED_TOP_LEVEL_FIELDS.get(key);
     const deprecationMessage = DEPRECATED_TOP_LEVEL_FIELDS.get(key);
-    if (deprecationMessage) {
+    if (removedMessage) {
+      errors.push({
+        severity: 'error',
+        filePath: absolutePath,
+        location: key,
+        message: removedMessage,
+      });
+    } else if (deprecationMessage) {
       errors.push({
         severity: 'warning',
         filePath: absolutePath,
@@ -370,8 +378,16 @@ export async function validateEvalFile(filePath: string): Promise<ValidationResu
 
     // Warn on deprecated or unknown test-level fields
     for (const key of Object.keys(evalCase)) {
+      const removedMessage = REMOVED_TEST_FIELDS.get(key);
       const deprecationMessage = DEPRECATED_TEST_FIELDS.get(key);
-      if (deprecationMessage) {
+      if (removedMessage) {
+        errors.push({
+          severity: 'error',
+          filePath: absolutePath,
+          location: `${location}.${key}`,
+          message: removedMessage,
+        });
+      } else if (deprecationMessage) {
         errors.push({
           severity: 'warning',
           filePath: absolutePath,
@@ -412,14 +428,14 @@ export async function validateEvalFile(filePath: string): Promise<ValidationResu
 
     // input field (string/object shorthand or message array). When omitted,
     // AgentV accepts Vercel-style PROMPT.md fallback beside EVAL.yaml or in input_files.
-    const caseExecution = isObject(evalCase.execution) ? evalCase.execution : undefined;
+    const caseExecution = isObject(evalCase.experiment) ? evalCase.experiment : undefined;
     if (caseExecution) {
       validateTestExecutionFields(caseExecution, absolutePath, errors, location);
       rejectRuntimeWorkspaceConfig(
         caseExecution.workspace,
         absolutePath,
         errors,
-        `${location}.execution.workspace`,
+        `${location}.experiment.workspace`,
       );
     }
     const skipDefaults = caseExecution?.skip_defaults === true;
@@ -512,14 +528,6 @@ async function validateSuiteWorkspaceConfigs(
       'experiment.workspace',
     );
   }
-  if (isObject(parsed.execution)) {
-    rejectRuntimeWorkspaceConfig(
-      parsed.execution.workspace,
-      absolutePath,
-      errors,
-      'execution.workspace',
-    );
-  }
 }
 
 function validateTestExecutionFields(
@@ -533,8 +541,8 @@ function validateTestExecutionFields(
       errors.push({
         severity: 'error',
         filePath,
-        location: `${location}.execution.${key}`,
-        message: `Unsupported test execution field '${key}'.`,
+        location: `${location}.experiment.${key}`,
+        message: `Unsupported test experiment field '${key}'.`,
       });
     }
   }
@@ -711,7 +719,7 @@ async function validateCompositionDiagnostics(
     return;
   }
 
-  const parentHasRuntime = parsed.experiment !== undefined || parsed.execution !== undefined;
+  const parentHasRuntime = parsed.experiment !== undefined;
   const hasSuiteImport = imports.some((entry) => entry.type === 'suite');
 
   if (hasSuiteImport) {
@@ -735,12 +743,15 @@ async function validateCompositionDiagnostics(
         if (!childParsed) {
           continue;
         }
-        const runtimeField =
-          childParsed.experiment !== undefined
-            ? 'experiment'
-            : childParsed.execution !== undefined
-              ? 'legacy execution'
-              : undefined;
+        const runtimeField = childParsed.experiment !== undefined ? 'experiment' : undefined;
+        if (childParsed.execution !== undefined) {
+          errors.push({
+            severity: 'error',
+            filePath,
+            location: entry.location,
+            message: `Imported suite '${entry.path}' uses removed 'execution'. Use 'experiment' instead.`,
+          });
+        }
         if (!runtimeField) {
           continue;
         }
@@ -780,9 +791,6 @@ function parentWorkspaceLocations(parsed: JsonObject): readonly string[] {
   }
   if (isObject(parsed.experiment) && parsed.experiment.workspace !== undefined) {
     locations.push('experiment.workspace');
-  }
-  if (isObject(parsed.execution) && parsed.execution.workspace !== undefined) {
-    locations.push('execution.workspace');
   }
   return locations;
 }

--- a/packages/core/src/evaluation/workspace/setup.ts
+++ b/packages/core/src/evaluation/workspace/setup.ts
@@ -470,7 +470,7 @@ export async function prepareSharedWorkspaceSetup(
         'If the agent under test makes file edits, concurrent runs may corrupt each other.',
         'To limit concurrency, add this to your eval YAML:',
         '',
-        '  execution:',
+        '  experiment:',
         '    workers: 1',
         '',
         'Or pass --workers 1 on the command line.',

--- a/packages/core/src/evaluation/yaml-parser.ts
+++ b/packages/core/src/evaluation/yaml-parser.ts
@@ -177,7 +177,6 @@ type RawTestSuite = JsonObject & {
   readonly evalcases?: JsonValue;
   readonly target?: JsonValue;
   readonly experiment?: JsonValue;
-  readonly execution?: JsonValue;
   readonly workspace?: JsonValue;
   readonly assertions?: JsonValue;
   readonly preprocessors?: JsonValue;
@@ -212,7 +211,6 @@ type RawEvalCase = JsonObject & {
   readonly expected_output?: JsonValue;
   readonly evaluator?: JsonValue;
   readonly experiment?: JsonValue;
-  readonly execution?: JsonValue;
   readonly run?: JsonValue;
   readonly evaluators?: JsonValue;
   readonly assertions?: JsonValue;
@@ -330,13 +328,13 @@ export async function readTestSuiteMetadata(testFilePath: string): Promise<{
  */
 export type EvalSuiteResult = {
   readonly tests: readonly EvalTest[];
-  /** Suite-level targets from execution.targets (matrix evaluation) */
+  /** Suite-level targets from experiment.targets (matrix evaluation) */
   readonly targets?: readonly string[];
-  /** Suite-level target refs with hooks from execution.targets (object form) */
+  /** Suite-level target refs with hooks from experiment.targets (object form) */
   readonly targetRefs?: readonly import('./types.js').EvalTargetRef[];
-  /** Suite-level workers from execution.workers */
+  /** Suite-level workers from experiment.workers */
   readonly workers?: number;
-  /** Suite-level cache config from execution.cache */
+  /** Suite-level cache config from experiment.cache */
   readonly cacheConfig?: import('./loaders/config-loader.js').CacheConfig;
   /** Suite-level metadata (name, description, version, etc.) */
   readonly metadata?: import('./metadata.js').EvalMetadata;
@@ -346,7 +344,7 @@ export type EvalSuiteResult = {
   readonly failOnError?: import('./types.js').FailOnError;
   /** Suite-level quality threshold (0-1) — suite fails if mean score is below */
   readonly threshold?: number;
-  /** Top-level runtime block from `experiment:` or legacy `execution:`. */
+  /** Top-level runtime block from `experiment:`. */
   readonly experimentConfig?: ExperimentConfig;
   /** Inline target definition from a TS eval config. */
   readonly inlineTarget?: import('./providers/types.js').TargetDefinition;
@@ -535,11 +533,11 @@ async function loadTestsFromParsedYamlValue(
   const rawSuiteInput = suite.input;
   const rawSuiteInputFiles = suite.input_files;
 
-  // Extract global target from execution.target (or legacy root-level target)
+  // Extract global target from experiment.target (or legacy root-level target)
   const rawGlobalExecution = readSuiteRuntimeBlock(suite, evalFilePath);
   const _globalTarget = asString(rawGlobalExecution?.target) ?? asString(suite.target);
 
-  // Build global execution context, including suite-level assertions (which is a sibling of execution)
+  // Build global experiment context, including suite-level assertions (which is a sibling of experiment)
   // Also accept legacy `assert` key with a deprecation warning
   const suiteAssertions = suite.assertions ?? suite.assert;
   if (suite.assert !== undefined && suite.assertions === undefined) {
@@ -902,7 +900,7 @@ type IncludeSelect = {
 function rejectUnsupportedTestExecutionFields(
   caseExecution: JsonObject | undefined,
   testId: string | undefined,
-  label = 'execution',
+  label = 'experiment',
 ): void {
   if (!caseExecution) return;
   for (const key of Object.keys(caseExecution)) {
@@ -1373,35 +1371,35 @@ function parentWorkspaceLocation(suite: RawTestSuite): string | undefined {
     return 'workspace';
   }
 
-  const runtime = suite.experiment ?? suite.execution;
+  const runtime = suite.experiment;
   if (isJsonObject(runtime) && runtime.workspace !== undefined) {
-    return suite.experiment !== undefined ? 'experiment.workspace' : 'execution.workspace';
+    return 'experiment.workspace';
   }
 
   return undefined;
 }
 
 function readSuiteRuntimeBlock(suite: RawTestSuite, evalFilePath: string): JsonObject | undefined {
-  if (suite.experiment !== undefined && suite.execution !== undefined) {
+  if ((suite as Record<string, unknown>).execution !== undefined) {
     throw new Error(
-      `Invalid eval runtime config in ${evalFilePath}: use either 'experiment' or legacy 'execution', not both.`,
+      `Invalid eval runtime config in ${evalFilePath}: 'execution' has been removed. Use 'experiment' instead.`,
     );
   }
-  const runtime = suite.experiment ?? suite.execution;
+  const runtime = suite.experiment;
   return isJsonObject(runtime) ? runtime : undefined;
 }
 
 function readTestRuntimeBlock(
   testCase: RawEvalCase,
   testId: string | undefined,
-): { runtime: JsonObject | undefined; label: 'experiment' | 'execution' } {
-  if (testCase.experiment !== undefined && testCase.execution !== undefined) {
+): { runtime: JsonObject | undefined; label: 'experiment' } {
+  if ((testCase as Record<string, unknown>).execution !== undefined) {
     throw new Error(
-      `Invalid eval runtime config for test '${testId ?? 'unknown'}': use either 'experiment' or legacy 'execution', not both.`,
+      `Invalid eval runtime config for test '${testId ?? 'unknown'}': 'execution' has been removed. Use 'experiment' instead.`,
     );
   }
-  const label = testCase.experiment !== undefined ? 'experiment' : 'execution';
-  const runtime = testCase.experiment ?? testCase.execution;
+  const label = 'experiment';
+  const runtime = testCase.experiment;
   return { runtime: isJsonObject(runtime) ? runtime : undefined, label };
 }
 

--- a/packages/core/src/evaluation/yaml-parser.ts
+++ b/packages/core/src/evaluation/yaml-parser.ts
@@ -211,6 +211,7 @@ type RawEvalCase = JsonObject & {
   readonly input_files?: JsonValue;
   readonly expected_output?: JsonValue;
   readonly evaluator?: JsonValue;
+  readonly experiment?: JsonValue;
   readonly execution?: JsonValue;
   readonly run?: JsonValue;
   readonly evaluators?: JsonValue;
@@ -579,12 +580,13 @@ async function loadTestsFromParsedYamlValue(
       }
     }
 
-    // Extract per-case execution config early (reused below for skip_defaults)
-    const caseExecution = isJsonObject(renderedCase.execution) ? renderedCase.execution : undefined;
-    rejectUnsupportedTestExecutionFields(caseExecution, id);
+    // Extract per-case runtime config early (reused below for skip_defaults)
+    const caseRuntime = readTestRuntimeBlock(renderedCase, id);
+    const caseExecution = caseRuntime.runtime;
+    rejectUnsupportedTestExecutionFields(caseExecution, id, caseRuntime.label);
     if (caseExecution?.workspace !== undefined) {
       throw new Error(
-        `test '${id ?? 'unknown'}'.execution.workspace has been removed from eval YAML. Put machine-local workspace_path/workspace_mode in .agentv/config.local.yaml under execution, or pass --workspace-path/--workspace-mode. Keep portable task setup in test workspace or suite workspace.`,
+        `test '${id ?? 'unknown'}'.${caseRuntime.label}.workspace has been removed from eval YAML. Put machine-local workspace_path/workspace_mode in .agentv/config.local.yaml under execution, or pass --workspace-path/--workspace-mode. Keep portable task setup in test workspace or suite workspace.`,
       );
     }
     const skipDefaults = caseExecution?.skip_defaults === true;
@@ -900,11 +902,12 @@ type IncludeSelect = {
 function rejectUnsupportedTestExecutionFields(
   caseExecution: JsonObject | undefined,
   testId: string | undefined,
+  label = 'execution',
 ): void {
   if (!caseExecution) return;
   for (const key of Object.keys(caseExecution)) {
     if (!KNOWN_TEST_EXECUTION_FIELDS.has(key)) {
-      throw new Error(`test '${testId ?? 'unknown'}'.execution.${key} is not supported.`);
+      throw new Error(`test '${testId ?? 'unknown'}'.${label}.${key} is not supported.`);
     }
   }
 }
@@ -1386,6 +1389,20 @@ function readSuiteRuntimeBlock(suite: RawTestSuite, evalFilePath: string): JsonO
   }
   const runtime = suite.experiment ?? suite.execution;
   return isJsonObject(runtime) ? runtime : undefined;
+}
+
+function readTestRuntimeBlock(
+  testCase: RawEvalCase,
+  testId: string | undefined,
+): { runtime: JsonObject | undefined; label: 'experiment' | 'execution' } {
+  if (testCase.experiment !== undefined && testCase.execution !== undefined) {
+    throw new Error(
+      `Invalid eval runtime config for test '${testId ?? 'unknown'}': use either 'experiment' or legacy 'execution', not both.`,
+    );
+  }
+  const label = testCase.experiment !== undefined ? 'experiment' : 'execution';
+  const runtime = testCase.experiment ?? testCase.execution;
+  return { runtime: isJsonObject(runtime) ? runtime : undefined, label };
 }
 
 function normalizeSuiteExperimentConfig(parsed: JsonObject): ExperimentConfig | undefined {

--- a/packages/core/test/evaluation/cache-config.test.ts
+++ b/packages/core/test/evaluation/cache-config.test.ts
@@ -4,42 +4,42 @@ import { extractCacheConfig } from '../../src/evaluation/loaders/config-loader.j
 import type { JsonObject } from '../../src/evaluation/types.js';
 
 describe('extractCacheConfig', () => {
-  it('should return undefined when no execution block', () => {
+  it('should return undefined when no experiment block', () => {
     const suite: JsonObject = { tests: [] };
     expect(extractCacheConfig(suite)).toBeUndefined();
   });
 
   it('should return undefined when no cache field', () => {
-    const suite: JsonObject = { execution: { target: 'default' } };
+    const suite: JsonObject = { experiment: { target: 'default' } };
     expect(extractCacheConfig(suite)).toBeUndefined();
   });
 
   it('should parse cache: true', () => {
-    const suite: JsonObject = { execution: { cache: true } };
+    const suite: JsonObject = { experiment: { cache: true } };
     const result = extractCacheConfig(suite);
     expect(result).toEqual({ enabled: true, cachePath: undefined });
   });
 
   it('should parse cache: false', () => {
-    const suite: JsonObject = { execution: { cache: false } };
+    const suite: JsonObject = { experiment: { cache: false } };
     const result = extractCacheConfig(suite);
     expect(result).toEqual({ enabled: false, cachePath: undefined });
   });
 
   it('should parse cache_path', () => {
-    const suite: JsonObject = { execution: { cache: true, cache_path: '.agentv/my-cache' } };
+    const suite: JsonObject = { experiment: { cache: true, cache_path: '.agentv/my-cache' } };
     const result = extractCacheConfig(suite);
     expect(result).toEqual({ enabled: true, cachePath: '.agentv/my-cache' });
   });
 
   it('should ignore camelCase cachePath on the YAML wire surface', () => {
-    const suite: JsonObject = { execution: { cache: true, cachePath: 'custom/cache' } };
+    const suite: JsonObject = { experiment: { cache: true, cachePath: 'custom/cache' } };
     const result = extractCacheConfig(suite);
     expect(result).toEqual({ enabled: true, cachePath: undefined });
   });
 
   it('should return undefined for invalid cache value', () => {
-    const suite: JsonObject = { execution: { cache: 'yes' } };
+    const suite: JsonObject = { experiment: { cache: 'yes' } };
     expect(extractCacheConfig(suite)).toBeUndefined();
   });
 });

--- a/packages/core/test/evaluation/eval-inline-experiment.test.ts
+++ b/packages/core/test/evaluation/eval-inline-experiment.test.ts
@@ -113,6 +113,48 @@ describe('eval.yaml inline experiment and tests imports', () => {
     );
   });
 
+  it('parses per-test experiment as the canonical runtime override', async () => {
+    const evalPath = path.join(tempDir, 'test-experiment.eval.yaml');
+    await writeFile(
+      evalPath,
+      [
+        'tests:',
+        '  - id: one',
+        '    input: hello',
+        '    criteria: ok',
+        '    experiment:',
+        '      threshold: 0.42',
+        '      skip_defaults: true',
+        '',
+      ].join('\n'),
+    );
+
+    const suite = await loadTestSuite(evalPath, tempDir);
+
+    expect(suite.tests[0]?.threshold).toBe(0.42);
+    expect(suite.tests[0]?.run?.threshold).toBe(0.42);
+  });
+
+  it('rejects test cases that define both experiment and execution runtime blocks', async () => {
+    const evalPath = path.join(tempDir, 'test-runtime-conflict.eval.yaml');
+    await writeFile(
+      evalPath,
+      [
+        'tests:',
+        '  - id: one',
+        '    input: hello',
+        '    criteria: ok',
+        '    experiment:',
+        '      threshold: 0.42',
+        '    execution:',
+        '      threshold: 0.7',
+        '',
+      ].join('\n'),
+    );
+
+    await expect(loadTestSuite(evalPath, tempDir)).rejects.toThrow(/experiment.*execution/);
+  });
+
   it('rejects unsupported per-test execution target blocks', async () => {
     const evalPath = path.join(tempDir, 'test-execution-target.eval.yaml');
     await writeFile(

--- a/packages/core/test/evaluation/eval-inline-experiment.test.ts
+++ b/packages/core/test/evaluation/eval-inline-experiment.test.ts
@@ -53,7 +53,7 @@ describe('eval.yaml inline experiment and tests imports', () => {
     expect(suite.workers).toBe(2);
   });
 
-  it('accepts top-level execution as a legacy runtime alias but rejects both blocks', async () => {
+  it('rejects top-level execution because experiment is the only runtime block', async () => {
     const legacyPath = path.join(tempDir, 'legacy.eval.yaml');
     await writeFile(
       legacyPath,
@@ -68,9 +68,9 @@ describe('eval.yaml inline experiment and tests imports', () => {
       ].join('\n'),
     );
 
-    const legacy = await loadTestSuite(legacyPath, tempDir);
-    expect(legacy.experimentConfig?.target).toBe('mock');
-    expect(legacy.targets).toBeUndefined();
+    await expect(loadTestSuite(legacyPath, tempDir)).rejects.toThrow(
+      /'execution' has been removed\. Use 'experiment' instead/,
+    );
 
     const conflictPath = path.join(tempDir, 'conflict.eval.yaml');
     await writeFile(
@@ -88,7 +88,9 @@ describe('eval.yaml inline experiment and tests imports', () => {
       ].join('\n'),
     );
 
-    await expect(loadTestSuite(conflictPath, tempDir)).rejects.toThrow(/experiment.*execution/);
+    await expect(loadTestSuite(conflictPath, tempDir)).rejects.toThrow(
+      /'execution' has been removed\. Use 'experiment' instead/,
+    );
   });
 
   it('rejects per-test execution workspace blocks', async () => {
@@ -109,7 +111,7 @@ describe('eval.yaml inline experiment and tests imports', () => {
     );
 
     await expect(loadTestSuite(evalPath, tempDir)).rejects.toThrow(
-      /execution\.workspace has been removed from eval YAML/,
+      /'execution' has been removed\. Use 'experiment' instead/,
     );
   });
 
@@ -135,7 +137,7 @@ describe('eval.yaml inline experiment and tests imports', () => {
     expect(suite.tests[0]?.run?.threshold).toBe(0.42);
   });
 
-  it('rejects test cases that define both experiment and execution runtime blocks', async () => {
+  it('rejects test cases that use removed execution runtime blocks', async () => {
     const evalPath = path.join(tempDir, 'test-runtime-conflict.eval.yaml');
     await writeFile(
       evalPath,
@@ -144,18 +146,18 @@ describe('eval.yaml inline experiment and tests imports', () => {
         '  - id: one',
         '    input: hello',
         '    criteria: ok',
-        '    experiment:',
-        '      threshold: 0.42',
         '    execution:',
         '      threshold: 0.7',
         '',
       ].join('\n'),
     );
 
-    await expect(loadTestSuite(evalPath, tempDir)).rejects.toThrow(/experiment.*execution/);
+    await expect(loadTestSuite(evalPath, tempDir)).rejects.toThrow(
+      /'execution' has been removed\. Use 'experiment' instead/,
+    );
   });
 
-  it('rejects unsupported per-test execution target blocks', async () => {
+  it('rejects unsupported per-test experiment target blocks', async () => {
     const evalPath = path.join(tempDir, 'test-execution-target.eval.yaml');
     await writeFile(
       evalPath,
@@ -164,14 +166,14 @@ describe('eval.yaml inline experiment and tests imports', () => {
         '  - id: one',
         '    input: hello',
         '    criteria: ok',
-        '    execution:',
+        '    experiment:',
         '      target: codex',
         '',
       ].join('\n'),
     );
 
     await expect(loadTestSuite(evalPath, tempDir)).rejects.toThrow(
-      "test 'one'.execution.target is not supported.",
+      "test 'one'.experiment.target is not supported.",
     );
   });
 
@@ -600,7 +602,7 @@ describe('eval.yaml inline experiment and tests imports', () => {
     );
   });
 
-  it('rejects legacy execution workspace when importing eval suites with type: suite', async () => {
+  it('rejects removed execution workspace when importing eval suites with type: suite', async () => {
     await writeFile(
       path.join(tempDir, 'child.eval.yaml'),
       [
@@ -628,7 +630,7 @@ describe('eval.yaml inline experiment and tests imports', () => {
     );
 
     await expect(loadTestSuite(parentPath, tempDir)).rejects.toThrow(
-      /Experiment workspace has been removed from eval YAML/,
+      /'execution' has been removed\. Use 'experiment' instead/,
     );
   });
 

--- a/packages/core/test/evaluation/input-files-shorthand.test.ts
+++ b/packages/core/test/evaluation/input-files-shorthand.test.ts
@@ -239,7 +239,7 @@ tests:
   - id: no-suite-files
     criteria: "Skips suite files"
     input: "Plain question."
-    execution:
+    experiment:
       skip_defaults: true
 `,
     );

--- a/packages/core/test/evaluation/loaders/config-loader.test.ts
+++ b/packages/core/test/evaluation/loaders/config-loader.test.ts
@@ -512,8 +512,8 @@ describe('resolveResultsConfigForProject', () => {
 });
 
 describe('extractTargetFromSuite', () => {
-  it('extracts target from execution.target', () => {
-    const suite: JsonObject = { execution: { target: 'my-target' } };
+  it('extracts target from experiment.target', () => {
+    const suite: JsonObject = { experiment: { target: 'my-target' } };
     expect(extractTargetFromSuite(suite)).toBe('my-target');
   });
 
@@ -522,10 +522,10 @@ describe('extractTargetFromSuite', () => {
     expect(extractTargetFromSuite(suite)).toBe('legacy-target');
   });
 
-  it('prefers execution.target over root-level target', () => {
+  it('prefers experiment.target over root-level target', () => {
     const suite: JsonObject = {
       target: 'legacy',
-      execution: { target: 'new' },
+      experiment: { target: 'new' },
     };
     expect(extractTargetFromSuite(suite)).toBe('new');
   });
@@ -537,68 +537,68 @@ describe('extractTargetFromSuite', () => {
 });
 
 describe('extractTargetsFromSuite', () => {
-  it('returns undefined when no execution block', () => {
+  it('returns undefined when no experiment block', () => {
     const suite: JsonObject = { tests: [] };
     expect(extractTargetsFromSuite(suite)).toBeUndefined();
   });
 
-  it('returns undefined when no targets array in execution', () => {
-    const suite: JsonObject = { execution: { target: 'default' } };
+  it('returns undefined when no targets array in experiment', () => {
+    const suite: JsonObject = { experiment: { target: 'default' } };
     expect(extractTargetsFromSuite(suite)).toBeUndefined();
   });
 
-  it('extracts targets array from execution.targets', () => {
+  it('extracts targets array from experiment.targets', () => {
     const suite: JsonObject = {
-      execution: { targets: ['copilot', 'claude'] },
+      experiment: { targets: ['copilot', 'claude'] },
     };
     expect(extractTargetsFromSuite(suite)).toEqual(['copilot', 'claude']);
   });
 
   it('filters out non-string entries', () => {
     const suite: JsonObject = {
-      execution: { targets: ['copilot', 123, null, 'claude'] },
+      experiment: { targets: ['copilot', 123, null, 'claude'] },
     };
     expect(extractTargetsFromSuite(suite)).toEqual(['copilot', 'claude']);
   });
 
   it('returns undefined for empty targets array', () => {
     const suite: JsonObject = {
-      execution: { targets: [] },
+      experiment: { targets: [] },
     };
     expect(extractTargetsFromSuite(suite)).toBeUndefined();
   });
 
   it('trims whitespace from target names', () => {
     const suite: JsonObject = {
-      execution: { targets: ['  copilot  ', 'claude  '] },
+      experiment: { targets: ['  copilot  ', 'claude  '] },
     };
     expect(extractTargetsFromSuite(suite)).toEqual(['copilot', 'claude']);
   });
 
   it('returns undefined when targets is not an array', () => {
     const suite: JsonObject = {
-      execution: { targets: 'copilot' },
+      experiment: { targets: 'copilot' },
     };
     expect(extractTargetsFromSuite(suite)).toBeUndefined();
   });
 });
 
 describe('extractTargetRefsFromSuite', () => {
-  it('returns undefined when no execution block', () => {
+  it('returns undefined when no experiment block', () => {
     const suite: JsonObject = { tests: [] };
     expect(extractTargetRefsFromSuite(suite)).toBeUndefined();
   });
 
   it('returns refs for string targets', () => {
     const suite: JsonObject = {
-      execution: { targets: ['copilot', 'claude'] },
+      experiment: { targets: ['copilot', 'claude'] },
     };
     expect(extractTargetRefsFromSuite(suite)).toEqual([{ name: 'copilot' }, { name: 'claude' }]);
   });
 
   it('returns refs for object targets with hooks', () => {
     const suite: JsonObject = {
-      execution: {
+      experiment: {
         targets: [
           { name: 'baseline' },
           {
@@ -625,7 +625,7 @@ describe('extractTargetRefsFromSuite', () => {
 
   it('handles mixed string and object targets', () => {
     const suite: JsonObject = {
-      execution: {
+      experiment: {
         targets: [
           'baseline',
           {
@@ -647,7 +647,7 @@ describe('extractTargetRefsFromSuite', () => {
 
   it('parses string command as shell command', () => {
     const suite: JsonObject = {
-      execution: {
+      experiment: {
         targets: [
           {
             name: 'test',
@@ -668,7 +668,7 @@ describe('extractTargetRefsFromSuite', () => {
 
   it('skips invalid entries', () => {
     const suite: JsonObject = {
-      execution: {
+      experiment: {
         targets: ['valid', 123, null, { name: '' }, { name: 'also-valid' }],
       },
     };
@@ -678,7 +678,7 @@ describe('extractTargetRefsFromSuite', () => {
 
   it('extractTargetsFromSuite derives names from refs', () => {
     const suite: JsonObject = {
-      execution: {
+      experiment: {
         targets: [
           'baseline',
           {
@@ -694,131 +694,131 @@ describe('extractTargetRefsFromSuite', () => {
 });
 
 describe('extractBudgetUsd', () => {
-  it('returns undefined when no execution block', () => {
+  it('returns undefined when no experiment block', () => {
     const suite: JsonObject = { tests: [] };
     expect(extractBudgetUsd(suite)).toBeUndefined();
   });
 
-  it('returns undefined when no budget_usd in execution', () => {
-    const suite: JsonObject = { execution: { target: 'default' } };
+  it('returns undefined when no budget_usd in experiment', () => {
+    const suite: JsonObject = { experiment: { target: 'default' } };
     expect(extractBudgetUsd(suite)).toBeUndefined();
   });
 
   it('parses valid budget_usd (snake_case)', () => {
-    const suite: JsonObject = { execution: { budget_usd: 10.0 } };
+    const suite: JsonObject = { experiment: { budget_usd: 10.0 } };
     expect(extractBudgetUsd(suite)).toBe(10.0);
   });
 
   it('parses valid budgetUsd (camelCase)', () => {
-    const suite: JsonObject = { execution: { budgetUsd: 5.5 } };
+    const suite: JsonObject = { experiment: { budgetUsd: 5.5 } };
     expect(extractBudgetUsd(suite)).toBe(5.5);
   });
 
   it('returns undefined for zero budget', () => {
-    const suite: JsonObject = { execution: { budget_usd: 0 } };
+    const suite: JsonObject = { experiment: { budget_usd: 0 } };
     expect(extractBudgetUsd(suite)).toBeUndefined();
   });
 
   it('returns undefined for negative budget', () => {
-    const suite: JsonObject = { execution: { budget_usd: -1 } };
+    const suite: JsonObject = { experiment: { budget_usd: -1 } };
     expect(extractBudgetUsd(suite)).toBeUndefined();
   });
 
   it('returns undefined for non-number budget', () => {
-    const suite: JsonObject = { execution: { budget_usd: 'ten' } };
+    const suite: JsonObject = { experiment: { budget_usd: 'ten' } };
     expect(extractBudgetUsd(suite)).toBeUndefined();
   });
 
   it('rejects old key total_budget_usd with a clear error', () => {
-    const suite: JsonObject = { execution: { total_budget_usd: 10.0 } };
+    const suite: JsonObject = { experiment: { total_budget_usd: 10.0 } };
     expect(() => extractBudgetUsd(suite)).toThrow(
-      'execution.total_budget_usd has been renamed to execution.budget_usd. Update your eval YAML.',
+      'experiment.total_budget_usd has been renamed to experiment.budget_usd. Update your eval YAML.',
     );
   });
 
   it('rejects old key totalBudgetUsd with a clear error', () => {
-    const suite: JsonObject = { execution: { totalBudgetUsd: 10.0 } };
+    const suite: JsonObject = { experiment: { totalBudgetUsd: 10.0 } };
     expect(() => extractBudgetUsd(suite)).toThrow(
-      'execution.total_budget_usd has been renamed to execution.budget_usd. Update your eval YAML.',
+      'experiment.total_budget_usd has been renamed to experiment.budget_usd. Update your eval YAML.',
     );
   });
 });
 
 describe('extractFailOnError', () => {
-  it('returns undefined when no execution block', () => {
+  it('returns undefined when no experiment block', () => {
     const suite: JsonObject = { tests: [] };
     expect(extractFailOnError(suite)).toBeUndefined();
   });
 
   it('returns undefined when fail_on_error not set', () => {
-    const suite: JsonObject = { execution: { target: 'default' } };
+    const suite: JsonObject = { experiment: { target: 'default' } };
     expect(extractFailOnError(suite)).toBeUndefined();
   });
 
   it('returns true for fail_on_error: true', () => {
-    const suite: JsonObject = { execution: { fail_on_error: true } };
+    const suite: JsonObject = { experiment: { fail_on_error: true } };
     expect(extractFailOnError(suite)).toBe(true);
   });
 
   it('returns false for fail_on_error: false', () => {
-    const suite: JsonObject = { execution: { fail_on_error: false } };
+    const suite: JsonObject = { experiment: { fail_on_error: false } };
     expect(extractFailOnError(suite)).toBe(false);
   });
 
   it('returns undefined for numeric value', () => {
-    const suite: JsonObject = { execution: { fail_on_error: 0.3 } };
+    const suite: JsonObject = { experiment: { fail_on_error: 0.3 } };
     expect(extractFailOnError(suite)).toBeUndefined();
   });
 
   it('returns undefined for invalid string value', () => {
-    const suite: JsonObject = { execution: { fail_on_error: 'always' } };
+    const suite: JsonObject = { experiment: { fail_on_error: 'always' } };
     expect(extractFailOnError(suite)).toBeUndefined();
   });
 
   it('supports camelCase failOnError alias', () => {
-    const suite: JsonObject = { execution: { failOnError: true } };
+    const suite: JsonObject = { experiment: { failOnError: true } };
     expect(extractFailOnError(suite)).toBe(true);
   });
 });
 
 describe('extractThreshold', () => {
-  it('returns undefined when no execution block', () => {
+  it('returns undefined when no experiment block', () => {
     const suite: JsonObject = { tests: [] };
     expect(extractThreshold(suite)).toBeUndefined();
   });
 
   it('returns undefined when threshold not set', () => {
-    const suite: JsonObject = { execution: { target: 'default' } };
+    const suite: JsonObject = { experiment: { target: 'default' } };
     expect(extractThreshold(suite)).toBeUndefined();
   });
 
   it('parses valid threshold', () => {
-    const suite: JsonObject = { execution: { threshold: 0.8 } };
+    const suite: JsonObject = { experiment: { threshold: 0.8 } };
     expect(extractThreshold(suite)).toBe(0.8);
   });
 
   it('accepts 0 as threshold', () => {
-    const suite: JsonObject = { execution: { threshold: 0 } };
+    const suite: JsonObject = { experiment: { threshold: 0 } };
     expect(extractThreshold(suite)).toBe(0);
   });
 
   it('accepts 1 as threshold', () => {
-    const suite: JsonObject = { execution: { threshold: 1 } };
+    const suite: JsonObject = { experiment: { threshold: 1 } };
     expect(extractThreshold(suite)).toBe(1);
   });
 
   it('returns undefined for negative threshold', () => {
-    const suite: JsonObject = { execution: { threshold: -0.1 } };
+    const suite: JsonObject = { experiment: { threshold: -0.1 } };
     expect(extractThreshold(suite)).toBeUndefined();
   });
 
   it('returns undefined for threshold > 1', () => {
-    const suite: JsonObject = { execution: { threshold: 1.5 } };
+    const suite: JsonObject = { experiment: { threshold: 1.5 } };
     expect(extractThreshold(suite)).toBeUndefined();
   });
 
   it('returns undefined for non-number threshold', () => {
-    const suite: JsonObject = { execution: { threshold: 'high' } };
+    const suite: JsonObject = { experiment: { threshold: 'high' } };
     expect(extractThreshold(suite)).toBeUndefined();
   });
 });

--- a/packages/core/test/evaluation/loaders/fixtures/sdk-define-eval.eval.ts
+++ b/packages/core/test/evaluation/loaders/fixtures/sdk-define-eval.eval.ts
@@ -5,7 +5,7 @@ const suite = {
   name: 'sdk-define-eval-suite',
   description: 'YAML-aligned TypeScript suite authored with @agentv/sdk',
   tags: ['sdk', 'typescript', 'yaml'],
-  execution: {
+  experiment: {
     targets: ['mock-target'],
     workers: 2,
     skipDefaults: true,
@@ -47,7 +47,7 @@ export default Object.defineProperties(suite, {
       name: suite.name,
       description: suite.description,
       tags: suite.tags,
-      execution: {
+      experiment: {
         targets: ['mock-target'],
         workers: 2,
         skip_defaults: true,

--- a/packages/core/test/evaluation/loaders/grader-parser.test.ts
+++ b/packages/core/test/evaluation/loaders/grader-parser.test.ts
@@ -1198,6 +1198,24 @@ describe('parseGraders - default evaluators merge', () => {
     expect(evaluators?.[0]).toEqual({ name: 'case-eval', type: 'latency', threshold: 3000 });
   });
 
+  it('reads canonical experiment evaluator overrides and skip_defaults', async () => {
+    const rawEvalCase = {
+      experiment: {
+        skip_defaults: true,
+        evaluators: [{ name: 'case-eval', type: 'latency', threshold: 3000 }],
+      },
+    };
+
+    const globalExecution = {
+      evaluators: [{ name: 'root-eval', type: 'latency', threshold: 5000 }],
+    };
+
+    const evaluators = await parseGraders(rawEvalCase, globalExecution, [process.cwd()], 'test');
+
+    expect(evaluators).toHaveLength(1);
+    expect(evaluators?.[0]).toEqual({ name: 'case-eval', type: 'latency', threshold: 3000 });
+  });
+
   it('returns undefined when no evaluators at any level', async () => {
     const rawEvalCase = {};
     const evaluators = await parseGraders(rawEvalCase, undefined, [process.cwd()], 'test');

--- a/packages/core/test/evaluation/loaders/grader-parser.test.ts
+++ b/packages/core/test/evaluation/loaders/grader-parser.test.ts
@@ -931,7 +931,7 @@ describe('parseGraders - token-usage', () => {
 
   it('inherits suite-level execution.evaluators when case has execution object without evaluators', async () => {
     const rawEvalCase = {
-      execution: {
+      experiment: {
         constraints: {
           max_total_tokens: 123,
         },
@@ -1151,7 +1151,7 @@ describe('parseGraders - execution-metrics', () => {
 describe('parseGraders - default evaluators merge', () => {
   it('appends root evaluators after case-level evaluators', async () => {
     const rawEvalCase = {
-      execution: {
+      experiment: {
         evaluators: [{ name: 'case-eval', type: 'latency', threshold: 3000 }],
       },
     };
@@ -1182,7 +1182,7 @@ describe('parseGraders - default evaluators merge', () => {
 
   it('skips root evaluators when skip_defaults is true', async () => {
     const rawEvalCase = {
-      execution: {
+      experiment: {
         skip_defaults: true,
         evaluators: [{ name: 'case-eval', type: 'latency', threshold: 3000 }],
       },
@@ -1224,7 +1224,7 @@ describe('parseGraders - default evaluators merge', () => {
 
   it('returns undefined when skip_defaults and no case evaluators', async () => {
     const rawEvalCase = {
-      execution: { skip_defaults: true },
+      experiment: { skip_defaults: true },
     };
 
     const globalExecution = {
@@ -1237,7 +1237,7 @@ describe('parseGraders - default evaluators merge', () => {
 
   it('backward compat: case with execution object but no evaluators inherits root', async () => {
     const rawEvalCase = {
-      execution: {
+      experiment: {
         constraints: { max_total_tokens: 123 },
       },
     };
@@ -1311,7 +1311,7 @@ describe('parseGraders - assert field', () => {
     const evaluators = await parseGraders(
       {
         assertions: [{ type: 'contains', value: 'DENIED' }],
-        execution: {
+        experiment: {
           evaluators: [{ name: 'latency-check', type: 'latency', threshold: 5000 }],
         },
       },
@@ -1355,7 +1355,7 @@ describe('parseGraders - assert field', () => {
     const evaluators = await parseGraders(
       {
         assertions: [{ type: 'contains', value: 'DENIED' }],
-        execution: { skip_defaults: true },
+        experiment: { skip_defaults: true },
       },
       { assertions: [{ name: 'latency-check', type: 'latency', threshold: 5000 }] },
       [tempDir],
@@ -1368,7 +1368,7 @@ describe('parseGraders - assert field', () => {
   it('falls back to execution.evaluators when assert is not present', async () => {
     const evaluators = await parseGraders(
       {
-        execution: {
+        experiment: {
           evaluators: [{ name: 'latency-check', type: 'latency', threshold: 5000 }],
         },
       },
@@ -1463,7 +1463,7 @@ assertions:
     const evaluators = await parseGraders(
       {
         assertions: [{ type: 'contains', value: 'case-only' }],
-        execution: { skip_defaults: true },
+        experiment: { skip_defaults: true },
       },
       {
         assertions: [{ include: './shared/local.yaml' }],

--- a/packages/core/test/evaluation/matrix-targets.test.ts
+++ b/packages/core/test/evaluation/matrix-targets.test.ts
@@ -15,7 +15,7 @@ function createTempYaml(content: string): { filePath: string; dir: string } {
 describe('matrix evaluation - loadTestSuite', () => {
   it('extracts suite-level targets from execution.targets', async () => {
     const { filePath, dir } = createTempYaml(`
-execution:
+experiment:
   targets:
     - copilot
     - claude
@@ -31,7 +31,7 @@ tests:
 
   it('returns undefined targets when not specified', async () => {
     const { filePath, dir } = createTempYaml(`
-execution:
+experiment:
   target: copilot
 tests:
   - id: test-1
@@ -43,9 +43,9 @@ tests:
     expect(suite.targets).toBeUndefined();
   });
 
-  it('rejects unsupported test-level execution.targets', async () => {
+  it('rejects unsupported test-level experiment.targets', async () => {
     const { filePath, dir } = createTempYaml(`
-execution:
+experiment:
   targets:
     - copilot
     - claude
@@ -56,13 +56,13 @@ tests:
   - id: copilot-only
     input: "GitHub task"
     criteria: "Reference GitHub"
-    execution:
+    experiment:
       targets:
         - copilot
 `);
 
     await expect(loadTestSuite(filePath, dir)).rejects.toThrow(
-      "test 'copilot-only'.execution.targets is not supported.",
+      "test 'copilot-only'.experiment.targets is not supported.",
     );
   });
 });

--- a/packages/core/test/evaluation/repo-schema-validation.test.ts
+++ b/packages/core/test/evaluation/repo-schema-validation.test.ts
@@ -208,7 +208,7 @@ describe('repo lifecycle schema validation', () => {
     expect(result.success).toBe(false);
   });
 
-  it('rejects test execution workspace blocks', () => {
+  it('rejects removed test execution workspace blocks', () => {
     const result = EvalFileSchema.safeParse({
       ...baseEval,
       tests: [

--- a/packages/core/test/evaluation/source-traceability.test.ts
+++ b/packages/core/test/evaluation/source-traceability.test.ts
@@ -119,4 +119,30 @@ tests:
     });
     expect(promptScriptDefinition?.definition).not.toHaveProperty('resolvedPromptScript');
   });
+
+  it('tracks assertion templates included from per-test experiment evaluators', async () => {
+    const evalFile = path.join(tempDir, 'experiment-template.eval.yaml');
+    await writeFile(
+      evalFile,
+      `tests:
+  - id: experiment-template-case
+    criteria: ok
+    input: hello
+    experiment:
+      evaluators:
+        - include: shared
+`,
+    );
+
+    const tests = await loadTests(evalFile, tempDir);
+
+    expect(tests).toHaveLength(1);
+    expect(tests[0]?.source?.references).toContainEqual(
+      expect.objectContaining({
+        kind: 'assertion_template',
+        displayPath: '.agentv/templates/shared.yaml',
+        resolvedPath: path.join(tempDir, '.agentv', 'templates', 'shared.yaml'),
+      }),
+    );
+  });
 });

--- a/packages/core/test/evaluation/suite-level-input.test.ts
+++ b/packages/core/test/evaluation/suite-level-input.test.ts
@@ -159,7 +159,7 @@ tests:
   - id: without-defaults
     criteria: "Skips suite input"
     input: "Query B"
-    execution:
+    experiment:
       skip_defaults: true
 `,
     );

--- a/packages/core/test/evaluation/validation/eval-file-schema.test.ts
+++ b/packages/core/test/evaluation/validation/eval-file-schema.test.ts
@@ -50,13 +50,10 @@ describe('EvalFileSchema input shorthand', () => {
     expect(result.success).toBe(false);
   });
 
-  it('rejects eval-level execution.trials because run counts belong on experiments', () => {
+  it('rejects eval-level execution because experiment is the only runtime block', () => {
     const result = EvalFileSchema.safeParse({
       execution: {
-        trials: {
-          count: 2,
-          strategy: 'pass_at_k',
-        },
+        target: 'codex',
       },
       tests: [baseTest],
     });
@@ -157,7 +154,7 @@ describe('EvalFileSchema input shorthand', () => {
     expect(result.success).toBe(true);
   });
 
-  it('rejects eval files that set both experiment and legacy execution', () => {
+  it('rejects eval files that set removed execution alongside experiment', () => {
     const result = EvalFileSchema.safeParse({
       experiment: { target: 'codex' },
       execution: { target: 'claude' },
@@ -183,23 +180,17 @@ describe('EvalFileSchema input shorthand', () => {
     expect(result.success).toBe(true);
   });
 
-  it('rejects test cases that set both experiment and legacy execution', () => {
+  it('rejects test cases that use removed execution', () => {
     const result = EvalFileSchema.safeParse({
       tests: [
         {
           ...baseTest,
-          experiment: { threshold: 0.7 },
           execution: { threshold: 0.8 },
         },
       ],
     });
 
     expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(collectIssueMessages(result.error.issues)).toContain(
-        "Use either per-test 'experiment' or legacy 'execution', not both.",
-      );
-    }
   });
 
   it('rejects experiment lifecycle commands', () => {
@@ -247,7 +238,7 @@ describe('EvalFileSchema input shorthand', () => {
     expect(result.success).toBe(false);
     if (result.success) throw new Error('Expected test-level execution.targets to be rejected');
     expect(collectIssueMessages(result.error.issues)).toContain(
-      "Unrecognized key(s) in object: 'targets'",
+      "'execution' has been removed. Use 'experiment' instead.",
     );
   });
 
@@ -266,7 +257,7 @@ describe('EvalFileSchema input shorthand', () => {
     expect(result.success).toBe(false);
     if (result.success) throw new Error('Expected test-level execution.target to be rejected');
     expect(collectIssueMessages(result.error.issues)).toContain(
-      "Unrecognized key(s) in object: 'target'",
+      "'execution' has been removed. Use 'experiment' instead.",
     );
   });
 });

--- a/packages/core/test/evaluation/validation/eval-file-schema.test.ts
+++ b/packages/core/test/evaluation/validation/eval-file-schema.test.ts
@@ -167,6 +167,41 @@ describe('EvalFileSchema input shorthand', () => {
     expect(result.success).toBe(false);
   });
 
+  it('accepts per-test experiment as the canonical runtime override', () => {
+    const result = EvalFileSchema.safeParse({
+      tests: [
+        {
+          ...baseTest,
+          experiment: {
+            threshold: 0.7,
+            skip_defaults: true,
+          },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects test cases that set both experiment and legacy execution', () => {
+    const result = EvalFileSchema.safeParse({
+      tests: [
+        {
+          ...baseTest,
+          experiment: { threshold: 0.7 },
+          execution: { threshold: 0.8 },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(collectIssueMessages(result.error.issues)).toContain(
+        "Use either per-test 'experiment' or legacy 'execution', not both.",
+      );
+    }
+  });
+
   it('rejects experiment lifecycle commands', () => {
     const result = EvalFileSchema.safeParse({
       experiment: {

--- a/packages/core/test/evaluation/validation/eval-validator.test.ts
+++ b/packages/core/test/evaluation/validation/eval-validator.test.ts
@@ -72,7 +72,7 @@ imports:
     expect(result.errors).toHaveLength(0);
   });
 
-  it('rejects unsupported test-level execution.targets', async () => {
+  it('rejects unsupported test-level experiment.targets', async () => {
     const filePath = path.join(tempDir, 'test-level-targets.yaml');
     await writeFile(
       filePath,
@@ -80,7 +80,7 @@ imports:
   - id: target-specific
     input: "Hello"
     criteria: "Greet"
-    execution:
+    experiment:
       targets: [codex]
 `,
     );
@@ -92,13 +92,13 @@ imports:
       result.errors.some(
         (error) =>
           error.severity === 'error' &&
-          error.location === 'tests[0].execution.targets' &&
-          error.message === "Unsupported test execution field 'targets'.",
+          error.location === 'tests[0].experiment.targets' &&
+          error.message === "Unsupported test experiment field 'targets'.",
       ),
     ).toBe(true);
   });
 
-  it('rejects unsupported test-level execution.target', async () => {
+  it('rejects unsupported test-level experiment.target', async () => {
     const filePath = path.join(tempDir, 'test-level-target.yaml');
     await writeFile(
       filePath,
@@ -106,7 +106,7 @@ imports:
   - id: target-specific
     input: "Hello"
     criteria: "Greet"
-    execution:
+    experiment:
       target: codex
 `,
     );
@@ -118,8 +118,8 @@ imports:
       result.errors.some(
         (error) =>
           error.severity === 'error' &&
-          error.location === 'tests[0].execution.target' &&
-          error.message === "Unsupported test execution field 'target'.",
+          error.location === 'tests[0].experiment.target' &&
+          error.message === "Unsupported test experiment field 'target'.",
       ),
     ).toBe(true);
   });
@@ -211,7 +211,7 @@ tests:
     ).toBe(true);
   });
 
-  it('rejects legacy execution workspace when importing suites', async () => {
+  it('rejects removed top-level execution when importing suites', async () => {
     await writeFile(
       path.join(tempDir, 'composition-child-execution-workspace.eval.yaml'),
       `tests:
@@ -239,9 +239,8 @@ tests:
       result.errors.some(
         (error) =>
           error.severity === 'error' &&
-          error.location === 'execution.workspace' &&
-          error.message.includes('Parent workspace is not allowed') &&
-          error.message.includes('type: suite'),
+          error.location === 'execution' &&
+          error.message === "'execution' has been removed. Use 'experiment' instead.",
       ),
     ).toBe(true);
   });
@@ -330,7 +329,7 @@ tests:
     ).toBe(true);
   });
 
-  it('rejects test execution workspace blocks', async () => {
+  it('rejects test experiment workspace blocks', async () => {
     const filePath = path.join(tempDir, 'test-execution-workspace.eval.yaml');
     await writeFile(
       filePath,
@@ -338,7 +337,7 @@ tests:
   - id: test-1
     criteria: Goal
     input: Query
-    execution:
+    experiment:
       workspace:
         mode: static
         path: /tmp/my-workspace
@@ -352,8 +351,34 @@ tests:
       result.errors.some(
         (error) =>
           error.severity === 'error' &&
-          error.location === 'tests[0].execution.workspace' &&
+          error.location === 'tests[0].experiment.workspace' &&
           error.message.includes('has been removed from eval YAML'),
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects removed test-level execution with a migration hint', async () => {
+    const filePath = path.join(tempDir, 'test-removed-execution.eval.yaml');
+    await writeFile(
+      filePath,
+      `tests:
+  - id: test-1
+    criteria: Goal
+    input: Query
+    execution:
+      threshold: 0.8
+`,
+    );
+
+    const result = await validateEvalFile(filePath);
+
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some(
+        (error) =>
+          error.severity === 'error' &&
+          error.location === 'tests[0].execution' &&
+          error.message === "'execution' has been removed. Use 'experiment' instead.",
       ),
     ).toBe(true);
   });
@@ -457,7 +482,7 @@ tests:
     ).toBe(true);
   });
 
-  it('rejects eval files with both experiment and legacy execution', async () => {
+  it('rejects eval files that still use removed execution', async () => {
     const filePath = path.join(tempDir, 'runtime-conflict.yaml');
     await writeFile(
       filePath,
@@ -475,7 +500,14 @@ tests:
     const result = await validateEvalFile(filePath);
 
     expect(result.valid).toBe(false);
-    expect(result.errors.some((error) => error.message.includes('experiment'))).toBe(true);
+    expect(
+      result.errors.some(
+        (error) =>
+          error.severity === 'error' &&
+          error.location === 'execution' &&
+          error.message === "'execution' has been removed. Use 'experiment' instead.",
+      ),
+    ).toBe(true);
   });
 
   it('rejects scoped run overrides that include target-changing fields', async () => {

--- a/packages/core/test/evaluation/yaml-parser-metadata.test.ts
+++ b/packages/core/test/evaluation/yaml-parser-metadata.test.ts
@@ -112,7 +112,7 @@ tests:
     const { filePath, dir } = createTempYaml(`
 name: matrix-eval
 description: Eval with targets
-execution:
+experiment:
   targets:
     - copilot
     - claude

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -152,7 +152,7 @@ import { defineEval, graders } from '@agentv/sdk';
 
 export default defineEval({
   name: 'hello-suite',
-  execution: {
+  experiment: {
     targets: ['mock-sdk'],
   },
   tests: [

--- a/packages/sdk/src/eval.ts
+++ b/packages/sdk/src/eval.ts
@@ -135,7 +135,7 @@ export interface EvalTrials {
   readonly costLimitUsd?: number;
 }
 
-export interface EvalExecution {
+export interface EvalExperiment {
   readonly target?: string;
   readonly targets?: readonly (string | EvalTargetRef)[];
   readonly workers?: number;
@@ -148,6 +148,9 @@ export interface EvalExecution {
   readonly threshold?: number;
   readonly [key: string]: unknown;
 }
+
+/** @deprecated Use EvalExperiment. */
+export type EvalExecution = EvalExperiment;
 
 export interface EvalTurn {
   readonly input: EvalMessageContent;
@@ -163,6 +166,8 @@ export interface EvalTest {
   readonly inputFiles?: readonly string[];
   readonly expectedOutput?: string | Readonly<Record<string, unknown>> | readonly EvalMessage[];
   readonly assertions?: readonly EvalAssertionConfig[];
+  readonly experiment?: EvalExperiment;
+  /** @deprecated Use experiment. */
   readonly execution?: EvalExecution;
   readonly workspace?: EvalWorkspace;
   readonly metadata?: Readonly<Record<string, unknown>>;
@@ -196,6 +201,8 @@ export interface EvalDefinition {
   readonly inputFiles?: readonly string[];
   readonly tests: readonly EvalTest[] | string;
   readonly target?: string;
+  readonly experiment?: EvalExperiment;
+  /** @deprecated Use experiment. */
   readonly execution?: EvalExecution;
   readonly assertions?: readonly EvalAssertionConfig[];
   readonly preprocessors?: readonly EvalPreprocessor[];

--- a/packages/sdk/src/eval.ts
+++ b/packages/sdk/src/eval.ts
@@ -149,9 +149,6 @@ export interface EvalExperiment {
   readonly [key: string]: unknown;
 }
 
-/** @deprecated Use EvalExperiment. */
-export type EvalExecution = EvalExperiment;
-
 export interface EvalTurn {
   readonly input: EvalMessageContent;
   readonly expectedOutput?: EvalMessageContent;
@@ -167,8 +164,6 @@ export interface EvalTest {
   readonly expectedOutput?: string | Readonly<Record<string, unknown>> | readonly EvalMessage[];
   readonly assertions?: readonly EvalAssertionConfig[];
   readonly experiment?: EvalExperiment;
-  /** @deprecated Use experiment. */
-  readonly execution?: EvalExecution;
   readonly workspace?: EvalWorkspace;
   readonly metadata?: Readonly<Record<string, unknown>>;
   readonly conversationId?: string;
@@ -202,8 +197,6 @@ export interface EvalDefinition {
   readonly tests: readonly EvalTest[] | string;
   readonly target?: string;
   readonly experiment?: EvalExperiment;
-  /** @deprecated Use experiment. */
-  readonly execution?: EvalExecution;
   readonly assertions?: readonly EvalAssertionConfig[];
   readonly preprocessors?: readonly EvalPreprocessor[];
   readonly workspace?: EvalWorkspace | string;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -138,7 +138,6 @@ export {
   type EvalAssertionConfig,
   type EvalDefinition,
   type EvalDockerWorkspace,
-  type EvalExecution,
   type EvalExperiment,
   type EvalMessage,
   type EvalMessageContent,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -139,6 +139,7 @@ export {
   type EvalDefinition,
   type EvalDockerWorkspace,
   type EvalExecution,
+  type EvalExperiment,
   type EvalMessage,
   type EvalMessageContent,
   type EvalPreprocessor,

--- a/packages/sdk/test/eval-authoring.test.ts
+++ b/packages/sdk/test/eval-authoring.test.ts
@@ -7,7 +7,7 @@ describe('YAML-aligned eval authoring helpers', () => {
     const suite = defineEval({
       name: 'sdk-yaml-suite',
       inputFiles: ['fixtures/shared-system.md'],
-      execution: {
+      experiment: {
         targets: [
           {
             name: 'mock-target',
@@ -40,6 +40,10 @@ describe('YAML-aligned eval authoring helpers', () => {
           input: 'Say hello.',
           inputFiles: ['fixtures/prompt.md'],
           expectedOutput: 'Hello there',
+          experiment: {
+            threshold: 0.8,
+            failOnError: true,
+          },
           workspace: {
             hooks: {
               beforeEach: {
@@ -86,11 +90,11 @@ describe('YAML-aligned eval authoring helpers', () => {
 
     const lowered = toEvalYamlObject(suite);
 
-    expect(suite.execution?.skipDefaults).toBe(true);
+    expect(suite.experiment?.skipDefaults).toBe(true);
     expect(lowered).toEqual({
       name: 'sdk-yaml-suite',
       input_files: ['fixtures/shared-system.md'],
-      execution: {
+      experiment: {
         targets: [
           {
             name: 'mock-target',
@@ -123,6 +127,10 @@ describe('YAML-aligned eval authoring helpers', () => {
           input: 'Say hello.',
           input_files: ['fixtures/prompt.md'],
           expected_output: 'Hello there',
+          experiment: {
+            threshold: 0.8,
+            fail_on_error: true,
+          },
           workspace: {
             hooks: {
               before_each: {
@@ -188,5 +196,46 @@ describe('YAML-aligned eval authoring helpers', () => {
     expect(yaml).toContain('assertions:');
     expect(yaml).not.toContain('expectedOutput');
     expect(yaml).not.toContain('inputFiles');
+  });
+
+  it('keeps execution as a deprecated YAML alias for back compatibility', () => {
+    const suite = defineEval({
+      name: 'legacy-execution-suite',
+      execution: {
+        targets: ['legacy-target'],
+        budgetUsd: 0.5,
+      },
+      tests: [
+        {
+          id: 'legacy-test',
+          input: 'Say hello',
+          execution: {
+            threshold: 0.6,
+            failOnError: true,
+          },
+        },
+      ],
+    });
+
+    const lowered = toEvalYamlObject(suite);
+
+    expect(suite.execution?.budgetUsd).toBe(0.5);
+    expect(lowered).toEqual({
+      name: 'legacy-execution-suite',
+      execution: {
+        targets: ['legacy-target'],
+        budget_usd: 0.5,
+      },
+      tests: [
+        {
+          id: 'legacy-test',
+          input: 'Say hello',
+          execution: {
+            threshold: 0.6,
+            fail_on_error: true,
+          },
+        },
+      ],
+    });
   });
 });

--- a/packages/sdk/test/eval-authoring.test.ts
+++ b/packages/sdk/test/eval-authoring.test.ts
@@ -197,45 +197,4 @@ describe('YAML-aligned eval authoring helpers', () => {
     expect(yaml).not.toContain('expectedOutput');
     expect(yaml).not.toContain('inputFiles');
   });
-
-  it('keeps execution as a deprecated YAML alias for back compatibility', () => {
-    const suite = defineEval({
-      name: 'legacy-execution-suite',
-      execution: {
-        targets: ['legacy-target'],
-        budgetUsd: 0.5,
-      },
-      tests: [
-        {
-          id: 'legacy-test',
-          input: 'Say hello',
-          execution: {
-            threshold: 0.6,
-            failOnError: true,
-          },
-        },
-      ],
-    });
-
-    const lowered = toEvalYamlObject(suite);
-
-    expect(suite.execution?.budgetUsd).toBe(0.5);
-    expect(lowered).toEqual({
-      name: 'legacy-execution-suite',
-      execution: {
-        targets: ['legacy-target'],
-        budget_usd: 0.5,
-      },
-      tests: [
-        {
-          id: 'legacy-test',
-          input: 'Say hello',
-          execution: {
-            threshold: 0.6,
-            fail_on_error: true,
-          },
-        },
-      ],
-    });
-  });
 });

--- a/skills-data/agentv-eval-writer/references/eval-schema.json
+++ b/skills-data/agentv-eval-writer/references/eval-schema.json
@@ -54,7 +54,12 @@
               "properties": {
                 "role": {
                   "type": "string",
-                  "enum": ["system", "user", "assistant", "tool"]
+                  "enum": [
+                    "system",
+                    "user",
+                    "assistant",
+                    "tool"
+                  ]
                 },
                 "content": {
                   "anyOf": [
@@ -73,20 +78,30 @@
                         "properties": {
                           "type": {
                             "type": "string",
-                            "enum": ["text", "file", "image"]
+                            "enum": [
+                              "text",
+                              "file",
+                              "image"
+                            ]
                           },
                           "value": {
                             "type": "string"
                           }
                         },
-                        "required": ["type", "value"],
+                        "required": [
+                          "type",
+                          "value"
+                        ],
                         "additionalProperties": false
                       }
                     }
                   ]
                 }
               },
-              "required": ["role", "content"],
+              "required": [
+                "role",
+                "content"
+              ],
               "additionalProperties": false
             },
             {
@@ -105,7 +120,12 @@
                 "properties": {
                   "role": {
                     "type": "string",
-                    "enum": ["system", "user", "assistant", "tool"]
+                    "enum": [
+                      "system",
+                      "user",
+                      "assistant",
+                      "tool"
+                    ]
                   },
                   "content": {
                     "anyOf": [
@@ -124,20 +144,30 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "enum": ["text", "file", "image"]
+                              "enum": [
+                                "text",
+                                "file",
+                                "image"
+                              ]
                             },
                             "value": {
                               "type": "string"
                             }
                           },
-                          "required": ["type", "value"],
+                          "required": [
+                            "type",
+                            "value"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     ]
                   }
                 },
-                "required": ["role", "content"],
+                "required": [
+                  "role",
+                  "content"
+                ],
                 "additionalProperties": false
               }
             }
@@ -234,7 +264,11 @@
                                         {
                                           "type": "array",
                                           "items": {
-                                            "type": ["string", "number", "boolean"]
+                                            "type": [
+                                              "string",
+                                              "number",
+                                              "boolean"
+                                            ]
                                           },
                                           "minItems": 1
                                         }
@@ -263,7 +297,12 @@
                                   },
                                   "strategy": {
                                     "type": "string",
-                                    "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                                    "enum": [
+                                      "pass_at_k",
+                                      "pass_all",
+                                      "mean",
+                                      "confidence_interval"
+                                    ]
                                   },
                                   "cost_limit_usd": {
                                     "type": "number",
@@ -274,7 +313,9 @@
                                     "minimum": 0
                                   }
                                 },
-                                "required": ["count"],
+                                "required": [
+                                  "count"
+                                ],
                                 "additionalProperties": false
                               },
                               "timeout_seconds": {
@@ -291,7 +332,9 @@
                             "additionalProperties": false
                           }
                         },
-                        "required": ["path"],
+                        "required": [
+                          "path"
+                        ],
                         "additionalProperties": false
                       },
                       {
@@ -381,7 +424,11 @@
                                   {
                                     "type": "array",
                                     "items": {
-                                      "type": ["string", "number", "boolean"]
+                                      "type": [
+                                        "string",
+                                        "number",
+                                        "boolean"
+                                      ]
                                     },
                                     "minItems": 1
                                   }
@@ -410,7 +457,12 @@
                             },
                             "strategy": {
                               "type": "string",
-                              "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                              "enum": [
+                                "pass_at_k",
+                                "pass_all",
+                                "mean",
+                                "confidence_interval"
+                              ]
                             },
                             "cost_limit_usd": {
                               "type": "number",
@@ -421,7 +473,9 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["count"],
+                          "required": [
+                            "count"
+                          ],
                           "additionalProperties": false
                         },
                         "timeout_seconds": {
@@ -438,7 +492,9 @@
                       "additionalProperties": false
                     }
                   },
-                  "required": ["path"],
+                  "required": [
+                    "path"
+                  ],
                   "additionalProperties": false
                 }
               ]
@@ -525,7 +581,11 @@
                                         {
                                           "type": "array",
                                           "items": {
-                                            "type": ["string", "number", "boolean"]
+                                            "type": [
+                                              "string",
+                                              "number",
+                                              "boolean"
+                                            ]
                                           },
                                           "minItems": 1
                                         }
@@ -554,7 +614,12 @@
                                   },
                                   "strategy": {
                                     "type": "string",
-                                    "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                                    "enum": [
+                                      "pass_at_k",
+                                      "pass_all",
+                                      "mean",
+                                      "confidence_interval"
+                                    ]
                                   },
                                   "cost_limit_usd": {
                                     "type": "number",
@@ -565,7 +630,9 @@
                                     "minimum": 0
                                   }
                                 },
-                                "required": ["count"],
+                                "required": [
+                                  "count"
+                                ],
                                 "additionalProperties": false
                               },
                               "timeout_seconds": {
@@ -582,7 +649,9 @@
                             "additionalProperties": false
                           }
                         },
-                        "required": ["path"],
+                        "required": [
+                          "path"
+                        ],
                         "additionalProperties": false
                       },
                       {
@@ -672,7 +741,11 @@
                                   {
                                     "type": "array",
                                     "items": {
-                                      "type": ["string", "number", "boolean"]
+                                      "type": [
+                                        "string",
+                                        "number",
+                                        "boolean"
+                                      ]
                                     },
                                     "minItems": 1
                                   }
@@ -701,7 +774,12 @@
                             },
                             "strategy": {
                               "type": "string",
-                              "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                              "enum": [
+                                "pass_at_k",
+                                "pass_all",
+                                "mean",
+                                "confidence_interval"
+                              ]
                             },
                             "cost_limit_usd": {
                               "type": "number",
@@ -712,7 +790,9 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["count"],
+                          "required": [
+                            "count"
+                          ],
                           "additionalProperties": false
                         },
                         "timeout_seconds": {
@@ -729,7 +809,9 @@
                       "additionalProperties": false
                     }
                   },
-                  "required": ["path"],
+                  "required": [
+                    "path"
+                  ],
                   "additionalProperties": false
                 }
               ]
@@ -768,7 +850,12 @@
                             "properties": {
                               "role": {
                                 "type": "string",
-                                "enum": ["system", "user", "assistant", "tool"]
+                                "enum": [
+                                  "system",
+                                  "user",
+                                  "assistant",
+                                  "tool"
+                                ]
                               },
                               "content": {
                                 "anyOf": [
@@ -787,20 +874,30 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": ["text", "file", "image"]
+                                          "enum": [
+                                            "text",
+                                            "file",
+                                            "image"
+                                          ]
                                         },
                                         "value": {
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type", "value"],
+                                      "required": [
+                                        "type",
+                                        "value"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   }
                                 ]
                               }
                             },
-                            "required": ["role", "content"],
+                            "required": [
+                              "role",
+                              "content"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -819,7 +916,12 @@
                               "properties": {
                                 "role": {
                                   "type": "string",
-                                  "enum": ["system", "user", "assistant", "tool"]
+                                  "enum": [
+                                    "system",
+                                    "user",
+                                    "assistant",
+                                    "tool"
+                                  ]
                                 },
                                 "content": {
                                   "anyOf": [
@@ -838,20 +940,30 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["text", "file", "image"]
+                                            "enum": [
+                                              "text",
+                                              "file",
+                                              "image"
+                                            ]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   ]
                                 }
                               },
-                              "required": ["role", "content"],
+                              "required": [
+                                "role",
+                                "content"
+                              ],
                               "additionalProperties": false
                             }
                           }
@@ -880,7 +992,12 @@
                               "properties": {
                                 "role": {
                                   "type": "string",
-                                  "enum": ["system", "user", "assistant", "tool"]
+                                  "enum": [
+                                    "system",
+                                    "user",
+                                    "assistant",
+                                    "tool"
+                                  ]
                                 },
                                 "content": {
                                   "anyOf": [
@@ -899,20 +1016,30 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["text", "file", "image"]
+                                            "enum": [
+                                              "text",
+                                              "file",
+                                              "image"
+                                            ]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   ]
                                 }
                               },
-                              "required": ["role", "content"],
+                              "required": [
+                                "role",
+                                "content"
+                              ],
                               "additionalProperties": false
                             }
                           }
@@ -956,7 +1083,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["code-grader", "code_grader"]
+                                  "enum": [
+                                    "code-grader",
+                                    "code_grader"
+                                  ]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -1030,12 +1160,18 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type", "command"],
+                              "required": [
+                                "type",
+                                "command"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1072,7 +1208,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["llm-grader", "llm_grader"]
+                                  "enum": [
+                                    "llm-grader",
+                                    "llm_grader"
+                                  ]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -1130,7 +1269,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -1171,7 +1313,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -1222,12 +1367,17 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1238,7 +1388,9 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": ["include"],
+                              "required": [
+                                "include"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1301,7 +1453,9 @@
                                           }
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -1317,7 +1471,10 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": ["type", "threshold"],
+                                      "required": [
+                                        "type",
+                                        "threshold"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -1334,7 +1491,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type", "path"],
+                                      "required": [
+                                        "type",
+                                        "path"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -1351,13 +1511,18 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["type", "aggregator"],
+                              "required": [
+                                "type",
+                                "aggregator"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1394,11 +1559,20 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["tool-trajectory", "tool_trajectory"]
+                                  "enum": [
+                                    "tool-trajectory",
+                                    "tool_trajectory"
+                                  ]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                                  "enum": [
+                                    "any_order",
+                                    "in_order",
+                                    "exact",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -1439,7 +1613,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -1453,7 +1632,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -1464,7 +1648,9 @@
                                         ]
                                       }
                                     },
-                                    "required": ["tool"],
+                                    "required": [
+                                      "tool"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 },
@@ -1472,7 +1658,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -1486,7 +1677,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -1497,7 +1693,10 @@
                                   ]
                                 }
                               },
-                              "required": ["type", "mode"],
+                              "required": [
+                                "type",
+                                "mode"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1534,7 +1733,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["field-accuracy", "field_accuracy"]
+                                  "enum": [
+                                    "field-accuracy",
+                                    "field_accuracy"
+                                  ]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -1546,7 +1748,11 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": ["exact", "numeric_tolerance", "date"]
+                                        "enum": [
+                                          "exact",
+                                          "numeric_tolerance",
+                                          "date"
+                                        ]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -1568,17 +1774,26 @@
                                         }
                                       }
                                     },
-                                    "required": ["path", "match"],
+                                    "required": [
+                                      "path",
+                                      "match"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": ["weighted_average", "all_or_nothing"]
+                                  "enum": [
+                                    "weighted_average",
+                                    "all_or_nothing"
+                                  ]
                                 }
                               },
-                              "required": ["type", "fields"],
+                              "required": [
+                                "type",
+                                "fields"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1622,7 +1837,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "threshold"],
+                              "required": [
+                                "type",
+                                "threshold"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1666,7 +1884,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "budget"],
+                              "required": [
+                                "type",
+                                "budget"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1703,7 +1924,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["token-usage", "token_usage"]
+                                  "enum": [
+                                    "token-usage",
+                                    "token_usage"
+                                  ]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -1718,7 +1942,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1755,7 +1981,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["execution-metrics", "execution_metrics"]
+                                  "enum": [
+                                    "execution-metrics",
+                                    "execution_metrics"
+                                  ]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -1787,7 +2016,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1830,7 +2061,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1873,7 +2107,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1910,10 +2147,15 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["is-json", "is_json"]
+                                  "enum": [
+                                    "is-json",
+                                    "is_json"
+                                  ]
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1956,7 +2198,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2008,7 +2253,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -2049,7 +2297,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -2059,7 +2310,10 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": ["type", "criteria"],
+                              "required": [
+                                "type",
+                                "criteria"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -2103,7 +2357,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["code-grader", "code_grader"]
+                                  "enum": [
+                                    "code-grader",
+                                    "code_grader"
+                                  ]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -2177,12 +2434,18 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type", "command"],
+                              "required": [
+                                "type",
+                                "command"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2219,7 +2482,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["llm-grader", "llm_grader"]
+                                  "enum": [
+                                    "llm-grader",
+                                    "llm_grader"
+                                  ]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -2277,7 +2543,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -2318,7 +2587,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -2369,12 +2641,17 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2385,7 +2662,9 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": ["include"],
+                              "required": [
+                                "include"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2448,7 +2727,9 @@
                                           }
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -2464,7 +2745,10 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": ["type", "threshold"],
+                                      "required": [
+                                        "type",
+                                        "threshold"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -2481,7 +2765,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type", "path"],
+                                      "required": [
+                                        "type",
+                                        "path"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -2498,13 +2785,18 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["type", "aggregator"],
+                              "required": [
+                                "type",
+                                "aggregator"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2541,11 +2833,20 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["tool-trajectory", "tool_trajectory"]
+                                  "enum": [
+                                    "tool-trajectory",
+                                    "tool_trajectory"
+                                  ]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                                  "enum": [
+                                    "any_order",
+                                    "in_order",
+                                    "exact",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -2586,7 +2887,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -2600,7 +2906,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -2611,7 +2922,9 @@
                                         ]
                                       }
                                     },
-                                    "required": ["tool"],
+                                    "required": [
+                                      "tool"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 },
@@ -2619,7 +2932,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -2633,7 +2951,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -2644,7 +2967,10 @@
                                   ]
                                 }
                               },
-                              "required": ["type", "mode"],
+                              "required": [
+                                "type",
+                                "mode"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2681,7 +3007,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["field-accuracy", "field_accuracy"]
+                                  "enum": [
+                                    "field-accuracy",
+                                    "field_accuracy"
+                                  ]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -2693,7 +3022,11 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": ["exact", "numeric_tolerance", "date"]
+                                        "enum": [
+                                          "exact",
+                                          "numeric_tolerance",
+                                          "date"
+                                        ]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -2715,17 +3048,26 @@
                                         }
                                       }
                                     },
-                                    "required": ["path", "match"],
+                                    "required": [
+                                      "path",
+                                      "match"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": ["weighted_average", "all_or_nothing"]
+                                  "enum": [
+                                    "weighted_average",
+                                    "all_or_nothing"
+                                  ]
                                 }
                               },
-                              "required": ["type", "fields"],
+                              "required": [
+                                "type",
+                                "fields"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2769,7 +3111,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "threshold"],
+                              "required": [
+                                "type",
+                                "threshold"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2813,7 +3158,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "budget"],
+                              "required": [
+                                "type",
+                                "budget"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2850,7 +3198,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["token-usage", "token_usage"]
+                                  "enum": [
+                                    "token-usage",
+                                    "token_usage"
+                                  ]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -2865,7 +3216,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2902,7 +3255,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["execution-metrics", "execution_metrics"]
+                                  "enum": [
+                                    "execution-metrics",
+                                    "execution_metrics"
+                                  ]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -2934,7 +3290,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2977,7 +3335,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3020,7 +3381,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3057,10 +3421,15 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["is-json", "is_json"]
+                                  "enum": [
+                                    "is-json",
+                                    "is_json"
+                                  ]
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3103,7 +3472,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3155,7 +3527,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -3196,7 +3571,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -3206,11 +3584,2604 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": ["type", "criteria"],
+                              "required": [
+                                "type",
+                                "criteria"
+                              ],
                               "additionalProperties": false
                             }
                           ]
                         }
+                      },
+                      "experiment": {
+                        "type": "object",
+                        "properties": {
+                          "workers": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50
+                          },
+                          "assertions": {
+                            "type": "array",
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "code-grader",
+                                        "code_grader"
+                                      ]
+                                    },
+                                    "command": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "script": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "cwd": {
+                                      "type": "string"
+                                    },
+                                    "target": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "max_calls": {
+                                              "type": "number"
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "config": {
+                                      "type": "object",
+                                      "additionalProperties": {}
+                                    },
+                                    "preprocessors": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "command": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "command"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "llm-grader",
+                                        "llm_grader"
+                                      ]
+                                    },
+                                    "prompt": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "command": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "script": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "config": {
+                                              "type": "object",
+                                              "additionalProperties": {}
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "rubrics": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "outcome": {
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "type": "string",
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
+                                          },
+                                          "weight": {
+                                            "type": "number"
+                                          },
+                                          "required": {
+                                            "type": "boolean"
+                                          },
+                                          "min_score": {
+                                            "type": "number",
+                                            "exclusiveMinimum": true,
+                                            "minimum": 0,
+                                            "maximum": 1
+                                          },
+                                          "score_ranges": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "score_range": {
+                                                  "type": "array",
+                                                  "minItems": 2,
+                                                  "maxItems": 2,
+                                                  "items": [
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    },
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    }
+                                                  ]
+                                                },
+                                                "outcome": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                }
+                                              },
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "model": {
+                                      "type": "string"
+                                    },
+                                    "target": {
+                                      "type": "string"
+                                    },
+                                    "config": {
+                                      "type": "object",
+                                      "additionalProperties": {}
+                                    },
+                                    "max_steps": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 50
+                                    },
+                                    "temperature": {
+                                      "type": "number",
+                                      "minimum": 0,
+                                      "maximum": 2
+                                    },
+                                    "preprocessors": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "command": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "include": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    }
+                                  },
+                                  "required": [
+                                    "include"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "composite"
+                                    },
+                                    "assertions": {
+                                      "type": "array",
+                                      "items": {}
+                                    },
+                                    "evaluators": {
+                                      "type": "array",
+                                      "items": {}
+                                    },
+                                    "aggregator": {
+                                      "anyOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "weighted_average"
+                                            },
+                                            "weights": {
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "type": "number"
+                                              }
+                                            }
+                                          },
+                                          "required": [
+                                            "type"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "threshold"
+                                            },
+                                            "threshold": {
+                                              "type": "number",
+                                              "minimum": 0,
+                                              "maximum": 1
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "threshold"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "code-grader"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "cwd": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "path"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "llm-grader"
+                                            },
+                                            "prompt": {
+                                              "type": "string"
+                                            },
+                                            "model": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "type"
+                                          ],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "aggregator"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "tool-trajectory",
+                                        "tool_trajectory"
+                                      ]
+                                    },
+                                    "mode": {
+                                      "type": "string",
+                                      "enum": [
+                                        "any_order",
+                                        "in_order",
+                                        "exact",
+                                        "subset",
+                                        "superset"
+                                      ]
+                                    },
+                                    "minimums": {
+                                      "type": "object",
+                                      "additionalProperties": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      }
+                                    },
+                                    "expected": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "tool": {
+                                            "type": "string"
+                                          },
+                                          "args": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string",
+                                                "const": "any"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "additionalProperties": {}
+                                              }
+                                            ]
+                                          },
+                                          "max_duration_ms": {
+                                            "type": "number",
+                                            "minimum": 0
+                                          },
+                                          "maxDurationMs": {
+                                            "type": "number",
+                                            "minimum": 0
+                                          },
+                                          "args_match": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string",
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
+                                              },
+                                              {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "argsMatch": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string",
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
+                                              },
+                                              {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "tool"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "args_match": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string",
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "argsMatch": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string",
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "mode"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "field-accuracy",
+                                        "field_accuracy"
+                                      ]
+                                    },
+                                    "fields": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "match": {
+                                            "type": "string",
+                                            "enum": [
+                                              "exact",
+                                              "numeric_tolerance",
+                                              "date"
+                                            ]
+                                          },
+                                          "required": {
+                                            "type": "boolean"
+                                          },
+                                          "weight": {
+                                            "type": "number"
+                                          },
+                                          "tolerance": {
+                                            "type": "number",
+                                            "minimum": 0
+                                          },
+                                          "relative": {
+                                            "type": "boolean"
+                                          },
+                                          "formats": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "required": [
+                                          "path",
+                                          "match"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "minItems": 1
+                                    },
+                                    "aggregation": {
+                                      "type": "string",
+                                      "enum": [
+                                        "weighted_average",
+                                        "all_or_nothing"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "fields"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "latency"
+                                    },
+                                    "threshold": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "threshold"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "cost"
+                                    },
+                                    "budget": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "budget"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "token-usage",
+                                        "token_usage"
+                                      ]
+                                    },
+                                    "max_total": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_input": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_output": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "execution-metrics",
+                                        "execution_metrics"
+                                      ]
+                                    },
+                                    "max_tool_calls": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_llm_calls": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_tokens": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_cost_usd": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_duration_ms": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "target_exploration_ratio": {
+                                      "type": "number",
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "exploration_tolerance": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "contains"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "regex"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "is-json",
+                                        "is_json"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "equals"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "rubrics"
+                                    },
+                                    "criteria": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "outcome": {
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "type": "string",
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
+                                          },
+                                          "weight": {
+                                            "type": "number"
+                                          },
+                                          "required": {
+                                            "type": "boolean"
+                                          },
+                                          "min_score": {
+                                            "type": "number",
+                                            "exclusiveMinimum": true,
+                                            "minimum": 0,
+                                            "maximum": 1
+                                          },
+                                          "score_ranges": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "score_range": {
+                                                  "type": "array",
+                                                  "minItems": 2,
+                                                  "maxItems": 2,
+                                                  "items": [
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    },
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    }
+                                                  ]
+                                                },
+                                                "outcome": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                }
+                                              },
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      },
+                                      "minItems": 1
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "criteria"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            }
+                          },
+                          "evaluators": {
+                            "type": "array",
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "code-grader",
+                                        "code_grader"
+                                      ]
+                                    },
+                                    "command": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "script": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "cwd": {
+                                      "type": "string"
+                                    },
+                                    "target": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "max_calls": {
+                                              "type": "number"
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "config": {
+                                      "type": "object",
+                                      "additionalProperties": {}
+                                    },
+                                    "preprocessors": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "command": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "command"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "llm-grader",
+                                        "llm_grader"
+                                      ]
+                                    },
+                                    "prompt": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "command": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "script": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "config": {
+                                              "type": "object",
+                                              "additionalProperties": {}
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "rubrics": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "outcome": {
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "type": "string",
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
+                                          },
+                                          "weight": {
+                                            "type": "number"
+                                          },
+                                          "required": {
+                                            "type": "boolean"
+                                          },
+                                          "min_score": {
+                                            "type": "number",
+                                            "exclusiveMinimum": true,
+                                            "minimum": 0,
+                                            "maximum": 1
+                                          },
+                                          "score_ranges": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "score_range": {
+                                                  "type": "array",
+                                                  "minItems": 2,
+                                                  "maxItems": 2,
+                                                  "items": [
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    },
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    }
+                                                  ]
+                                                },
+                                                "outcome": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                }
+                                              },
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "model": {
+                                      "type": "string"
+                                    },
+                                    "target": {
+                                      "type": "string"
+                                    },
+                                    "config": {
+                                      "type": "object",
+                                      "additionalProperties": {}
+                                    },
+                                    "max_steps": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 50
+                                    },
+                                    "temperature": {
+                                      "type": "number",
+                                      "minimum": 0,
+                                      "maximum": 2
+                                    },
+                                    "preprocessors": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "command": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "include": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    }
+                                  },
+                                  "required": [
+                                    "include"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "composite"
+                                    },
+                                    "assertions": {
+                                      "type": "array",
+                                      "items": {}
+                                    },
+                                    "evaluators": {
+                                      "type": "array",
+                                      "items": {}
+                                    },
+                                    "aggregator": {
+                                      "anyOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "weighted_average"
+                                            },
+                                            "weights": {
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "type": "number"
+                                              }
+                                            }
+                                          },
+                                          "required": [
+                                            "type"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "threshold"
+                                            },
+                                            "threshold": {
+                                              "type": "number",
+                                              "minimum": 0,
+                                              "maximum": 1
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "threshold"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "code-grader"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "cwd": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "path"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "llm-grader"
+                                            },
+                                            "prompt": {
+                                              "type": "string"
+                                            },
+                                            "model": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "type"
+                                          ],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "aggregator"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "tool-trajectory",
+                                        "tool_trajectory"
+                                      ]
+                                    },
+                                    "mode": {
+                                      "type": "string",
+                                      "enum": [
+                                        "any_order",
+                                        "in_order",
+                                        "exact",
+                                        "subset",
+                                        "superset"
+                                      ]
+                                    },
+                                    "minimums": {
+                                      "type": "object",
+                                      "additionalProperties": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      }
+                                    },
+                                    "expected": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "tool": {
+                                            "type": "string"
+                                          },
+                                          "args": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string",
+                                                "const": "any"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "additionalProperties": {}
+                                              }
+                                            ]
+                                          },
+                                          "max_duration_ms": {
+                                            "type": "number",
+                                            "minimum": 0
+                                          },
+                                          "maxDurationMs": {
+                                            "type": "number",
+                                            "minimum": 0
+                                          },
+                                          "args_match": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string",
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
+                                              },
+                                              {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "argsMatch": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string",
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
+                                              },
+                                              {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "tool"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "args_match": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string",
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "argsMatch": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string",
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "mode"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "field-accuracy",
+                                        "field_accuracy"
+                                      ]
+                                    },
+                                    "fields": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "match": {
+                                            "type": "string",
+                                            "enum": [
+                                              "exact",
+                                              "numeric_tolerance",
+                                              "date"
+                                            ]
+                                          },
+                                          "required": {
+                                            "type": "boolean"
+                                          },
+                                          "weight": {
+                                            "type": "number"
+                                          },
+                                          "tolerance": {
+                                            "type": "number",
+                                            "minimum": 0
+                                          },
+                                          "relative": {
+                                            "type": "boolean"
+                                          },
+                                          "formats": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "required": [
+                                          "path",
+                                          "match"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "minItems": 1
+                                    },
+                                    "aggregation": {
+                                      "type": "string",
+                                      "enum": [
+                                        "weighted_average",
+                                        "all_or_nothing"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "fields"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "latency"
+                                    },
+                                    "threshold": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "threshold"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "cost"
+                                    },
+                                    "budget": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "budget"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "token-usage",
+                                        "token_usage"
+                                      ]
+                                    },
+                                    "max_total": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_input": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_output": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "execution-metrics",
+                                        "execution_metrics"
+                                      ]
+                                    },
+                                    "max_tool_calls": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_llm_calls": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_tokens": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_cost_usd": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_duration_ms": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "target_exploration_ratio": {
+                                      "type": "number",
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "exploration_tolerance": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "contains"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "regex"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "is-json",
+                                        "is_json"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "equals"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "rubrics"
+                                    },
+                                    "criteria": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "outcome": {
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "type": "string",
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
+                                          },
+                                          "weight": {
+                                            "type": "number"
+                                          },
+                                          "required": {
+                                            "type": "boolean"
+                                          },
+                                          "min_score": {
+                                            "type": "number",
+                                            "exclusiveMinimum": true,
+                                            "minimum": 0,
+                                            "maximum": 1
+                                          },
+                                          "score_ranges": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "score_range": {
+                                                  "type": "array",
+                                                  "minItems": 2,
+                                                  "maxItems": 2,
+                                                  "items": [
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    },
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    }
+                                                  ]
+                                                },
+                                                "outcome": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                }
+                                              },
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      },
+                                      "minItems": 1
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "criteria"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            }
+                          },
+                          "skip_defaults": {
+                            "type": "boolean"
+                          },
+                          "cache": {
+                            "type": "boolean"
+                          },
+                          "trials": {
+                            "not": {}
+                          },
+                          "budget_usd": {
+                            "type": "number",
+                            "minimum": 0
+                          },
+                          "budgetUsd": {
+                            "type": "number",
+                            "minimum": 0
+                          },
+                          "fail_on_error": {
+                            "type": "boolean"
+                          },
+                          "failOnError": {
+                            "type": "boolean"
+                          },
+                          "threshold": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "workspace": {
+                            "not": {}
+                          }
+                        },
+                        "additionalProperties": false
                       },
                       "execution": {
                         "type": "object",
@@ -3258,7 +6229,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["code-grader", "code_grader"]
+                                      "enum": [
+                                        "code-grader",
+                                        "code_grader"
+                                      ]
                                     },
                                     "command": {
                                       "anyOf": [
@@ -3332,12 +6306,18 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": ["type", "command"],
+                                  "required": [
+                                    "type",
+                                    "command"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -3374,7 +6354,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["llm-grader", "llm_grader"]
+                                      "enum": [
+                                        "llm-grader",
+                                        "llm_grader"
+                                      ]
                                     },
                                     "prompt": {
                                       "anyOf": [
@@ -3432,7 +6415,10 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": ["correctness", "contradiction"]
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -3473,7 +6459,10 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": ["score_range", "outcome"],
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
@@ -3524,12 +6513,17 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -3540,7 +6534,9 @@
                                       "minLength": 1
                                     }
                                   },
-                                  "required": ["include"],
+                                  "required": [
+                                    "include"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -3603,7 +6599,9 @@
                                               }
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -3619,7 +6617,10 @@
                                               "maximum": 1
                                             }
                                           },
-                                          "required": ["type", "threshold"],
+                                          "required": [
+                                            "type",
+                                            "threshold"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -3636,7 +6637,10 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["type", "path"],
+                                          "required": [
+                                            "type",
+                                            "path"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -3653,13 +6657,18 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": ["type", "aggregator"],
+                                  "required": [
+                                    "type",
+                                    "aggregator"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -3696,7 +6705,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["tool-trajectory", "tool_trajectory"]
+                                      "enum": [
+                                        "tool-trajectory",
+                                        "tool_trajectory"
+                                      ]
                                     },
                                     "mode": {
                                       "type": "string",
@@ -3747,7 +6759,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -3761,7 +6778,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -3772,7 +6794,9 @@
                                             ]
                                           }
                                         },
-                                        "required": ["tool"],
+                                        "required": [
+                                          "tool"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     },
@@ -3780,7 +6804,12 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": ["exact", "ignore", "subset", "superset"]
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
                                         },
                                         {
                                           "type": "array",
@@ -3794,7 +6823,12 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": ["exact", "ignore", "subset", "superset"]
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
                                         },
                                         {
                                           "type": "array",
@@ -3805,7 +6839,10 @@
                                       ]
                                     }
                                   },
-                                  "required": ["type", "mode"],
+                                  "required": [
+                                    "type",
+                                    "mode"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -3842,7 +6879,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["field-accuracy", "field_accuracy"]
+                                      "enum": [
+                                        "field-accuracy",
+                                        "field_accuracy"
+                                      ]
                                     },
                                     "fields": {
                                       "type": "array",
@@ -3854,7 +6894,11 @@
                                           },
                                           "match": {
                                             "type": "string",
-                                            "enum": ["exact", "numeric_tolerance", "date"]
+                                            "enum": [
+                                              "exact",
+                                              "numeric_tolerance",
+                                              "date"
+                                            ]
                                           },
                                           "required": {
                                             "type": "boolean"
@@ -3876,17 +6920,26 @@
                                             }
                                           }
                                         },
-                                        "required": ["path", "match"],
+                                        "required": [
+                                          "path",
+                                          "match"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       "minItems": 1
                                     },
                                     "aggregation": {
                                       "type": "string",
-                                      "enum": ["weighted_average", "all_or_nothing"]
+                                      "enum": [
+                                        "weighted_average",
+                                        "all_or_nothing"
+                                      ]
                                     }
                                   },
-                                  "required": ["type", "fields"],
+                                  "required": [
+                                    "type",
+                                    "fields"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -3930,7 +6983,10 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type", "threshold"],
+                                  "required": [
+                                    "type",
+                                    "threshold"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -3974,7 +7030,10 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type", "budget"],
+                                  "required": [
+                                    "type",
+                                    "budget"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4011,7 +7070,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["token-usage", "token_usage"]
+                                      "enum": [
+                                        "token-usage",
+                                        "token_usage"
+                                      ]
                                     },
                                     "max_total": {
                                       "type": "number",
@@ -4026,7 +7088,9 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4063,7 +7127,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["execution-metrics", "execution_metrics"]
+                                      "enum": [
+                                        "execution-metrics",
+                                        "execution_metrics"
+                                      ]
                                     },
                                     "max_tool_calls": {
                                       "type": "number",
@@ -4095,7 +7162,9 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4138,7 +7207,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4181,7 +7253,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4218,10 +7293,15 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["is-json", "is_json"]
+                                      "enum": [
+                                        "is-json",
+                                        "is_json"
+                                      ]
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4264,7 +7344,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4316,7 +7399,10 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": ["correctness", "contradiction"]
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -4357,7 +7443,10 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": ["score_range", "outcome"],
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
@@ -4367,7 +7456,10 @@
                                       "minItems": 1
                                     }
                                   },
-                                  "required": ["type", "criteria"],
+                                  "required": [
+                                    "type",
+                                    "criteria"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -4411,7 +7503,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["code-grader", "code_grader"]
+                                      "enum": [
+                                        "code-grader",
+                                        "code_grader"
+                                      ]
                                     },
                                     "command": {
                                       "anyOf": [
@@ -4485,12 +7580,18 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": ["type", "command"],
+                                  "required": [
+                                    "type",
+                                    "command"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4527,7 +7628,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["llm-grader", "llm_grader"]
+                                      "enum": [
+                                        "llm-grader",
+                                        "llm_grader"
+                                      ]
                                     },
                                     "prompt": {
                                       "anyOf": [
@@ -4585,7 +7689,10 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": ["correctness", "contradiction"]
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -4626,7 +7733,10 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": ["score_range", "outcome"],
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
@@ -4677,12 +7787,17 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4693,7 +7808,9 @@
                                       "minLength": 1
                                     }
                                   },
-                                  "required": ["include"],
+                                  "required": [
+                                    "include"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4756,7 +7873,9 @@
                                               }
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -4772,7 +7891,10 @@
                                               "maximum": 1
                                             }
                                           },
-                                          "required": ["type", "threshold"],
+                                          "required": [
+                                            "type",
+                                            "threshold"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -4789,7 +7911,10 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["type", "path"],
+                                          "required": [
+                                            "type",
+                                            "path"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -4806,13 +7931,18 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": ["type", "aggregator"],
+                                  "required": [
+                                    "type",
+                                    "aggregator"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4849,7 +7979,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["tool-trajectory", "tool_trajectory"]
+                                      "enum": [
+                                        "tool-trajectory",
+                                        "tool_trajectory"
+                                      ]
                                     },
                                     "mode": {
                                       "type": "string",
@@ -4900,7 +8033,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -4914,7 +8052,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -4925,7 +8068,9 @@
                                             ]
                                           }
                                         },
-                                        "required": ["tool"],
+                                        "required": [
+                                          "tool"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     },
@@ -4933,7 +8078,12 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": ["exact", "ignore", "subset", "superset"]
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
                                         },
                                         {
                                           "type": "array",
@@ -4947,7 +8097,12 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": ["exact", "ignore", "subset", "superset"]
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
                                         },
                                         {
                                           "type": "array",
@@ -4958,7 +8113,10 @@
                                       ]
                                     }
                                   },
-                                  "required": ["type", "mode"],
+                                  "required": [
+                                    "type",
+                                    "mode"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4995,7 +8153,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["field-accuracy", "field_accuracy"]
+                                      "enum": [
+                                        "field-accuracy",
+                                        "field_accuracy"
+                                      ]
                                     },
                                     "fields": {
                                       "type": "array",
@@ -5007,7 +8168,11 @@
                                           },
                                           "match": {
                                             "type": "string",
-                                            "enum": ["exact", "numeric_tolerance", "date"]
+                                            "enum": [
+                                              "exact",
+                                              "numeric_tolerance",
+                                              "date"
+                                            ]
                                           },
                                           "required": {
                                             "type": "boolean"
@@ -5029,17 +8194,26 @@
                                             }
                                           }
                                         },
-                                        "required": ["path", "match"],
+                                        "required": [
+                                          "path",
+                                          "match"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       "minItems": 1
                                     },
                                     "aggregation": {
                                       "type": "string",
-                                      "enum": ["weighted_average", "all_or_nothing"]
+                                      "enum": [
+                                        "weighted_average",
+                                        "all_or_nothing"
+                                      ]
                                     }
                                   },
-                                  "required": ["type", "fields"],
+                                  "required": [
+                                    "type",
+                                    "fields"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5083,7 +8257,10 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type", "threshold"],
+                                  "required": [
+                                    "type",
+                                    "threshold"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5127,7 +8304,10 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type", "budget"],
+                                  "required": [
+                                    "type",
+                                    "budget"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5164,7 +8344,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["token-usage", "token_usage"]
+                                      "enum": [
+                                        "token-usage",
+                                        "token_usage"
+                                      ]
                                     },
                                     "max_total": {
                                       "type": "number",
@@ -5179,7 +8362,9 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5216,7 +8401,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["execution-metrics", "execution_metrics"]
+                                      "enum": [
+                                        "execution-metrics",
+                                        "execution_metrics"
+                                      ]
                                     },
                                     "max_tool_calls": {
                                       "type": "number",
@@ -5248,7 +8436,9 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5291,7 +8481,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5334,7 +8527,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5371,10 +8567,15 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["is-json", "is_json"]
+                                      "enum": [
+                                        "is-json",
+                                        "is_json"
+                                      ]
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5417,7 +8618,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5469,7 +8673,10 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": ["correctness", "contradiction"]
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -5510,7 +8717,10 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": ["score_range", "outcome"],
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
@@ -5520,7 +8730,10 @@
                                       "minItems": 1
                                     }
                                   },
-                                  "required": ["type", "criteria"],
+                                  "required": [
+                                    "type",
+                                    "criteria"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -5577,7 +8790,12 @@
                               },
                               "strategy": {
                                 "type": "string",
-                                "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                                "enum": [
+                                  "pass_at_k",
+                                  "pass_all",
+                                  "mean",
+                                  "confidence_interval"
+                                ]
                               },
                               "cost_limit_usd": {
                                 "type": "number",
@@ -5588,7 +8806,9 @@
                                 "minimum": 0
                               }
                             },
-                            "required": ["count"],
+                            "required": [
+                              "count"
+                            ],
                             "additionalProperties": false
                           },
                           "timeout_seconds": {
@@ -5612,7 +8832,10 @@
                           },
                           "isolation": {
                             "type": "string",
-                            "enum": ["shared", "per_case"]
+                            "enum": [
+                              "shared",
+                              "per_case"
+                            ]
                           },
                           "repos": {
                             "type": "array",
@@ -5694,7 +8917,11 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": ["none", "fast", "strict"]
+                                    "enum": [
+                                      "none",
+                                      "fast",
+                                      "strict"
+                                    ]
                                   }
                                 },
                                 "additionalProperties": false
@@ -5739,7 +8966,11 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": ["none", "fast", "strict"]
+                                    "enum": [
+                                      "none",
+                                      "fast",
+                                      "strict"
+                                    ]
                                   }
                                 },
                                 "additionalProperties": false
@@ -5784,7 +9015,11 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": ["none", "fast", "strict"]
+                                    "enum": [
+                                      "none",
+                                      "fast",
+                                      "strict"
+                                    ]
                                   }
                                 },
                                 "additionalProperties": false
@@ -5829,7 +9064,11 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": ["none", "fast", "strict"]
+                                    "enum": [
+                                      "none",
+                                      "fast",
+                                      "strict"
+                                    ]
                                   }
                                 },
                                 "additionalProperties": false
@@ -5855,7 +9094,9 @@
                                 "minimum": 0.1
                               }
                             },
-                            "required": ["image"],
+                            "required": [
+                              "image"
+                            ],
                             "additionalProperties": false
                           },
                           "env": {
@@ -5899,11 +9140,17 @@
                       },
                       "on_dependency_failure": {
                         "type": "string",
-                        "enum": ["skip", "fail", "run"]
+                        "enum": [
+                          "skip",
+                          "fail",
+                          "run"
+                        ]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": ["conversation"]
+                        "enum": [
+                          "conversation"
+                        ]
                       },
                       "turns": {
                         "type": "array",
@@ -5932,13 +9179,20 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["text", "file", "image"]
+                                            "enum": [
+                                              "text",
+                                              "file",
+                                              "image"
+                                            ]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
@@ -5968,13 +9222,20 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["text", "file", "image"]
+                                            "enum": [
+                                              "text",
+                                              "file",
+                                              "image"
+                                            ]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
@@ -6025,7 +9286,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["code-grader", "code_grader"]
+                                            "enum": [
+                                              "code-grader",
+                                              "code_grader"
+                                            ]
                                           },
                                           "command": {
                                             "anyOf": [
@@ -6099,12 +9363,18 @@
                                                   ]
                                                 }
                                               },
-                                              "required": ["type", "command"],
+                                              "required": [
+                                                "type",
+                                                "command"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6141,7 +9411,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["llm-grader", "llm_grader"]
+                                            "enum": [
+                                              "llm-grader",
+                                              "llm_grader"
+                                            ]
                                           },
                                           "prompt": {
                                             "anyOf": [
@@ -6199,7 +9472,10 @@
                                                 },
                                                 "operator": {
                                                   "type": "string",
-                                                  "enum": ["correctness", "contradiction"]
+                                                  "enum": [
+                                                    "correctness",
+                                                    "contradiction"
+                                                  ]
                                                 },
                                                 "weight": {
                                                   "type": "number"
@@ -6240,7 +9516,10 @@
                                                         "minLength": 1
                                                       }
                                                     },
-                                                    "required": ["score_range", "outcome"],
+                                                    "required": [
+                                                      "score_range",
+                                                      "outcome"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 }
@@ -6291,12 +9570,17 @@
                                                   ]
                                                 }
                                               },
-                                              "required": ["type", "command"],
+                                              "required": [
+                                                "type",
+                                                "command"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6307,7 +9591,9 @@
                                             "minLength": 1
                                           }
                                         },
-                                        "required": ["include"],
+                                        "required": [
+                                          "include"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6370,7 +9656,9 @@
                                                     }
                                                   }
                                                 },
-                                                "required": ["type"],
+                                                "required": [
+                                                  "type"
+                                                ],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -6386,7 +9674,10 @@
                                                     "maximum": 1
                                                   }
                                                 },
-                                                "required": ["type", "threshold"],
+                                                "required": [
+                                                  "type",
+                                                  "threshold"
+                                                ],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -6403,7 +9694,10 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["type", "path"],
+                                                "required": [
+                                                  "type",
+                                                  "path"
+                                                ],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -6420,13 +9714,18 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["type"],
+                                                "required": [
+                                                  "type"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
                                           }
                                         },
-                                        "required": ["type", "aggregator"],
+                                        "required": [
+                                          "type",
+                                          "aggregator"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6463,7 +9762,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["tool-trajectory", "tool_trajectory"]
+                                            "enum": [
+                                              "tool-trajectory",
+                                              "tool_trajectory"
+                                            ]
                                           },
                                           "mode": {
                                             "type": "string",
@@ -6549,7 +9851,9 @@
                                                   ]
                                                 }
                                               },
-                                              "required": ["tool"],
+                                              "required": [
+                                                "tool"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           },
@@ -6557,7 +9861,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -6571,7 +9880,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -6582,7 +9896,10 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "mode"],
+                                        "required": [
+                                          "type",
+                                          "mode"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6619,7 +9936,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["field-accuracy", "field_accuracy"]
+                                            "enum": [
+                                              "field-accuracy",
+                                              "field_accuracy"
+                                            ]
                                           },
                                           "fields": {
                                             "type": "array",
@@ -6631,7 +9951,11 @@
                                                 },
                                                 "match": {
                                                   "type": "string",
-                                                  "enum": ["exact", "numeric_tolerance", "date"]
+                                                  "enum": [
+                                                    "exact",
+                                                    "numeric_tolerance",
+                                                    "date"
+                                                  ]
                                                 },
                                                 "required": {
                                                   "type": "boolean"
@@ -6653,17 +9977,26 @@
                                                   }
                                                 }
                                               },
-                                              "required": ["path", "match"],
+                                              "required": [
+                                                "path",
+                                                "match"
+                                              ],
                                               "additionalProperties": false
                                             },
                                             "minItems": 1
                                           },
                                           "aggregation": {
                                             "type": "string",
-                                            "enum": ["weighted_average", "all_or_nothing"]
+                                            "enum": [
+                                              "weighted_average",
+                                              "all_or_nothing"
+                                            ]
                                           }
                                         },
-                                        "required": ["type", "fields"],
+                                        "required": [
+                                          "type",
+                                          "fields"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6707,7 +10040,10 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": ["type", "threshold"],
+                                        "required": [
+                                          "type",
+                                          "threshold"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6751,7 +10087,10 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": ["type", "budget"],
+                                        "required": [
+                                          "type",
+                                          "budget"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6788,7 +10127,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["token-usage", "token_usage"]
+                                            "enum": [
+                                              "token-usage",
+                                              "token_usage"
+                                            ]
                                           },
                                           "max_total": {
                                             "type": "number",
@@ -6803,7 +10145,9 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6840,7 +10184,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["execution-metrics", "execution_metrics"]
+                                            "enum": [
+                                              "execution-metrics",
+                                              "execution_metrics"
+                                            ]
                                           },
                                           "max_tool_calls": {
                                             "type": "number",
@@ -6872,7 +10219,9 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6915,7 +10264,10 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6958,7 +10310,10 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6995,10 +10350,15 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["is-json", "is_json"]
+                                            "enum": [
+                                              "is-json",
+                                              "is_json"
+                                            ]
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -7041,7 +10401,10 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -7093,7 +10456,10 @@
                                                 },
                                                 "operator": {
                                                   "type": "string",
-                                                  "enum": ["correctness", "contradiction"]
+                                                  "enum": [
+                                                    "correctness",
+                                                    "contradiction"
+                                                  ]
                                                 },
                                                 "weight": {
                                                   "type": "number"
@@ -7134,7 +10500,10 @@
                                                         "minLength": 1
                                                       }
                                                     },
-                                                    "required": ["score_range", "outcome"],
+                                                    "required": [
+                                                      "score_range",
+                                                      "outcome"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 }
@@ -7144,7 +10513,10 @@
                                             "minItems": 1
                                           }
                                         },
-                                        "required": ["type", "criteria"],
+                                        "required": [
+                                          "type",
+                                          "criteria"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     ]
@@ -7153,25 +10525,36 @@
                               }
                             }
                           },
-                          "required": ["input"],
+                          "required": [
+                            "input"
+                          ],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": ["mean", "min", "max"]
+                        "enum": [
+                          "mean",
+                          "min",
+                          "max"
+                        ]
                       },
                       "on_turn_failure": {
                         "type": "string",
-                        "enum": ["continue", "stop"]
+                        "enum": [
+                          "continue",
+                          "stop"
+                        ]
                       },
                       "window_size": {
                         "type": "integer",
                         "minimum": 1
                       }
                     },
-                    "required": ["id"],
+                    "required": [
+                      "id"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -7183,7 +10566,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["suite", "tests"]
+                        "enum": [
+                          "suite",
+                          "tests"
+                        ]
                       },
                       "select": {
                         "anyOf": [
@@ -7254,7 +10640,11 @@
                                     {
                                       "type": "array",
                                       "items": {
-                                        "type": ["string", "number", "boolean"]
+                                        "type": [
+                                          "string",
+                                          "number",
+                                          "boolean"
+                                        ]
                                       },
                                       "minItems": 1
                                     }
@@ -7283,7 +10673,12 @@
                               },
                               "strategy": {
                                 "type": "string",
-                                "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                                "enum": [
+                                  "pass_at_k",
+                                  "pass_all",
+                                  "mean",
+                                  "confidence_interval"
+                                ]
                               },
                               "cost_limit_usd": {
                                 "type": "number",
@@ -7294,7 +10689,9 @@
                                 "minimum": 0
                               }
                             },
-                            "required": ["count"],
+                            "required": [
+                              "count"
+                            ],
                             "additionalProperties": false
                           },
                           "timeout_seconds": {
@@ -7311,7 +10708,10 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["include", "type"],
+                    "required": [
+                      "include",
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -7358,7 +10758,12 @@
                             "properties": {
                               "role": {
                                 "type": "string",
-                                "enum": ["system", "user", "assistant", "tool"]
+                                "enum": [
+                                  "system",
+                                  "user",
+                                  "assistant",
+                                  "tool"
+                                ]
                               },
                               "content": {
                                 "anyOf": [
@@ -7377,20 +10782,30 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": ["text", "file", "image"]
+                                          "enum": [
+                                            "text",
+                                            "file",
+                                            "image"
+                                          ]
                                         },
                                         "value": {
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type", "value"],
+                                      "required": [
+                                        "type",
+                                        "value"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   }
                                 ]
                               }
                             },
-                            "required": ["role", "content"],
+                            "required": [
+                              "role",
+                              "content"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -7409,7 +10824,12 @@
                               "properties": {
                                 "role": {
                                   "type": "string",
-                                  "enum": ["system", "user", "assistant", "tool"]
+                                  "enum": [
+                                    "system",
+                                    "user",
+                                    "assistant",
+                                    "tool"
+                                  ]
                                 },
                                 "content": {
                                   "anyOf": [
@@ -7428,20 +10848,30 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["text", "file", "image"]
+                                            "enum": [
+                                              "text",
+                                              "file",
+                                              "image"
+                                            ]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   ]
                                 }
                               },
-                              "required": ["role", "content"],
+                              "required": [
+                                "role",
+                                "content"
+                              ],
                               "additionalProperties": false
                             }
                           }
@@ -7470,7 +10900,12 @@
                               "properties": {
                                 "role": {
                                   "type": "string",
-                                  "enum": ["system", "user", "assistant", "tool"]
+                                  "enum": [
+                                    "system",
+                                    "user",
+                                    "assistant",
+                                    "tool"
+                                  ]
                                 },
                                 "content": {
                                   "anyOf": [
@@ -7489,20 +10924,30 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["text", "file", "image"]
+                                            "enum": [
+                                              "text",
+                                              "file",
+                                              "image"
+                                            ]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   ]
                                 }
                               },
-                              "required": ["role", "content"],
+                              "required": [
+                                "role",
+                                "content"
+                              ],
                               "additionalProperties": false
                             }
                           }
@@ -7546,7 +10991,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["code-grader", "code_grader"]
+                                  "enum": [
+                                    "code-grader",
+                                    "code_grader"
+                                  ]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -7620,12 +11068,18 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type", "command"],
+                              "required": [
+                                "type",
+                                "command"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -7662,7 +11116,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["llm-grader", "llm_grader"]
+                                  "enum": [
+                                    "llm-grader",
+                                    "llm_grader"
+                                  ]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -7720,7 +11177,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -7761,7 +11221,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -7812,12 +11275,17 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -7828,7 +11296,9 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": ["include"],
+                              "required": [
+                                "include"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -7891,7 +11361,9 @@
                                           }
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -7907,7 +11379,10 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": ["type", "threshold"],
+                                      "required": [
+                                        "type",
+                                        "threshold"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -7924,7 +11399,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type", "path"],
+                                      "required": [
+                                        "type",
+                                        "path"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -7941,13 +11419,18 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["type", "aggregator"],
+                              "required": [
+                                "type",
+                                "aggregator"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -7984,11 +11467,20 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["tool-trajectory", "tool_trajectory"]
+                                  "enum": [
+                                    "tool-trajectory",
+                                    "tool_trajectory"
+                                  ]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                                  "enum": [
+                                    "any_order",
+                                    "in_order",
+                                    "exact",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -8029,7 +11521,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -8043,7 +11540,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -8054,7 +11556,9 @@
                                         ]
                                       }
                                     },
-                                    "required": ["tool"],
+                                    "required": [
+                                      "tool"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 },
@@ -8062,7 +11566,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -8076,7 +11585,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -8087,7 +11601,10 @@
                                   ]
                                 }
                               },
-                              "required": ["type", "mode"],
+                              "required": [
+                                "type",
+                                "mode"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8124,7 +11641,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["field-accuracy", "field_accuracy"]
+                                  "enum": [
+                                    "field-accuracy",
+                                    "field_accuracy"
+                                  ]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -8136,7 +11656,11 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": ["exact", "numeric_tolerance", "date"]
+                                        "enum": [
+                                          "exact",
+                                          "numeric_tolerance",
+                                          "date"
+                                        ]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -8158,17 +11682,26 @@
                                         }
                                       }
                                     },
-                                    "required": ["path", "match"],
+                                    "required": [
+                                      "path",
+                                      "match"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": ["weighted_average", "all_or_nothing"]
+                                  "enum": [
+                                    "weighted_average",
+                                    "all_or_nothing"
+                                  ]
                                 }
                               },
-                              "required": ["type", "fields"],
+                              "required": [
+                                "type",
+                                "fields"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8212,7 +11745,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "threshold"],
+                              "required": [
+                                "type",
+                                "threshold"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8256,7 +11792,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "budget"],
+                              "required": [
+                                "type",
+                                "budget"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8293,7 +11832,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["token-usage", "token_usage"]
+                                  "enum": [
+                                    "token-usage",
+                                    "token_usage"
+                                  ]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -8308,7 +11850,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8345,7 +11889,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["execution-metrics", "execution_metrics"]
+                                  "enum": [
+                                    "execution-metrics",
+                                    "execution_metrics"
+                                  ]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -8377,7 +11924,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8420,7 +11969,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8463,7 +12015,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8500,10 +12055,15 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["is-json", "is_json"]
+                                  "enum": [
+                                    "is-json",
+                                    "is_json"
+                                  ]
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8546,7 +12106,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8598,7 +12161,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -8639,7 +12205,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -8649,7 +12218,10 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": ["type", "criteria"],
+                              "required": [
+                                "type",
+                                "criteria"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -8693,7 +12265,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["code-grader", "code_grader"]
+                                  "enum": [
+                                    "code-grader",
+                                    "code_grader"
+                                  ]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -8767,12 +12342,18 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type", "command"],
+                              "required": [
+                                "type",
+                                "command"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8809,7 +12390,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["llm-grader", "llm_grader"]
+                                  "enum": [
+                                    "llm-grader",
+                                    "llm_grader"
+                                  ]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -8867,7 +12451,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -8908,7 +12495,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -8959,12 +12549,17 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8975,7 +12570,9 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": ["include"],
+                              "required": [
+                                "include"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9038,7 +12635,9 @@
                                           }
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -9054,7 +12653,10 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": ["type", "threshold"],
+                                      "required": [
+                                        "type",
+                                        "threshold"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -9071,7 +12673,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type", "path"],
+                                      "required": [
+                                        "type",
+                                        "path"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -9088,13 +12693,18 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["type", "aggregator"],
+                              "required": [
+                                "type",
+                                "aggregator"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9131,11 +12741,20 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["tool-trajectory", "tool_trajectory"]
+                                  "enum": [
+                                    "tool-trajectory",
+                                    "tool_trajectory"
+                                  ]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                                  "enum": [
+                                    "any_order",
+                                    "in_order",
+                                    "exact",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -9176,7 +12795,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -9190,7 +12814,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -9201,7 +12830,9 @@
                                         ]
                                       }
                                     },
-                                    "required": ["tool"],
+                                    "required": [
+                                      "tool"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 },
@@ -9209,7 +12840,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -9223,7 +12859,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -9234,7 +12875,10 @@
                                   ]
                                 }
                               },
-                              "required": ["type", "mode"],
+                              "required": [
+                                "type",
+                                "mode"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9271,7 +12915,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["field-accuracy", "field_accuracy"]
+                                  "enum": [
+                                    "field-accuracy",
+                                    "field_accuracy"
+                                  ]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -9283,7 +12930,11 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": ["exact", "numeric_tolerance", "date"]
+                                        "enum": [
+                                          "exact",
+                                          "numeric_tolerance",
+                                          "date"
+                                        ]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -9305,17 +12956,26 @@
                                         }
                                       }
                                     },
-                                    "required": ["path", "match"],
+                                    "required": [
+                                      "path",
+                                      "match"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": ["weighted_average", "all_or_nothing"]
+                                  "enum": [
+                                    "weighted_average",
+                                    "all_or_nothing"
+                                  ]
                                 }
                               },
-                              "required": ["type", "fields"],
+                              "required": [
+                                "type",
+                                "fields"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9359,7 +13019,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "threshold"],
+                              "required": [
+                                "type",
+                                "threshold"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9403,7 +13066,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "budget"],
+                              "required": [
+                                "type",
+                                "budget"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9440,7 +13106,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["token-usage", "token_usage"]
+                                  "enum": [
+                                    "token-usage",
+                                    "token_usage"
+                                  ]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -9455,7 +13124,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9492,7 +13163,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["execution-metrics", "execution_metrics"]
+                                  "enum": [
+                                    "execution-metrics",
+                                    "execution_metrics"
+                                  ]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -9524,7 +13198,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9567,7 +13243,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9610,7 +13289,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9647,10 +13329,15 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["is-json", "is_json"]
+                                  "enum": [
+                                    "is-json",
+                                    "is_json"
+                                  ]
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9693,7 +13380,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9745,7 +13435,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -9786,7 +13479,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -9796,11 +13492,2604 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": ["type", "criteria"],
+                              "required": [
+                                "type",
+                                "criteria"
+                              ],
                               "additionalProperties": false
                             }
                           ]
                         }
+                      },
+                      "experiment": {
+                        "type": "object",
+                        "properties": {
+                          "workers": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50
+                          },
+                          "assertions": {
+                            "type": "array",
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "code-grader",
+                                        "code_grader"
+                                      ]
+                                    },
+                                    "command": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "script": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "cwd": {
+                                      "type": "string"
+                                    },
+                                    "target": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "max_calls": {
+                                              "type": "number"
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "config": {
+                                      "type": "object",
+                                      "additionalProperties": {}
+                                    },
+                                    "preprocessors": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "command": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "command"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "llm-grader",
+                                        "llm_grader"
+                                      ]
+                                    },
+                                    "prompt": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "command": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "script": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "config": {
+                                              "type": "object",
+                                              "additionalProperties": {}
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "rubrics": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "outcome": {
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "type": "string",
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
+                                          },
+                                          "weight": {
+                                            "type": "number"
+                                          },
+                                          "required": {
+                                            "type": "boolean"
+                                          },
+                                          "min_score": {
+                                            "type": "number",
+                                            "exclusiveMinimum": true,
+                                            "minimum": 0,
+                                            "maximum": 1
+                                          },
+                                          "score_ranges": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "score_range": {
+                                                  "type": "array",
+                                                  "minItems": 2,
+                                                  "maxItems": 2,
+                                                  "items": [
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    },
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    }
+                                                  ]
+                                                },
+                                                "outcome": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                }
+                                              },
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "model": {
+                                      "type": "string"
+                                    },
+                                    "target": {
+                                      "type": "string"
+                                    },
+                                    "config": {
+                                      "type": "object",
+                                      "additionalProperties": {}
+                                    },
+                                    "max_steps": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 50
+                                    },
+                                    "temperature": {
+                                      "type": "number",
+                                      "minimum": 0,
+                                      "maximum": 2
+                                    },
+                                    "preprocessors": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "command": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "include": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    }
+                                  },
+                                  "required": [
+                                    "include"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "composite"
+                                    },
+                                    "assertions": {
+                                      "type": "array",
+                                      "items": {}
+                                    },
+                                    "evaluators": {
+                                      "type": "array",
+                                      "items": {}
+                                    },
+                                    "aggregator": {
+                                      "anyOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "weighted_average"
+                                            },
+                                            "weights": {
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "type": "number"
+                                              }
+                                            }
+                                          },
+                                          "required": [
+                                            "type"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "threshold"
+                                            },
+                                            "threshold": {
+                                              "type": "number",
+                                              "minimum": 0,
+                                              "maximum": 1
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "threshold"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "code-grader"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "cwd": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "path"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "llm-grader"
+                                            },
+                                            "prompt": {
+                                              "type": "string"
+                                            },
+                                            "model": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "type"
+                                          ],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "aggregator"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "tool-trajectory",
+                                        "tool_trajectory"
+                                      ]
+                                    },
+                                    "mode": {
+                                      "type": "string",
+                                      "enum": [
+                                        "any_order",
+                                        "in_order",
+                                        "exact",
+                                        "subset",
+                                        "superset"
+                                      ]
+                                    },
+                                    "minimums": {
+                                      "type": "object",
+                                      "additionalProperties": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      }
+                                    },
+                                    "expected": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "tool": {
+                                            "type": "string"
+                                          },
+                                          "args": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string",
+                                                "const": "any"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "additionalProperties": {}
+                                              }
+                                            ]
+                                          },
+                                          "max_duration_ms": {
+                                            "type": "number",
+                                            "minimum": 0
+                                          },
+                                          "maxDurationMs": {
+                                            "type": "number",
+                                            "minimum": 0
+                                          },
+                                          "args_match": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string",
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
+                                              },
+                                              {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "argsMatch": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string",
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
+                                              },
+                                              {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "tool"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "args_match": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string",
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "argsMatch": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string",
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "mode"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "field-accuracy",
+                                        "field_accuracy"
+                                      ]
+                                    },
+                                    "fields": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "match": {
+                                            "type": "string",
+                                            "enum": [
+                                              "exact",
+                                              "numeric_tolerance",
+                                              "date"
+                                            ]
+                                          },
+                                          "required": {
+                                            "type": "boolean"
+                                          },
+                                          "weight": {
+                                            "type": "number"
+                                          },
+                                          "tolerance": {
+                                            "type": "number",
+                                            "minimum": 0
+                                          },
+                                          "relative": {
+                                            "type": "boolean"
+                                          },
+                                          "formats": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "required": [
+                                          "path",
+                                          "match"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "minItems": 1
+                                    },
+                                    "aggregation": {
+                                      "type": "string",
+                                      "enum": [
+                                        "weighted_average",
+                                        "all_or_nothing"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "fields"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "latency"
+                                    },
+                                    "threshold": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "threshold"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "cost"
+                                    },
+                                    "budget": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "budget"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "token-usage",
+                                        "token_usage"
+                                      ]
+                                    },
+                                    "max_total": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_input": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_output": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "execution-metrics",
+                                        "execution_metrics"
+                                      ]
+                                    },
+                                    "max_tool_calls": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_llm_calls": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_tokens": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_cost_usd": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_duration_ms": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "target_exploration_ratio": {
+                                      "type": "number",
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "exploration_tolerance": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "contains"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "regex"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "is-json",
+                                        "is_json"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "equals"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "rubrics"
+                                    },
+                                    "criteria": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "outcome": {
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "type": "string",
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
+                                          },
+                                          "weight": {
+                                            "type": "number"
+                                          },
+                                          "required": {
+                                            "type": "boolean"
+                                          },
+                                          "min_score": {
+                                            "type": "number",
+                                            "exclusiveMinimum": true,
+                                            "minimum": 0,
+                                            "maximum": 1
+                                          },
+                                          "score_ranges": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "score_range": {
+                                                  "type": "array",
+                                                  "minItems": 2,
+                                                  "maxItems": 2,
+                                                  "items": [
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    },
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    }
+                                                  ]
+                                                },
+                                                "outcome": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                }
+                                              },
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      },
+                                      "minItems": 1
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "criteria"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            }
+                          },
+                          "evaluators": {
+                            "type": "array",
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "code-grader",
+                                        "code_grader"
+                                      ]
+                                    },
+                                    "command": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "script": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "cwd": {
+                                      "type": "string"
+                                    },
+                                    "target": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "max_calls": {
+                                              "type": "number"
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "config": {
+                                      "type": "object",
+                                      "additionalProperties": {}
+                                    },
+                                    "preprocessors": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "command": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "command"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "llm-grader",
+                                        "llm_grader"
+                                      ]
+                                    },
+                                    "prompt": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "command": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "script": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "config": {
+                                              "type": "object",
+                                              "additionalProperties": {}
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "rubrics": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "outcome": {
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "type": "string",
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
+                                          },
+                                          "weight": {
+                                            "type": "number"
+                                          },
+                                          "required": {
+                                            "type": "boolean"
+                                          },
+                                          "min_score": {
+                                            "type": "number",
+                                            "exclusiveMinimum": true,
+                                            "minimum": 0,
+                                            "maximum": 1
+                                          },
+                                          "score_ranges": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "score_range": {
+                                                  "type": "array",
+                                                  "minItems": 2,
+                                                  "maxItems": 2,
+                                                  "items": [
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    },
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    }
+                                                  ]
+                                                },
+                                                "outcome": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                }
+                                              },
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "model": {
+                                      "type": "string"
+                                    },
+                                    "target": {
+                                      "type": "string"
+                                    },
+                                    "config": {
+                                      "type": "object",
+                                      "additionalProperties": {}
+                                    },
+                                    "max_steps": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 50
+                                    },
+                                    "temperature": {
+                                      "type": "number",
+                                      "minimum": 0,
+                                      "maximum": 2
+                                    },
+                                    "preprocessors": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "command": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "include": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    }
+                                  },
+                                  "required": [
+                                    "include"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "composite"
+                                    },
+                                    "assertions": {
+                                      "type": "array",
+                                      "items": {}
+                                    },
+                                    "evaluators": {
+                                      "type": "array",
+                                      "items": {}
+                                    },
+                                    "aggregator": {
+                                      "anyOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "weighted_average"
+                                            },
+                                            "weights": {
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "type": "number"
+                                              }
+                                            }
+                                          },
+                                          "required": [
+                                            "type"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "threshold"
+                                            },
+                                            "threshold": {
+                                              "type": "number",
+                                              "minimum": 0,
+                                              "maximum": 1
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "threshold"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "code-grader"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "cwd": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "path"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "llm-grader"
+                                            },
+                                            "prompt": {
+                                              "type": "string"
+                                            },
+                                            "model": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "type"
+                                          ],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "aggregator"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "tool-trajectory",
+                                        "tool_trajectory"
+                                      ]
+                                    },
+                                    "mode": {
+                                      "type": "string",
+                                      "enum": [
+                                        "any_order",
+                                        "in_order",
+                                        "exact",
+                                        "subset",
+                                        "superset"
+                                      ]
+                                    },
+                                    "minimums": {
+                                      "type": "object",
+                                      "additionalProperties": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      }
+                                    },
+                                    "expected": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "tool": {
+                                            "type": "string"
+                                          },
+                                          "args": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string",
+                                                "const": "any"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "additionalProperties": {}
+                                              }
+                                            ]
+                                          },
+                                          "max_duration_ms": {
+                                            "type": "number",
+                                            "minimum": 0
+                                          },
+                                          "maxDurationMs": {
+                                            "type": "number",
+                                            "minimum": 0
+                                          },
+                                          "args_match": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string",
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
+                                              },
+                                              {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "argsMatch": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string",
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
+                                              },
+                                              {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "tool"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "args_match": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string",
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "argsMatch": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string",
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "mode"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "field-accuracy",
+                                        "field_accuracy"
+                                      ]
+                                    },
+                                    "fields": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "match": {
+                                            "type": "string",
+                                            "enum": [
+                                              "exact",
+                                              "numeric_tolerance",
+                                              "date"
+                                            ]
+                                          },
+                                          "required": {
+                                            "type": "boolean"
+                                          },
+                                          "weight": {
+                                            "type": "number"
+                                          },
+                                          "tolerance": {
+                                            "type": "number",
+                                            "minimum": 0
+                                          },
+                                          "relative": {
+                                            "type": "boolean"
+                                          },
+                                          "formats": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "required": [
+                                          "path",
+                                          "match"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "minItems": 1
+                                    },
+                                    "aggregation": {
+                                      "type": "string",
+                                      "enum": [
+                                        "weighted_average",
+                                        "all_or_nothing"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "fields"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "latency"
+                                    },
+                                    "threshold": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "threshold"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "cost"
+                                    },
+                                    "budget": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "budget"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "token-usage",
+                                        "token_usage"
+                                      ]
+                                    },
+                                    "max_total": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_input": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_output": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "execution-metrics",
+                                        "execution_metrics"
+                                      ]
+                                    },
+                                    "max_tool_calls": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_llm_calls": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_tokens": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_cost_usd": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "max_duration_ms": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "target_exploration_ratio": {
+                                      "type": "number",
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "exploration_tolerance": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "contains"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "regex"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "is-json",
+                                        "is_json"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "equals"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "weight": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "required": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "exclusiveMinimum": true,
+                                          "minimum": 0,
+                                          "maximum": 1
+                                        }
+                                      ]
+                                    },
+                                    "min_score": {
+                                      "type": "number",
+                                      "exclusiveMinimum": true,
+                                      "minimum": 0,
+                                      "maximum": 1
+                                    },
+                                    "negate": {
+                                      "type": "boolean"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "const": "rubrics"
+                                    },
+                                    "criteria": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "outcome": {
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "type": "string",
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
+                                          },
+                                          "weight": {
+                                            "type": "number"
+                                          },
+                                          "required": {
+                                            "type": "boolean"
+                                          },
+                                          "min_score": {
+                                            "type": "number",
+                                            "exclusiveMinimum": true,
+                                            "minimum": 0,
+                                            "maximum": 1
+                                          },
+                                          "score_ranges": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "score_range": {
+                                                  "type": "array",
+                                                  "minItems": 2,
+                                                  "maxItems": 2,
+                                                  "items": [
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    },
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    }
+                                                  ]
+                                                },
+                                                "outcome": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                }
+                                              },
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      },
+                                      "minItems": 1
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "criteria"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            }
+                          },
+                          "skip_defaults": {
+                            "type": "boolean"
+                          },
+                          "cache": {
+                            "type": "boolean"
+                          },
+                          "trials": {
+                            "not": {}
+                          },
+                          "budget_usd": {
+                            "type": "number",
+                            "minimum": 0
+                          },
+                          "budgetUsd": {
+                            "type": "number",
+                            "minimum": 0
+                          },
+                          "fail_on_error": {
+                            "type": "boolean"
+                          },
+                          "failOnError": {
+                            "type": "boolean"
+                          },
+                          "threshold": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "workspace": {
+                            "not": {}
+                          }
+                        },
+                        "additionalProperties": false
                       },
                       "execution": {
                         "type": "object",
@@ -9848,7 +16137,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["code-grader", "code_grader"]
+                                      "enum": [
+                                        "code-grader",
+                                        "code_grader"
+                                      ]
                                     },
                                     "command": {
                                       "anyOf": [
@@ -9922,12 +16214,18 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": ["type", "command"],
+                                  "required": [
+                                    "type",
+                                    "command"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -9964,7 +16262,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["llm-grader", "llm_grader"]
+                                      "enum": [
+                                        "llm-grader",
+                                        "llm_grader"
+                                      ]
                                     },
                                     "prompt": {
                                       "anyOf": [
@@ -10022,7 +16323,10 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": ["correctness", "contradiction"]
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -10063,7 +16367,10 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": ["score_range", "outcome"],
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
@@ -10114,12 +16421,17 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10130,7 +16442,9 @@
                                       "minLength": 1
                                     }
                                   },
-                                  "required": ["include"],
+                                  "required": [
+                                    "include"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10193,7 +16507,9 @@
                                               }
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -10209,7 +16525,10 @@
                                               "maximum": 1
                                             }
                                           },
-                                          "required": ["type", "threshold"],
+                                          "required": [
+                                            "type",
+                                            "threshold"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -10226,7 +16545,10 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["type", "path"],
+                                          "required": [
+                                            "type",
+                                            "path"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -10243,13 +16565,18 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": ["type", "aggregator"],
+                                  "required": [
+                                    "type",
+                                    "aggregator"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10286,7 +16613,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["tool-trajectory", "tool_trajectory"]
+                                      "enum": [
+                                        "tool-trajectory",
+                                        "tool_trajectory"
+                                      ]
                                     },
                                     "mode": {
                                       "type": "string",
@@ -10337,7 +16667,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -10351,7 +16686,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -10362,7 +16702,9 @@
                                             ]
                                           }
                                         },
-                                        "required": ["tool"],
+                                        "required": [
+                                          "tool"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     },
@@ -10370,7 +16712,12 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": ["exact", "ignore", "subset", "superset"]
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
                                         },
                                         {
                                           "type": "array",
@@ -10384,7 +16731,12 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": ["exact", "ignore", "subset", "superset"]
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
                                         },
                                         {
                                           "type": "array",
@@ -10395,7 +16747,10 @@
                                       ]
                                     }
                                   },
-                                  "required": ["type", "mode"],
+                                  "required": [
+                                    "type",
+                                    "mode"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10432,7 +16787,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["field-accuracy", "field_accuracy"]
+                                      "enum": [
+                                        "field-accuracy",
+                                        "field_accuracy"
+                                      ]
                                     },
                                     "fields": {
                                       "type": "array",
@@ -10444,7 +16802,11 @@
                                           },
                                           "match": {
                                             "type": "string",
-                                            "enum": ["exact", "numeric_tolerance", "date"]
+                                            "enum": [
+                                              "exact",
+                                              "numeric_tolerance",
+                                              "date"
+                                            ]
                                           },
                                           "required": {
                                             "type": "boolean"
@@ -10466,17 +16828,26 @@
                                             }
                                           }
                                         },
-                                        "required": ["path", "match"],
+                                        "required": [
+                                          "path",
+                                          "match"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       "minItems": 1
                                     },
                                     "aggregation": {
                                       "type": "string",
-                                      "enum": ["weighted_average", "all_or_nothing"]
+                                      "enum": [
+                                        "weighted_average",
+                                        "all_or_nothing"
+                                      ]
                                     }
                                   },
-                                  "required": ["type", "fields"],
+                                  "required": [
+                                    "type",
+                                    "fields"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10520,7 +16891,10 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type", "threshold"],
+                                  "required": [
+                                    "type",
+                                    "threshold"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10564,7 +16938,10 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type", "budget"],
+                                  "required": [
+                                    "type",
+                                    "budget"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10601,7 +16978,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["token-usage", "token_usage"]
+                                      "enum": [
+                                        "token-usage",
+                                        "token_usage"
+                                      ]
                                     },
                                     "max_total": {
                                       "type": "number",
@@ -10616,7 +16996,9 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10653,7 +17035,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["execution-metrics", "execution_metrics"]
+                                      "enum": [
+                                        "execution-metrics",
+                                        "execution_metrics"
+                                      ]
                                     },
                                     "max_tool_calls": {
                                       "type": "number",
@@ -10685,7 +17070,9 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10728,7 +17115,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10771,7 +17161,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10808,10 +17201,15 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["is-json", "is_json"]
+                                      "enum": [
+                                        "is-json",
+                                        "is_json"
+                                      ]
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10854,7 +17252,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10906,7 +17307,10 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": ["correctness", "contradiction"]
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -10947,7 +17351,10 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": ["score_range", "outcome"],
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
@@ -10957,7 +17364,10 @@
                                       "minItems": 1
                                     }
                                   },
-                                  "required": ["type", "criteria"],
+                                  "required": [
+                                    "type",
+                                    "criteria"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -11001,7 +17411,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["code-grader", "code_grader"]
+                                      "enum": [
+                                        "code-grader",
+                                        "code_grader"
+                                      ]
                                     },
                                     "command": {
                                       "anyOf": [
@@ -11075,12 +17488,18 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": ["type", "command"],
+                                  "required": [
+                                    "type",
+                                    "command"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11117,7 +17536,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["llm-grader", "llm_grader"]
+                                      "enum": [
+                                        "llm-grader",
+                                        "llm_grader"
+                                      ]
                                     },
                                     "prompt": {
                                       "anyOf": [
@@ -11175,7 +17597,10 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": ["correctness", "contradiction"]
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -11216,7 +17641,10 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": ["score_range", "outcome"],
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
@@ -11267,12 +17695,17 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11283,7 +17716,9 @@
                                       "minLength": 1
                                     }
                                   },
-                                  "required": ["include"],
+                                  "required": [
+                                    "include"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11346,7 +17781,9 @@
                                               }
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -11362,7 +17799,10 @@
                                               "maximum": 1
                                             }
                                           },
-                                          "required": ["type", "threshold"],
+                                          "required": [
+                                            "type",
+                                            "threshold"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -11379,7 +17819,10 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["type", "path"],
+                                          "required": [
+                                            "type",
+                                            "path"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -11396,13 +17839,18 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": ["type", "aggregator"],
+                                  "required": [
+                                    "type",
+                                    "aggregator"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11439,7 +17887,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["tool-trajectory", "tool_trajectory"]
+                                      "enum": [
+                                        "tool-trajectory",
+                                        "tool_trajectory"
+                                      ]
                                     },
                                     "mode": {
                                       "type": "string",
@@ -11490,7 +17941,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -11504,7 +17960,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -11515,7 +17976,9 @@
                                             ]
                                           }
                                         },
-                                        "required": ["tool"],
+                                        "required": [
+                                          "tool"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     },
@@ -11523,7 +17986,12 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": ["exact", "ignore", "subset", "superset"]
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
                                         },
                                         {
                                           "type": "array",
@@ -11537,7 +18005,12 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": ["exact", "ignore", "subset", "superset"]
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
                                         },
                                         {
                                           "type": "array",
@@ -11548,7 +18021,10 @@
                                       ]
                                     }
                                   },
-                                  "required": ["type", "mode"],
+                                  "required": [
+                                    "type",
+                                    "mode"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11585,7 +18061,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["field-accuracy", "field_accuracy"]
+                                      "enum": [
+                                        "field-accuracy",
+                                        "field_accuracy"
+                                      ]
                                     },
                                     "fields": {
                                       "type": "array",
@@ -11597,7 +18076,11 @@
                                           },
                                           "match": {
                                             "type": "string",
-                                            "enum": ["exact", "numeric_tolerance", "date"]
+                                            "enum": [
+                                              "exact",
+                                              "numeric_tolerance",
+                                              "date"
+                                            ]
                                           },
                                           "required": {
                                             "type": "boolean"
@@ -11619,17 +18102,26 @@
                                             }
                                           }
                                         },
-                                        "required": ["path", "match"],
+                                        "required": [
+                                          "path",
+                                          "match"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       "minItems": 1
                                     },
                                     "aggregation": {
                                       "type": "string",
-                                      "enum": ["weighted_average", "all_or_nothing"]
+                                      "enum": [
+                                        "weighted_average",
+                                        "all_or_nothing"
+                                      ]
                                     }
                                   },
-                                  "required": ["type", "fields"],
+                                  "required": [
+                                    "type",
+                                    "fields"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11673,7 +18165,10 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type", "threshold"],
+                                  "required": [
+                                    "type",
+                                    "threshold"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11717,7 +18212,10 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type", "budget"],
+                                  "required": [
+                                    "type",
+                                    "budget"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11754,7 +18252,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["token-usage", "token_usage"]
+                                      "enum": [
+                                        "token-usage",
+                                        "token_usage"
+                                      ]
                                     },
                                     "max_total": {
                                       "type": "number",
@@ -11769,7 +18270,9 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11806,7 +18309,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["execution-metrics", "execution_metrics"]
+                                      "enum": [
+                                        "execution-metrics",
+                                        "execution_metrics"
+                                      ]
                                     },
                                     "max_tool_calls": {
                                       "type": "number",
@@ -11838,7 +18344,9 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11881,7 +18389,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11924,7 +18435,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11961,10 +18475,15 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["is-json", "is_json"]
+                                      "enum": [
+                                        "is-json",
+                                        "is_json"
+                                      ]
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -12007,7 +18526,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -12059,7 +18581,10 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": ["correctness", "contradiction"]
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -12100,7 +18625,10 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": ["score_range", "outcome"],
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
@@ -12110,7 +18638,10 @@
                                       "minItems": 1
                                     }
                                   },
-                                  "required": ["type", "criteria"],
+                                  "required": [
+                                    "type",
+                                    "criteria"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -12167,7 +18698,12 @@
                               },
                               "strategy": {
                                 "type": "string",
-                                "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                                "enum": [
+                                  "pass_at_k",
+                                  "pass_all",
+                                  "mean",
+                                  "confidence_interval"
+                                ]
                               },
                               "cost_limit_usd": {
                                 "type": "number",
@@ -12178,7 +18714,9 @@
                                 "minimum": 0
                               }
                             },
-                            "required": ["count"],
+                            "required": [
+                              "count"
+                            ],
                             "additionalProperties": false
                           },
                           "timeout_seconds": {
@@ -12202,7 +18740,10 @@
                           },
                           "isolation": {
                             "type": "string",
-                            "enum": ["shared", "per_case"]
+                            "enum": [
+                              "shared",
+                              "per_case"
+                            ]
                           },
                           "repos": {
                             "type": "array",
@@ -12284,7 +18825,11 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": ["none", "fast", "strict"]
+                                    "enum": [
+                                      "none",
+                                      "fast",
+                                      "strict"
+                                    ]
                                   }
                                 },
                                 "additionalProperties": false
@@ -12329,7 +18874,11 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": ["none", "fast", "strict"]
+                                    "enum": [
+                                      "none",
+                                      "fast",
+                                      "strict"
+                                    ]
                                   }
                                 },
                                 "additionalProperties": false
@@ -12374,7 +18923,11 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": ["none", "fast", "strict"]
+                                    "enum": [
+                                      "none",
+                                      "fast",
+                                      "strict"
+                                    ]
                                   }
                                 },
                                 "additionalProperties": false
@@ -12419,7 +18972,11 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": ["none", "fast", "strict"]
+                                    "enum": [
+                                      "none",
+                                      "fast",
+                                      "strict"
+                                    ]
                                   }
                                 },
                                 "additionalProperties": false
@@ -12445,7 +19002,9 @@
                                 "minimum": 0.1
                               }
                             },
-                            "required": ["image"],
+                            "required": [
+                              "image"
+                            ],
                             "additionalProperties": false
                           },
                           "env": {
@@ -12489,11 +19048,17 @@
                       },
                       "on_dependency_failure": {
                         "type": "string",
-                        "enum": ["skip", "fail", "run"]
+                        "enum": [
+                          "skip",
+                          "fail",
+                          "run"
+                        ]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": ["conversation"]
+                        "enum": [
+                          "conversation"
+                        ]
                       },
                       "turns": {
                         "type": "array",
@@ -12522,13 +19087,20 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["text", "file", "image"]
+                                            "enum": [
+                                              "text",
+                                              "file",
+                                              "image"
+                                            ]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
@@ -12558,13 +19130,20 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["text", "file", "image"]
+                                            "enum": [
+                                              "text",
+                                              "file",
+                                              "image"
+                                            ]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
@@ -12615,7 +19194,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["code-grader", "code_grader"]
+                                            "enum": [
+                                              "code-grader",
+                                              "code_grader"
+                                            ]
                                           },
                                           "command": {
                                             "anyOf": [
@@ -12689,12 +19271,18 @@
                                                   ]
                                                 }
                                               },
-                                              "required": ["type", "command"],
+                                              "required": [
+                                                "type",
+                                                "command"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -12731,7 +19319,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["llm-grader", "llm_grader"]
+                                            "enum": [
+                                              "llm-grader",
+                                              "llm_grader"
+                                            ]
                                           },
                                           "prompt": {
                                             "anyOf": [
@@ -12789,7 +19380,10 @@
                                                 },
                                                 "operator": {
                                                   "type": "string",
-                                                  "enum": ["correctness", "contradiction"]
+                                                  "enum": [
+                                                    "correctness",
+                                                    "contradiction"
+                                                  ]
                                                 },
                                                 "weight": {
                                                   "type": "number"
@@ -12830,7 +19424,10 @@
                                                         "minLength": 1
                                                       }
                                                     },
-                                                    "required": ["score_range", "outcome"],
+                                                    "required": [
+                                                      "score_range",
+                                                      "outcome"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 }
@@ -12881,12 +19478,17 @@
                                                   ]
                                                 }
                                               },
-                                              "required": ["type", "command"],
+                                              "required": [
+                                                "type",
+                                                "command"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -12897,7 +19499,9 @@
                                             "minLength": 1
                                           }
                                         },
-                                        "required": ["include"],
+                                        "required": [
+                                          "include"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -12960,7 +19564,9 @@
                                                     }
                                                   }
                                                 },
-                                                "required": ["type"],
+                                                "required": [
+                                                  "type"
+                                                ],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -12976,7 +19582,10 @@
                                                     "maximum": 1
                                                   }
                                                 },
-                                                "required": ["type", "threshold"],
+                                                "required": [
+                                                  "type",
+                                                  "threshold"
+                                                ],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -12993,7 +19602,10 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["type", "path"],
+                                                "required": [
+                                                  "type",
+                                                  "path"
+                                                ],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -13010,13 +19622,18 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["type"],
+                                                "required": [
+                                                  "type"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
                                           }
                                         },
-                                        "required": ["type", "aggregator"],
+                                        "required": [
+                                          "type",
+                                          "aggregator"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13053,7 +19670,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["tool-trajectory", "tool_trajectory"]
+                                            "enum": [
+                                              "tool-trajectory",
+                                              "tool_trajectory"
+                                            ]
                                           },
                                           "mode": {
                                             "type": "string",
@@ -13139,7 +19759,9 @@
                                                   ]
                                                 }
                                               },
-                                              "required": ["tool"],
+                                              "required": [
+                                                "tool"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           },
@@ -13147,7 +19769,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -13161,7 +19788,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -13172,7 +19804,10 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "mode"],
+                                        "required": [
+                                          "type",
+                                          "mode"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13209,7 +19844,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["field-accuracy", "field_accuracy"]
+                                            "enum": [
+                                              "field-accuracy",
+                                              "field_accuracy"
+                                            ]
                                           },
                                           "fields": {
                                             "type": "array",
@@ -13221,7 +19859,11 @@
                                                 },
                                                 "match": {
                                                   "type": "string",
-                                                  "enum": ["exact", "numeric_tolerance", "date"]
+                                                  "enum": [
+                                                    "exact",
+                                                    "numeric_tolerance",
+                                                    "date"
+                                                  ]
                                                 },
                                                 "required": {
                                                   "type": "boolean"
@@ -13243,17 +19885,26 @@
                                                   }
                                                 }
                                               },
-                                              "required": ["path", "match"],
+                                              "required": [
+                                                "path",
+                                                "match"
+                                              ],
                                               "additionalProperties": false
                                             },
                                             "minItems": 1
                                           },
                                           "aggregation": {
                                             "type": "string",
-                                            "enum": ["weighted_average", "all_or_nothing"]
+                                            "enum": [
+                                              "weighted_average",
+                                              "all_or_nothing"
+                                            ]
                                           }
                                         },
-                                        "required": ["type", "fields"],
+                                        "required": [
+                                          "type",
+                                          "fields"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13297,7 +19948,10 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": ["type", "threshold"],
+                                        "required": [
+                                          "type",
+                                          "threshold"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13341,7 +19995,10 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": ["type", "budget"],
+                                        "required": [
+                                          "type",
+                                          "budget"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13378,7 +20035,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["token-usage", "token_usage"]
+                                            "enum": [
+                                              "token-usage",
+                                              "token_usage"
+                                            ]
                                           },
                                           "max_total": {
                                             "type": "number",
@@ -13393,7 +20053,9 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13430,7 +20092,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["execution-metrics", "execution_metrics"]
+                                            "enum": [
+                                              "execution-metrics",
+                                              "execution_metrics"
+                                            ]
                                           },
                                           "max_tool_calls": {
                                             "type": "number",
@@ -13462,7 +20127,9 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13505,7 +20172,10 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13548,7 +20218,10 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13585,10 +20258,15 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["is-json", "is_json"]
+                                            "enum": [
+                                              "is-json",
+                                              "is_json"
+                                            ]
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13631,7 +20309,10 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13683,7 +20364,10 @@
                                                 },
                                                 "operator": {
                                                   "type": "string",
-                                                  "enum": ["correctness", "contradiction"]
+                                                  "enum": [
+                                                    "correctness",
+                                                    "contradiction"
+                                                  ]
                                                 },
                                                 "weight": {
                                                   "type": "number"
@@ -13724,7 +20408,10 @@
                                                         "minLength": 1
                                                       }
                                                     },
-                                                    "required": ["score_range", "outcome"],
+                                                    "required": [
+                                                      "score_range",
+                                                      "outcome"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 }
@@ -13734,7 +20421,10 @@
                                             "minItems": 1
                                           }
                                         },
-                                        "required": ["type", "criteria"],
+                                        "required": [
+                                          "type",
+                                          "criteria"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     ]
@@ -13743,25 +20433,36 @@
                               }
                             }
                           },
-                          "required": ["input"],
+                          "required": [
+                            "input"
+                          ],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": ["mean", "min", "max"]
+                        "enum": [
+                          "mean",
+                          "min",
+                          "max"
+                        ]
                       },
                       "on_turn_failure": {
                         "type": "string",
-                        "enum": ["continue", "stop"]
+                        "enum": [
+                          "continue",
+                          "stop"
+                        ]
                       },
                       "window_size": {
                         "type": "integer",
                         "minimum": 1
                       }
                     },
-                    "required": ["id"],
+                    "required": [
+                      "id"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -13773,7 +20474,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["suite", "tests"]
+                        "enum": [
+                          "suite",
+                          "tests"
+                        ]
                       },
                       "select": {
                         "anyOf": [
@@ -13844,7 +20548,11 @@
                                     {
                                       "type": "array",
                                       "items": {
-                                        "type": ["string", "number", "boolean"]
+                                        "type": [
+                                          "string",
+                                          "number",
+                                          "boolean"
+                                        ]
                                       },
                                       "minItems": 1
                                     }
@@ -13873,7 +20581,12 @@
                               },
                               "strategy": {
                                 "type": "string",
-                                "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                                "enum": [
+                                  "pass_at_k",
+                                  "pass_all",
+                                  "mean",
+                                  "confidence_interval"
+                                ]
                               },
                               "cost_limit_usd": {
                                 "type": "number",
@@ -13884,7 +20597,9 @@
                                 "minimum": 0
                               }
                             },
-                            "required": ["count"],
+                            "required": [
+                              "count"
+                            ],
                             "additionalProperties": false
                           },
                           "timeout_seconds": {
@@ -13901,7 +20616,10 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["include", "type"],
+                    "required": [
+                      "include",
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -13951,7 +20669,9 @@
                         "additionalProperties": {}
                       }
                     },
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "additionalProperties": false
                   }
                 ]
@@ -14001,7 +20721,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["code-grader", "code_grader"]
+                        "enum": [
+                          "code-grader",
+                          "code_grader"
+                        ]
                       },
                       "command": {
                         "anyOf": [
@@ -14075,12 +20798,18 @@
                               ]
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": ["type", "command"],
+                    "required": [
+                      "type",
+                      "command"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14117,7 +20846,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["llm-grader", "llm_grader"]
+                        "enum": [
+                          "llm-grader",
+                          "llm_grader"
+                        ]
                       },
                       "prompt": {
                         "anyOf": [
@@ -14175,7 +20907,10 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": ["correctness", "contradiction"]
+                              "enum": [
+                                "correctness",
+                                "contradiction"
+                              ]
                             },
                             "weight": {
                               "type": "number"
@@ -14216,7 +20951,10 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": ["score_range", "outcome"],
+                                "required": [
+                                  "score_range",
+                                  "outcome"
+                                ],
                                 "additionalProperties": false
                               }
                             }
@@ -14267,12 +21005,17 @@
                               ]
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14283,7 +21026,9 @@
                         "minLength": 1
                       }
                     },
-                    "required": ["include"],
+                    "required": [
+                      "include"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14346,7 +21091,9 @@
                                 }
                               }
                             },
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -14362,7 +21109,10 @@
                                 "maximum": 1
                               }
                             },
-                            "required": ["type", "threshold"],
+                            "required": [
+                              "type",
+                              "threshold"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -14379,7 +21129,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["type", "path"],
+                            "required": [
+                              "type",
+                              "path"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -14396,13 +21149,18 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "additionalProperties": false
                           }
                         ]
                       }
                     },
-                    "required": ["type", "aggregator"],
+                    "required": [
+                      "type",
+                      "aggregator"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14439,11 +21197,20 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["tool-trajectory", "tool_trajectory"]
+                        "enum": [
+                          "tool-trajectory",
+                          "tool_trajectory"
+                        ]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                        "enum": [
+                          "any_order",
+                          "in_order",
+                          "exact",
+                          "subset",
+                          "superset"
+                        ]
                       },
                       "minimums": {
                         "type": "object",
@@ -14484,7 +21251,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -14498,7 +21270,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -14509,7 +21286,9 @@
                               ]
                             }
                           },
-                          "required": ["tool"],
+                          "required": [
+                            "tool"
+                          ],
                           "additionalProperties": false
                         }
                       },
@@ -14517,7 +21296,12 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": ["exact", "ignore", "subset", "superset"]
+                            "enum": [
+                              "exact",
+                              "ignore",
+                              "subset",
+                              "superset"
+                            ]
                           },
                           {
                             "type": "array",
@@ -14531,7 +21315,12 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": ["exact", "ignore", "subset", "superset"]
+                            "enum": [
+                              "exact",
+                              "ignore",
+                              "subset",
+                              "superset"
+                            ]
                           },
                           {
                             "type": "array",
@@ -14542,7 +21331,10 @@
                         ]
                       }
                     },
-                    "required": ["type", "mode"],
+                    "required": [
+                      "type",
+                      "mode"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14579,7 +21371,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["field-accuracy", "field_accuracy"]
+                        "enum": [
+                          "field-accuracy",
+                          "field_accuracy"
+                        ]
                       },
                       "fields": {
                         "type": "array",
@@ -14591,7 +21386,11 @@
                             },
                             "match": {
                               "type": "string",
-                              "enum": ["exact", "numeric_tolerance", "date"]
+                              "enum": [
+                                "exact",
+                                "numeric_tolerance",
+                                "date"
+                              ]
                             },
                             "required": {
                               "type": "boolean"
@@ -14613,17 +21412,26 @@
                               }
                             }
                           },
-                          "required": ["path", "match"],
+                          "required": [
+                            "path",
+                            "match"
+                          ],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": ["weighted_average", "all_or_nothing"]
+                        "enum": [
+                          "weighted_average",
+                          "all_or_nothing"
+                        ]
                       }
                     },
-                    "required": ["type", "fields"],
+                    "required": [
+                      "type",
+                      "fields"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14667,7 +21475,10 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type", "threshold"],
+                    "required": [
+                      "type",
+                      "threshold"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14711,7 +21522,10 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type", "budget"],
+                    "required": [
+                      "type",
+                      "budget"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14748,7 +21562,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["token-usage", "token_usage"]
+                        "enum": [
+                          "token-usage",
+                          "token_usage"
+                        ]
                       },
                       "max_total": {
                         "type": "number",
@@ -14763,7 +21580,9 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14800,7 +21619,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["execution-metrics", "execution_metrics"]
+                        "enum": [
+                          "execution-metrics",
+                          "execution_metrics"
+                        ]
                       },
                       "max_tool_calls": {
                         "type": "number",
@@ -14832,7 +21654,9 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14875,7 +21699,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14918,7 +21745,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14955,10 +21785,15 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["is-json", "is_json"]
+                        "enum": [
+                          "is-json",
+                          "is_json"
+                        ]
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15001,7 +21836,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15053,7 +21891,10 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": ["correctness", "contradiction"]
+                              "enum": [
+                                "correctness",
+                                "contradiction"
+                              ]
                             },
                             "weight": {
                               "type": "number"
@@ -15094,7 +21935,10 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": ["score_range", "outcome"],
+                                "required": [
+                                  "score_range",
+                                  "outcome"
+                                ],
                                 "additionalProperties": false
                               }
                             }
@@ -15104,7 +21948,10 @@
                         "minItems": 1
                       }
                     },
-                    "required": ["type", "criteria"],
+                    "required": [
+                      "type",
+                      "criteria"
+                    ],
                     "additionalProperties": false
                   }
                 ]
@@ -15148,7 +21995,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["code-grader", "code_grader"]
+                        "enum": [
+                          "code-grader",
+                          "code_grader"
+                        ]
                       },
                       "command": {
                         "anyOf": [
@@ -15222,12 +22072,18 @@
                               ]
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": ["type", "command"],
+                    "required": [
+                      "type",
+                      "command"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15264,7 +22120,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["llm-grader", "llm_grader"]
+                        "enum": [
+                          "llm-grader",
+                          "llm_grader"
+                        ]
                       },
                       "prompt": {
                         "anyOf": [
@@ -15322,7 +22181,10 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": ["correctness", "contradiction"]
+                              "enum": [
+                                "correctness",
+                                "contradiction"
+                              ]
                             },
                             "weight": {
                               "type": "number"
@@ -15363,7 +22225,10 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": ["score_range", "outcome"],
+                                "required": [
+                                  "score_range",
+                                  "outcome"
+                                ],
                                 "additionalProperties": false
                               }
                             }
@@ -15414,12 +22279,17 @@
                               ]
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15430,7 +22300,9 @@
                         "minLength": 1
                       }
                     },
-                    "required": ["include"],
+                    "required": [
+                      "include"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15493,7 +22365,9 @@
                                 }
                               }
                             },
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -15509,7 +22383,10 @@
                                 "maximum": 1
                               }
                             },
-                            "required": ["type", "threshold"],
+                            "required": [
+                              "type",
+                              "threshold"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -15526,7 +22403,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["type", "path"],
+                            "required": [
+                              "type",
+                              "path"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -15543,13 +22423,18 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "additionalProperties": false
                           }
                         ]
                       }
                     },
-                    "required": ["type", "aggregator"],
+                    "required": [
+                      "type",
+                      "aggregator"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15586,11 +22471,20 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["tool-trajectory", "tool_trajectory"]
+                        "enum": [
+                          "tool-trajectory",
+                          "tool_trajectory"
+                        ]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                        "enum": [
+                          "any_order",
+                          "in_order",
+                          "exact",
+                          "subset",
+                          "superset"
+                        ]
                       },
                       "minimums": {
                         "type": "object",
@@ -15631,7 +22525,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -15645,7 +22544,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -15656,7 +22560,9 @@
                               ]
                             }
                           },
-                          "required": ["tool"],
+                          "required": [
+                            "tool"
+                          ],
                           "additionalProperties": false
                         }
                       },
@@ -15664,7 +22570,12 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": ["exact", "ignore", "subset", "superset"]
+                            "enum": [
+                              "exact",
+                              "ignore",
+                              "subset",
+                              "superset"
+                            ]
                           },
                           {
                             "type": "array",
@@ -15678,7 +22589,12 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": ["exact", "ignore", "subset", "superset"]
+                            "enum": [
+                              "exact",
+                              "ignore",
+                              "subset",
+                              "superset"
+                            ]
                           },
                           {
                             "type": "array",
@@ -15689,7 +22605,10 @@
                         ]
                       }
                     },
-                    "required": ["type", "mode"],
+                    "required": [
+                      "type",
+                      "mode"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15726,7 +22645,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["field-accuracy", "field_accuracy"]
+                        "enum": [
+                          "field-accuracy",
+                          "field_accuracy"
+                        ]
                       },
                       "fields": {
                         "type": "array",
@@ -15738,7 +22660,11 @@
                             },
                             "match": {
                               "type": "string",
-                              "enum": ["exact", "numeric_tolerance", "date"]
+                              "enum": [
+                                "exact",
+                                "numeric_tolerance",
+                                "date"
+                              ]
                             },
                             "required": {
                               "type": "boolean"
@@ -15760,17 +22686,26 @@
                               }
                             }
                           },
-                          "required": ["path", "match"],
+                          "required": [
+                            "path",
+                            "match"
+                          ],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": ["weighted_average", "all_or_nothing"]
+                        "enum": [
+                          "weighted_average",
+                          "all_or_nothing"
+                        ]
                       }
                     },
-                    "required": ["type", "fields"],
+                    "required": [
+                      "type",
+                      "fields"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15814,7 +22749,10 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type", "threshold"],
+                    "required": [
+                      "type",
+                      "threshold"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15858,7 +22796,10 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type", "budget"],
+                    "required": [
+                      "type",
+                      "budget"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15895,7 +22836,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["token-usage", "token_usage"]
+                        "enum": [
+                          "token-usage",
+                          "token_usage"
+                        ]
                       },
                       "max_total": {
                         "type": "number",
@@ -15910,7 +22854,9 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15947,7 +22893,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["execution-metrics", "execution_metrics"]
+                        "enum": [
+                          "execution-metrics",
+                          "execution_metrics"
+                        ]
                       },
                       "max_tool_calls": {
                         "type": "number",
@@ -15979,7 +22928,9 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -16022,7 +22973,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -16065,7 +23019,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -16102,10 +23059,15 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["is-json", "is_json"]
+                        "enum": [
+                          "is-json",
+                          "is_json"
+                        ]
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -16148,7 +23110,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -16200,7 +23165,10 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": ["correctness", "contradiction"]
+                              "enum": [
+                                "correctness",
+                                "contradiction"
+                              ]
                             },
                             "weight": {
                               "type": "number"
@@ -16241,7 +23209,10 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": ["score_range", "outcome"],
+                                "required": [
+                                  "score_range",
+                                  "outcome"
+                                ],
                                 "additionalProperties": false
                               }
                             }
@@ -16251,7 +23222,10 @@
                         "minItems": 1
                       }
                     },
-                    "required": ["type", "criteria"],
+                    "required": [
+                      "type",
+                      "criteria"
+                    ],
                     "additionalProperties": false
                   }
                 ]
@@ -16314,7 +23288,12 @@
                 },
                 "strategy": {
                   "type": "string",
-                  "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                  "enum": [
+                    "pass_at_k",
+                    "pass_all",
+                    "mean",
+                    "confidence_interval"
+                  ]
                 },
                 "cost_limit_usd": {
                   "type": "number",
@@ -16325,7 +23304,9 @@
                   "minimum": 0
                 }
               },
-              "required": ["count"],
+              "required": [
+                "count"
+              ],
               "additionalProperties": false
             },
             "runs": {
@@ -16342,7 +23323,11 @@
             },
             "sandbox": {
               "type": "string",
-              "enum": ["auto", "docker", "vercel"]
+              "enum": [
+                "auto",
+                "docker",
+                "vercel"
+              ]
             },
             "setup": {
               "not": {}
@@ -16381,7 +23366,9 @@
                         "additionalProperties": {}
                       }
                     },
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "additionalProperties": false
                   }
                 ]
@@ -16431,7 +23418,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["code-grader", "code_grader"]
+                        "enum": [
+                          "code-grader",
+                          "code_grader"
+                        ]
                       },
                       "command": {
                         "anyOf": [
@@ -16505,12 +23495,18 @@
                               ]
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": ["type", "command"],
+                    "required": [
+                      "type",
+                      "command"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -16547,7 +23543,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["llm-grader", "llm_grader"]
+                        "enum": [
+                          "llm-grader",
+                          "llm_grader"
+                        ]
                       },
                       "prompt": {
                         "anyOf": [
@@ -16605,7 +23604,10 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": ["correctness", "contradiction"]
+                              "enum": [
+                                "correctness",
+                                "contradiction"
+                              ]
                             },
                             "weight": {
                               "type": "number"
@@ -16646,7 +23648,10 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": ["score_range", "outcome"],
+                                "required": [
+                                  "score_range",
+                                  "outcome"
+                                ],
                                 "additionalProperties": false
                               }
                             }
@@ -16697,12 +23702,17 @@
                               ]
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -16713,7 +23723,9 @@
                         "minLength": 1
                       }
                     },
-                    "required": ["include"],
+                    "required": [
+                      "include"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -16776,7 +23788,9 @@
                                 }
                               }
                             },
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -16792,7 +23806,10 @@
                                 "maximum": 1
                               }
                             },
-                            "required": ["type", "threshold"],
+                            "required": [
+                              "type",
+                              "threshold"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -16809,7 +23826,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["type", "path"],
+                            "required": [
+                              "type",
+                              "path"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -16826,13 +23846,18 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "additionalProperties": false
                           }
                         ]
                       }
                     },
-                    "required": ["type", "aggregator"],
+                    "required": [
+                      "type",
+                      "aggregator"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -16869,11 +23894,20 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["tool-trajectory", "tool_trajectory"]
+                        "enum": [
+                          "tool-trajectory",
+                          "tool_trajectory"
+                        ]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                        "enum": [
+                          "any_order",
+                          "in_order",
+                          "exact",
+                          "subset",
+                          "superset"
+                        ]
                       },
                       "minimums": {
                         "type": "object",
@@ -16914,7 +23948,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -16928,7 +23967,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -16939,7 +23983,9 @@
                               ]
                             }
                           },
-                          "required": ["tool"],
+                          "required": [
+                            "tool"
+                          ],
                           "additionalProperties": false
                         }
                       },
@@ -16947,7 +23993,12 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": ["exact", "ignore", "subset", "superset"]
+                            "enum": [
+                              "exact",
+                              "ignore",
+                              "subset",
+                              "superset"
+                            ]
                           },
                           {
                             "type": "array",
@@ -16961,7 +24012,12 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": ["exact", "ignore", "subset", "superset"]
+                            "enum": [
+                              "exact",
+                              "ignore",
+                              "subset",
+                              "superset"
+                            ]
                           },
                           {
                             "type": "array",
@@ -16972,7 +24028,10 @@
                         ]
                       }
                     },
-                    "required": ["type", "mode"],
+                    "required": [
+                      "type",
+                      "mode"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -17009,7 +24068,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["field-accuracy", "field_accuracy"]
+                        "enum": [
+                          "field-accuracy",
+                          "field_accuracy"
+                        ]
                       },
                       "fields": {
                         "type": "array",
@@ -17021,7 +24083,11 @@
                             },
                             "match": {
                               "type": "string",
-                              "enum": ["exact", "numeric_tolerance", "date"]
+                              "enum": [
+                                "exact",
+                                "numeric_tolerance",
+                                "date"
+                              ]
                             },
                             "required": {
                               "type": "boolean"
@@ -17043,17 +24109,26 @@
                               }
                             }
                           },
-                          "required": ["path", "match"],
+                          "required": [
+                            "path",
+                            "match"
+                          ],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": ["weighted_average", "all_or_nothing"]
+                        "enum": [
+                          "weighted_average",
+                          "all_or_nothing"
+                        ]
                       }
                     },
-                    "required": ["type", "fields"],
+                    "required": [
+                      "type",
+                      "fields"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -17097,7 +24172,10 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type", "threshold"],
+                    "required": [
+                      "type",
+                      "threshold"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -17141,7 +24219,10 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type", "budget"],
+                    "required": [
+                      "type",
+                      "budget"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -17178,7 +24259,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["token-usage", "token_usage"]
+                        "enum": [
+                          "token-usage",
+                          "token_usage"
+                        ]
                       },
                       "max_total": {
                         "type": "number",
@@ -17193,7 +24277,9 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -17230,7 +24316,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["execution-metrics", "execution_metrics"]
+                        "enum": [
+                          "execution-metrics",
+                          "execution_metrics"
+                        ]
                       },
                       "max_tool_calls": {
                         "type": "number",
@@ -17262,7 +24351,9 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -17305,7 +24396,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -17348,7 +24442,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -17385,10 +24482,15 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["is-json", "is_json"]
+                        "enum": [
+                          "is-json",
+                          "is_json"
+                        ]
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -17431,7 +24533,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -17483,7 +24588,10 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": ["correctness", "contradiction"]
+                              "enum": [
+                                "correctness",
+                                "contradiction"
+                              ]
                             },
                             "weight": {
                               "type": "number"
@@ -17524,7 +24632,10 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": ["score_range", "outcome"],
+                                "required": [
+                                  "score_range",
+                                  "outcome"
+                                ],
                                 "additionalProperties": false
                               }
                             }
@@ -17534,7 +24645,10 @@
                         "minItems": 1
                       }
                     },
-                    "required": ["type", "criteria"],
+                    "required": [
+                      "type",
+                      "criteria"
+                    ],
                     "additionalProperties": false
                   }
                 ]
@@ -17578,7 +24692,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["code-grader", "code_grader"]
+                        "enum": [
+                          "code-grader",
+                          "code_grader"
+                        ]
                       },
                       "command": {
                         "anyOf": [
@@ -17652,12 +24769,18 @@
                               ]
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": ["type", "command"],
+                    "required": [
+                      "type",
+                      "command"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -17694,7 +24817,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["llm-grader", "llm_grader"]
+                        "enum": [
+                          "llm-grader",
+                          "llm_grader"
+                        ]
                       },
                       "prompt": {
                         "anyOf": [
@@ -17752,7 +24878,10 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": ["correctness", "contradiction"]
+                              "enum": [
+                                "correctness",
+                                "contradiction"
+                              ]
                             },
                             "weight": {
                               "type": "number"
@@ -17793,7 +24922,10 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": ["score_range", "outcome"],
+                                "required": [
+                                  "score_range",
+                                  "outcome"
+                                ],
                                 "additionalProperties": false
                               }
                             }
@@ -17844,12 +24976,17 @@
                               ]
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -17860,7 +24997,9 @@
                         "minLength": 1
                       }
                     },
-                    "required": ["include"],
+                    "required": [
+                      "include"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -17923,7 +25062,9 @@
                                 }
                               }
                             },
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -17939,7 +25080,10 @@
                                 "maximum": 1
                               }
                             },
-                            "required": ["type", "threshold"],
+                            "required": [
+                              "type",
+                              "threshold"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -17956,7 +25100,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["type", "path"],
+                            "required": [
+                              "type",
+                              "path"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -17973,13 +25120,18 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "additionalProperties": false
                           }
                         ]
                       }
                     },
-                    "required": ["type", "aggregator"],
+                    "required": [
+                      "type",
+                      "aggregator"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -18016,11 +25168,20 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["tool-trajectory", "tool_trajectory"]
+                        "enum": [
+                          "tool-trajectory",
+                          "tool_trajectory"
+                        ]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                        "enum": [
+                          "any_order",
+                          "in_order",
+                          "exact",
+                          "subset",
+                          "superset"
+                        ]
                       },
                       "minimums": {
                         "type": "object",
@@ -18061,7 +25222,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -18075,7 +25241,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -18086,7 +25257,9 @@
                               ]
                             }
                           },
-                          "required": ["tool"],
+                          "required": [
+                            "tool"
+                          ],
                           "additionalProperties": false
                         }
                       },
@@ -18094,7 +25267,12 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": ["exact", "ignore", "subset", "superset"]
+                            "enum": [
+                              "exact",
+                              "ignore",
+                              "subset",
+                              "superset"
+                            ]
                           },
                           {
                             "type": "array",
@@ -18108,7 +25286,12 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": ["exact", "ignore", "subset", "superset"]
+                            "enum": [
+                              "exact",
+                              "ignore",
+                              "subset",
+                              "superset"
+                            ]
                           },
                           {
                             "type": "array",
@@ -18119,7 +25302,10 @@
                         ]
                       }
                     },
-                    "required": ["type", "mode"],
+                    "required": [
+                      "type",
+                      "mode"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -18156,7 +25342,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["field-accuracy", "field_accuracy"]
+                        "enum": [
+                          "field-accuracy",
+                          "field_accuracy"
+                        ]
                       },
                       "fields": {
                         "type": "array",
@@ -18168,7 +25357,11 @@
                             },
                             "match": {
                               "type": "string",
-                              "enum": ["exact", "numeric_tolerance", "date"]
+                              "enum": [
+                                "exact",
+                                "numeric_tolerance",
+                                "date"
+                              ]
                             },
                             "required": {
                               "type": "boolean"
@@ -18190,17 +25383,26 @@
                               }
                             }
                           },
-                          "required": ["path", "match"],
+                          "required": [
+                            "path",
+                            "match"
+                          ],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": ["weighted_average", "all_or_nothing"]
+                        "enum": [
+                          "weighted_average",
+                          "all_or_nothing"
+                        ]
                       }
                     },
-                    "required": ["type", "fields"],
+                    "required": [
+                      "type",
+                      "fields"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -18244,7 +25446,10 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type", "threshold"],
+                    "required": [
+                      "type",
+                      "threshold"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -18288,7 +25493,10 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type", "budget"],
+                    "required": [
+                      "type",
+                      "budget"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -18325,7 +25533,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["token-usage", "token_usage"]
+                        "enum": [
+                          "token-usage",
+                          "token_usage"
+                        ]
                       },
                       "max_total": {
                         "type": "number",
@@ -18340,7 +25551,9 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -18377,7 +25590,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["execution-metrics", "execution_metrics"]
+                        "enum": [
+                          "execution-metrics",
+                          "execution_metrics"
+                        ]
                       },
                       "max_tool_calls": {
                         "type": "number",
@@ -18409,7 +25625,9 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -18452,7 +25670,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -18495,7 +25716,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -18532,10 +25756,15 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["is-json", "is_json"]
+                        "enum": [
+                          "is-json",
+                          "is_json"
+                        ]
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -18578,7 +25807,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -18630,7 +25862,10 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": ["correctness", "contradiction"]
+                              "enum": [
+                                "correctness",
+                                "contradiction"
+                              ]
                             },
                             "weight": {
                               "type": "number"
@@ -18671,7 +25906,10 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": ["score_range", "outcome"],
+                                "required": [
+                                  "score_range",
+                                  "outcome"
+                                ],
                                 "additionalProperties": false
                               }
                             }
@@ -18681,7 +25919,10 @@
                         "minItems": 1
                       }
                     },
-                    "required": ["type", "criteria"],
+                    "required": [
+                      "type",
+                      "criteria"
+                    ],
                     "additionalProperties": false
                   }
                 ]
@@ -18744,7 +25985,12 @@
                 },
                 "strategy": {
                   "type": "string",
-                  "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                  "enum": [
+                    "pass_at_k",
+                    "pass_all",
+                    "mean",
+                    "confidence_interval"
+                  ]
                 },
                 "cost_limit_usd": {
                   "type": "number",
@@ -18755,7 +26001,9 @@
                   "minimum": 0
                 }
               },
-              "required": ["count"],
+              "required": [
+                "count"
+              ],
               "additionalProperties": false
             },
             "runs": {
@@ -18772,7 +26020,11 @@
             },
             "sandbox": {
               "type": "string",
-              "enum": ["auto", "docker", "vercel"]
+              "enum": [
+                "auto",
+                "docker",
+                "vercel"
+              ]
             },
             "setup": {
               "not": {}
@@ -18818,7 +26070,10 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["code-grader", "code_grader"]
+                    "enum": [
+                      "code-grader",
+                      "code_grader"
+                    ]
                   },
                   "command": {
                     "anyOf": [
@@ -18892,12 +26147,18 @@
                           ]
                         }
                       },
-                      "required": ["type", "command"],
+                      "required": [
+                        "type",
+                        "command"
+                      ],
                       "additionalProperties": false
                     }
                   }
                 },
-                "required": ["type", "command"],
+                "required": [
+                  "type",
+                  "command"
+                ],
                 "additionalProperties": false
               },
               {
@@ -18934,7 +26195,10 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["llm-grader", "llm_grader"]
+                    "enum": [
+                      "llm-grader",
+                      "llm_grader"
+                    ]
                   },
                   "prompt": {
                     "anyOf": [
@@ -18992,7 +26256,10 @@
                         },
                         "operator": {
                           "type": "string",
-                          "enum": ["correctness", "contradiction"]
+                          "enum": [
+                            "correctness",
+                            "contradiction"
+                          ]
                         },
                         "weight": {
                           "type": "number"
@@ -19033,7 +26300,10 @@
                                 "minLength": 1
                               }
                             },
-                            "required": ["score_range", "outcome"],
+                            "required": [
+                              "score_range",
+                              "outcome"
+                            ],
                             "additionalProperties": false
                           }
                         }
@@ -19084,12 +26354,17 @@
                           ]
                         }
                       },
-                      "required": ["type", "command"],
+                      "required": [
+                        "type",
+                        "command"
+                      ],
                       "additionalProperties": false
                     }
                   }
                 },
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "additionalProperties": false
               },
               {
@@ -19100,7 +26375,9 @@
                     "minLength": 1
                   }
                 },
-                "required": ["include"],
+                "required": [
+                  "include"
+                ],
                 "additionalProperties": false
               },
               {
@@ -19163,7 +26440,9 @@
                             }
                           }
                         },
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "additionalProperties": false
                       },
                       {
@@ -19179,7 +26458,10 @@
                             "maximum": 1
                           }
                         },
-                        "required": ["type", "threshold"],
+                        "required": [
+                          "type",
+                          "threshold"
+                        ],
                         "additionalProperties": false
                       },
                       {
@@ -19196,7 +26478,10 @@
                             "type": "string"
                           }
                         },
-                        "required": ["type", "path"],
+                        "required": [
+                          "type",
+                          "path"
+                        ],
                         "additionalProperties": false
                       },
                       {
@@ -19213,13 +26498,18 @@
                             "type": "string"
                           }
                         },
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "additionalProperties": false
                       }
                     ]
                   }
                 },
-                "required": ["type", "aggregator"],
+                "required": [
+                  "type",
+                  "aggregator"
+                ],
                 "additionalProperties": false
               },
               {
@@ -19256,11 +26546,20 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["tool-trajectory", "tool_trajectory"]
+                    "enum": [
+                      "tool-trajectory",
+                      "tool_trajectory"
+                    ]
                   },
                   "mode": {
                     "type": "string",
-                    "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                    "enum": [
+                      "any_order",
+                      "in_order",
+                      "exact",
+                      "subset",
+                      "superset"
+                    ]
                   },
                   "minimums": {
                     "type": "object",
@@ -19301,7 +26600,12 @@
                           "anyOf": [
                             {
                               "type": "string",
-                              "enum": ["exact", "ignore", "subset", "superset"]
+                              "enum": [
+                                "exact",
+                                "ignore",
+                                "subset",
+                                "superset"
+                              ]
                             },
                             {
                               "type": "array",
@@ -19315,7 +26619,12 @@
                           "anyOf": [
                             {
                               "type": "string",
-                              "enum": ["exact", "ignore", "subset", "superset"]
+                              "enum": [
+                                "exact",
+                                "ignore",
+                                "subset",
+                                "superset"
+                              ]
                             },
                             {
                               "type": "array",
@@ -19326,7 +26635,9 @@
                           ]
                         }
                       },
-                      "required": ["tool"],
+                      "required": [
+                        "tool"
+                      ],
                       "additionalProperties": false
                     }
                   },
@@ -19334,7 +26645,12 @@
                     "anyOf": [
                       {
                         "type": "string",
-                        "enum": ["exact", "ignore", "subset", "superset"]
+                        "enum": [
+                          "exact",
+                          "ignore",
+                          "subset",
+                          "superset"
+                        ]
                       },
                       {
                         "type": "array",
@@ -19348,7 +26664,12 @@
                     "anyOf": [
                       {
                         "type": "string",
-                        "enum": ["exact", "ignore", "subset", "superset"]
+                        "enum": [
+                          "exact",
+                          "ignore",
+                          "subset",
+                          "superset"
+                        ]
                       },
                       {
                         "type": "array",
@@ -19359,7 +26680,10 @@
                     ]
                   }
                 },
-                "required": ["type", "mode"],
+                "required": [
+                  "type",
+                  "mode"
+                ],
                 "additionalProperties": false
               },
               {
@@ -19396,7 +26720,10 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["field-accuracy", "field_accuracy"]
+                    "enum": [
+                      "field-accuracy",
+                      "field_accuracy"
+                    ]
                   },
                   "fields": {
                     "type": "array",
@@ -19408,7 +26735,11 @@
                         },
                         "match": {
                           "type": "string",
-                          "enum": ["exact", "numeric_tolerance", "date"]
+                          "enum": [
+                            "exact",
+                            "numeric_tolerance",
+                            "date"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -19430,17 +26761,26 @@
                           }
                         }
                       },
-                      "required": ["path", "match"],
+                      "required": [
+                        "path",
+                        "match"
+                      ],
                       "additionalProperties": false
                     },
                     "minItems": 1
                   },
                   "aggregation": {
                     "type": "string",
-                    "enum": ["weighted_average", "all_or_nothing"]
+                    "enum": [
+                      "weighted_average",
+                      "all_or_nothing"
+                    ]
                   }
                 },
-                "required": ["type", "fields"],
+                "required": [
+                  "type",
+                  "fields"
+                ],
                 "additionalProperties": false
               },
               {
@@ -19484,7 +26824,10 @@
                     "minimum": 0
                   }
                 },
-                "required": ["type", "threshold"],
+                "required": [
+                  "type",
+                  "threshold"
+                ],
                 "additionalProperties": false
               },
               {
@@ -19528,7 +26871,10 @@
                     "minimum": 0
                   }
                 },
-                "required": ["type", "budget"],
+                "required": [
+                  "type",
+                  "budget"
+                ],
                 "additionalProperties": false
               },
               {
@@ -19565,7 +26911,10 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["token-usage", "token_usage"]
+                    "enum": [
+                      "token-usage",
+                      "token_usage"
+                    ]
                   },
                   "max_total": {
                     "type": "number",
@@ -19580,7 +26929,9 @@
                     "minimum": 0
                   }
                 },
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "additionalProperties": false
               },
               {
@@ -19617,7 +26968,10 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["execution-metrics", "execution_metrics"]
+                    "enum": [
+                      "execution-metrics",
+                      "execution_metrics"
+                    ]
                   },
                   "max_tool_calls": {
                     "type": "number",
@@ -19649,7 +27003,9 @@
                     "minimum": 0
                   }
                 },
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "additionalProperties": false
               },
               {
@@ -19692,7 +27048,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["type", "value"],
+                "required": [
+                  "type",
+                  "value"
+                ],
                 "additionalProperties": false
               },
               {
@@ -19735,7 +27094,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["type", "value"],
+                "required": [
+                  "type",
+                  "value"
+                ],
                 "additionalProperties": false
               },
               {
@@ -19772,10 +27134,15 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["is-json", "is_json"]
+                    "enum": [
+                      "is-json",
+                      "is_json"
+                    ]
                   }
                 },
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "additionalProperties": false
               },
               {
@@ -19818,7 +27185,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["type", "value"],
+                "required": [
+                  "type",
+                  "value"
+                ],
                 "additionalProperties": false
               },
               {
@@ -19870,7 +27240,10 @@
                         },
                         "operator": {
                           "type": "string",
-                          "enum": ["correctness", "contradiction"]
+                          "enum": [
+                            "correctness",
+                            "contradiction"
+                          ]
                         },
                         "weight": {
                           "type": "number"
@@ -19911,7 +27284,10 @@
                                 "minLength": 1
                               }
                             },
-                            "required": ["score_range", "outcome"],
+                            "required": [
+                              "score_range",
+                              "outcome"
+                            ],
                             "additionalProperties": false
                           }
                         }
@@ -19921,7 +27297,10 @@
                     "minItems": 1
                   }
                 },
-                "required": ["type", "criteria"],
+                "required": [
+                  "type",
+                  "criteria"
+                ],
                 "additionalProperties": false
               }
             ]
@@ -19950,7 +27329,10 @@
                 ]
               }
             },
-            "required": ["type", "command"],
+            "required": [
+              "type",
+              "command"
+            ],
             "additionalProperties": false
           }
         },
@@ -19964,7 +27346,10 @@
                 },
                 "isolation": {
                   "type": "string",
-                  "enum": ["shared", "per_case"]
+                  "enum": [
+                    "shared",
+                    "per_case"
+                  ]
                 },
                 "repos": {
                   "type": "array",
@@ -20046,7 +27431,11 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": ["none", "fast", "strict"]
+                          "enum": [
+                            "none",
+                            "fast",
+                            "strict"
+                          ]
                         }
                       },
                       "additionalProperties": false
@@ -20091,7 +27480,11 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": ["none", "fast", "strict"]
+                          "enum": [
+                            "none",
+                            "fast",
+                            "strict"
+                          ]
                         }
                       },
                       "additionalProperties": false
@@ -20136,7 +27529,11 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": ["none", "fast", "strict"]
+                          "enum": [
+                            "none",
+                            "fast",
+                            "strict"
+                          ]
                         }
                       },
                       "additionalProperties": false
@@ -20181,7 +27578,11 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": ["none", "fast", "strict"]
+                          "enum": [
+                            "none",
+                            "fast",
+                            "strict"
+                          ]
                         }
                       },
                       "additionalProperties": false
@@ -20207,7 +27608,9 @@
                       "minimum": 0.1
                     }
                   },
-                  "required": ["image"],
+                  "required": [
+                    "image"
+                  ],
                   "additionalProperties": false
                 },
                 "env": {

--- a/skills-data/agentv-eval-writer/references/eval-schema.json
+++ b/skills-data/agentv-eval-writer/references/eval-schema.json
@@ -54,12 +54,7 @@
               "properties": {
                 "role": {
                   "type": "string",
-                  "enum": [
-                    "system",
-                    "user",
-                    "assistant",
-                    "tool"
-                  ]
+                  "enum": ["system", "user", "assistant", "tool"]
                 },
                 "content": {
                   "anyOf": [
@@ -78,30 +73,20 @@
                         "properties": {
                           "type": {
                             "type": "string",
-                            "enum": [
-                              "text",
-                              "file",
-                              "image"
-                            ]
+                            "enum": ["text", "file", "image"]
                           },
                           "value": {
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "type",
-                          "value"
-                        ],
+                        "required": ["type", "value"],
                         "additionalProperties": false
                       }
                     }
                   ]
                 }
               },
-              "required": [
-                "role",
-                "content"
-              ],
+              "required": ["role", "content"],
               "additionalProperties": false
             },
             {
@@ -120,12 +105,7 @@
                 "properties": {
                   "role": {
                     "type": "string",
-                    "enum": [
-                      "system",
-                      "user",
-                      "assistant",
-                      "tool"
-                    ]
+                    "enum": ["system", "user", "assistant", "tool"]
                   },
                   "content": {
                     "anyOf": [
@@ -144,30 +124,20 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "text",
-                                "file",
-                                "image"
-                              ]
+                              "enum": ["text", "file", "image"]
                             },
                             "value": {
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type",
-                            "value"
-                          ],
+                          "required": ["type", "value"],
                           "additionalProperties": false
                         }
                       }
                     ]
                   }
                 },
-                "required": [
-                  "role",
-                  "content"
-                ],
+                "required": ["role", "content"],
                 "additionalProperties": false
               }
             }
@@ -264,11 +234,7 @@
                                         {
                                           "type": "array",
                                           "items": {
-                                            "type": [
-                                              "string",
-                                              "number",
-                                              "boolean"
-                                            ]
+                                            "type": ["string", "number", "boolean"]
                                           },
                                           "minItems": 1
                                         }
@@ -297,12 +263,7 @@
                                   },
                                   "strategy": {
                                     "type": "string",
-                                    "enum": [
-                                      "pass_at_k",
-                                      "pass_all",
-                                      "mean",
-                                      "confidence_interval"
-                                    ]
+                                    "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
                                   },
                                   "cost_limit_usd": {
                                     "type": "number",
@@ -313,9 +274,7 @@
                                     "minimum": 0
                                   }
                                 },
-                                "required": [
-                                  "count"
-                                ],
+                                "required": ["count"],
                                 "additionalProperties": false
                               },
                               "timeout_seconds": {
@@ -332,9 +291,7 @@
                             "additionalProperties": false
                           }
                         },
-                        "required": [
-                          "path"
-                        ],
+                        "required": ["path"],
                         "additionalProperties": false
                       },
                       {
@@ -424,11 +381,7 @@
                                   {
                                     "type": "array",
                                     "items": {
-                                      "type": [
-                                        "string",
-                                        "number",
-                                        "boolean"
-                                      ]
+                                      "type": ["string", "number", "boolean"]
                                     },
                                     "minItems": 1
                                   }
@@ -457,12 +410,7 @@
                             },
                             "strategy": {
                               "type": "string",
-                              "enum": [
-                                "pass_at_k",
-                                "pass_all",
-                                "mean",
-                                "confidence_interval"
-                              ]
+                              "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
                             },
                             "cost_limit_usd": {
                               "type": "number",
@@ -473,9 +421,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "count"
-                          ],
+                          "required": ["count"],
                           "additionalProperties": false
                         },
                         "timeout_seconds": {
@@ -492,9 +438,7 @@
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "path"
-                  ],
+                  "required": ["path"],
                   "additionalProperties": false
                 }
               ]
@@ -581,11 +525,7 @@
                                         {
                                           "type": "array",
                                           "items": {
-                                            "type": [
-                                              "string",
-                                              "number",
-                                              "boolean"
-                                            ]
+                                            "type": ["string", "number", "boolean"]
                                           },
                                           "minItems": 1
                                         }
@@ -614,12 +554,7 @@
                                   },
                                   "strategy": {
                                     "type": "string",
-                                    "enum": [
-                                      "pass_at_k",
-                                      "pass_all",
-                                      "mean",
-                                      "confidence_interval"
-                                    ]
+                                    "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
                                   },
                                   "cost_limit_usd": {
                                     "type": "number",
@@ -630,9 +565,7 @@
                                     "minimum": 0
                                   }
                                 },
-                                "required": [
-                                  "count"
-                                ],
+                                "required": ["count"],
                                 "additionalProperties": false
                               },
                               "timeout_seconds": {
@@ -649,9 +582,7 @@
                             "additionalProperties": false
                           }
                         },
-                        "required": [
-                          "path"
-                        ],
+                        "required": ["path"],
                         "additionalProperties": false
                       },
                       {
@@ -741,11 +672,7 @@
                                   {
                                     "type": "array",
                                     "items": {
-                                      "type": [
-                                        "string",
-                                        "number",
-                                        "boolean"
-                                      ]
+                                      "type": ["string", "number", "boolean"]
                                     },
                                     "minItems": 1
                                   }
@@ -774,12 +701,7 @@
                             },
                             "strategy": {
                               "type": "string",
-                              "enum": [
-                                "pass_at_k",
-                                "pass_all",
-                                "mean",
-                                "confidence_interval"
-                              ]
+                              "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
                             },
                             "cost_limit_usd": {
                               "type": "number",
@@ -790,9 +712,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "count"
-                          ],
+                          "required": ["count"],
                           "additionalProperties": false
                         },
                         "timeout_seconds": {
@@ -809,9 +729,7 @@
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "path"
-                  ],
+                  "required": ["path"],
                   "additionalProperties": false
                 }
               ]
@@ -850,12 +768,7 @@
                             "properties": {
                               "role": {
                                 "type": "string",
-                                "enum": [
-                                  "system",
-                                  "user",
-                                  "assistant",
-                                  "tool"
-                                ]
+                                "enum": ["system", "user", "assistant", "tool"]
                               },
                               "content": {
                                 "anyOf": [
@@ -874,30 +787,20 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "text",
-                                            "file",
-                                            "image"
-                                          ]
+                                          "enum": ["text", "file", "image"]
                                         },
                                         "value": {
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "value"
-                                      ],
+                                      "required": ["type", "value"],
                                       "additionalProperties": false
                                     }
                                   }
                                 ]
                               }
                             },
-                            "required": [
-                              "role",
-                              "content"
-                            ],
+                            "required": ["role", "content"],
                             "additionalProperties": false
                           },
                           {
@@ -916,12 +819,7 @@
                               "properties": {
                                 "role": {
                                   "type": "string",
-                                  "enum": [
-                                    "system",
-                                    "user",
-                                    "assistant",
-                                    "tool"
-                                  ]
+                                  "enum": ["system", "user", "assistant", "tool"]
                                 },
                                 "content": {
                                   "anyOf": [
@@ -940,30 +838,20 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "text",
-                                              "file",
-                                              "image"
-                                            ]
+                                            "enum": ["text", "file", "image"]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       }
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "role",
-                                "content"
-                              ],
+                              "required": ["role", "content"],
                               "additionalProperties": false
                             }
                           }
@@ -992,12 +880,7 @@
                               "properties": {
                                 "role": {
                                   "type": "string",
-                                  "enum": [
-                                    "system",
-                                    "user",
-                                    "assistant",
-                                    "tool"
-                                  ]
+                                  "enum": ["system", "user", "assistant", "tool"]
                                 },
                                 "content": {
                                   "anyOf": [
@@ -1016,30 +899,20 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "text",
-                                              "file",
-                                              "image"
-                                            ]
+                                            "enum": ["text", "file", "image"]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       }
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "role",
-                                "content"
-                              ],
+                              "required": ["role", "content"],
                               "additionalProperties": false
                             }
                           }
@@ -1083,10 +956,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "code-grader",
-                                    "code_grader"
-                                  ]
+                                  "enum": ["code-grader", "code_grader"]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -1160,18 +1030,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type",
-                                "command"
-                              ],
+                              "required": ["type", "command"],
                               "additionalProperties": false
                             },
                             {
@@ -1208,10 +1072,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "llm-grader",
-                                    "llm_grader"
-                                  ]
+                                  "enum": ["llm-grader", "llm_grader"]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -1269,10 +1130,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -1313,10 +1171,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -1367,17 +1222,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -1388,9 +1238,7 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": [
-                                "include"
-                              ],
+                              "required": ["include"],
                               "additionalProperties": false
                             },
                             {
@@ -1453,9 +1301,7 @@
                                           }
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -1471,10 +1317,7 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "threshold"
-                                      ],
+                                      "required": ["type", "threshold"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -1491,10 +1334,7 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "path"
-                                      ],
+                                      "required": ["type", "path"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -1511,18 +1351,13 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "aggregator"
-                              ],
+                              "required": ["type", "aggregator"],
                               "additionalProperties": false
                             },
                             {
@@ -1559,20 +1394,11 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "tool-trajectory",
-                                    "tool_trajectory"
-                                  ]
+                                  "enum": ["tool-trajectory", "tool_trajectory"]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": [
-                                    "any_order",
-                                    "in_order",
-                                    "exact",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -1613,12 +1439,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -1632,12 +1453,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -1648,9 +1464,7 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "tool"
-                                    ],
+                                    "required": ["tool"],
                                     "additionalProperties": false
                                   }
                                 },
@@ -1658,12 +1472,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -1677,12 +1486,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -1693,10 +1497,7 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "mode"
-                              ],
+                              "required": ["type", "mode"],
                               "additionalProperties": false
                             },
                             {
@@ -1733,10 +1534,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "field-accuracy",
-                                    "field_accuracy"
-                                  ]
+                                  "enum": ["field-accuracy", "field_accuracy"]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -1748,11 +1546,7 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "numeric_tolerance",
-                                          "date"
-                                        ]
+                                        "enum": ["exact", "numeric_tolerance", "date"]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -1774,26 +1568,17 @@
                                         }
                                       }
                                     },
-                                    "required": [
-                                      "path",
-                                      "match"
-                                    ],
+                                    "required": ["path", "match"],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": [
-                                    "weighted_average",
-                                    "all_or_nothing"
-                                  ]
+                                  "enum": ["weighted_average", "all_or_nothing"]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "fields"
-                              ],
+                              "required": ["type", "fields"],
                               "additionalProperties": false
                             },
                             {
@@ -1837,10 +1622,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "threshold"
-                              ],
+                              "required": ["type", "threshold"],
                               "additionalProperties": false
                             },
                             {
@@ -1884,10 +1666,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "budget"
-                              ],
+                              "required": ["type", "budget"],
                               "additionalProperties": false
                             },
                             {
@@ -1924,10 +1703,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "token-usage",
-                                    "token_usage"
-                                  ]
+                                  "enum": ["token-usage", "token_usage"]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -1942,9 +1718,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -1981,10 +1755,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "execution-metrics",
-                                    "execution_metrics"
-                                  ]
+                                  "enum": ["execution-metrics", "execution_metrics"]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -2016,9 +1787,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -2061,10 +1830,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -2107,10 +1873,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -2147,15 +1910,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "is-json",
-                                    "is_json"
-                                  ]
+                                  "enum": ["is-json", "is_json"]
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -2198,10 +1956,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -2253,10 +2008,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -2297,10 +2049,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -2310,10 +2059,7 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": [
-                                "type",
-                                "criteria"
-                              ],
+                              "required": ["type", "criteria"],
                               "additionalProperties": false
                             }
                           ]
@@ -2357,10 +2103,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "code-grader",
-                                    "code_grader"
-                                  ]
+                                  "enum": ["code-grader", "code_grader"]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -2434,18 +2177,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type",
-                                "command"
-                              ],
+                              "required": ["type", "command"],
                               "additionalProperties": false
                             },
                             {
@@ -2482,10 +2219,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "llm-grader",
-                                    "llm_grader"
-                                  ]
+                                  "enum": ["llm-grader", "llm_grader"]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -2543,10 +2277,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -2587,10 +2318,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -2641,17 +2369,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -2662,9 +2385,7 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": [
-                                "include"
-                              ],
+                              "required": ["include"],
                               "additionalProperties": false
                             },
                             {
@@ -2727,9 +2448,7 @@
                                           }
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -2745,10 +2464,7 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "threshold"
-                                      ],
+                                      "required": ["type", "threshold"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -2765,10 +2481,7 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "path"
-                                      ],
+                                      "required": ["type", "path"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -2785,18 +2498,13 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "aggregator"
-                              ],
+                              "required": ["type", "aggregator"],
                               "additionalProperties": false
                             },
                             {
@@ -2833,20 +2541,11 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "tool-trajectory",
-                                    "tool_trajectory"
-                                  ]
+                                  "enum": ["tool-trajectory", "tool_trajectory"]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": [
-                                    "any_order",
-                                    "in_order",
-                                    "exact",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -2887,12 +2586,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -2906,12 +2600,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -2922,9 +2611,7 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "tool"
-                                    ],
+                                    "required": ["tool"],
                                     "additionalProperties": false
                                   }
                                 },
@@ -2932,12 +2619,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -2951,12 +2633,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -2967,10 +2644,7 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "mode"
-                              ],
+                              "required": ["type", "mode"],
                               "additionalProperties": false
                             },
                             {
@@ -3007,10 +2681,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "field-accuracy",
-                                    "field_accuracy"
-                                  ]
+                                  "enum": ["field-accuracy", "field_accuracy"]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -3022,11 +2693,7 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "numeric_tolerance",
-                                          "date"
-                                        ]
+                                        "enum": ["exact", "numeric_tolerance", "date"]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -3048,26 +2715,17 @@
                                         }
                                       }
                                     },
-                                    "required": [
-                                      "path",
-                                      "match"
-                                    ],
+                                    "required": ["path", "match"],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": [
-                                    "weighted_average",
-                                    "all_or_nothing"
-                                  ]
+                                  "enum": ["weighted_average", "all_or_nothing"]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "fields"
-                              ],
+                              "required": ["type", "fields"],
                               "additionalProperties": false
                             },
                             {
@@ -3111,10 +2769,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "threshold"
-                              ],
+                              "required": ["type", "threshold"],
                               "additionalProperties": false
                             },
                             {
@@ -3158,10 +2813,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "budget"
-                              ],
+                              "required": ["type", "budget"],
                               "additionalProperties": false
                             },
                             {
@@ -3198,10 +2850,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "token-usage",
-                                    "token_usage"
-                                  ]
+                                  "enum": ["token-usage", "token_usage"]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -3216,9 +2865,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -3255,10 +2902,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "execution-metrics",
-                                    "execution_metrics"
-                                  ]
+                                  "enum": ["execution-metrics", "execution_metrics"]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -3290,9 +2934,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -3335,10 +2977,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -3381,10 +3020,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -3421,15 +3057,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "is-json",
-                                    "is_json"
-                                  ]
+                                  "enum": ["is-json", "is_json"]
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -3472,10 +3103,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -3527,10 +3155,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -3571,10 +3196,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -3584,10 +3206,7 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": [
-                                "type",
-                                "criteria"
-                              ],
+                              "required": ["type", "criteria"],
                               "additionalProperties": false
                             }
                           ]
@@ -3639,10 +3258,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "code-grader",
-                                        "code_grader"
-                                      ]
+                                      "enum": ["code-grader", "code_grader"]
                                     },
                                     "command": {
                                       "anyOf": [
@@ -3716,18 +3332,12 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "command"
-                                  ],
+                                  "required": ["type", "command"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -3764,10 +3374,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "llm-grader",
-                                        "llm_grader"
-                                      ]
+                                      "enum": ["llm-grader", "llm_grader"]
                                     },
                                     "prompt": {
                                       "anyOf": [
@@ -3825,10 +3432,7 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
+                                            "enum": ["correctness", "contradiction"]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -3869,10 +3473,7 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
+                                              "required": ["score_range", "outcome"],
                                               "additionalProperties": false
                                             }
                                           }
@@ -3923,17 +3524,12 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -3944,9 +3540,7 @@
                                       "minLength": 1
                                     }
                                   },
-                                  "required": [
-                                    "include"
-                                  ],
+                                  "required": ["include"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4009,9 +3603,7 @@
                                               }
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
+                                          "required": ["type"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -4027,10 +3619,7 @@
                                               "maximum": 1
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "threshold"
-                                          ],
+                                          "required": ["type", "threshold"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -4047,10 +3636,7 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "path"
-                                          ],
+                                          "required": ["type", "path"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -4067,18 +3653,13 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
+                                          "required": ["type"],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "aggregator"
-                                  ],
+                                  "required": ["type", "aggregator"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4115,10 +3696,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "tool-trajectory",
-                                        "tool_trajectory"
-                                      ]
+                                      "enum": ["tool-trajectory", "tool_trajectory"]
                                     },
                                     "mode": {
                                       "type": "string",
@@ -4169,12 +3747,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -4188,12 +3761,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -4204,9 +3772,7 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "tool"
-                                        ],
+                                        "required": ["tool"],
                                         "additionalProperties": false
                                       }
                                     },
@@ -4214,12 +3780,7 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
+                                          "enum": ["exact", "ignore", "subset", "superset"]
                                         },
                                         {
                                           "type": "array",
@@ -4233,12 +3794,7 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
+                                          "enum": ["exact", "ignore", "subset", "superset"]
                                         },
                                         {
                                           "type": "array",
@@ -4249,10 +3805,7 @@
                                       ]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "mode"
-                                  ],
+                                  "required": ["type", "mode"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4289,10 +3842,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "field-accuracy",
-                                        "field_accuracy"
-                                      ]
+                                      "enum": ["field-accuracy", "field_accuracy"]
                                     },
                                     "fields": {
                                       "type": "array",
@@ -4304,11 +3854,7 @@
                                           },
                                           "match": {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "numeric_tolerance",
-                                              "date"
-                                            ]
+                                            "enum": ["exact", "numeric_tolerance", "date"]
                                           },
                                           "required": {
                                             "type": "boolean"
@@ -4330,26 +3876,17 @@
                                             }
                                           }
                                         },
-                                        "required": [
-                                          "path",
-                                          "match"
-                                        ],
+                                        "required": ["path", "match"],
                                         "additionalProperties": false
                                       },
                                       "minItems": 1
                                     },
                                     "aggregation": {
                                       "type": "string",
-                                      "enum": [
-                                        "weighted_average",
-                                        "all_or_nothing"
-                                      ]
+                                      "enum": ["weighted_average", "all_or_nothing"]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "fields"
-                                  ],
+                                  "required": ["type", "fields"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4393,10 +3930,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "threshold"
-                                  ],
+                                  "required": ["type", "threshold"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4440,10 +3974,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "budget"
-                                  ],
+                                  "required": ["type", "budget"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4480,10 +4011,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "token-usage",
-                                        "token_usage"
-                                      ]
+                                      "enum": ["token-usage", "token_usage"]
                                     },
                                     "max_total": {
                                       "type": "number",
@@ -4498,9 +4026,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4537,10 +4063,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "execution-metrics",
-                                        "execution_metrics"
-                                      ]
+                                      "enum": ["execution-metrics", "execution_metrics"]
                                     },
                                     "max_tool_calls": {
                                       "type": "number",
@@ -4572,9 +4095,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4617,10 +4138,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4663,10 +4181,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4703,15 +4218,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "is-json",
-                                        "is_json"
-                                      ]
+                                      "enum": ["is-json", "is_json"]
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4754,10 +4264,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4809,10 +4316,7 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
+                                            "enum": ["correctness", "contradiction"]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -4853,10 +4357,7 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
+                                              "required": ["score_range", "outcome"],
                                               "additionalProperties": false
                                             }
                                           }
@@ -4866,10 +4367,7 @@
                                       "minItems": 1
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "criteria"
-                                  ],
+                                  "required": ["type", "criteria"],
                                   "additionalProperties": false
                                 }
                               ]
@@ -4913,10 +4411,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "code-grader",
-                                        "code_grader"
-                                      ]
+                                      "enum": ["code-grader", "code_grader"]
                                     },
                                     "command": {
                                       "anyOf": [
@@ -4990,18 +4485,12 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "command"
-                                  ],
+                                  "required": ["type", "command"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5038,10 +4527,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "llm-grader",
-                                        "llm_grader"
-                                      ]
+                                      "enum": ["llm-grader", "llm_grader"]
                                     },
                                     "prompt": {
                                       "anyOf": [
@@ -5099,10 +4585,7 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
+                                            "enum": ["correctness", "contradiction"]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -5143,10 +4626,7 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
+                                              "required": ["score_range", "outcome"],
                                               "additionalProperties": false
                                             }
                                           }
@@ -5197,17 +4677,12 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5218,9 +4693,7 @@
                                       "minLength": 1
                                     }
                                   },
-                                  "required": [
-                                    "include"
-                                  ],
+                                  "required": ["include"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5283,9 +4756,7 @@
                                               }
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
+                                          "required": ["type"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -5301,10 +4772,7 @@
                                               "maximum": 1
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "threshold"
-                                          ],
+                                          "required": ["type", "threshold"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -5321,10 +4789,7 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "path"
-                                          ],
+                                          "required": ["type", "path"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -5341,18 +4806,13 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
+                                          "required": ["type"],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "aggregator"
-                                  ],
+                                  "required": ["type", "aggregator"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5389,10 +4849,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "tool-trajectory",
-                                        "tool_trajectory"
-                                      ]
+                                      "enum": ["tool-trajectory", "tool_trajectory"]
                                     },
                                     "mode": {
                                       "type": "string",
@@ -5443,12 +4900,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -5462,12 +4914,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -5478,9 +4925,7 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "tool"
-                                        ],
+                                        "required": ["tool"],
                                         "additionalProperties": false
                                       }
                                     },
@@ -5488,12 +4933,7 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
+                                          "enum": ["exact", "ignore", "subset", "superset"]
                                         },
                                         {
                                           "type": "array",
@@ -5507,12 +4947,7 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
+                                          "enum": ["exact", "ignore", "subset", "superset"]
                                         },
                                         {
                                           "type": "array",
@@ -5523,10 +4958,7 @@
                                       ]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "mode"
-                                  ],
+                                  "required": ["type", "mode"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5563,10 +4995,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "field-accuracy",
-                                        "field_accuracy"
-                                      ]
+                                      "enum": ["field-accuracy", "field_accuracy"]
                                     },
                                     "fields": {
                                       "type": "array",
@@ -5578,11 +5007,7 @@
                                           },
                                           "match": {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "numeric_tolerance",
-                                              "date"
-                                            ]
+                                            "enum": ["exact", "numeric_tolerance", "date"]
                                           },
                                           "required": {
                                             "type": "boolean"
@@ -5604,26 +5029,17 @@
                                             }
                                           }
                                         },
-                                        "required": [
-                                          "path",
-                                          "match"
-                                        ],
+                                        "required": ["path", "match"],
                                         "additionalProperties": false
                                       },
                                       "minItems": 1
                                     },
                                     "aggregation": {
                                       "type": "string",
-                                      "enum": [
-                                        "weighted_average",
-                                        "all_or_nothing"
-                                      ]
+                                      "enum": ["weighted_average", "all_or_nothing"]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "fields"
-                                  ],
+                                  "required": ["type", "fields"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5667,10 +5083,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "threshold"
-                                  ],
+                                  "required": ["type", "threshold"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5714,10 +5127,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "budget"
-                                  ],
+                                  "required": ["type", "budget"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5754,10 +5164,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "token-usage",
-                                        "token_usage"
-                                      ]
+                                      "enum": ["token-usage", "token_usage"]
                                     },
                                     "max_total": {
                                       "type": "number",
@@ -5772,9 +5179,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5811,10 +5216,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "execution-metrics",
-                                        "execution_metrics"
-                                      ]
+                                      "enum": ["execution-metrics", "execution_metrics"]
                                     },
                                     "max_tool_calls": {
                                       "type": "number",
@@ -5846,9 +5248,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5891,10 +5291,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5937,10 +5334,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5977,15 +5371,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "is-json",
-                                        "is_json"
-                                      ]
+                                      "enum": ["is-json", "is_json"]
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -6028,10 +5417,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -6083,10 +5469,7 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
+                                            "enum": ["correctness", "contradiction"]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -6127,10 +5510,7 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
+                                              "required": ["score_range", "outcome"],
                                               "additionalProperties": false
                                             }
                                           }
@@ -6140,2600 +5520,7 @@
                                       "minItems": 1
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "criteria"
-                                  ],
-                                  "additionalProperties": false
-                                }
-                              ]
-                            }
-                          },
-                          "skip_defaults": {
-                            "type": "boolean"
-                          },
-                          "cache": {
-                            "type": "boolean"
-                          },
-                          "trials": {
-                            "not": {}
-                          },
-                          "budget_usd": {
-                            "type": "number",
-                            "minimum": 0
-                          },
-                          "budgetUsd": {
-                            "type": "number",
-                            "minimum": 0
-                          },
-                          "fail_on_error": {
-                            "type": "boolean"
-                          },
-                          "failOnError": {
-                            "type": "boolean"
-                          },
-                          "threshold": {
-                            "type": "number",
-                            "minimum": 0,
-                            "maximum": 1
-                          },
-                          "workspace": {
-                            "not": {}
-                          }
-                        },
-                        "additionalProperties": false
-                      },
-                      "execution": {
-                        "type": "object",
-                        "properties": {
-                          "workers": {
-                            "type": "integer",
-                            "minimum": 1,
-                            "maximum": 50
-                          },
-                          "assertions": {
-                            "type": "array",
-                            "items": {
-                              "anyOf": [
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "code-grader",
-                                        "code_grader"
-                                      ]
-                                    },
-                                    "command": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string"
-                                        },
-                                        {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "script": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string"
-                                        },
-                                        {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "cwd": {
-                                      "type": "string"
-                                    },
-                                    "target": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "max_calls": {
-                                              "type": "number"
-                                            }
-                                          },
-                                          "additionalProperties": false
-                                        }
-                                      ]
-                                    },
-                                    "config": {
-                                      "type": "object",
-                                      "additionalProperties": {}
-                                    },
-                                    "preprocessors": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "type": {
-                                            "type": "string",
-                                            "minLength": 1
-                                          },
-                                          "command": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string"
-                                              },
-                                              {
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "string"
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
-                                        "additionalProperties": false
-                                      }
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "command"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "llm-grader",
-                                        "llm_grader"
-                                      ]
-                                    },
-                                    "prompt": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string"
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "command": {
-                                              "anyOf": [
-                                                {
-                                                  "type": "string"
-                                                },
-                                                {
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "string"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "script": {
-                                              "anyOf": [
-                                                {
-                                                  "type": "string"
-                                                },
-                                                {
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "string"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "config": {
-                                              "type": "object",
-                                              "additionalProperties": {}
-                                            }
-                                          },
-                                          "additionalProperties": false
-                                        }
-                                      ]
-                                    },
-                                    "rubrics": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "id": {
-                                            "type": "string"
-                                          },
-                                          "outcome": {
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
-                                          },
-                                          "weight": {
-                                            "type": "number"
-                                          },
-                                          "required": {
-                                            "type": "boolean"
-                                          },
-                                          "min_score": {
-                                            "type": "number",
-                                            "exclusiveMinimum": true,
-                                            "minimum": 0,
-                                            "maximum": 1
-                                          },
-                                          "score_ranges": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object",
-                                              "properties": {
-                                                "score_range": {
-                                                  "type": "array",
-                                                  "minItems": 2,
-                                                  "maxItems": 2,
-                                                  "items": [
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    },
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    }
-                                                  ]
-                                                },
-                                                "outcome": {
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                }
-                                              },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
-                                              "additionalProperties": false
-                                            }
-                                          }
-                                        },
-                                        "additionalProperties": false
-                                      }
-                                    },
-                                    "model": {
-                                      "type": "string"
-                                    },
-                                    "target": {
-                                      "type": "string"
-                                    },
-                                    "config": {
-                                      "type": "object",
-                                      "additionalProperties": {}
-                                    },
-                                    "max_steps": {
-                                      "type": "integer",
-                                      "minimum": 1,
-                                      "maximum": 50
-                                    },
-                                    "temperature": {
-                                      "type": "number",
-                                      "minimum": 0,
-                                      "maximum": 2
-                                    },
-                                    "preprocessors": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "type": {
-                                            "type": "string",
-                                            "minLength": 1
-                                          },
-                                          "command": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string"
-                                              },
-                                              {
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "string"
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
-                                        "additionalProperties": false
-                                      }
-                                    }
-                                  },
-                                  "required": [
-                                    "type"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "include": {
-                                      "type": "string",
-                                      "minLength": 1
-                                    }
-                                  },
-                                  "required": [
-                                    "include"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "composite"
-                                    },
-                                    "assertions": {
-                                      "type": "array",
-                                      "items": {}
-                                    },
-                                    "evaluators": {
-                                      "type": "array",
-                                      "items": {}
-                                    },
-                                    "aggregator": {
-                                      "anyOf": [
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "type": {
-                                              "type": "string",
-                                              "const": "weighted_average"
-                                            },
-                                            "weights": {
-                                              "type": "object",
-                                              "additionalProperties": {
-                                                "type": "number"
-                                              }
-                                            }
-                                          },
-                                          "required": [
-                                            "type"
-                                          ],
-                                          "additionalProperties": false
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "type": {
-                                              "type": "string",
-                                              "const": "threshold"
-                                            },
-                                            "threshold": {
-                                              "type": "number",
-                                              "minimum": 0,
-                                              "maximum": 1
-                                            }
-                                          },
-                                          "required": [
-                                            "type",
-                                            "threshold"
-                                          ],
-                                          "additionalProperties": false
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "type": {
-                                              "type": "string",
-                                              "const": "code-grader"
-                                            },
-                                            "path": {
-                                              "type": "string"
-                                            },
-                                            "cwd": {
-                                              "type": "string"
-                                            }
-                                          },
-                                          "required": [
-                                            "type",
-                                            "path"
-                                          ],
-                                          "additionalProperties": false
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "type": {
-                                              "type": "string",
-                                              "const": "llm-grader"
-                                            },
-                                            "prompt": {
-                                              "type": "string"
-                                            },
-                                            "model": {
-                                              "type": "string"
-                                            }
-                                          },
-                                          "required": [
-                                            "type"
-                                          ],
-                                          "additionalProperties": false
-                                        }
-                                      ]
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "aggregator"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "tool-trajectory",
-                                        "tool_trajectory"
-                                      ]
-                                    },
-                                    "mode": {
-                                      "type": "string",
-                                      "enum": [
-                                        "any_order",
-                                        "in_order",
-                                        "exact",
-                                        "subset",
-                                        "superset"
-                                      ]
-                                    },
-                                    "minimums": {
-                                      "type": "object",
-                                      "additionalProperties": {
-                                        "type": "integer",
-                                        "minimum": 0
-                                      }
-                                    },
-                                    "expected": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "tool": {
-                                            "type": "string"
-                                          },
-                                          "args": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string",
-                                                "const": "any"
-                                              },
-                                              {
-                                                "type": "object",
-                                                "additionalProperties": {}
-                                              }
-                                            ]
-                                          },
-                                          "max_duration_ms": {
-                                            "type": "number",
-                                            "minimum": 0
-                                          },
-                                          "maxDurationMs": {
-                                            "type": "number",
-                                            "minimum": 0
-                                          },
-                                          "args_match": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
-                                              },
-                                              {
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "string"
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "argsMatch": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
-                                              },
-                                              {
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "string"
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        },
-                                        "required": [
-                                          "tool"
-                                        ],
-                                        "additionalProperties": false
-                                      }
-                                    },
-                                    "args_match": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
-                                        },
-                                        {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "argsMatch": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
-                                        },
-                                        {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "mode"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "field-accuracy",
-                                        "field_accuracy"
-                                      ]
-                                    },
-                                    "fields": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "path": {
-                                            "type": "string"
-                                          },
-                                          "match": {
-                                            "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "numeric_tolerance",
-                                              "date"
-                                            ]
-                                          },
-                                          "required": {
-                                            "type": "boolean"
-                                          },
-                                          "weight": {
-                                            "type": "number"
-                                          },
-                                          "tolerance": {
-                                            "type": "number",
-                                            "minimum": 0
-                                          },
-                                          "relative": {
-                                            "type": "boolean"
-                                          },
-                                          "formats": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "string"
-                                            }
-                                          }
-                                        },
-                                        "required": [
-                                          "path",
-                                          "match"
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "minItems": 1
-                                    },
-                                    "aggregation": {
-                                      "type": "string",
-                                      "enum": [
-                                        "weighted_average",
-                                        "all_or_nothing"
-                                      ]
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "fields"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "latency"
-                                    },
-                                    "threshold": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "threshold"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "cost"
-                                    },
-                                    "budget": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "budget"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "token-usage",
-                                        "token_usage"
-                                      ]
-                                    },
-                                    "max_total": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_input": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_output": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    }
-                                  },
-                                  "required": [
-                                    "type"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "execution-metrics",
-                                        "execution_metrics"
-                                      ]
-                                    },
-                                    "max_tool_calls": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_llm_calls": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_tokens": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_cost_usd": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_duration_ms": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "target_exploration_ratio": {
-                                      "type": "number",
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "exploration_tolerance": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    }
-                                  },
-                                  "required": [
-                                    "type"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "contains"
-                                    },
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "regex"
-                                    },
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "is-json",
-                                        "is_json"
-                                      ]
-                                    }
-                                  },
-                                  "required": [
-                                    "type"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "equals"
-                                    },
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "rubrics"
-                                    },
-                                    "criteria": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "id": {
-                                            "type": "string"
-                                          },
-                                          "outcome": {
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
-                                          },
-                                          "weight": {
-                                            "type": "number"
-                                          },
-                                          "required": {
-                                            "type": "boolean"
-                                          },
-                                          "min_score": {
-                                            "type": "number",
-                                            "exclusiveMinimum": true,
-                                            "minimum": 0,
-                                            "maximum": 1
-                                          },
-                                          "score_ranges": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object",
-                                              "properties": {
-                                                "score_range": {
-                                                  "type": "array",
-                                                  "minItems": 2,
-                                                  "maxItems": 2,
-                                                  "items": [
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    },
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    }
-                                                  ]
-                                                },
-                                                "outcome": {
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                }
-                                              },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
-                                              "additionalProperties": false
-                                            }
-                                          }
-                                        },
-                                        "additionalProperties": false
-                                      },
-                                      "minItems": 1
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "criteria"
-                                  ],
-                                  "additionalProperties": false
-                                }
-                              ]
-                            }
-                          },
-                          "evaluators": {
-                            "type": "array",
-                            "items": {
-                              "anyOf": [
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "code-grader",
-                                        "code_grader"
-                                      ]
-                                    },
-                                    "command": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string"
-                                        },
-                                        {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "script": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string"
-                                        },
-                                        {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "cwd": {
-                                      "type": "string"
-                                    },
-                                    "target": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "max_calls": {
-                                              "type": "number"
-                                            }
-                                          },
-                                          "additionalProperties": false
-                                        }
-                                      ]
-                                    },
-                                    "config": {
-                                      "type": "object",
-                                      "additionalProperties": {}
-                                    },
-                                    "preprocessors": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "type": {
-                                            "type": "string",
-                                            "minLength": 1
-                                          },
-                                          "command": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string"
-                                              },
-                                              {
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "string"
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
-                                        "additionalProperties": false
-                                      }
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "command"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "llm-grader",
-                                        "llm_grader"
-                                      ]
-                                    },
-                                    "prompt": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string"
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "command": {
-                                              "anyOf": [
-                                                {
-                                                  "type": "string"
-                                                },
-                                                {
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "string"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "script": {
-                                              "anyOf": [
-                                                {
-                                                  "type": "string"
-                                                },
-                                                {
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "string"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "config": {
-                                              "type": "object",
-                                              "additionalProperties": {}
-                                            }
-                                          },
-                                          "additionalProperties": false
-                                        }
-                                      ]
-                                    },
-                                    "rubrics": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "id": {
-                                            "type": "string"
-                                          },
-                                          "outcome": {
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
-                                          },
-                                          "weight": {
-                                            "type": "number"
-                                          },
-                                          "required": {
-                                            "type": "boolean"
-                                          },
-                                          "min_score": {
-                                            "type": "number",
-                                            "exclusiveMinimum": true,
-                                            "minimum": 0,
-                                            "maximum": 1
-                                          },
-                                          "score_ranges": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object",
-                                              "properties": {
-                                                "score_range": {
-                                                  "type": "array",
-                                                  "minItems": 2,
-                                                  "maxItems": 2,
-                                                  "items": [
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    },
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    }
-                                                  ]
-                                                },
-                                                "outcome": {
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                }
-                                              },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
-                                              "additionalProperties": false
-                                            }
-                                          }
-                                        },
-                                        "additionalProperties": false
-                                      }
-                                    },
-                                    "model": {
-                                      "type": "string"
-                                    },
-                                    "target": {
-                                      "type": "string"
-                                    },
-                                    "config": {
-                                      "type": "object",
-                                      "additionalProperties": {}
-                                    },
-                                    "max_steps": {
-                                      "type": "integer",
-                                      "minimum": 1,
-                                      "maximum": 50
-                                    },
-                                    "temperature": {
-                                      "type": "number",
-                                      "minimum": 0,
-                                      "maximum": 2
-                                    },
-                                    "preprocessors": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "type": {
-                                            "type": "string",
-                                            "minLength": 1
-                                          },
-                                          "command": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string"
-                                              },
-                                              {
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "string"
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
-                                        "additionalProperties": false
-                                      }
-                                    }
-                                  },
-                                  "required": [
-                                    "type"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "include": {
-                                      "type": "string",
-                                      "minLength": 1
-                                    }
-                                  },
-                                  "required": [
-                                    "include"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "composite"
-                                    },
-                                    "assertions": {
-                                      "type": "array",
-                                      "items": {}
-                                    },
-                                    "evaluators": {
-                                      "type": "array",
-                                      "items": {}
-                                    },
-                                    "aggregator": {
-                                      "anyOf": [
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "type": {
-                                              "type": "string",
-                                              "const": "weighted_average"
-                                            },
-                                            "weights": {
-                                              "type": "object",
-                                              "additionalProperties": {
-                                                "type": "number"
-                                              }
-                                            }
-                                          },
-                                          "required": [
-                                            "type"
-                                          ],
-                                          "additionalProperties": false
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "type": {
-                                              "type": "string",
-                                              "const": "threshold"
-                                            },
-                                            "threshold": {
-                                              "type": "number",
-                                              "minimum": 0,
-                                              "maximum": 1
-                                            }
-                                          },
-                                          "required": [
-                                            "type",
-                                            "threshold"
-                                          ],
-                                          "additionalProperties": false
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "type": {
-                                              "type": "string",
-                                              "const": "code-grader"
-                                            },
-                                            "path": {
-                                              "type": "string"
-                                            },
-                                            "cwd": {
-                                              "type": "string"
-                                            }
-                                          },
-                                          "required": [
-                                            "type",
-                                            "path"
-                                          ],
-                                          "additionalProperties": false
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "type": {
-                                              "type": "string",
-                                              "const": "llm-grader"
-                                            },
-                                            "prompt": {
-                                              "type": "string"
-                                            },
-                                            "model": {
-                                              "type": "string"
-                                            }
-                                          },
-                                          "required": [
-                                            "type"
-                                          ],
-                                          "additionalProperties": false
-                                        }
-                                      ]
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "aggregator"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "tool-trajectory",
-                                        "tool_trajectory"
-                                      ]
-                                    },
-                                    "mode": {
-                                      "type": "string",
-                                      "enum": [
-                                        "any_order",
-                                        "in_order",
-                                        "exact",
-                                        "subset",
-                                        "superset"
-                                      ]
-                                    },
-                                    "minimums": {
-                                      "type": "object",
-                                      "additionalProperties": {
-                                        "type": "integer",
-                                        "minimum": 0
-                                      }
-                                    },
-                                    "expected": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "tool": {
-                                            "type": "string"
-                                          },
-                                          "args": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string",
-                                                "const": "any"
-                                              },
-                                              {
-                                                "type": "object",
-                                                "additionalProperties": {}
-                                              }
-                                            ]
-                                          },
-                                          "max_duration_ms": {
-                                            "type": "number",
-                                            "minimum": 0
-                                          },
-                                          "maxDurationMs": {
-                                            "type": "number",
-                                            "minimum": 0
-                                          },
-                                          "args_match": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
-                                              },
-                                              {
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "string"
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "argsMatch": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
-                                              },
-                                              {
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "string"
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        },
-                                        "required": [
-                                          "tool"
-                                        ],
-                                        "additionalProperties": false
-                                      }
-                                    },
-                                    "args_match": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
-                                        },
-                                        {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "argsMatch": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
-                                        },
-                                        {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "mode"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "field-accuracy",
-                                        "field_accuracy"
-                                      ]
-                                    },
-                                    "fields": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "path": {
-                                            "type": "string"
-                                          },
-                                          "match": {
-                                            "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "numeric_tolerance",
-                                              "date"
-                                            ]
-                                          },
-                                          "required": {
-                                            "type": "boolean"
-                                          },
-                                          "weight": {
-                                            "type": "number"
-                                          },
-                                          "tolerance": {
-                                            "type": "number",
-                                            "minimum": 0
-                                          },
-                                          "relative": {
-                                            "type": "boolean"
-                                          },
-                                          "formats": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "string"
-                                            }
-                                          }
-                                        },
-                                        "required": [
-                                          "path",
-                                          "match"
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "minItems": 1
-                                    },
-                                    "aggregation": {
-                                      "type": "string",
-                                      "enum": [
-                                        "weighted_average",
-                                        "all_or_nothing"
-                                      ]
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "fields"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "latency"
-                                    },
-                                    "threshold": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "threshold"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "cost"
-                                    },
-                                    "budget": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "budget"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "token-usage",
-                                        "token_usage"
-                                      ]
-                                    },
-                                    "max_total": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_input": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_output": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    }
-                                  },
-                                  "required": [
-                                    "type"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "execution-metrics",
-                                        "execution_metrics"
-                                      ]
-                                    },
-                                    "max_tool_calls": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_llm_calls": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_tokens": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_cost_usd": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_duration_ms": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "target_exploration_ratio": {
-                                      "type": "number",
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "exploration_tolerance": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    }
-                                  },
-                                  "required": [
-                                    "type"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "contains"
-                                    },
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "regex"
-                                    },
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "is-json",
-                                        "is_json"
-                                      ]
-                                    }
-                                  },
-                                  "required": [
-                                    "type"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "equals"
-                                    },
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "rubrics"
-                                    },
-                                    "criteria": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "id": {
-                                            "type": "string"
-                                          },
-                                          "outcome": {
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
-                                          },
-                                          "weight": {
-                                            "type": "number"
-                                          },
-                                          "required": {
-                                            "type": "boolean"
-                                          },
-                                          "min_score": {
-                                            "type": "number",
-                                            "exclusiveMinimum": true,
-                                            "minimum": 0,
-                                            "maximum": 1
-                                          },
-                                          "score_ranges": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object",
-                                              "properties": {
-                                                "score_range": {
-                                                  "type": "array",
-                                                  "minItems": 2,
-                                                  "maxItems": 2,
-                                                  "items": [
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    },
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    }
-                                                  ]
-                                                },
-                                                "outcome": {
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                }
-                                              },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
-                                              "additionalProperties": false
-                                            }
-                                          }
-                                        },
-                                        "additionalProperties": false
-                                      },
-                                      "minItems": 1
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "criteria"
-                                  ],
+                                  "required": ["type", "criteria"],
                                   "additionalProperties": false
                                 }
                               ]
@@ -8790,12 +5577,7 @@
                               },
                               "strategy": {
                                 "type": "string",
-                                "enum": [
-                                  "pass_at_k",
-                                  "pass_all",
-                                  "mean",
-                                  "confidence_interval"
-                                ]
+                                "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
                               },
                               "cost_limit_usd": {
                                 "type": "number",
@@ -8806,9 +5588,7 @@
                                 "minimum": 0
                               }
                             },
-                            "required": [
-                              "count"
-                            ],
+                            "required": ["count"],
                             "additionalProperties": false
                           },
                           "timeout_seconds": {
@@ -8832,10 +5612,7 @@
                           },
                           "isolation": {
                             "type": "string",
-                            "enum": [
-                              "shared",
-                              "per_case"
-                            ]
+                            "enum": ["shared", "per_case"]
                           },
                           "repos": {
                             "type": "array",
@@ -8917,11 +5694,7 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": [
-                                      "none",
-                                      "fast",
-                                      "strict"
-                                    ]
+                                    "enum": ["none", "fast", "strict"]
                                   }
                                 },
                                 "additionalProperties": false
@@ -8966,11 +5739,7 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": [
-                                      "none",
-                                      "fast",
-                                      "strict"
-                                    ]
+                                    "enum": ["none", "fast", "strict"]
                                   }
                                 },
                                 "additionalProperties": false
@@ -9015,11 +5784,7 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": [
-                                      "none",
-                                      "fast",
-                                      "strict"
-                                    ]
+                                    "enum": ["none", "fast", "strict"]
                                   }
                                 },
                                 "additionalProperties": false
@@ -9064,11 +5829,7 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": [
-                                      "none",
-                                      "fast",
-                                      "strict"
-                                    ]
+                                    "enum": ["none", "fast", "strict"]
                                   }
                                 },
                                 "additionalProperties": false
@@ -9094,9 +5855,7 @@
                                 "minimum": 0.1
                               }
                             },
-                            "required": [
-                              "image"
-                            ],
+                            "required": ["image"],
                             "additionalProperties": false
                           },
                           "env": {
@@ -9140,17 +5899,11 @@
                       },
                       "on_dependency_failure": {
                         "type": "string",
-                        "enum": [
-                          "skip",
-                          "fail",
-                          "run"
-                        ]
+                        "enum": ["skip", "fail", "run"]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": [
-                          "conversation"
-                        ]
+                        "enum": ["conversation"]
                       },
                       "turns": {
                         "type": "array",
@@ -9179,20 +5932,13 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "text",
-                                              "file",
-                                              "image"
-                                            ]
+                                            "enum": ["text", "file", "image"]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       }
                                     }
@@ -9222,20 +5968,13 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "text",
-                                              "file",
-                                              "image"
-                                            ]
+                                            "enum": ["text", "file", "image"]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       }
                                     }
@@ -9286,10 +6025,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "code-grader",
-                                              "code_grader"
-                                            ]
+                                            "enum": ["code-grader", "code_grader"]
                                           },
                                           "command": {
                                             "anyOf": [
@@ -9363,18 +6099,12 @@
                                                   ]
                                                 }
                                               },
-                                              "required": [
-                                                "type",
-                                                "command"
-                                              ],
+                                              "required": ["type", "command"],
                                               "additionalProperties": false
                                             }
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -9411,10 +6141,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "llm-grader",
-                                              "llm_grader"
-                                            ]
+                                            "enum": ["llm-grader", "llm_grader"]
                                           },
                                           "prompt": {
                                             "anyOf": [
@@ -9472,10 +6199,7 @@
                                                 },
                                                 "operator": {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "correctness",
-                                                    "contradiction"
-                                                  ]
+                                                  "enum": ["correctness", "contradiction"]
                                                 },
                                                 "weight": {
                                                   "type": "number"
@@ -9516,10 +6240,7 @@
                                                         "minLength": 1
                                                       }
                                                     },
-                                                    "required": [
-                                                      "score_range",
-                                                      "outcome"
-                                                    ],
+                                                    "required": ["score_range", "outcome"],
                                                     "additionalProperties": false
                                                   }
                                                 }
@@ -9570,17 +6291,12 @@
                                                   ]
                                                 }
                                               },
-                                              "required": [
-                                                "type",
-                                                "command"
-                                              ],
+                                              "required": ["type", "command"],
                                               "additionalProperties": false
                                             }
                                           }
                                         },
-                                        "required": [
-                                          "type"
-                                        ],
+                                        "required": ["type"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -9591,9 +6307,7 @@
                                             "minLength": 1
                                           }
                                         },
-                                        "required": [
-                                          "include"
-                                        ],
+                                        "required": ["include"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -9656,9 +6370,7 @@
                                                     }
                                                   }
                                                 },
-                                                "required": [
-                                                  "type"
-                                                ],
+                                                "required": ["type"],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -9674,10 +6386,7 @@
                                                     "maximum": 1
                                                   }
                                                 },
-                                                "required": [
-                                                  "type",
-                                                  "threshold"
-                                                ],
+                                                "required": ["type", "threshold"],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -9694,10 +6403,7 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": [
-                                                  "type",
-                                                  "path"
-                                                ],
+                                                "required": ["type", "path"],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -9714,18 +6420,13 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": [
-                                                  "type"
-                                                ],
+                                                "required": ["type"],
                                                 "additionalProperties": false
                                               }
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "aggregator"
-                                        ],
+                                        "required": ["type", "aggregator"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -9762,10 +6463,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "tool-trajectory",
-                                              "tool_trajectory"
-                                            ]
+                                            "enum": ["tool-trajectory", "tool_trajectory"]
                                           },
                                           "mode": {
                                             "type": "string",
@@ -9851,9 +6549,7 @@
                                                   ]
                                                 }
                                               },
-                                              "required": [
-                                                "tool"
-                                              ],
+                                              "required": ["tool"],
                                               "additionalProperties": false
                                             }
                                           },
@@ -9861,12 +6557,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -9880,12 +6571,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -9896,10 +6582,7 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "mode"
-                                        ],
+                                        "required": ["type", "mode"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -9936,10 +6619,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "field-accuracy",
-                                              "field_accuracy"
-                                            ]
+                                            "enum": ["field-accuracy", "field_accuracy"]
                                           },
                                           "fields": {
                                             "type": "array",
@@ -9951,11 +6631,7 @@
                                                 },
                                                 "match": {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "exact",
-                                                    "numeric_tolerance",
-                                                    "date"
-                                                  ]
+                                                  "enum": ["exact", "numeric_tolerance", "date"]
                                                 },
                                                 "required": {
                                                   "type": "boolean"
@@ -9977,26 +6653,17 @@
                                                   }
                                                 }
                                               },
-                                              "required": [
-                                                "path",
-                                                "match"
-                                              ],
+                                              "required": ["path", "match"],
                                               "additionalProperties": false
                                             },
                                             "minItems": 1
                                           },
                                           "aggregation": {
                                             "type": "string",
-                                            "enum": [
-                                              "weighted_average",
-                                              "all_or_nothing"
-                                            ]
+                                            "enum": ["weighted_average", "all_or_nothing"]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "fields"
-                                        ],
+                                        "required": ["type", "fields"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -10040,10 +6707,7 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "threshold"
-                                        ],
+                                        "required": ["type", "threshold"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -10087,10 +6751,7 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "budget"
-                                        ],
+                                        "required": ["type", "budget"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -10127,10 +6788,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "token-usage",
-                                              "token_usage"
-                                            ]
+                                            "enum": ["token-usage", "token_usage"]
                                           },
                                           "max_total": {
                                             "type": "number",
@@ -10145,9 +6803,7 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": [
-                                          "type"
-                                        ],
+                                        "required": ["type"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -10184,10 +6840,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "execution-metrics",
-                                              "execution_metrics"
-                                            ]
+                                            "enum": ["execution-metrics", "execution_metrics"]
                                           },
                                           "max_tool_calls": {
                                             "type": "number",
@@ -10219,9 +6872,7 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": [
-                                          "type"
-                                        ],
+                                        "required": ["type"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -10264,10 +6915,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -10310,10 +6958,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -10350,15 +6995,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "is-json",
-                                              "is_json"
-                                            ]
+                                            "enum": ["is-json", "is_json"]
                                           }
                                         },
-                                        "required": [
-                                          "type"
-                                        ],
+                                        "required": ["type"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -10401,10 +7041,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -10456,10 +7093,7 @@
                                                 },
                                                 "operator": {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "correctness",
-                                                    "contradiction"
-                                                  ]
+                                                  "enum": ["correctness", "contradiction"]
                                                 },
                                                 "weight": {
                                                   "type": "number"
@@ -10500,10 +7134,7 @@
                                                         "minLength": 1
                                                       }
                                                     },
-                                                    "required": [
-                                                      "score_range",
-                                                      "outcome"
-                                                    ],
+                                                    "required": ["score_range", "outcome"],
                                                     "additionalProperties": false
                                                   }
                                                 }
@@ -10513,10 +7144,7 @@
                                             "minItems": 1
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "criteria"
-                                        ],
+                                        "required": ["type", "criteria"],
                                         "additionalProperties": false
                                       }
                                     ]
@@ -10525,37 +7153,26 @@
                               }
                             }
                           },
-                          "required": [
-                            "input"
-                          ],
+                          "required": ["input"],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": [
-                          "mean",
-                          "min",
-                          "max"
-                        ]
+                        "enum": ["mean", "min", "max"]
                       },
                       "on_turn_failure": {
                         "type": "string",
-                        "enum": [
-                          "continue",
-                          "stop"
-                        ]
+                        "enum": ["continue", "stop"]
                       },
                       "window_size": {
                         "type": "integer",
                         "minimum": 1
                       }
                     },
-                    "required": [
-                      "id"
-                    ],
-                    "additionalProperties": false
+                    "required": ["id"],
+                    "additionalProperties": true
                   },
                   {
                     "type": "object",
@@ -10566,10 +7183,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "suite",
-                          "tests"
-                        ]
+                        "enum": ["suite", "tests"]
                       },
                       "select": {
                         "anyOf": [
@@ -10640,11 +7254,7 @@
                                     {
                                       "type": "array",
                                       "items": {
-                                        "type": [
-                                          "string",
-                                          "number",
-                                          "boolean"
-                                        ]
+                                        "type": ["string", "number", "boolean"]
                                       },
                                       "minItems": 1
                                     }
@@ -10673,12 +7283,7 @@
                               },
                               "strategy": {
                                 "type": "string",
-                                "enum": [
-                                  "pass_at_k",
-                                  "pass_all",
-                                  "mean",
-                                  "confidence_interval"
-                                ]
+                                "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
                               },
                               "cost_limit_usd": {
                                 "type": "number",
@@ -10689,9 +7294,7 @@
                                 "minimum": 0
                               }
                             },
-                            "required": [
-                              "count"
-                            ],
+                            "required": ["count"],
                             "additionalProperties": false
                           },
                           "timeout_seconds": {
@@ -10708,10 +7311,7 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": [
-                      "include",
-                      "type"
-                    ],
+                    "required": ["include", "type"],
                     "additionalProperties": false
                   },
                   {
@@ -10758,12 +7358,7 @@
                             "properties": {
                               "role": {
                                 "type": "string",
-                                "enum": [
-                                  "system",
-                                  "user",
-                                  "assistant",
-                                  "tool"
-                                ]
+                                "enum": ["system", "user", "assistant", "tool"]
                               },
                               "content": {
                                 "anyOf": [
@@ -10782,30 +7377,20 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "text",
-                                            "file",
-                                            "image"
-                                          ]
+                                          "enum": ["text", "file", "image"]
                                         },
                                         "value": {
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "value"
-                                      ],
+                                      "required": ["type", "value"],
                                       "additionalProperties": false
                                     }
                                   }
                                 ]
                               }
                             },
-                            "required": [
-                              "role",
-                              "content"
-                            ],
+                            "required": ["role", "content"],
                             "additionalProperties": false
                           },
                           {
@@ -10824,12 +7409,7 @@
                               "properties": {
                                 "role": {
                                   "type": "string",
-                                  "enum": [
-                                    "system",
-                                    "user",
-                                    "assistant",
-                                    "tool"
-                                  ]
+                                  "enum": ["system", "user", "assistant", "tool"]
                                 },
                                 "content": {
                                   "anyOf": [
@@ -10848,30 +7428,20 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "text",
-                                              "file",
-                                              "image"
-                                            ]
+                                            "enum": ["text", "file", "image"]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       }
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "role",
-                                "content"
-                              ],
+                              "required": ["role", "content"],
                               "additionalProperties": false
                             }
                           }
@@ -10900,12 +7470,7 @@
                               "properties": {
                                 "role": {
                                   "type": "string",
-                                  "enum": [
-                                    "system",
-                                    "user",
-                                    "assistant",
-                                    "tool"
-                                  ]
+                                  "enum": ["system", "user", "assistant", "tool"]
                                 },
                                 "content": {
                                   "anyOf": [
@@ -10924,30 +7489,20 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "text",
-                                              "file",
-                                              "image"
-                                            ]
+                                            "enum": ["text", "file", "image"]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       }
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "role",
-                                "content"
-                              ],
+                              "required": ["role", "content"],
                               "additionalProperties": false
                             }
                           }
@@ -10991,10 +7546,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "code-grader",
-                                    "code_grader"
-                                  ]
+                                  "enum": ["code-grader", "code_grader"]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -11068,18 +7620,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type",
-                                "command"
-                              ],
+                              "required": ["type", "command"],
                               "additionalProperties": false
                             },
                             {
@@ -11116,10 +7662,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "llm-grader",
-                                    "llm_grader"
-                                  ]
+                                  "enum": ["llm-grader", "llm_grader"]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -11177,10 +7720,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -11221,10 +7761,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -11275,17 +7812,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -11296,9 +7828,7 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": [
-                                "include"
-                              ],
+                              "required": ["include"],
                               "additionalProperties": false
                             },
                             {
@@ -11361,9 +7891,7 @@
                                           }
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -11379,10 +7907,7 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "threshold"
-                                      ],
+                                      "required": ["type", "threshold"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -11399,10 +7924,7 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "path"
-                                      ],
+                                      "required": ["type", "path"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -11419,18 +7941,13 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "aggregator"
-                              ],
+                              "required": ["type", "aggregator"],
                               "additionalProperties": false
                             },
                             {
@@ -11467,20 +7984,11 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "tool-trajectory",
-                                    "tool_trajectory"
-                                  ]
+                                  "enum": ["tool-trajectory", "tool_trajectory"]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": [
-                                    "any_order",
-                                    "in_order",
-                                    "exact",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -11521,12 +8029,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -11540,12 +8043,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -11556,9 +8054,7 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "tool"
-                                    ],
+                                    "required": ["tool"],
                                     "additionalProperties": false
                                   }
                                 },
@@ -11566,12 +8062,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -11585,12 +8076,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -11601,10 +8087,7 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "mode"
-                              ],
+                              "required": ["type", "mode"],
                               "additionalProperties": false
                             },
                             {
@@ -11641,10 +8124,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "field-accuracy",
-                                    "field_accuracy"
-                                  ]
+                                  "enum": ["field-accuracy", "field_accuracy"]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -11656,11 +8136,7 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "numeric_tolerance",
-                                          "date"
-                                        ]
+                                        "enum": ["exact", "numeric_tolerance", "date"]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -11682,26 +8158,17 @@
                                         }
                                       }
                                     },
-                                    "required": [
-                                      "path",
-                                      "match"
-                                    ],
+                                    "required": ["path", "match"],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": [
-                                    "weighted_average",
-                                    "all_or_nothing"
-                                  ]
+                                  "enum": ["weighted_average", "all_or_nothing"]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "fields"
-                              ],
+                              "required": ["type", "fields"],
                               "additionalProperties": false
                             },
                             {
@@ -11745,10 +8212,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "threshold"
-                              ],
+                              "required": ["type", "threshold"],
                               "additionalProperties": false
                             },
                             {
@@ -11792,10 +8256,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "budget"
-                              ],
+                              "required": ["type", "budget"],
                               "additionalProperties": false
                             },
                             {
@@ -11832,10 +8293,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "token-usage",
-                                    "token_usage"
-                                  ]
+                                  "enum": ["token-usage", "token_usage"]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -11850,9 +8308,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -11889,10 +8345,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "execution-metrics",
-                                    "execution_metrics"
-                                  ]
+                                  "enum": ["execution-metrics", "execution_metrics"]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -11924,9 +8377,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -11969,10 +8420,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -12015,10 +8463,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -12055,15 +8500,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "is-json",
-                                    "is_json"
-                                  ]
+                                  "enum": ["is-json", "is_json"]
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -12106,10 +8546,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -12161,10 +8598,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -12205,10 +8639,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -12218,10 +8649,7 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": [
-                                "type",
-                                "criteria"
-                              ],
+                              "required": ["type", "criteria"],
                               "additionalProperties": false
                             }
                           ]
@@ -12265,10 +8693,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "code-grader",
-                                    "code_grader"
-                                  ]
+                                  "enum": ["code-grader", "code_grader"]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -12342,18 +8767,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type",
-                                "command"
-                              ],
+                              "required": ["type", "command"],
                               "additionalProperties": false
                             },
                             {
@@ -12390,10 +8809,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "llm-grader",
-                                    "llm_grader"
-                                  ]
+                                  "enum": ["llm-grader", "llm_grader"]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -12451,10 +8867,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -12495,10 +8908,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -12549,17 +8959,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -12570,9 +8975,7 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": [
-                                "include"
-                              ],
+                              "required": ["include"],
                               "additionalProperties": false
                             },
                             {
@@ -12635,9 +9038,7 @@
                                           }
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -12653,10 +9054,7 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "threshold"
-                                      ],
+                                      "required": ["type", "threshold"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -12673,10 +9071,7 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "path"
-                                      ],
+                                      "required": ["type", "path"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -12693,18 +9088,13 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "aggregator"
-                              ],
+                              "required": ["type", "aggregator"],
                               "additionalProperties": false
                             },
                             {
@@ -12741,20 +9131,11 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "tool-trajectory",
-                                    "tool_trajectory"
-                                  ]
+                                  "enum": ["tool-trajectory", "tool_trajectory"]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": [
-                                    "any_order",
-                                    "in_order",
-                                    "exact",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -12795,12 +9176,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -12814,12 +9190,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -12830,9 +9201,7 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "tool"
-                                    ],
+                                    "required": ["tool"],
                                     "additionalProperties": false
                                   }
                                 },
@@ -12840,12 +9209,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -12859,12 +9223,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -12875,10 +9234,7 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "mode"
-                              ],
+                              "required": ["type", "mode"],
                               "additionalProperties": false
                             },
                             {
@@ -12915,10 +9271,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "field-accuracy",
-                                    "field_accuracy"
-                                  ]
+                                  "enum": ["field-accuracy", "field_accuracy"]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -12930,11 +9283,7 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "numeric_tolerance",
-                                          "date"
-                                        ]
+                                        "enum": ["exact", "numeric_tolerance", "date"]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -12956,26 +9305,17 @@
                                         }
                                       }
                                     },
-                                    "required": [
-                                      "path",
-                                      "match"
-                                    ],
+                                    "required": ["path", "match"],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": [
-                                    "weighted_average",
-                                    "all_or_nothing"
-                                  ]
+                                  "enum": ["weighted_average", "all_or_nothing"]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "fields"
-                              ],
+                              "required": ["type", "fields"],
                               "additionalProperties": false
                             },
                             {
@@ -13019,10 +9359,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "threshold"
-                              ],
+                              "required": ["type", "threshold"],
                               "additionalProperties": false
                             },
                             {
@@ -13066,10 +9403,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "budget"
-                              ],
+                              "required": ["type", "budget"],
                               "additionalProperties": false
                             },
                             {
@@ -13106,10 +9440,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "token-usage",
-                                    "token_usage"
-                                  ]
+                                  "enum": ["token-usage", "token_usage"]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -13124,9 +9455,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -13163,10 +9492,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "execution-metrics",
-                                    "execution_metrics"
-                                  ]
+                                  "enum": ["execution-metrics", "execution_metrics"]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -13198,9 +9524,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -13243,10 +9567,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -13289,10 +9610,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -13329,15 +9647,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "is-json",
-                                    "is_json"
-                                  ]
+                                  "enum": ["is-json", "is_json"]
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -13380,10 +9693,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -13435,10 +9745,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -13479,10 +9786,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -13492,10 +9796,7 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": [
-                                "type",
-                                "criteria"
-                              ],
+                              "required": ["type", "criteria"],
                               "additionalProperties": false
                             }
                           ]
@@ -13547,10 +9848,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "code-grader",
-                                        "code_grader"
-                                      ]
+                                      "enum": ["code-grader", "code_grader"]
                                     },
                                     "command": {
                                       "anyOf": [
@@ -13624,18 +9922,12 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "command"
-                                  ],
+                                  "required": ["type", "command"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -13672,10 +9964,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "llm-grader",
-                                        "llm_grader"
-                                      ]
+                                      "enum": ["llm-grader", "llm_grader"]
                                     },
                                     "prompt": {
                                       "anyOf": [
@@ -13733,10 +10022,7 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
+                                            "enum": ["correctness", "contradiction"]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -13777,10 +10063,7 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
+                                              "required": ["score_range", "outcome"],
                                               "additionalProperties": false
                                             }
                                           }
@@ -13831,17 +10114,12 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -13852,9 +10130,7 @@
                                       "minLength": 1
                                     }
                                   },
-                                  "required": [
-                                    "include"
-                                  ],
+                                  "required": ["include"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -13917,9 +10193,7 @@
                                               }
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
+                                          "required": ["type"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -13935,10 +10209,7 @@
                                               "maximum": 1
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "threshold"
-                                          ],
+                                          "required": ["type", "threshold"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -13955,10 +10226,7 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "path"
-                                          ],
+                                          "required": ["type", "path"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -13975,18 +10243,13 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
+                                          "required": ["type"],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "aggregator"
-                                  ],
+                                  "required": ["type", "aggregator"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -14023,10 +10286,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "tool-trajectory",
-                                        "tool_trajectory"
-                                      ]
+                                      "enum": ["tool-trajectory", "tool_trajectory"]
                                     },
                                     "mode": {
                                       "type": "string",
@@ -14077,12 +10337,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -14096,12 +10351,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -14112,9 +10362,7 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "tool"
-                                        ],
+                                        "required": ["tool"],
                                         "additionalProperties": false
                                       }
                                     },
@@ -14122,12 +10370,7 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
+                                          "enum": ["exact", "ignore", "subset", "superset"]
                                         },
                                         {
                                           "type": "array",
@@ -14141,12 +10384,7 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
+                                          "enum": ["exact", "ignore", "subset", "superset"]
                                         },
                                         {
                                           "type": "array",
@@ -14157,10 +10395,7 @@
                                       ]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "mode"
-                                  ],
+                                  "required": ["type", "mode"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -14197,10 +10432,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "field-accuracy",
-                                        "field_accuracy"
-                                      ]
+                                      "enum": ["field-accuracy", "field_accuracy"]
                                     },
                                     "fields": {
                                       "type": "array",
@@ -14212,11 +10444,7 @@
                                           },
                                           "match": {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "numeric_tolerance",
-                                              "date"
-                                            ]
+                                            "enum": ["exact", "numeric_tolerance", "date"]
                                           },
                                           "required": {
                                             "type": "boolean"
@@ -14238,26 +10466,17 @@
                                             }
                                           }
                                         },
-                                        "required": [
-                                          "path",
-                                          "match"
-                                        ],
+                                        "required": ["path", "match"],
                                         "additionalProperties": false
                                       },
                                       "minItems": 1
                                     },
                                     "aggregation": {
                                       "type": "string",
-                                      "enum": [
-                                        "weighted_average",
-                                        "all_or_nothing"
-                                      ]
+                                      "enum": ["weighted_average", "all_or_nothing"]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "fields"
-                                  ],
+                                  "required": ["type", "fields"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -14301,10 +10520,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "threshold"
-                                  ],
+                                  "required": ["type", "threshold"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -14348,10 +10564,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "budget"
-                                  ],
+                                  "required": ["type", "budget"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -14388,10 +10601,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "token-usage",
-                                        "token_usage"
-                                      ]
+                                      "enum": ["token-usage", "token_usage"]
                                     },
                                     "max_total": {
                                       "type": "number",
@@ -14406,9 +10616,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -14445,10 +10653,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "execution-metrics",
-                                        "execution_metrics"
-                                      ]
+                                      "enum": ["execution-metrics", "execution_metrics"]
                                     },
                                     "max_tool_calls": {
                                       "type": "number",
@@ -14480,9 +10685,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -14525,10 +10728,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -14571,10 +10771,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -14611,15 +10808,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "is-json",
-                                        "is_json"
-                                      ]
+                                      "enum": ["is-json", "is_json"]
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -14662,10 +10854,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -14717,10 +10906,7 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
+                                            "enum": ["correctness", "contradiction"]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -14761,10 +10947,7 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
+                                              "required": ["score_range", "outcome"],
                                               "additionalProperties": false
                                             }
                                           }
@@ -14774,10 +10957,7 @@
                                       "minItems": 1
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "criteria"
-                                  ],
+                                  "required": ["type", "criteria"],
                                   "additionalProperties": false
                                 }
                               ]
@@ -14821,10 +11001,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "code-grader",
-                                        "code_grader"
-                                      ]
+                                      "enum": ["code-grader", "code_grader"]
                                     },
                                     "command": {
                                       "anyOf": [
@@ -14898,18 +11075,12 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "command"
-                                  ],
+                                  "required": ["type", "command"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -14946,10 +11117,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "llm-grader",
-                                        "llm_grader"
-                                      ]
+                                      "enum": ["llm-grader", "llm_grader"]
                                     },
                                     "prompt": {
                                       "anyOf": [
@@ -15007,10 +11175,7 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
+                                            "enum": ["correctness", "contradiction"]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -15051,10 +11216,7 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
+                                              "required": ["score_range", "outcome"],
                                               "additionalProperties": false
                                             }
                                           }
@@ -15105,17 +11267,12 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -15126,9 +11283,7 @@
                                       "minLength": 1
                                     }
                                   },
-                                  "required": [
-                                    "include"
-                                  ],
+                                  "required": ["include"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -15191,9 +11346,7 @@
                                               }
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
+                                          "required": ["type"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -15209,10 +11362,7 @@
                                               "maximum": 1
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "threshold"
-                                          ],
+                                          "required": ["type", "threshold"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -15229,10 +11379,7 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "path"
-                                          ],
+                                          "required": ["type", "path"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -15249,18 +11396,13 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
+                                          "required": ["type"],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "aggregator"
-                                  ],
+                                  "required": ["type", "aggregator"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -15297,10 +11439,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "tool-trajectory",
-                                        "tool_trajectory"
-                                      ]
+                                      "enum": ["tool-trajectory", "tool_trajectory"]
                                     },
                                     "mode": {
                                       "type": "string",
@@ -15351,12 +11490,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -15370,12 +11504,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -15386,9 +11515,7 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "tool"
-                                        ],
+                                        "required": ["tool"],
                                         "additionalProperties": false
                                       }
                                     },
@@ -15396,12 +11523,7 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
+                                          "enum": ["exact", "ignore", "subset", "superset"]
                                         },
                                         {
                                           "type": "array",
@@ -15415,12 +11537,7 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
+                                          "enum": ["exact", "ignore", "subset", "superset"]
                                         },
                                         {
                                           "type": "array",
@@ -15431,10 +11548,7 @@
                                       ]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "mode"
-                                  ],
+                                  "required": ["type", "mode"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -15471,10 +11585,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "field-accuracy",
-                                        "field_accuracy"
-                                      ]
+                                      "enum": ["field-accuracy", "field_accuracy"]
                                     },
                                     "fields": {
                                       "type": "array",
@@ -15486,11 +11597,7 @@
                                           },
                                           "match": {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "numeric_tolerance",
-                                              "date"
-                                            ]
+                                            "enum": ["exact", "numeric_tolerance", "date"]
                                           },
                                           "required": {
                                             "type": "boolean"
@@ -15512,26 +11619,17 @@
                                             }
                                           }
                                         },
-                                        "required": [
-                                          "path",
-                                          "match"
-                                        ],
+                                        "required": ["path", "match"],
                                         "additionalProperties": false
                                       },
                                       "minItems": 1
                                     },
                                     "aggregation": {
                                       "type": "string",
-                                      "enum": [
-                                        "weighted_average",
-                                        "all_or_nothing"
-                                      ]
+                                      "enum": ["weighted_average", "all_or_nothing"]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "fields"
-                                  ],
+                                  "required": ["type", "fields"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -15575,10 +11673,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "threshold"
-                                  ],
+                                  "required": ["type", "threshold"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -15622,10 +11717,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "budget"
-                                  ],
+                                  "required": ["type", "budget"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -15662,10 +11754,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "token-usage",
-                                        "token_usage"
-                                      ]
+                                      "enum": ["token-usage", "token_usage"]
                                     },
                                     "max_total": {
                                       "type": "number",
@@ -15680,9 +11769,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -15719,10 +11806,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "execution-metrics",
-                                        "execution_metrics"
-                                      ]
+                                      "enum": ["execution-metrics", "execution_metrics"]
                                     },
                                     "max_tool_calls": {
                                       "type": "number",
@@ -15754,9 +11838,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -15799,10 +11881,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -15845,10 +11924,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -15885,15 +11961,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "is-json",
-                                        "is_json"
-                                      ]
+                                      "enum": ["is-json", "is_json"]
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -15936,10 +12007,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -15991,10 +12059,7 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
+                                            "enum": ["correctness", "contradiction"]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -16035,10 +12100,7 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
+                                              "required": ["score_range", "outcome"],
                                               "additionalProperties": false
                                             }
                                           }
@@ -16048,2600 +12110,7 @@
                                       "minItems": 1
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "criteria"
-                                  ],
-                                  "additionalProperties": false
-                                }
-                              ]
-                            }
-                          },
-                          "skip_defaults": {
-                            "type": "boolean"
-                          },
-                          "cache": {
-                            "type": "boolean"
-                          },
-                          "trials": {
-                            "not": {}
-                          },
-                          "budget_usd": {
-                            "type": "number",
-                            "minimum": 0
-                          },
-                          "budgetUsd": {
-                            "type": "number",
-                            "minimum": 0
-                          },
-                          "fail_on_error": {
-                            "type": "boolean"
-                          },
-                          "failOnError": {
-                            "type": "boolean"
-                          },
-                          "threshold": {
-                            "type": "number",
-                            "minimum": 0,
-                            "maximum": 1
-                          },
-                          "workspace": {
-                            "not": {}
-                          }
-                        },
-                        "additionalProperties": false
-                      },
-                      "execution": {
-                        "type": "object",
-                        "properties": {
-                          "workers": {
-                            "type": "integer",
-                            "minimum": 1,
-                            "maximum": 50
-                          },
-                          "assertions": {
-                            "type": "array",
-                            "items": {
-                              "anyOf": [
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "code-grader",
-                                        "code_grader"
-                                      ]
-                                    },
-                                    "command": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string"
-                                        },
-                                        {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "script": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string"
-                                        },
-                                        {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "cwd": {
-                                      "type": "string"
-                                    },
-                                    "target": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "max_calls": {
-                                              "type": "number"
-                                            }
-                                          },
-                                          "additionalProperties": false
-                                        }
-                                      ]
-                                    },
-                                    "config": {
-                                      "type": "object",
-                                      "additionalProperties": {}
-                                    },
-                                    "preprocessors": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "type": {
-                                            "type": "string",
-                                            "minLength": 1
-                                          },
-                                          "command": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string"
-                                              },
-                                              {
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "string"
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
-                                        "additionalProperties": false
-                                      }
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "command"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "llm-grader",
-                                        "llm_grader"
-                                      ]
-                                    },
-                                    "prompt": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string"
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "command": {
-                                              "anyOf": [
-                                                {
-                                                  "type": "string"
-                                                },
-                                                {
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "string"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "script": {
-                                              "anyOf": [
-                                                {
-                                                  "type": "string"
-                                                },
-                                                {
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "string"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "config": {
-                                              "type": "object",
-                                              "additionalProperties": {}
-                                            }
-                                          },
-                                          "additionalProperties": false
-                                        }
-                                      ]
-                                    },
-                                    "rubrics": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "id": {
-                                            "type": "string"
-                                          },
-                                          "outcome": {
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
-                                          },
-                                          "weight": {
-                                            "type": "number"
-                                          },
-                                          "required": {
-                                            "type": "boolean"
-                                          },
-                                          "min_score": {
-                                            "type": "number",
-                                            "exclusiveMinimum": true,
-                                            "minimum": 0,
-                                            "maximum": 1
-                                          },
-                                          "score_ranges": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object",
-                                              "properties": {
-                                                "score_range": {
-                                                  "type": "array",
-                                                  "minItems": 2,
-                                                  "maxItems": 2,
-                                                  "items": [
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    },
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    }
-                                                  ]
-                                                },
-                                                "outcome": {
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                }
-                                              },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
-                                              "additionalProperties": false
-                                            }
-                                          }
-                                        },
-                                        "additionalProperties": false
-                                      }
-                                    },
-                                    "model": {
-                                      "type": "string"
-                                    },
-                                    "target": {
-                                      "type": "string"
-                                    },
-                                    "config": {
-                                      "type": "object",
-                                      "additionalProperties": {}
-                                    },
-                                    "max_steps": {
-                                      "type": "integer",
-                                      "minimum": 1,
-                                      "maximum": 50
-                                    },
-                                    "temperature": {
-                                      "type": "number",
-                                      "minimum": 0,
-                                      "maximum": 2
-                                    },
-                                    "preprocessors": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "type": {
-                                            "type": "string",
-                                            "minLength": 1
-                                          },
-                                          "command": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string"
-                                              },
-                                              {
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "string"
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
-                                        "additionalProperties": false
-                                      }
-                                    }
-                                  },
-                                  "required": [
-                                    "type"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "include": {
-                                      "type": "string",
-                                      "minLength": 1
-                                    }
-                                  },
-                                  "required": [
-                                    "include"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "composite"
-                                    },
-                                    "assertions": {
-                                      "type": "array",
-                                      "items": {}
-                                    },
-                                    "evaluators": {
-                                      "type": "array",
-                                      "items": {}
-                                    },
-                                    "aggregator": {
-                                      "anyOf": [
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "type": {
-                                              "type": "string",
-                                              "const": "weighted_average"
-                                            },
-                                            "weights": {
-                                              "type": "object",
-                                              "additionalProperties": {
-                                                "type": "number"
-                                              }
-                                            }
-                                          },
-                                          "required": [
-                                            "type"
-                                          ],
-                                          "additionalProperties": false
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "type": {
-                                              "type": "string",
-                                              "const": "threshold"
-                                            },
-                                            "threshold": {
-                                              "type": "number",
-                                              "minimum": 0,
-                                              "maximum": 1
-                                            }
-                                          },
-                                          "required": [
-                                            "type",
-                                            "threshold"
-                                          ],
-                                          "additionalProperties": false
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "type": {
-                                              "type": "string",
-                                              "const": "code-grader"
-                                            },
-                                            "path": {
-                                              "type": "string"
-                                            },
-                                            "cwd": {
-                                              "type": "string"
-                                            }
-                                          },
-                                          "required": [
-                                            "type",
-                                            "path"
-                                          ],
-                                          "additionalProperties": false
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "type": {
-                                              "type": "string",
-                                              "const": "llm-grader"
-                                            },
-                                            "prompt": {
-                                              "type": "string"
-                                            },
-                                            "model": {
-                                              "type": "string"
-                                            }
-                                          },
-                                          "required": [
-                                            "type"
-                                          ],
-                                          "additionalProperties": false
-                                        }
-                                      ]
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "aggregator"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "tool-trajectory",
-                                        "tool_trajectory"
-                                      ]
-                                    },
-                                    "mode": {
-                                      "type": "string",
-                                      "enum": [
-                                        "any_order",
-                                        "in_order",
-                                        "exact",
-                                        "subset",
-                                        "superset"
-                                      ]
-                                    },
-                                    "minimums": {
-                                      "type": "object",
-                                      "additionalProperties": {
-                                        "type": "integer",
-                                        "minimum": 0
-                                      }
-                                    },
-                                    "expected": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "tool": {
-                                            "type": "string"
-                                          },
-                                          "args": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string",
-                                                "const": "any"
-                                              },
-                                              {
-                                                "type": "object",
-                                                "additionalProperties": {}
-                                              }
-                                            ]
-                                          },
-                                          "max_duration_ms": {
-                                            "type": "number",
-                                            "minimum": 0
-                                          },
-                                          "maxDurationMs": {
-                                            "type": "number",
-                                            "minimum": 0
-                                          },
-                                          "args_match": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
-                                              },
-                                              {
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "string"
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "argsMatch": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
-                                              },
-                                              {
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "string"
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        },
-                                        "required": [
-                                          "tool"
-                                        ],
-                                        "additionalProperties": false
-                                      }
-                                    },
-                                    "args_match": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
-                                        },
-                                        {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "argsMatch": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
-                                        },
-                                        {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "mode"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "field-accuracy",
-                                        "field_accuracy"
-                                      ]
-                                    },
-                                    "fields": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "path": {
-                                            "type": "string"
-                                          },
-                                          "match": {
-                                            "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "numeric_tolerance",
-                                              "date"
-                                            ]
-                                          },
-                                          "required": {
-                                            "type": "boolean"
-                                          },
-                                          "weight": {
-                                            "type": "number"
-                                          },
-                                          "tolerance": {
-                                            "type": "number",
-                                            "minimum": 0
-                                          },
-                                          "relative": {
-                                            "type": "boolean"
-                                          },
-                                          "formats": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "string"
-                                            }
-                                          }
-                                        },
-                                        "required": [
-                                          "path",
-                                          "match"
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "minItems": 1
-                                    },
-                                    "aggregation": {
-                                      "type": "string",
-                                      "enum": [
-                                        "weighted_average",
-                                        "all_or_nothing"
-                                      ]
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "fields"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "latency"
-                                    },
-                                    "threshold": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "threshold"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "cost"
-                                    },
-                                    "budget": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "budget"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "token-usage",
-                                        "token_usage"
-                                      ]
-                                    },
-                                    "max_total": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_input": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_output": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    }
-                                  },
-                                  "required": [
-                                    "type"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "execution-metrics",
-                                        "execution_metrics"
-                                      ]
-                                    },
-                                    "max_tool_calls": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_llm_calls": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_tokens": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_cost_usd": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_duration_ms": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "target_exploration_ratio": {
-                                      "type": "number",
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "exploration_tolerance": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    }
-                                  },
-                                  "required": [
-                                    "type"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "contains"
-                                    },
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "regex"
-                                    },
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "is-json",
-                                        "is_json"
-                                      ]
-                                    }
-                                  },
-                                  "required": [
-                                    "type"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "equals"
-                                    },
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "rubrics"
-                                    },
-                                    "criteria": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "id": {
-                                            "type": "string"
-                                          },
-                                          "outcome": {
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
-                                          },
-                                          "weight": {
-                                            "type": "number"
-                                          },
-                                          "required": {
-                                            "type": "boolean"
-                                          },
-                                          "min_score": {
-                                            "type": "number",
-                                            "exclusiveMinimum": true,
-                                            "minimum": 0,
-                                            "maximum": 1
-                                          },
-                                          "score_ranges": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object",
-                                              "properties": {
-                                                "score_range": {
-                                                  "type": "array",
-                                                  "minItems": 2,
-                                                  "maxItems": 2,
-                                                  "items": [
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    },
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    }
-                                                  ]
-                                                },
-                                                "outcome": {
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                }
-                                              },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
-                                              "additionalProperties": false
-                                            }
-                                          }
-                                        },
-                                        "additionalProperties": false
-                                      },
-                                      "minItems": 1
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "criteria"
-                                  ],
-                                  "additionalProperties": false
-                                }
-                              ]
-                            }
-                          },
-                          "evaluators": {
-                            "type": "array",
-                            "items": {
-                              "anyOf": [
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "code-grader",
-                                        "code_grader"
-                                      ]
-                                    },
-                                    "command": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string"
-                                        },
-                                        {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "script": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string"
-                                        },
-                                        {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "cwd": {
-                                      "type": "string"
-                                    },
-                                    "target": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "max_calls": {
-                                              "type": "number"
-                                            }
-                                          },
-                                          "additionalProperties": false
-                                        }
-                                      ]
-                                    },
-                                    "config": {
-                                      "type": "object",
-                                      "additionalProperties": {}
-                                    },
-                                    "preprocessors": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "type": {
-                                            "type": "string",
-                                            "minLength": 1
-                                          },
-                                          "command": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string"
-                                              },
-                                              {
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "string"
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
-                                        "additionalProperties": false
-                                      }
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "command"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "llm-grader",
-                                        "llm_grader"
-                                      ]
-                                    },
-                                    "prompt": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string"
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "command": {
-                                              "anyOf": [
-                                                {
-                                                  "type": "string"
-                                                },
-                                                {
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "string"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "script": {
-                                              "anyOf": [
-                                                {
-                                                  "type": "string"
-                                                },
-                                                {
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "string"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "config": {
-                                              "type": "object",
-                                              "additionalProperties": {}
-                                            }
-                                          },
-                                          "additionalProperties": false
-                                        }
-                                      ]
-                                    },
-                                    "rubrics": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "id": {
-                                            "type": "string"
-                                          },
-                                          "outcome": {
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
-                                          },
-                                          "weight": {
-                                            "type": "number"
-                                          },
-                                          "required": {
-                                            "type": "boolean"
-                                          },
-                                          "min_score": {
-                                            "type": "number",
-                                            "exclusiveMinimum": true,
-                                            "minimum": 0,
-                                            "maximum": 1
-                                          },
-                                          "score_ranges": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object",
-                                              "properties": {
-                                                "score_range": {
-                                                  "type": "array",
-                                                  "minItems": 2,
-                                                  "maxItems": 2,
-                                                  "items": [
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    },
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    }
-                                                  ]
-                                                },
-                                                "outcome": {
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                }
-                                              },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
-                                              "additionalProperties": false
-                                            }
-                                          }
-                                        },
-                                        "additionalProperties": false
-                                      }
-                                    },
-                                    "model": {
-                                      "type": "string"
-                                    },
-                                    "target": {
-                                      "type": "string"
-                                    },
-                                    "config": {
-                                      "type": "object",
-                                      "additionalProperties": {}
-                                    },
-                                    "max_steps": {
-                                      "type": "integer",
-                                      "minimum": 1,
-                                      "maximum": 50
-                                    },
-                                    "temperature": {
-                                      "type": "number",
-                                      "minimum": 0,
-                                      "maximum": 2
-                                    },
-                                    "preprocessors": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "type": {
-                                            "type": "string",
-                                            "minLength": 1
-                                          },
-                                          "command": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string"
-                                              },
-                                              {
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "string"
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
-                                        "additionalProperties": false
-                                      }
-                                    }
-                                  },
-                                  "required": [
-                                    "type"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "include": {
-                                      "type": "string",
-                                      "minLength": 1
-                                    }
-                                  },
-                                  "required": [
-                                    "include"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "composite"
-                                    },
-                                    "assertions": {
-                                      "type": "array",
-                                      "items": {}
-                                    },
-                                    "evaluators": {
-                                      "type": "array",
-                                      "items": {}
-                                    },
-                                    "aggregator": {
-                                      "anyOf": [
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "type": {
-                                              "type": "string",
-                                              "const": "weighted_average"
-                                            },
-                                            "weights": {
-                                              "type": "object",
-                                              "additionalProperties": {
-                                                "type": "number"
-                                              }
-                                            }
-                                          },
-                                          "required": [
-                                            "type"
-                                          ],
-                                          "additionalProperties": false
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "type": {
-                                              "type": "string",
-                                              "const": "threshold"
-                                            },
-                                            "threshold": {
-                                              "type": "number",
-                                              "minimum": 0,
-                                              "maximum": 1
-                                            }
-                                          },
-                                          "required": [
-                                            "type",
-                                            "threshold"
-                                          ],
-                                          "additionalProperties": false
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "type": {
-                                              "type": "string",
-                                              "const": "code-grader"
-                                            },
-                                            "path": {
-                                              "type": "string"
-                                            },
-                                            "cwd": {
-                                              "type": "string"
-                                            }
-                                          },
-                                          "required": [
-                                            "type",
-                                            "path"
-                                          ],
-                                          "additionalProperties": false
-                                        },
-                                        {
-                                          "type": "object",
-                                          "properties": {
-                                            "type": {
-                                              "type": "string",
-                                              "const": "llm-grader"
-                                            },
-                                            "prompt": {
-                                              "type": "string"
-                                            },
-                                            "model": {
-                                              "type": "string"
-                                            }
-                                          },
-                                          "required": [
-                                            "type"
-                                          ],
-                                          "additionalProperties": false
-                                        }
-                                      ]
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "aggregator"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "tool-trajectory",
-                                        "tool_trajectory"
-                                      ]
-                                    },
-                                    "mode": {
-                                      "type": "string",
-                                      "enum": [
-                                        "any_order",
-                                        "in_order",
-                                        "exact",
-                                        "subset",
-                                        "superset"
-                                      ]
-                                    },
-                                    "minimums": {
-                                      "type": "object",
-                                      "additionalProperties": {
-                                        "type": "integer",
-                                        "minimum": 0
-                                      }
-                                    },
-                                    "expected": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "tool": {
-                                            "type": "string"
-                                          },
-                                          "args": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string",
-                                                "const": "any"
-                                              },
-                                              {
-                                                "type": "object",
-                                                "additionalProperties": {}
-                                              }
-                                            ]
-                                          },
-                                          "max_duration_ms": {
-                                            "type": "number",
-                                            "minimum": 0
-                                          },
-                                          "maxDurationMs": {
-                                            "type": "number",
-                                            "minimum": 0
-                                          },
-                                          "args_match": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
-                                              },
-                                              {
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "string"
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "argsMatch": {
-                                            "anyOf": [
-                                              {
-                                                "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
-                                              },
-                                              {
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "string"
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        },
-                                        "required": [
-                                          "tool"
-                                        ],
-                                        "additionalProperties": false
-                                      }
-                                    },
-                                    "args_match": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
-                                        },
-                                        {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "argsMatch": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
-                                        },
-                                        {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "mode"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "field-accuracy",
-                                        "field_accuracy"
-                                      ]
-                                    },
-                                    "fields": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "path": {
-                                            "type": "string"
-                                          },
-                                          "match": {
-                                            "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "numeric_tolerance",
-                                              "date"
-                                            ]
-                                          },
-                                          "required": {
-                                            "type": "boolean"
-                                          },
-                                          "weight": {
-                                            "type": "number"
-                                          },
-                                          "tolerance": {
-                                            "type": "number",
-                                            "minimum": 0
-                                          },
-                                          "relative": {
-                                            "type": "boolean"
-                                          },
-                                          "formats": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "string"
-                                            }
-                                          }
-                                        },
-                                        "required": [
-                                          "path",
-                                          "match"
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      "minItems": 1
-                                    },
-                                    "aggregation": {
-                                      "type": "string",
-                                      "enum": [
-                                        "weighted_average",
-                                        "all_or_nothing"
-                                      ]
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "fields"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "latency"
-                                    },
-                                    "threshold": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "threshold"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "cost"
-                                    },
-                                    "budget": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "budget"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "token-usage",
-                                        "token_usage"
-                                      ]
-                                    },
-                                    "max_total": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_input": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_output": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    }
-                                  },
-                                  "required": [
-                                    "type"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "execution-metrics",
-                                        "execution_metrics"
-                                      ]
-                                    },
-                                    "max_tool_calls": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_llm_calls": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_tokens": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_cost_usd": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "max_duration_ms": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "target_exploration_ratio": {
-                                      "type": "number",
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "exploration_tolerance": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    }
-                                  },
-                                  "required": [
-                                    "type"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "contains"
-                                    },
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "regex"
-                                    },
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "is-json",
-                                        "is_json"
-                                      ]
-                                    }
-                                  },
-                                  "required": [
-                                    "type"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "equals"
-                                    },
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "weight": {
-                                      "type": "number",
-                                      "minimum": 0
-                                    },
-                                    "required": {
-                                      "anyOf": [
-                                        {
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "type": "number",
-                                          "exclusiveMinimum": true,
-                                          "minimum": 0,
-                                          "maximum": 1
-                                        }
-                                      ]
-                                    },
-                                    "min_score": {
-                                      "type": "number",
-                                      "exclusiveMinimum": true,
-                                      "minimum": 0,
-                                      "maximum": 1
-                                    },
-                                    "negate": {
-                                      "type": "boolean"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "const": "rubrics"
-                                    },
-                                    "criteria": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "id": {
-                                            "type": "string"
-                                          },
-                                          "outcome": {
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
-                                          },
-                                          "weight": {
-                                            "type": "number"
-                                          },
-                                          "required": {
-                                            "type": "boolean"
-                                          },
-                                          "min_score": {
-                                            "type": "number",
-                                            "exclusiveMinimum": true,
-                                            "minimum": 0,
-                                            "maximum": 1
-                                          },
-                                          "score_ranges": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object",
-                                              "properties": {
-                                                "score_range": {
-                                                  "type": "array",
-                                                  "minItems": 2,
-                                                  "maxItems": 2,
-                                                  "items": [
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    },
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    }
-                                                  ]
-                                                },
-                                                "outcome": {
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                }
-                                              },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
-                                              "additionalProperties": false
-                                            }
-                                          }
-                                        },
-                                        "additionalProperties": false
-                                      },
-                                      "minItems": 1
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "criteria"
-                                  ],
+                                  "required": ["type", "criteria"],
                                   "additionalProperties": false
                                 }
                               ]
@@ -18698,12 +12167,7 @@
                               },
                               "strategy": {
                                 "type": "string",
-                                "enum": [
-                                  "pass_at_k",
-                                  "pass_all",
-                                  "mean",
-                                  "confidence_interval"
-                                ]
+                                "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
                               },
                               "cost_limit_usd": {
                                 "type": "number",
@@ -18714,9 +12178,7 @@
                                 "minimum": 0
                               }
                             },
-                            "required": [
-                              "count"
-                            ],
+                            "required": ["count"],
                             "additionalProperties": false
                           },
                           "timeout_seconds": {
@@ -18740,10 +12202,7 @@
                           },
                           "isolation": {
                             "type": "string",
-                            "enum": [
-                              "shared",
-                              "per_case"
-                            ]
+                            "enum": ["shared", "per_case"]
                           },
                           "repos": {
                             "type": "array",
@@ -18825,11 +12284,7 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": [
-                                      "none",
-                                      "fast",
-                                      "strict"
-                                    ]
+                                    "enum": ["none", "fast", "strict"]
                                   }
                                 },
                                 "additionalProperties": false
@@ -18874,11 +12329,7 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": [
-                                      "none",
-                                      "fast",
-                                      "strict"
-                                    ]
+                                    "enum": ["none", "fast", "strict"]
                                   }
                                 },
                                 "additionalProperties": false
@@ -18923,11 +12374,7 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": [
-                                      "none",
-                                      "fast",
-                                      "strict"
-                                    ]
+                                    "enum": ["none", "fast", "strict"]
                                   }
                                 },
                                 "additionalProperties": false
@@ -18972,11 +12419,7 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": [
-                                      "none",
-                                      "fast",
-                                      "strict"
-                                    ]
+                                    "enum": ["none", "fast", "strict"]
                                   }
                                 },
                                 "additionalProperties": false
@@ -19002,9 +12445,7 @@
                                 "minimum": 0.1
                               }
                             },
-                            "required": [
-                              "image"
-                            ],
+                            "required": ["image"],
                             "additionalProperties": false
                           },
                           "env": {
@@ -19048,17 +12489,11 @@
                       },
                       "on_dependency_failure": {
                         "type": "string",
-                        "enum": [
-                          "skip",
-                          "fail",
-                          "run"
-                        ]
+                        "enum": ["skip", "fail", "run"]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": [
-                          "conversation"
-                        ]
+                        "enum": ["conversation"]
                       },
                       "turns": {
                         "type": "array",
@@ -19087,20 +12522,13 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "text",
-                                              "file",
-                                              "image"
-                                            ]
+                                            "enum": ["text", "file", "image"]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       }
                                     }
@@ -19130,20 +12558,13 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "text",
-                                              "file",
-                                              "image"
-                                            ]
+                                            "enum": ["text", "file", "image"]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       }
                                     }
@@ -19194,10 +12615,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "code-grader",
-                                              "code_grader"
-                                            ]
+                                            "enum": ["code-grader", "code_grader"]
                                           },
                                           "command": {
                                             "anyOf": [
@@ -19271,18 +12689,12 @@
                                                   ]
                                                 }
                                               },
-                                              "required": [
-                                                "type",
-                                                "command"
-                                              ],
+                                              "required": ["type", "command"],
                                               "additionalProperties": false
                                             }
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -19319,10 +12731,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "llm-grader",
-                                              "llm_grader"
-                                            ]
+                                            "enum": ["llm-grader", "llm_grader"]
                                           },
                                           "prompt": {
                                             "anyOf": [
@@ -19380,10 +12789,7 @@
                                                 },
                                                 "operator": {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "correctness",
-                                                    "contradiction"
-                                                  ]
+                                                  "enum": ["correctness", "contradiction"]
                                                 },
                                                 "weight": {
                                                   "type": "number"
@@ -19424,10 +12830,7 @@
                                                         "minLength": 1
                                                       }
                                                     },
-                                                    "required": [
-                                                      "score_range",
-                                                      "outcome"
-                                                    ],
+                                                    "required": ["score_range", "outcome"],
                                                     "additionalProperties": false
                                                   }
                                                 }
@@ -19478,17 +12881,12 @@
                                                   ]
                                                 }
                                               },
-                                              "required": [
-                                                "type",
-                                                "command"
-                                              ],
+                                              "required": ["type", "command"],
                                               "additionalProperties": false
                                             }
                                           }
                                         },
-                                        "required": [
-                                          "type"
-                                        ],
+                                        "required": ["type"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -19499,9 +12897,7 @@
                                             "minLength": 1
                                           }
                                         },
-                                        "required": [
-                                          "include"
-                                        ],
+                                        "required": ["include"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -19564,9 +12960,7 @@
                                                     }
                                                   }
                                                 },
-                                                "required": [
-                                                  "type"
-                                                ],
+                                                "required": ["type"],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -19582,10 +12976,7 @@
                                                     "maximum": 1
                                                   }
                                                 },
-                                                "required": [
-                                                  "type",
-                                                  "threshold"
-                                                ],
+                                                "required": ["type", "threshold"],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -19602,10 +12993,7 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": [
-                                                  "type",
-                                                  "path"
-                                                ],
+                                                "required": ["type", "path"],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -19622,18 +13010,13 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": [
-                                                  "type"
-                                                ],
+                                                "required": ["type"],
                                                 "additionalProperties": false
                                               }
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "aggregator"
-                                        ],
+                                        "required": ["type", "aggregator"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -19670,10 +13053,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "tool-trajectory",
-                                              "tool_trajectory"
-                                            ]
+                                            "enum": ["tool-trajectory", "tool_trajectory"]
                                           },
                                           "mode": {
                                             "type": "string",
@@ -19759,9 +13139,7 @@
                                                   ]
                                                 }
                                               },
-                                              "required": [
-                                                "tool"
-                                              ],
+                                              "required": ["tool"],
                                               "additionalProperties": false
                                             }
                                           },
@@ -19769,12 +13147,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -19788,12 +13161,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -19804,10 +13172,7 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "mode"
-                                        ],
+                                        "required": ["type", "mode"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -19844,10 +13209,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "field-accuracy",
-                                              "field_accuracy"
-                                            ]
+                                            "enum": ["field-accuracy", "field_accuracy"]
                                           },
                                           "fields": {
                                             "type": "array",
@@ -19859,11 +13221,7 @@
                                                 },
                                                 "match": {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "exact",
-                                                    "numeric_tolerance",
-                                                    "date"
-                                                  ]
+                                                  "enum": ["exact", "numeric_tolerance", "date"]
                                                 },
                                                 "required": {
                                                   "type": "boolean"
@@ -19885,26 +13243,17 @@
                                                   }
                                                 }
                                               },
-                                              "required": [
-                                                "path",
-                                                "match"
-                                              ],
+                                              "required": ["path", "match"],
                                               "additionalProperties": false
                                             },
                                             "minItems": 1
                                           },
                                           "aggregation": {
                                             "type": "string",
-                                            "enum": [
-                                              "weighted_average",
-                                              "all_or_nothing"
-                                            ]
+                                            "enum": ["weighted_average", "all_or_nothing"]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "fields"
-                                        ],
+                                        "required": ["type", "fields"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -19948,10 +13297,7 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "threshold"
-                                        ],
+                                        "required": ["type", "threshold"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -19995,10 +13341,7 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "budget"
-                                        ],
+                                        "required": ["type", "budget"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -20035,10 +13378,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "token-usage",
-                                              "token_usage"
-                                            ]
+                                            "enum": ["token-usage", "token_usage"]
                                           },
                                           "max_total": {
                                             "type": "number",
@@ -20053,9 +13393,7 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": [
-                                          "type"
-                                        ],
+                                        "required": ["type"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -20092,10 +13430,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "execution-metrics",
-                                              "execution_metrics"
-                                            ]
+                                            "enum": ["execution-metrics", "execution_metrics"]
                                           },
                                           "max_tool_calls": {
                                             "type": "number",
@@ -20127,9 +13462,7 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": [
-                                          "type"
-                                        ],
+                                        "required": ["type"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -20172,10 +13505,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -20218,10 +13548,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -20258,15 +13585,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "is-json",
-                                              "is_json"
-                                            ]
+                                            "enum": ["is-json", "is_json"]
                                           }
                                         },
-                                        "required": [
-                                          "type"
-                                        ],
+                                        "required": ["type"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -20309,10 +13631,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -20364,10 +13683,7 @@
                                                 },
                                                 "operator": {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "correctness",
-                                                    "contradiction"
-                                                  ]
+                                                  "enum": ["correctness", "contradiction"]
                                                 },
                                                 "weight": {
                                                   "type": "number"
@@ -20408,10 +13724,7 @@
                                                         "minLength": 1
                                                       }
                                                     },
-                                                    "required": [
-                                                      "score_range",
-                                                      "outcome"
-                                                    ],
+                                                    "required": ["score_range", "outcome"],
                                                     "additionalProperties": false
                                                   }
                                                 }
@@ -20421,10 +13734,7 @@
                                             "minItems": 1
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "criteria"
-                                        ],
+                                        "required": ["type", "criteria"],
                                         "additionalProperties": false
                                       }
                                     ]
@@ -20433,37 +13743,26 @@
                               }
                             }
                           },
-                          "required": [
-                            "input"
-                          ],
+                          "required": ["input"],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": [
-                          "mean",
-                          "min",
-                          "max"
-                        ]
+                        "enum": ["mean", "min", "max"]
                       },
                       "on_turn_failure": {
                         "type": "string",
-                        "enum": [
-                          "continue",
-                          "stop"
-                        ]
+                        "enum": ["continue", "stop"]
                       },
                       "window_size": {
                         "type": "integer",
                         "minimum": 1
                       }
                     },
-                    "required": [
-                      "id"
-                    ],
-                    "additionalProperties": false
+                    "required": ["id"],
+                    "additionalProperties": true
                   },
                   {
                     "type": "object",
@@ -20474,10 +13773,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "suite",
-                          "tests"
-                        ]
+                        "enum": ["suite", "tests"]
                       },
                       "select": {
                         "anyOf": [
@@ -20548,11 +13844,7 @@
                                     {
                                       "type": "array",
                                       "items": {
-                                        "type": [
-                                          "string",
-                                          "number",
-                                          "boolean"
-                                        ]
+                                        "type": ["string", "number", "boolean"]
                                       },
                                       "minItems": 1
                                     }
@@ -20581,12 +13873,7 @@
                               },
                               "strategy": {
                                 "type": "string",
-                                "enum": [
-                                  "pass_at_k",
-                                  "pass_all",
-                                  "mean",
-                                  "confidence_interval"
-                                ]
+                                "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
                               },
                               "cost_limit_usd": {
                                 "type": "number",
@@ -20597,9 +13884,7 @@
                                 "minimum": 0
                               }
                             },
-                            "required": [
-                              "count"
-                            ],
+                            "required": ["count"],
                             "additionalProperties": false
                           },
                           "timeout_seconds": {
@@ -20616,10 +13901,7 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": [
-                      "include",
-                      "type"
-                    ],
+                    "required": ["include", "type"],
                     "additionalProperties": false
                   },
                   {
@@ -20669,9 +13951,7 @@
                         "additionalProperties": {}
                       }
                     },
-                    "required": [
-                      "name"
-                    ],
+                    "required": ["name"],
                     "additionalProperties": false
                   }
                 ]
@@ -20721,10 +14001,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "code-grader",
-                          "code_grader"
-                        ]
+                        "enum": ["code-grader", "code_grader"]
                       },
                       "command": {
                         "anyOf": [
@@ -20798,18 +14075,12 @@
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
+                          "required": ["type", "command"],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": [
-                      "type",
-                      "command"
-                    ],
+                    "required": ["type", "command"],
                     "additionalProperties": false
                   },
                   {
@@ -20846,10 +14117,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "llm-grader",
-                          "llm_grader"
-                        ]
+                        "enum": ["llm-grader", "llm_grader"]
                       },
                       "prompt": {
                         "anyOf": [
@@ -20907,10 +14175,7 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": [
-                                "correctness",
-                                "contradiction"
-                              ]
+                              "enum": ["correctness", "contradiction"]
                             },
                             "weight": {
                               "type": "number"
@@ -20951,10 +14216,7 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": [
-                                  "score_range",
-                                  "outcome"
-                                ],
+                                "required": ["score_range", "outcome"],
                                 "additionalProperties": false
                               }
                             }
@@ -21005,17 +14267,12 @@
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
+                          "required": ["type", "command"],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -21026,9 +14283,7 @@
                         "minLength": 1
                       }
                     },
-                    "required": [
-                      "include"
-                    ],
+                    "required": ["include"],
                     "additionalProperties": false
                   },
                   {
@@ -21091,9 +14346,7 @@
                                 }
                               }
                             },
-                            "required": [
-                              "type"
-                            ],
+                            "required": ["type"],
                             "additionalProperties": false
                           },
                           {
@@ -21109,10 +14362,7 @@
                                 "maximum": 1
                               }
                             },
-                            "required": [
-                              "type",
-                              "threshold"
-                            ],
+                            "required": ["type", "threshold"],
                             "additionalProperties": false
                           },
                           {
@@ -21129,10 +14379,7 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "type",
-                              "path"
-                            ],
+                            "required": ["type", "path"],
                             "additionalProperties": false
                           },
                           {
@@ -21149,18 +14396,13 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "type"
-                            ],
+                            "required": ["type"],
                             "additionalProperties": false
                           }
                         ]
                       }
                     },
-                    "required": [
-                      "type",
-                      "aggregator"
-                    ],
+                    "required": ["type", "aggregator"],
                     "additionalProperties": false
                   },
                   {
@@ -21197,20 +14439,11 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "tool-trajectory",
-                          "tool_trajectory"
-                        ]
+                        "enum": ["tool-trajectory", "tool_trajectory"]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": [
-                          "any_order",
-                          "in_order",
-                          "exact",
-                          "subset",
-                          "superset"
-                        ]
+                        "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                       },
                       "minimums": {
                         "type": "object",
@@ -21251,12 +14484,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -21270,12 +14498,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -21286,9 +14509,7 @@
                               ]
                             }
                           },
-                          "required": [
-                            "tool"
-                          ],
+                          "required": ["tool"],
                           "additionalProperties": false
                         }
                       },
@@ -21296,12 +14517,7 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": [
-                              "exact",
-                              "ignore",
-                              "subset",
-                              "superset"
-                            ]
+                            "enum": ["exact", "ignore", "subset", "superset"]
                           },
                           {
                             "type": "array",
@@ -21315,12 +14531,7 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": [
-                              "exact",
-                              "ignore",
-                              "subset",
-                              "superset"
-                            ]
+                            "enum": ["exact", "ignore", "subset", "superset"]
                           },
                           {
                             "type": "array",
@@ -21331,10 +14542,7 @@
                         ]
                       }
                     },
-                    "required": [
-                      "type",
-                      "mode"
-                    ],
+                    "required": ["type", "mode"],
                     "additionalProperties": false
                   },
                   {
@@ -21371,10 +14579,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "field-accuracy",
-                          "field_accuracy"
-                        ]
+                        "enum": ["field-accuracy", "field_accuracy"]
                       },
                       "fields": {
                         "type": "array",
@@ -21386,11 +14591,7 @@
                             },
                             "match": {
                               "type": "string",
-                              "enum": [
-                                "exact",
-                                "numeric_tolerance",
-                                "date"
-                              ]
+                              "enum": ["exact", "numeric_tolerance", "date"]
                             },
                             "required": {
                               "type": "boolean"
@@ -21412,26 +14613,17 @@
                               }
                             }
                           },
-                          "required": [
-                            "path",
-                            "match"
-                          ],
+                          "required": ["path", "match"],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": [
-                          "weighted_average",
-                          "all_or_nothing"
-                        ]
+                        "enum": ["weighted_average", "all_or_nothing"]
                       }
                     },
-                    "required": [
-                      "type",
-                      "fields"
-                    ],
+                    "required": ["type", "fields"],
                     "additionalProperties": false
                   },
                   {
@@ -21475,10 +14667,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type",
-                      "threshold"
-                    ],
+                    "required": ["type", "threshold"],
                     "additionalProperties": false
                   },
                   {
@@ -21522,10 +14711,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type",
-                      "budget"
-                    ],
+                    "required": ["type", "budget"],
                     "additionalProperties": false
                   },
                   {
@@ -21562,10 +14748,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "token-usage",
-                          "token_usage"
-                        ]
+                        "enum": ["token-usage", "token_usage"]
                       },
                       "max_total": {
                         "type": "number",
@@ -21580,9 +14763,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -21619,10 +14800,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "execution-metrics",
-                          "execution_metrics"
-                        ]
+                        "enum": ["execution-metrics", "execution_metrics"]
                       },
                       "max_tool_calls": {
                         "type": "number",
@@ -21654,9 +14832,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -21699,10 +14875,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
+                    "required": ["type", "value"],
                     "additionalProperties": false
                   },
                   {
@@ -21745,10 +14918,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
+                    "required": ["type", "value"],
                     "additionalProperties": false
                   },
                   {
@@ -21785,15 +14955,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "is-json",
-                          "is_json"
-                        ]
+                        "enum": ["is-json", "is_json"]
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -21836,10 +15001,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
+                    "required": ["type", "value"],
                     "additionalProperties": false
                   },
                   {
@@ -21891,10 +15053,7 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": [
-                                "correctness",
-                                "contradiction"
-                              ]
+                              "enum": ["correctness", "contradiction"]
                             },
                             "weight": {
                               "type": "number"
@@ -21935,10 +15094,7 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": [
-                                  "score_range",
-                                  "outcome"
-                                ],
+                                "required": ["score_range", "outcome"],
                                 "additionalProperties": false
                               }
                             }
@@ -21948,10 +15104,7 @@
                         "minItems": 1
                       }
                     },
-                    "required": [
-                      "type",
-                      "criteria"
-                    ],
+                    "required": ["type", "criteria"],
                     "additionalProperties": false
                   }
                 ]
@@ -21995,10 +15148,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "code-grader",
-                          "code_grader"
-                        ]
+                        "enum": ["code-grader", "code_grader"]
                       },
                       "command": {
                         "anyOf": [
@@ -22072,18 +15222,12 @@
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
+                          "required": ["type", "command"],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": [
-                      "type",
-                      "command"
-                    ],
+                    "required": ["type", "command"],
                     "additionalProperties": false
                   },
                   {
@@ -22120,10 +15264,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "llm-grader",
-                          "llm_grader"
-                        ]
+                        "enum": ["llm-grader", "llm_grader"]
                       },
                       "prompt": {
                         "anyOf": [
@@ -22181,10 +15322,7 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": [
-                                "correctness",
-                                "contradiction"
-                              ]
+                              "enum": ["correctness", "contradiction"]
                             },
                             "weight": {
                               "type": "number"
@@ -22225,10 +15363,7 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": [
-                                  "score_range",
-                                  "outcome"
-                                ],
+                                "required": ["score_range", "outcome"],
                                 "additionalProperties": false
                               }
                             }
@@ -22279,17 +15414,12 @@
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
+                          "required": ["type", "command"],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -22300,9 +15430,7 @@
                         "minLength": 1
                       }
                     },
-                    "required": [
-                      "include"
-                    ],
+                    "required": ["include"],
                     "additionalProperties": false
                   },
                   {
@@ -22365,9 +15493,7 @@
                                 }
                               }
                             },
-                            "required": [
-                              "type"
-                            ],
+                            "required": ["type"],
                             "additionalProperties": false
                           },
                           {
@@ -22383,10 +15509,7 @@
                                 "maximum": 1
                               }
                             },
-                            "required": [
-                              "type",
-                              "threshold"
-                            ],
+                            "required": ["type", "threshold"],
                             "additionalProperties": false
                           },
                           {
@@ -22403,10 +15526,7 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "type",
-                              "path"
-                            ],
+                            "required": ["type", "path"],
                             "additionalProperties": false
                           },
                           {
@@ -22423,18 +15543,13 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "type"
-                            ],
+                            "required": ["type"],
                             "additionalProperties": false
                           }
                         ]
                       }
                     },
-                    "required": [
-                      "type",
-                      "aggregator"
-                    ],
+                    "required": ["type", "aggregator"],
                     "additionalProperties": false
                   },
                   {
@@ -22471,20 +15586,11 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "tool-trajectory",
-                          "tool_trajectory"
-                        ]
+                        "enum": ["tool-trajectory", "tool_trajectory"]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": [
-                          "any_order",
-                          "in_order",
-                          "exact",
-                          "subset",
-                          "superset"
-                        ]
+                        "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                       },
                       "minimums": {
                         "type": "object",
@@ -22525,12 +15631,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -22544,12 +15645,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -22560,9 +15656,7 @@
                               ]
                             }
                           },
-                          "required": [
-                            "tool"
-                          ],
+                          "required": ["tool"],
                           "additionalProperties": false
                         }
                       },
@@ -22570,12 +15664,7 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": [
-                              "exact",
-                              "ignore",
-                              "subset",
-                              "superset"
-                            ]
+                            "enum": ["exact", "ignore", "subset", "superset"]
                           },
                           {
                             "type": "array",
@@ -22589,12 +15678,7 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": [
-                              "exact",
-                              "ignore",
-                              "subset",
-                              "superset"
-                            ]
+                            "enum": ["exact", "ignore", "subset", "superset"]
                           },
                           {
                             "type": "array",
@@ -22605,10 +15689,7 @@
                         ]
                       }
                     },
-                    "required": [
-                      "type",
-                      "mode"
-                    ],
+                    "required": ["type", "mode"],
                     "additionalProperties": false
                   },
                   {
@@ -22645,10 +15726,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "field-accuracy",
-                          "field_accuracy"
-                        ]
+                        "enum": ["field-accuracy", "field_accuracy"]
                       },
                       "fields": {
                         "type": "array",
@@ -22660,11 +15738,7 @@
                             },
                             "match": {
                               "type": "string",
-                              "enum": [
-                                "exact",
-                                "numeric_tolerance",
-                                "date"
-                              ]
+                              "enum": ["exact", "numeric_tolerance", "date"]
                             },
                             "required": {
                               "type": "boolean"
@@ -22686,26 +15760,17 @@
                               }
                             }
                           },
-                          "required": [
-                            "path",
-                            "match"
-                          ],
+                          "required": ["path", "match"],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": [
-                          "weighted_average",
-                          "all_or_nothing"
-                        ]
+                        "enum": ["weighted_average", "all_or_nothing"]
                       }
                     },
-                    "required": [
-                      "type",
-                      "fields"
-                    ],
+                    "required": ["type", "fields"],
                     "additionalProperties": false
                   },
                   {
@@ -22749,10 +15814,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type",
-                      "threshold"
-                    ],
+                    "required": ["type", "threshold"],
                     "additionalProperties": false
                   },
                   {
@@ -22796,10 +15858,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type",
-                      "budget"
-                    ],
+                    "required": ["type", "budget"],
                     "additionalProperties": false
                   },
                   {
@@ -22836,10 +15895,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "token-usage",
-                          "token_usage"
-                        ]
+                        "enum": ["token-usage", "token_usage"]
                       },
                       "max_total": {
                         "type": "number",
@@ -22854,9 +15910,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -22893,10 +15947,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "execution-metrics",
-                          "execution_metrics"
-                        ]
+                        "enum": ["execution-metrics", "execution_metrics"]
                       },
                       "max_tool_calls": {
                         "type": "number",
@@ -22928,9 +15979,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -22973,10 +16022,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
+                    "required": ["type", "value"],
                     "additionalProperties": false
                   },
                   {
@@ -23019,10 +16065,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
+                    "required": ["type", "value"],
                     "additionalProperties": false
                   },
                   {
@@ -23059,15 +16102,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "is-json",
-                          "is_json"
-                        ]
+                        "enum": ["is-json", "is_json"]
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -23110,10 +16148,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
+                    "required": ["type", "value"],
                     "additionalProperties": false
                   },
                   {
@@ -23165,10 +16200,7 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": [
-                                "correctness",
-                                "contradiction"
-                              ]
+                              "enum": ["correctness", "contradiction"]
                             },
                             "weight": {
                               "type": "number"
@@ -23209,10 +16241,7 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": [
-                                  "score_range",
-                                  "outcome"
-                                ],
+                                "required": ["score_range", "outcome"],
                                 "additionalProperties": false
                               }
                             }
@@ -23222,10 +16251,7 @@
                         "minItems": 1
                       }
                     },
-                    "required": [
-                      "type",
-                      "criteria"
-                    ],
+                    "required": ["type", "criteria"],
                     "additionalProperties": false
                   }
                 ]
@@ -23288,12 +16314,7 @@
                 },
                 "strategy": {
                   "type": "string",
-                  "enum": [
-                    "pass_at_k",
-                    "pass_all",
-                    "mean",
-                    "confidence_interval"
-                  ]
+                  "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
                 },
                 "cost_limit_usd": {
                   "type": "number",
@@ -23304,9 +16325,7 @@
                   "minimum": 0
                 }
               },
-              "required": [
-                "count"
-              ],
+              "required": ["count"],
               "additionalProperties": false
             },
             "runs": {
@@ -23323,2708 +16342,7 @@
             },
             "sandbox": {
               "type": "string",
-              "enum": [
-                "auto",
-                "docker",
-                "vercel"
-              ]
-            },
-            "setup": {
-              "not": {}
-            }
-          },
-          "additionalProperties": false
-        },
-        "execution": {
-          "type": "object",
-          "properties": {
-            "target": {
-              "type": "string"
-            },
-            "targets": {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string",
-                        "minLength": 1
-                      },
-                      "use_target": {
-                        "type": "string",
-                        "minLength": 1
-                      },
-                      "hooks": {
-                        "type": "object",
-                        "properties": {},
-                        "additionalProperties": {}
-                      }
-                    },
-                    "required": [
-                      "name"
-                    ],
-                    "additionalProperties": false
-                  }
-                ]
-              },
-              "minItems": 1
-            },
-            "workers": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 50
-            },
-            "assertions": {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "code-grader",
-                          "code_grader"
-                        ]
-                      },
-                      "command": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          }
-                        ]
-                      },
-                      "script": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          }
-                        ]
-                      },
-                      "cwd": {
-                        "type": "string"
-                      },
-                      "target": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "max_calls": {
-                                "type": "number"
-                              }
-                            },
-                            "additionalProperties": false
-                          }
-                        ]
-                      },
-                      "config": {
-                        "type": "object",
-                        "additionalProperties": {}
-                      },
-                      "preprocessors": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "minLength": 1
-                            },
-                            "command": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                }
-                              ]
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
-                          "additionalProperties": false
-                        }
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "command"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "llm-grader",
-                          "llm_grader"
-                        ]
-                      },
-                      "prompt": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "command": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "string"
-                                    }
-                                  }
-                                ]
-                              },
-                              "script": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "string"
-                                    }
-                                  }
-                                ]
-                              },
-                              "config": {
-                                "type": "object",
-                                "additionalProperties": {}
-                              }
-                            },
-                            "additionalProperties": false
-                          }
-                        ]
-                      },
-                      "rubrics": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "outcome": {
-                              "type": "string"
-                            },
-                            "operator": {
-                              "type": "string",
-                              "enum": [
-                                "correctness",
-                                "contradiction"
-                              ]
-                            },
-                            "weight": {
-                              "type": "number"
-                            },
-                            "required": {
-                              "type": "boolean"
-                            },
-                            "min_score": {
-                              "type": "number",
-                              "exclusiveMinimum": true,
-                              "minimum": 0,
-                              "maximum": 1
-                            },
-                            "score_ranges": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "score_range": {
-                                    "type": "array",
-                                    "minItems": 2,
-                                    "maxItems": 2,
-                                    "items": [
-                                      {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "maximum": 10
-                                      },
-                                      {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "maximum": 10
-                                      }
-                                    ]
-                                  },
-                                  "outcome": {
-                                    "type": "string",
-                                    "minLength": 1
-                                  }
-                                },
-                                "required": [
-                                  "score_range",
-                                  "outcome"
-                                ],
-                                "additionalProperties": false
-                              }
-                            }
-                          },
-                          "additionalProperties": false
-                        }
-                      },
-                      "model": {
-                        "type": "string"
-                      },
-                      "target": {
-                        "type": "string"
-                      },
-                      "config": {
-                        "type": "object",
-                        "additionalProperties": {}
-                      },
-                      "max_steps": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": 50
-                      },
-                      "temperature": {
-                        "type": "number",
-                        "minimum": 0,
-                        "maximum": 2
-                      },
-                      "preprocessors": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "minLength": 1
-                            },
-                            "command": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                }
-                              ]
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
-                          "additionalProperties": false
-                        }
-                      }
-                    },
-                    "required": [
-                      "type"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "include": {
-                        "type": "string",
-                        "minLength": 1
-                      }
-                    },
-                    "required": [
-                      "include"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "const": "composite"
-                      },
-                      "assertions": {
-                        "type": "array",
-                        "items": {}
-                      },
-                      "evaluators": {
-                        "type": "array",
-                        "items": {}
-                      },
-                      "aggregator": {
-                        "anyOf": [
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "weighted_average"
-                              },
-                              "weights": {
-                                "type": "object",
-                                "additionalProperties": {
-                                  "type": "number"
-                                }
-                              }
-                            },
-                            "required": [
-                              "type"
-                            ],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "threshold"
-                              },
-                              "threshold": {
-                                "type": "number",
-                                "minimum": 0,
-                                "maximum": 1
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "threshold"
-                            ],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "code-grader"
-                              },
-                              "path": {
-                                "type": "string"
-                              },
-                              "cwd": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "path"
-                            ],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "llm-grader"
-                              },
-                              "prompt": {
-                                "type": "string"
-                              },
-                              "model": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "type"
-                            ],
-                            "additionalProperties": false
-                          }
-                        ]
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "aggregator"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "tool-trajectory",
-                          "tool_trajectory"
-                        ]
-                      },
-                      "mode": {
-                        "type": "string",
-                        "enum": [
-                          "any_order",
-                          "in_order",
-                          "exact",
-                          "subset",
-                          "superset"
-                        ]
-                      },
-                      "minimums": {
-                        "type": "object",
-                        "additionalProperties": {
-                          "type": "integer",
-                          "minimum": 0
-                        }
-                      },
-                      "expected": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "tool": {
-                              "type": "string"
-                            },
-                            "args": {
-                              "anyOf": [
-                                {
-                                  "type": "string",
-                                  "const": "any"
-                                },
-                                {
-                                  "type": "object",
-                                  "additionalProperties": {}
-                                }
-                              ]
-                            },
-                            "max_duration_ms": {
-                              "type": "number",
-                              "minimum": 0
-                            },
-                            "maxDurationMs": {
-                              "type": "number",
-                              "minimum": 0
-                            },
-                            "args_match": {
-                              "anyOf": [
-                                {
-                                  "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
-                                },
-                                {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                }
-                              ]
-                            },
-                            "argsMatch": {
-                              "anyOf": [
-                                {
-                                  "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
-                                },
-                                {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                }
-                              ]
-                            }
-                          },
-                          "required": [
-                            "tool"
-                          ],
-                          "additionalProperties": false
-                        }
-                      },
-                      "args_match": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "exact",
-                              "ignore",
-                              "subset",
-                              "superset"
-                            ]
-                          },
-                          {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          }
-                        ]
-                      },
-                      "argsMatch": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "exact",
-                              "ignore",
-                              "subset",
-                              "superset"
-                            ]
-                          },
-                          {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "mode"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "field-accuracy",
-                          "field_accuracy"
-                        ]
-                      },
-                      "fields": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "path": {
-                              "type": "string"
-                            },
-                            "match": {
-                              "type": "string",
-                              "enum": [
-                                "exact",
-                                "numeric_tolerance",
-                                "date"
-                              ]
-                            },
-                            "required": {
-                              "type": "boolean"
-                            },
-                            "weight": {
-                              "type": "number"
-                            },
-                            "tolerance": {
-                              "type": "number",
-                              "minimum": 0
-                            },
-                            "relative": {
-                              "type": "boolean"
-                            },
-                            "formats": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "required": [
-                            "path",
-                            "match"
-                          ],
-                          "additionalProperties": false
-                        },
-                        "minItems": 1
-                      },
-                      "aggregation": {
-                        "type": "string",
-                        "enum": [
-                          "weighted_average",
-                          "all_or_nothing"
-                        ]
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "fields"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "const": "latency"
-                      },
-                      "threshold": {
-                        "type": "number",
-                        "minimum": 0
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "threshold"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "const": "cost"
-                      },
-                      "budget": {
-                        "type": "number",
-                        "minimum": 0
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "budget"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "token-usage",
-                          "token_usage"
-                        ]
-                      },
-                      "max_total": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "max_input": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "max_output": {
-                        "type": "number",
-                        "minimum": 0
-                      }
-                    },
-                    "required": [
-                      "type"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "execution-metrics",
-                          "execution_metrics"
-                        ]
-                      },
-                      "max_tool_calls": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "max_llm_calls": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "max_tokens": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "max_cost_usd": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "max_duration_ms": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "target_exploration_ratio": {
-                        "type": "number",
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "exploration_tolerance": {
-                        "type": "number",
-                        "minimum": 0
-                      }
-                    },
-                    "required": [
-                      "type"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "const": "contains"
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "const": "regex"
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "is-json",
-                          "is_json"
-                        ]
-                      }
-                    },
-                    "required": [
-                      "type"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "const": "equals"
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "const": "rubrics"
-                      },
-                      "criteria": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "outcome": {
-                              "type": "string"
-                            },
-                            "operator": {
-                              "type": "string",
-                              "enum": [
-                                "correctness",
-                                "contradiction"
-                              ]
-                            },
-                            "weight": {
-                              "type": "number"
-                            },
-                            "required": {
-                              "type": "boolean"
-                            },
-                            "min_score": {
-                              "type": "number",
-                              "exclusiveMinimum": true,
-                              "minimum": 0,
-                              "maximum": 1
-                            },
-                            "score_ranges": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "score_range": {
-                                    "type": "array",
-                                    "minItems": 2,
-                                    "maxItems": 2,
-                                    "items": [
-                                      {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "maximum": 10
-                                      },
-                                      {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "maximum": 10
-                                      }
-                                    ]
-                                  },
-                                  "outcome": {
-                                    "type": "string",
-                                    "minLength": 1
-                                  }
-                                },
-                                "required": [
-                                  "score_range",
-                                  "outcome"
-                                ],
-                                "additionalProperties": false
-                              }
-                            }
-                          },
-                          "additionalProperties": false
-                        },
-                        "minItems": 1
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "criteria"
-                    ],
-                    "additionalProperties": false
-                  }
-                ]
-              }
-            },
-            "evaluators": {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "code-grader",
-                          "code_grader"
-                        ]
-                      },
-                      "command": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          }
-                        ]
-                      },
-                      "script": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          }
-                        ]
-                      },
-                      "cwd": {
-                        "type": "string"
-                      },
-                      "target": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "max_calls": {
-                                "type": "number"
-                              }
-                            },
-                            "additionalProperties": false
-                          }
-                        ]
-                      },
-                      "config": {
-                        "type": "object",
-                        "additionalProperties": {}
-                      },
-                      "preprocessors": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "minLength": 1
-                            },
-                            "command": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                }
-                              ]
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
-                          "additionalProperties": false
-                        }
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "command"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "llm-grader",
-                          "llm_grader"
-                        ]
-                      },
-                      "prompt": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "command": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "string"
-                                    }
-                                  }
-                                ]
-                              },
-                              "script": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "string"
-                                    }
-                                  }
-                                ]
-                              },
-                              "config": {
-                                "type": "object",
-                                "additionalProperties": {}
-                              }
-                            },
-                            "additionalProperties": false
-                          }
-                        ]
-                      },
-                      "rubrics": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "outcome": {
-                              "type": "string"
-                            },
-                            "operator": {
-                              "type": "string",
-                              "enum": [
-                                "correctness",
-                                "contradiction"
-                              ]
-                            },
-                            "weight": {
-                              "type": "number"
-                            },
-                            "required": {
-                              "type": "boolean"
-                            },
-                            "min_score": {
-                              "type": "number",
-                              "exclusiveMinimum": true,
-                              "minimum": 0,
-                              "maximum": 1
-                            },
-                            "score_ranges": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "score_range": {
-                                    "type": "array",
-                                    "minItems": 2,
-                                    "maxItems": 2,
-                                    "items": [
-                                      {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "maximum": 10
-                                      },
-                                      {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "maximum": 10
-                                      }
-                                    ]
-                                  },
-                                  "outcome": {
-                                    "type": "string",
-                                    "minLength": 1
-                                  }
-                                },
-                                "required": [
-                                  "score_range",
-                                  "outcome"
-                                ],
-                                "additionalProperties": false
-                              }
-                            }
-                          },
-                          "additionalProperties": false
-                        }
-                      },
-                      "model": {
-                        "type": "string"
-                      },
-                      "target": {
-                        "type": "string"
-                      },
-                      "config": {
-                        "type": "object",
-                        "additionalProperties": {}
-                      },
-                      "max_steps": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": 50
-                      },
-                      "temperature": {
-                        "type": "number",
-                        "minimum": 0,
-                        "maximum": 2
-                      },
-                      "preprocessors": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "minLength": 1
-                            },
-                            "command": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                }
-                              ]
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
-                          "additionalProperties": false
-                        }
-                      }
-                    },
-                    "required": [
-                      "type"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "include": {
-                        "type": "string",
-                        "minLength": 1
-                      }
-                    },
-                    "required": [
-                      "include"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "const": "composite"
-                      },
-                      "assertions": {
-                        "type": "array",
-                        "items": {}
-                      },
-                      "evaluators": {
-                        "type": "array",
-                        "items": {}
-                      },
-                      "aggregator": {
-                        "anyOf": [
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "weighted_average"
-                              },
-                              "weights": {
-                                "type": "object",
-                                "additionalProperties": {
-                                  "type": "number"
-                                }
-                              }
-                            },
-                            "required": [
-                              "type"
-                            ],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "threshold"
-                              },
-                              "threshold": {
-                                "type": "number",
-                                "minimum": 0,
-                                "maximum": 1
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "threshold"
-                            ],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "code-grader"
-                              },
-                              "path": {
-                                "type": "string"
-                              },
-                              "cwd": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "path"
-                            ],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "llm-grader"
-                              },
-                              "prompt": {
-                                "type": "string"
-                              },
-                              "model": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "type"
-                            ],
-                            "additionalProperties": false
-                          }
-                        ]
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "aggregator"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "tool-trajectory",
-                          "tool_trajectory"
-                        ]
-                      },
-                      "mode": {
-                        "type": "string",
-                        "enum": [
-                          "any_order",
-                          "in_order",
-                          "exact",
-                          "subset",
-                          "superset"
-                        ]
-                      },
-                      "minimums": {
-                        "type": "object",
-                        "additionalProperties": {
-                          "type": "integer",
-                          "minimum": 0
-                        }
-                      },
-                      "expected": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "tool": {
-                              "type": "string"
-                            },
-                            "args": {
-                              "anyOf": [
-                                {
-                                  "type": "string",
-                                  "const": "any"
-                                },
-                                {
-                                  "type": "object",
-                                  "additionalProperties": {}
-                                }
-                              ]
-                            },
-                            "max_duration_ms": {
-                              "type": "number",
-                              "minimum": 0
-                            },
-                            "maxDurationMs": {
-                              "type": "number",
-                              "minimum": 0
-                            },
-                            "args_match": {
-                              "anyOf": [
-                                {
-                                  "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
-                                },
-                                {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                }
-                              ]
-                            },
-                            "argsMatch": {
-                              "anyOf": [
-                                {
-                                  "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
-                                },
-                                {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                }
-                              ]
-                            }
-                          },
-                          "required": [
-                            "tool"
-                          ],
-                          "additionalProperties": false
-                        }
-                      },
-                      "args_match": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "exact",
-                              "ignore",
-                              "subset",
-                              "superset"
-                            ]
-                          },
-                          {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          }
-                        ]
-                      },
-                      "argsMatch": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "exact",
-                              "ignore",
-                              "subset",
-                              "superset"
-                            ]
-                          },
-                          {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "mode"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "field-accuracy",
-                          "field_accuracy"
-                        ]
-                      },
-                      "fields": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "path": {
-                              "type": "string"
-                            },
-                            "match": {
-                              "type": "string",
-                              "enum": [
-                                "exact",
-                                "numeric_tolerance",
-                                "date"
-                              ]
-                            },
-                            "required": {
-                              "type": "boolean"
-                            },
-                            "weight": {
-                              "type": "number"
-                            },
-                            "tolerance": {
-                              "type": "number",
-                              "minimum": 0
-                            },
-                            "relative": {
-                              "type": "boolean"
-                            },
-                            "formats": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "required": [
-                            "path",
-                            "match"
-                          ],
-                          "additionalProperties": false
-                        },
-                        "minItems": 1
-                      },
-                      "aggregation": {
-                        "type": "string",
-                        "enum": [
-                          "weighted_average",
-                          "all_or_nothing"
-                        ]
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "fields"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "const": "latency"
-                      },
-                      "threshold": {
-                        "type": "number",
-                        "minimum": 0
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "threshold"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "const": "cost"
-                      },
-                      "budget": {
-                        "type": "number",
-                        "minimum": 0
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "budget"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "token-usage",
-                          "token_usage"
-                        ]
-                      },
-                      "max_total": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "max_input": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "max_output": {
-                        "type": "number",
-                        "minimum": 0
-                      }
-                    },
-                    "required": [
-                      "type"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "execution-metrics",
-                          "execution_metrics"
-                        ]
-                      },
-                      "max_tool_calls": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "max_llm_calls": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "max_tokens": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "max_cost_usd": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "max_duration_ms": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "target_exploration_ratio": {
-                        "type": "number",
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "exploration_tolerance": {
-                        "type": "number",
-                        "minimum": 0
-                      }
-                    },
-                    "required": [
-                      "type"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "const": "contains"
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "const": "regex"
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "is-json",
-                          "is_json"
-                        ]
-                      }
-                    },
-                    "required": [
-                      "type"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "const": "equals"
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "weight": {
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "required": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "number",
-                            "exclusiveMinimum": true,
-                            "minimum": 0,
-                            "maximum": 1
-                          }
-                        ]
-                      },
-                      "min_score": {
-                        "type": "number",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
-                        "maximum": 1
-                      },
-                      "negate": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string",
-                        "const": "rubrics"
-                      },
-                      "criteria": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "outcome": {
-                              "type": "string"
-                            },
-                            "operator": {
-                              "type": "string",
-                              "enum": [
-                                "correctness",
-                                "contradiction"
-                              ]
-                            },
-                            "weight": {
-                              "type": "number"
-                            },
-                            "required": {
-                              "type": "boolean"
-                            },
-                            "min_score": {
-                              "type": "number",
-                              "exclusiveMinimum": true,
-                              "minimum": 0,
-                              "maximum": 1
-                            },
-                            "score_ranges": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "score_range": {
-                                    "type": "array",
-                                    "minItems": 2,
-                                    "maxItems": 2,
-                                    "items": [
-                                      {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "maximum": 10
-                                      },
-                                      {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "maximum": 10
-                                      }
-                                    ]
-                                  },
-                                  "outcome": {
-                                    "type": "string",
-                                    "minLength": 1
-                                  }
-                                },
-                                "required": [
-                                  "score_range",
-                                  "outcome"
-                                ],
-                                "additionalProperties": false
-                              }
-                            }
-                          },
-                          "additionalProperties": false
-                        },
-                        "minItems": 1
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "criteria"
-                    ],
-                    "additionalProperties": false
-                  }
-                ]
-              }
-            },
-            "skip_defaults": {
-              "type": "boolean"
-            },
-            "cache": {
-              "type": "boolean"
-            },
-            "trials": {
-              "not": {}
-            },
-            "budget_usd": {
-              "type": "number",
-              "exclusiveMinimum": true,
-              "minimum": 0
-            },
-            "budgetUsd": {
-              "type": "number",
-              "minimum": 0
-            },
-            "fail_on_error": {
-              "type": "boolean"
-            },
-            "failOnError": {
-              "type": "boolean"
-            },
-            "threshold": {
-              "type": "number",
-              "minimum": 0,
-              "maximum": 1
-            },
-            "workspace": {
-              "not": {}
-            },
-            "agent": {
-              "type": "string",
-              "minLength": 1
-            },
-            "model": {
-              "type": "string",
-              "minLength": 1
-            },
-            "agent_options": {
-              "type": "object",
-              "properties": {},
-              "additionalProperties": {}
-            },
-            "scripts": {
-              "not": {}
-            },
-            "repeat": {
-              "type": "object",
-              "properties": {
-                "count": {
-                  "type": "integer",
-                  "minimum": 1
-                },
-                "strategy": {
-                  "type": "string",
-                  "enum": [
-                    "pass_at_k",
-                    "pass_all",
-                    "mean",
-                    "confidence_interval"
-                  ]
-                },
-                "cost_limit_usd": {
-                  "type": "number",
-                  "minimum": 0
-                },
-                "costLimitUsd": {
-                  "type": "number",
-                  "minimum": 0
-                }
-              },
-              "required": [
-                "count"
-              ],
-              "additionalProperties": false
-            },
-            "runs": {
-              "type": "integer",
-              "minimum": 1
-            },
-            "early_exit": {
-              "type": "boolean"
-            },
-            "timeout_seconds": {
-              "type": "number",
-              "exclusiveMinimum": true,
-              "minimum": 0
-            },
-            "sandbox": {
-              "type": "string",
-              "enum": [
-                "auto",
-                "docker",
-                "vercel"
-              ]
+              "enum": ["auto", "docker", "vercel"]
             },
             "setup": {
               "not": {}
@@ -26070,10 +16388,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "code-grader",
-                      "code_grader"
-                    ]
+                    "enum": ["code-grader", "code_grader"]
                   },
                   "command": {
                     "anyOf": [
@@ -26147,18 +16462,12 @@
                           ]
                         }
                       },
-                      "required": [
-                        "type",
-                        "command"
-                      ],
+                      "required": ["type", "command"],
                       "additionalProperties": false
                     }
                   }
                 },
-                "required": [
-                  "type",
-                  "command"
-                ],
+                "required": ["type", "command"],
                 "additionalProperties": false
               },
               {
@@ -26195,10 +16504,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "llm-grader",
-                      "llm_grader"
-                    ]
+                    "enum": ["llm-grader", "llm_grader"]
                   },
                   "prompt": {
                     "anyOf": [
@@ -26256,10 +16562,7 @@
                         },
                         "operator": {
                           "type": "string",
-                          "enum": [
-                            "correctness",
-                            "contradiction"
-                          ]
+                          "enum": ["correctness", "contradiction"]
                         },
                         "weight": {
                           "type": "number"
@@ -26300,10 +16603,7 @@
                                 "minLength": 1
                               }
                             },
-                            "required": [
-                              "score_range",
-                              "outcome"
-                            ],
+                            "required": ["score_range", "outcome"],
                             "additionalProperties": false
                           }
                         }
@@ -26354,17 +16654,12 @@
                           ]
                         }
                       },
-                      "required": [
-                        "type",
-                        "command"
-                      ],
+                      "required": ["type", "command"],
                       "additionalProperties": false
                     }
                   }
                 },
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "additionalProperties": false
               },
               {
@@ -26375,9 +16670,7 @@
                     "minLength": 1
                   }
                 },
-                "required": [
-                  "include"
-                ],
+                "required": ["include"],
                 "additionalProperties": false
               },
               {
@@ -26440,9 +16733,7 @@
                             }
                           }
                         },
-                        "required": [
-                          "type"
-                        ],
+                        "required": ["type"],
                         "additionalProperties": false
                       },
                       {
@@ -26458,10 +16749,7 @@
                             "maximum": 1
                           }
                         },
-                        "required": [
-                          "type",
-                          "threshold"
-                        ],
+                        "required": ["type", "threshold"],
                         "additionalProperties": false
                       },
                       {
@@ -26478,10 +16766,7 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "type",
-                          "path"
-                        ],
+                        "required": ["type", "path"],
                         "additionalProperties": false
                       },
                       {
@@ -26498,18 +16783,13 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "type"
-                        ],
+                        "required": ["type"],
                         "additionalProperties": false
                       }
                     ]
                   }
                 },
-                "required": [
-                  "type",
-                  "aggregator"
-                ],
+                "required": ["type", "aggregator"],
                 "additionalProperties": false
               },
               {
@@ -26546,20 +16826,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "tool-trajectory",
-                      "tool_trajectory"
-                    ]
+                    "enum": ["tool-trajectory", "tool_trajectory"]
                   },
                   "mode": {
                     "type": "string",
-                    "enum": [
-                      "any_order",
-                      "in_order",
-                      "exact",
-                      "subset",
-                      "superset"
-                    ]
+                    "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                   },
                   "minimums": {
                     "type": "object",
@@ -26600,12 +16871,7 @@
                           "anyOf": [
                             {
                               "type": "string",
-                              "enum": [
-                                "exact",
-                                "ignore",
-                                "subset",
-                                "superset"
-                              ]
+                              "enum": ["exact", "ignore", "subset", "superset"]
                             },
                             {
                               "type": "array",
@@ -26619,12 +16885,7 @@
                           "anyOf": [
                             {
                               "type": "string",
-                              "enum": [
-                                "exact",
-                                "ignore",
-                                "subset",
-                                "superset"
-                              ]
+                              "enum": ["exact", "ignore", "subset", "superset"]
                             },
                             {
                               "type": "array",
@@ -26635,9 +16896,7 @@
                           ]
                         }
                       },
-                      "required": [
-                        "tool"
-                      ],
+                      "required": ["tool"],
                       "additionalProperties": false
                     }
                   },
@@ -26645,12 +16904,7 @@
                     "anyOf": [
                       {
                         "type": "string",
-                        "enum": [
-                          "exact",
-                          "ignore",
-                          "subset",
-                          "superset"
-                        ]
+                        "enum": ["exact", "ignore", "subset", "superset"]
                       },
                       {
                         "type": "array",
@@ -26664,12 +16918,7 @@
                     "anyOf": [
                       {
                         "type": "string",
-                        "enum": [
-                          "exact",
-                          "ignore",
-                          "subset",
-                          "superset"
-                        ]
+                        "enum": ["exact", "ignore", "subset", "superset"]
                       },
                       {
                         "type": "array",
@@ -26680,10 +16929,7 @@
                     ]
                   }
                 },
-                "required": [
-                  "type",
-                  "mode"
-                ],
+                "required": ["type", "mode"],
                 "additionalProperties": false
               },
               {
@@ -26720,10 +16966,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "field-accuracy",
-                      "field_accuracy"
-                    ]
+                    "enum": ["field-accuracy", "field_accuracy"]
                   },
                   "fields": {
                     "type": "array",
@@ -26735,11 +16978,7 @@
                         },
                         "match": {
                           "type": "string",
-                          "enum": [
-                            "exact",
-                            "numeric_tolerance",
-                            "date"
-                          ]
+                          "enum": ["exact", "numeric_tolerance", "date"]
                         },
                         "required": {
                           "type": "boolean"
@@ -26761,26 +17000,17 @@
                           }
                         }
                       },
-                      "required": [
-                        "path",
-                        "match"
-                      ],
+                      "required": ["path", "match"],
                       "additionalProperties": false
                     },
                     "minItems": 1
                   },
                   "aggregation": {
                     "type": "string",
-                    "enum": [
-                      "weighted_average",
-                      "all_or_nothing"
-                    ]
+                    "enum": ["weighted_average", "all_or_nothing"]
                   }
                 },
-                "required": [
-                  "type",
-                  "fields"
-                ],
+                "required": ["type", "fields"],
                 "additionalProperties": false
               },
               {
@@ -26824,10 +17054,7 @@
                     "minimum": 0
                   }
                 },
-                "required": [
-                  "type",
-                  "threshold"
-                ],
+                "required": ["type", "threshold"],
                 "additionalProperties": false
               },
               {
@@ -26871,10 +17098,7 @@
                     "minimum": 0
                   }
                 },
-                "required": [
-                  "type",
-                  "budget"
-                ],
+                "required": ["type", "budget"],
                 "additionalProperties": false
               },
               {
@@ -26911,10 +17135,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "token-usage",
-                      "token_usage"
-                    ]
+                    "enum": ["token-usage", "token_usage"]
                   },
                   "max_total": {
                     "type": "number",
@@ -26929,9 +17150,7 @@
                     "minimum": 0
                   }
                 },
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "additionalProperties": false
               },
               {
@@ -26968,10 +17187,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "execution-metrics",
-                      "execution_metrics"
-                    ]
+                    "enum": ["execution-metrics", "execution_metrics"]
                   },
                   "max_tool_calls": {
                     "type": "number",
@@ -27003,9 +17219,7 @@
                     "minimum": 0
                   }
                 },
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "additionalProperties": false
               },
               {
@@ -27048,10 +17262,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "type",
-                  "value"
-                ],
+                "required": ["type", "value"],
                 "additionalProperties": false
               },
               {
@@ -27094,10 +17305,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "type",
-                  "value"
-                ],
+                "required": ["type", "value"],
                 "additionalProperties": false
               },
               {
@@ -27134,15 +17342,10 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "is-json",
-                      "is_json"
-                    ]
+                    "enum": ["is-json", "is_json"]
                   }
                 },
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "additionalProperties": false
               },
               {
@@ -27185,10 +17388,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "type",
-                  "value"
-                ],
+                "required": ["type", "value"],
                 "additionalProperties": false
               },
               {
@@ -27240,10 +17440,7 @@
                         },
                         "operator": {
                           "type": "string",
-                          "enum": [
-                            "correctness",
-                            "contradiction"
-                          ]
+                          "enum": ["correctness", "contradiction"]
                         },
                         "weight": {
                           "type": "number"
@@ -27284,10 +17481,7 @@
                                 "minLength": 1
                               }
                             },
-                            "required": [
-                              "score_range",
-                              "outcome"
-                            ],
+                            "required": ["score_range", "outcome"],
                             "additionalProperties": false
                           }
                         }
@@ -27297,10 +17491,7 @@
                     "minItems": 1
                   }
                 },
-                "required": [
-                  "type",
-                  "criteria"
-                ],
+                "required": ["type", "criteria"],
                 "additionalProperties": false
               }
             ]
@@ -27329,10 +17520,7 @@
                 ]
               }
             },
-            "required": [
-              "type",
-              "command"
-            ],
+            "required": ["type", "command"],
             "additionalProperties": false
           }
         },
@@ -27346,10 +17534,7 @@
                 },
                 "isolation": {
                   "type": "string",
-                  "enum": [
-                    "shared",
-                    "per_case"
-                  ]
+                  "enum": ["shared", "per_case"]
                 },
                 "repos": {
                   "type": "array",
@@ -27431,11 +17616,7 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": [
-                            "none",
-                            "fast",
-                            "strict"
-                          ]
+                          "enum": ["none", "fast", "strict"]
                         }
                       },
                       "additionalProperties": false
@@ -27480,11 +17661,7 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": [
-                            "none",
-                            "fast",
-                            "strict"
-                          ]
+                          "enum": ["none", "fast", "strict"]
                         }
                       },
                       "additionalProperties": false
@@ -27529,11 +17706,7 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": [
-                            "none",
-                            "fast",
-                            "strict"
-                          ]
+                          "enum": ["none", "fast", "strict"]
                         }
                       },
                       "additionalProperties": false
@@ -27578,11 +17751,7 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": [
-                            "none",
-                            "fast",
-                            "strict"
-                          ]
+                          "enum": ["none", "fast", "strict"]
                         }
                       },
                       "additionalProperties": false
@@ -27608,9 +17777,7 @@
                       "minimum": 0.1
                     }
                   },
-                  "required": [
-                    "image"
-                  ],
+                  "required": ["image"],
                   "additionalProperties": false
                 },
                 "env": {
@@ -27642,7 +17809,7 @@
           ]
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     }
   }
 }


### PR DESCRIPTION
## Summary

BREAKING: canonicalizes eval runtime authoring on `experiment` only.

- Removes `execution` from the SDK eval authoring types/exports and YAML/core eval-suite parsing.
- Rejects top-level, per-test, imported-suite, and JSONL `execution` runtime blocks with migration guidance.
- Migrates examples, docs, tests, generated schema references, and CLI-generated eval YAML to `experiment`.
- Amends ADR 0006 with the 2026-06-30 decision that `execution:` is fully removed.

Migration: rename eval runtime blocks from `execution:` to `experiment:`.

Note: `defineConfig().execution` and `.agentv/config*.yaml` execution defaults are intentionally untouched; that is a separate run-level config surface.

## Validation

- `bun --filter @agentv/core build && bun --filter @agentv/sdk build && bun --filter @agentv/core typecheck && bun --filter @agentv/sdk typecheck`
- `bun test packages/core/test/evaluation/validation/eval-file-schema.test.ts packages/core/test/evaluation/validation/eval-schema-sync.test.ts packages/core/test/evaluation/validation/eval-validator.test.ts packages/core/test/evaluation/eval-inline-experiment.test.ts packages/core/test/evaluation/loaders/grader-parser.test.ts packages/core/test/evaluation/source-traceability.test.ts packages/core/test/evaluation/loaders/config-loader.test.ts packages/core/test/evaluation/cache-config.test.ts packages/core/test/evaluation/matrix-targets.test.ts packages/core/test/evaluation/input-files-shorthand.test.ts packages/core/test/evaluation/suite-level-input.test.ts packages/core/test/evaluation/repo-schema-validation.test.ts packages/core/test/evaluation/yaml-parser-metadata.test.ts packages/sdk/test/eval-authoring.test.ts apps/cli/test/commands/eval/bundle.test.ts apps/cli/test/commands/prepare/prepare.test.ts apps/cli/test/commands/runs/rerun.test.ts apps/cli/test/eval.integration.test.ts`
- `git diff --name-only -z | xargs -0 bunx biome check`
- `git diff --check`