### PR TITLE
docs(readme): modernize quick start eval and fix `agentv compare` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ agentv eval evals/math.yaml
 - **Version-controlled** — evals, judges, and results all live in Git
 - **Hybrid graders** — deterministic code checks + LLM-based subjective scoring
 - **CI/CD native** — exit codes, JSONL output, threshold flags for pipeline gating
-- **Any agent** — supports Claude, Codex, Copilot, VS Code, Pi, Azure OpenAI, or any CLI agent
+- **Any agent** — supports Claude, Codex, Copilot, Pi, or any CLI agent
 
 ## Quick start
 
@@ -53,13 +53,20 @@ agentv init
 **3. Create an eval** in `evals/`:
 ```yaml
 description: Code generation quality
+
+experiment:
+  target: copilot
+  threshold: 0.8
+
 tests:
   - id: fizzbuzz
-    criteria: Write a correct FizzBuzz implementation
     input: Write FizzBuzz in Python
     assertions:
       - type: contains
         value: "fizz"
+      - type: rubrics
+        criteria:
+          - Implements correct FizzBuzz logic for multiples of 3, 5, and 15
       - type: code-grader
         command: ./validators/check_syntax.py
       - type: llm-grader
@@ -71,9 +78,9 @@ tests:
 agentv eval evals/my-eval.yaml
 ```
 
-**5. Compare results across targets:**
+**5. Compare two runs** (pass two `index.jsonl` manifests — e.g. before and after a change):
 ```bash
-agentv compare .agentv/results/default/<timestamp>/index.jsonl
+agentv compare .agentv/results/default/<before-timestamp>/index.jsonl .agentv/results/default/<after-timestamp>/index.jsonl
 ```
 
 ## Output formats

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Test AI targets on real repo tasks and measure what actually works.
 - **Workspace / fixtures / graders** are task-owned context: repos, setup scripts, files, fixtures, isolation, deterministic checks, and LLM grading prompts.
 - **Target** is the system under test: an agent, provider, gateway, replay target, CLI wrapper, transcript provider, or future app/service wrapper. Use `model` when you need to override the target's default model for a run.
 - **Experiment** is the named condition being measured over that corpus, such as `backend-with-skills` or `backend-without-skills`.
-- **Policy** controls how AgentV executes and gates the eval: runs, early exit, thresholds, timeouts, and budgets. It is not the experiment identity.
+- **Policy** controls how AgentV executes and gates the eval: runs, thresholds, timeouts, and budgets. It is not the experiment identity.
 - **Run** is one concrete execution of an experiment against a target/model that writes portable artifacts for readers such as Dashboard, compare, and trend.
 
 ```mermaid
@@ -57,7 +57,7 @@ agentv init
 
 **3. Create an eval** in `evals/`:
 ```yaml
-experiment: backend-with-skills
+name: backend-with-skills
 description: Code generation quality
 target: copilot-sdk
 model: claude-sonnet-4.6
@@ -67,7 +67,6 @@ workspace:
 
 policy:
   runs: 3
-  early_exit: false
   timeout_seconds: 600
   threshold: 0.8
   budget_usd: 5
@@ -97,7 +96,7 @@ agentv compare .agentv/results/backend-without-skills/<timestamp>/copilot-sdk--c
 
 ## Results
 
-Each run writes a timestamped invocation directory under `.agentv/results/<experiment>/<timestamp>/`. In this example, `experiment: backend-with-skills` names the condition being measured, `target: copilot-sdk` selects the system under test, and `model: claude-sonnet-4.6` overrides that target's default model. The resolved target identity is still `copilot-sdk--claude-sonnet-4.6` so CI baselines can distinguish model changes. The flat `index.jsonl` manifest is the portable surface used by scripts, CI, and `agentv compare`:
+Each run writes a timestamped invocation directory under `.agentv/results/<experiment>/<timestamp>/`. In this example, `name: backend-with-skills` names the condition being measured, `target: copilot-sdk` selects the system under test, and `model: claude-sonnet-4.6` overrides that target's default model. The resolved target identity is still `copilot-sdk--claude-sonnet-4.6` so CI baselines can distinguish model changes. The flat `index.jsonl` manifest is the portable surface used by scripts, CI, and `agentv compare`:
 
 ```bash
 agentv eval evals/my-eval.yaml
@@ -163,13 +162,13 @@ Use `defineEval()` when you want AgentV to run the TypeScript eval file:
 import { defineEval } from '@agentv/sdk';
 
 export default defineEval({
-  experiment: 'backend-with-skills',
+  name: 'backend-with-skills',
   description: 'Code generation quality',
   target: 'copilot-sdk',
   model: 'claude-sonnet-4.6',
   policy: {
     runs: 3,
-    earlyExit: false,
+    timeoutSeconds: 600,
     threshold: 0.8,
     budgetUsd: 5,
   },

--- a/README.md
+++ b/README.md
@@ -119,12 +119,13 @@ Run bundle layout:
 
 ## TypeScript SDK
 
-Use AgentV programmatically. The inline definition mirrors the YAML eval above — same test, same `assertions` (targets come from `.agentv/targets.yaml`):
+Use `evaluate()` when your application owns the run:
 
 ```typescript
 import { evaluate } from '@agentv/sdk';
 
 const { results, summary } = await evaluate({
+  target: { name: 'copilot', provider: 'copilot' },
   threshold: 0.8,
   tests: [
     {
@@ -144,6 +145,35 @@ const { results, summary } = await evaluate({
 });
 
 console.log(`${summary.passed}/${summary.total} passed`);
+```
+
+Use `defineEval()` when you want AgentV to run the TypeScript eval file:
+
+```typescript
+import { defineEval } from '@agentv/sdk';
+
+export default defineEval({
+  description: 'Code generation quality',
+  experiment: {
+    target: 'copilot',
+    threshold: 0.8,
+  },
+  tests: [
+    {
+      id: 'fizzbuzz',
+      input: 'Write FizzBuzz in Python',
+      assertions: [
+        { type: 'contains', value: 'fizz' },
+        {
+          type: 'rubrics',
+          criteria: ['Implements correct FizzBuzz logic for multiples of 3, 5, and 15'],
+        },
+        { type: 'code-grader', command: ['python3', './validators/check_syntax.py'] },
+        { type: 'llm-grader', prompt: './graders/correctness.md' },
+      ],
+    },
+  ],
+});
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -80,40 +80,41 @@ agentv eval evals/my-eval.yaml
 
 **5. Compare two runs** (pass two `index.jsonl` manifests — e.g. before and after a change):
 ```bash
-agentv compare .agentv/results/default/<before-timestamp>/index.jsonl .agentv/results/default/<after-timestamp>/index.jsonl
+agentv compare .agentv/results/<experiment>/<before-timestamp>/default/index.jsonl .agentv/results/<experiment>/<after-timestamp>/default/index.jsonl
 ```
 
 ## Results
 
-Each run writes a timestamped bundle under `.agentv/results/<experiment>/<timestamp>/`. The flat `index.jsonl` manifest is the portable surface used by scripts, CI, and `agentv compare`:
+Each run writes a timestamped bundle under `.agentv/results/<experiment>/<timestamp>/<run-id>/`. The flat `index.jsonl` manifest is the portable surface used by scripts, CI, and `agentv compare`:
 
 ```bash
-agentv eval evals/my-eval.yaml --output ./run   # writes ./run/index.jsonl
-cat ./run/index.jsonl                            # JSONL results for scripts/CI
+agentv eval evals/my-eval.yaml --output ./run   # writes ./run/default/index.jsonl
+cat ./run/default/index.jsonl                    # JSONL results for scripts/CI
 ```
 
 Run bundle layout:
 
 ```
 .agentv/results/
-└── default/                          # <experiment> — the eval name
+└── my-eval/                          # <experiment> — the eval name
     └── 2026-06-30T08-30-00-000Z/     # <timestamp> — one run
-        ├── index.jsonl               # flat per-test results (scripts/CI, `agentv compare`)
-        ├── summary.json              # run rollup: pass rate, counts, cost
-        └── fizzbuzz/                 # <test-id>
-            ├── summary.json          # per-test rollup across runs
-            ├── task/                 # frozen inputs, for reproducibility
-            │   ├── EVAL.yaml         #   resolved eval spec
-            │   ├── targets.yaml      #   resolved target config
-            │   └── graders/          #   grader files used
-            └── run-1/                # one attempt (run-N for repeats/trials)
-                ├── result.json       # attempt result + score
-                ├── grading.json      # per-assertion grading detail
-                ├── metrics.json      # tokens, cost, tool calls
-                ├── timing.json       # durations
-                ├── transcript.jsonl       # parsed agent transcript
-                ├── transcript-raw.jsonl   # raw agent output (debugging)
-                └── outputs/          # captured stdout and grader outputs
+        └── default/                  # <run-id>
+            ├── index.jsonl           # flat per-test results (scripts/CI, `agentv compare`)
+            ├── summary.json          # run rollup: pass rate, counts, cost
+            └── fizzbuzz--a1b2c3d4/   # <case-allocation>
+                ├── summary.json      # per-test rollup across runs
+                ├── task/             # frozen inputs, for reproducibility
+                │   ├── EVAL.yaml     #   resolved eval spec
+                │   ├── targets.yaml  #   resolved target config
+                │   └── graders/      #   grader files used
+                └── run-1/            # one attempt (run-N for repeats/trials)
+                    ├── result.json   # compact attempt manifest
+                    ├── grading.json  # per-assertion grading detail
+                    ├── metrics.json  # tool calls, transcript stats, behavior metrics
+                    ├── timing.json   # duration, token usage, cost
+                    ├── transcript.jsonl       # parsed agent transcript
+                    ├── transcript-raw.jsonl   # raw agent output (debugging)
+                    └── outputs/      # captured stdout and grader outputs
 ```
 
 ## TypeScript SDK

--- a/README.md
+++ b/README.md
@@ -1,36 +1,8 @@
 # AgentV
 
-**Evaluate AI targets against real repos from the terminal. No server. No signup.**
+Test AI targets on real repo tasks and measure what actually works.
 
-```bash
-npm install -g agentv
-agentv init
-agentv eval evals/example.yaml
-```
-
-That's it. Results in seconds, not minutes.
-
-## What it does
-
-AgentV runs evaluation cases against configured targets and scores them with deterministic code graders + customizable LLM graders. Everything lives in Git — YAML eval files, markdown judge prompts, JSONL results.
-
-```yaml
-# evals/math.yaml
-description: Math problem solving
-tests:
-  - id: addition
-    input: What is 15 + 27?
-    expected_output: "42"
-    assertions:
-      - type: contains
-        value: "42"
-```
-
-```bash
-agentv eval evals/math.yaml
-```
-
-## Why AgentV?
+## Why?
 
 - **Local-first** — runs on your machine, no cloud accounts or API keys for eval infrastructure
 - **Repo-backed workspaces** — reuse real repos, setup scripts, and existing harnesses instead of rebuilding synthetic tasks
@@ -42,23 +14,28 @@ agentv eval evals/math.yaml
 
 ## Core Concepts
 
-- **Suite / imports / tests** are the task corpus: the prompts, cases, datasets, and imported benchmarks you want to evaluate.
-- **Workspace / fixtures / graders** are task-owned context: repos, setup scripts, files, fixtures, deterministic checks, and LLM grading prompts.
-- **Target** is the system under test: an agent, model/provider, gateway, replay target, CLI wrapper, transcript provider, or future app/service wrapper.
-- **Experiment** names comparison intent: target/model, variant, repeats, gates, timeout/runtime policy, and result grouping.
+- **Imports / tests** are the task corpus: the prompts, cases, datasets, and imported benchmarks you want to evaluate.
+- **Workspace / fixtures / graders** are task-owned context: repos, setup scripts, files, fixtures, isolation, deterministic checks, and LLM grading prompts.
+- **Target** is the system under test: an agent, provider, gateway, replay target, CLI wrapper, transcript provider, or future app/service wrapper. Use `model` when you need to override the target's default model for a run.
+- **Policy** controls how AgentV runs and gates the eval: run count, thresholds, timeouts, and budgets.
+- **Experiment** is created automatically from the eval definition. The top-level `name` gives the experiment namespace, `target` identifies the system under test, and AgentV groups concrete runs under that resolved identity.
 - **Run** is one concrete execution that writes portable artifacts for readers such as Dashboard, compare, and trend.
 
 ```mermaid
 flowchart LR
-  corpus["Suite / imports / tests<br/>task corpus"]
+  corpus["Imports / tests<br/>task corpus"]
   context["Workspace / fixtures / graders<br/>task-owned context"]
-  experiment["Experiment<br/>target + variant + runtime policy"]
+  target["Target<br/>system under test"]
+  policy["Policy<br/>runtime + gates"]
+  experiment["Experiment<br/>auto-created grouping"]
   run["Run<br/>concrete execution"]
   artifacts["Run artifacts<br/>summary.json + index.jsonl + sidecars"]
   readers["Dashboard / compare / trend<br/>derived readers"]
 
   corpus --> run
   context --> run
+  target --> experiment
+  policy --> experiment
   experiment --> run
   run --> artifacts
   artifacts --> readers
@@ -76,11 +53,20 @@ agentv init
 
 **3. Create an eval** in `evals/`:
 ```yaml
+name: backend-with-skills
 description: Code generation quality
+target: copilot-sdk
+model: claude-sonnet-4.6
 
-experiment:
-  target: copilot
+workspace:
+  isolation: per_case
+
+policy:
+  runs: 3
+  early_exit: false
+  timeout_seconds: 600
   threshold: 0.8
+  budget_usd: 5
 
 tests:
   - id: fizzbuzz
@@ -88,9 +74,7 @@ tests:
     assertions:
       - type: contains
         value: "fizz"
-      - type: rubrics
-        criteria:
-          - Implements correct FizzBuzz logic for multiples of 3, 5, and 15
+      - Implements correct FizzBuzz logic for multiples of 3, 5, and 15
       - type: code-grader
         command: ["python3", "./validators/check_syntax.py"]
       - type: llm-grader
@@ -104,30 +88,30 @@ agentv eval evals/my-eval.yaml
 
 **5. Compare two runs** (pass two `index.jsonl` manifests — e.g. before and after a change):
 ```bash
-agentv compare .agentv/results/<experiment>/<before-timestamp>/default/index.jsonl .agentv/results/<experiment>/<after-timestamp>/default/index.jsonl
+agentv compare .agentv/results/backend-without-skills/<timestamp>/copilot-sdk--claude-sonnet-4.6/index.jsonl .agentv/results/backend-with-skills/<timestamp>/copilot-sdk--claude-sonnet-4.6/index.jsonl
 ```
 
 ## Results
 
-Each run writes a timestamped bundle under `.agentv/results/<experiment>/<timestamp>/<run-id>/`. The flat `index.jsonl` manifest is the portable surface used by scripts, CI, and `agentv compare`:
+Each run writes a timestamped invocation directory under `.agentv/results/<experiment>/<timestamp>/`. In this example, the top-level eval `name` creates the `backend-with-skills` experiment namespace, `target: copilot-sdk` selects the system under test, and `model: claude-sonnet-4.6` overrides that target's default model. The resolved target identity is still `copilot-sdk--claude-sonnet-4.6` so CI baselines can distinguish model changes. The flat `index.jsonl` manifest is the portable surface used by scripts, CI, and `agentv compare`:
 
 ```bash
-agentv eval evals/my-eval.yaml --output ./run   # writes ./run/default/index.jsonl
-cat ./run/default/index.jsonl                    # JSONL results for scripts/CI
+agentv eval evals/my-eval.yaml
+cat .agentv/results/backend-with-skills/<timestamp>/copilot-sdk--claude-sonnet-4.6/index.jsonl
 ```
 
 Run bundle layout:
 
 ```
 .agentv/results/
-└── my-eval/                          # <experiment> — comparison/run grouping
+└── backend-with-skills/              # <experiment> — comparison/run grouping
     └── 2026-06-30T08-30-00-000Z/     # <timestamp> — one run
-        └── default/                  # <run-id>
+        └── copilot-sdk--claude-sonnet-4.6/ # <target> — resolved system under test
             ├── index.jsonl           # flat per-test results (scripts/CI, `agentv compare`)
             ├── summary.json          # run rollup: pass rate, counts, cost
-            └── fizzbuzz--a1b2c3d4/   # <case-allocation>
+            └── fizzbuzz--a1b2c3d4/   # <result_dir> for one test case
                 ├── summary.json      # per-test rollup across runs
-                ├── task/             # frozen inputs, for reproducibility
+                ├── test/             # generated test bundle: frozen inputs for reproducibility
                 │   ├── EVAL.yaml     #   resolved eval spec
                 │   ├── targets.yaml  #   resolved target config
                 │   └── graders/      #   grader files used
@@ -149,7 +133,7 @@ Use `evaluate()` when your application owns the run:
 import { evaluate } from '@agentv/sdk';
 
 const { results, summary } = await evaluate({
-  target: { name: 'copilot', provider: 'copilot' },
+  task: async (input) => runMyAppTarget(input),
   threshold: 0.8,
   tests: [
     {
@@ -177,10 +161,18 @@ Use `defineEval()` when you want AgentV to run the TypeScript eval file:
 import { defineEval } from '@agentv/sdk';
 
 export default defineEval({
+  name: 'backend-with-skills',
   description: 'Code generation quality',
-  experiment: {
-    target: 'copilot',
+  target: 'copilot-sdk',
+  model: 'claude-sonnet-4.6',
+  policy: {
+    runs: 3,
+    earlyExit: false,
     threshold: 0.8,
+    budgetUsd: 5,
+  },
+  workspace: {
+    isolation: 'per_case',
   },
   tests: [
     {

--- a/README.md
+++ b/README.md
@@ -14,29 +14,33 @@ Test AI targets on real repo tasks and measure what actually works.
 
 ## Core Concepts
 
-- **Imports / tests** are the task corpus: the prompts, cases, datasets, and imported benchmarks you want to evaluate.
+- **Eval suite / imports / tests** are the task corpus: the prompts, cases, datasets, and imported benchmarks you want to evaluate.
+- **Category** is derived from where the eval lives, such as folder path and file name. Use paths to organize the corpus instead of repeating category labels in every eval.
 - **Workspace / fixtures / graders** are task-owned context: repos, setup scripts, files, fixtures, isolation, deterministic checks, and LLM grading prompts.
 - **Target** is the system under test: an agent, provider, gateway, replay target, CLI wrapper, transcript provider, or future app/service wrapper. Use `model` when you need to override the target's default model for a run.
-- **Policy** controls how AgentV runs and gates the eval: run count, thresholds, timeouts, and budgets.
-- **Experiment** is created automatically from the eval definition. The top-level `name` gives the experiment namespace, `target` identifies the system under test, and AgentV groups concrete runs under that resolved identity.
-- **Run** is one concrete execution that writes portable artifacts for readers such as Dashboard, compare, and trend.
+- **Experiment** is the named condition being measured over that corpus, such as `backend-with-skills` or `backend-without-skills`.
+- **Policy** controls how AgentV executes and gates the eval: runs, early exit, thresholds, timeouts, and budgets. It is not the experiment identity.
+- **Run** is one concrete execution of an experiment against a target/model that writes portable artifacts for readers such as Dashboard, compare, and trend.
 
 ```mermaid
 flowchart LR
-  corpus["Imports / tests<br/>task corpus"]
+  corpus["Eval suite / imports / tests<br/>task corpus"]
+  category["Category<br/>path-derived grouping"]
   context["Workspace / fixtures / graders<br/>task-owned context"]
-  target["Target<br/>system under test"]
-  policy["Policy<br/>runtime + gates"]
-  experiment["Experiment<br/>auto-created grouping"]
+  experiment["Experiment<br/>named run condition"]
+  target["Target + model<br/>system under test"]
+  policy["Policy<br/>execution + gates"]
   run["Run<br/>concrete execution"]
   artifacts["Run artifacts<br/>summary.json + index.jsonl + sidecars"]
   readers["Dashboard / compare / trend<br/>derived readers"]
 
+  corpus --> category
   corpus --> run
   context --> run
-  target --> experiment
-  policy --> experiment
+  category --> run
   experiment --> run
+  target --> run
+  policy --> run
   run --> artifacts
   artifacts --> readers
 ```
@@ -53,7 +57,7 @@ agentv init
 
 **3. Create an eval** in `evals/`:
 ```yaml
-name: backend-with-skills
+experiment: backend-with-skills
 description: Code generation quality
 target: copilot-sdk
 model: claude-sonnet-4.6
@@ -93,7 +97,7 @@ agentv compare .agentv/results/backend-without-skills/<timestamp>/copilot-sdk--c
 
 ## Results
 
-Each run writes a timestamped invocation directory under `.agentv/results/<experiment>/<timestamp>/`. In this example, the top-level eval `name` creates the `backend-with-skills` experiment namespace, `target: copilot-sdk` selects the system under test, and `model: claude-sonnet-4.6` overrides that target's default model. The resolved target identity is still `copilot-sdk--claude-sonnet-4.6` so CI baselines can distinguish model changes. The flat `index.jsonl` manifest is the portable surface used by scripts, CI, and `agentv compare`:
+Each run writes a timestamped invocation directory under `.agentv/results/<experiment>/<timestamp>/`. In this example, `experiment: backend-with-skills` names the condition being measured, `target: copilot-sdk` selects the system under test, and `model: claude-sonnet-4.6` overrides that target's default model. The resolved target identity is still `copilot-sdk--claude-sonnet-4.6` so CI baselines can distinguish model changes. The flat `index.jsonl` manifest is the portable surface used by scripts, CI, and `agentv compare`:
 
 ```bash
 agentv eval evals/my-eval.yaml
@@ -133,6 +137,7 @@ Use `evaluate()` when your application owns the run:
 import { evaluate } from '@agentv/sdk';
 
 const { results, summary } = await evaluate({
+  experiment: 'backend-with-skills',
   task: async (input) => runMyAppTarget(input),
   threshold: 0.8,
   tests: [
@@ -141,10 +146,7 @@ const { results, summary } = await evaluate({
       input: 'Write FizzBuzz in Python',
       assertions: [
         { type: 'contains', value: 'fizz' },
-        {
-          type: 'rubrics',
-          criteria: ['Implements correct FizzBuzz logic for multiples of 3, 5, and 15'],
-        },
+        'Implements correct FizzBuzz logic for multiples of 3, 5, and 15',
         { type: 'code-grader', command: ['python3', './validators/check_syntax.py'] },
         { type: 'llm-grader', prompt: './graders/correctness.md' },
       ],
@@ -161,7 +163,7 @@ Use `defineEval()` when you want AgentV to run the TypeScript eval file:
 import { defineEval } from '@agentv/sdk';
 
 export default defineEval({
-  name: 'backend-with-skills',
+  experiment: 'backend-with-skills',
   description: 'Code generation quality',
   target: 'copilot-sdk',
   model: 'claude-sonnet-4.6',
@@ -180,10 +182,7 @@ export default defineEval({
       input: 'Write FizzBuzz in Python',
       assertions: [
         { type: 'contains', value: 'fizz' },
-        {
-          type: 'rubrics',
-          criteria: ['Implements correct FizzBuzz logic for multiples of 3, 5, and 15'],
-        },
+        'Implements correct FizzBuzz logic for multiples of 3, 5, and 15',
         { type: 'code-grader', command: ['python3', './validators/check_syntax.py'] },
         { type: 'llm-grader', prompt: './graders/correctness.md' },
       ],

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AgentV
 
-**Evaluate AI agents against real repos from the terminal. No server. No signup.**
+**Evaluate AI targets against real repos from the terminal. No server. No signup.**
 
 ```bash
 npm install -g agentv
@@ -12,7 +12,7 @@ That's it. Results in seconds, not minutes.
 
 ## What it does
 
-AgentV runs evaluation cases against your AI agents and scores them with deterministic code graders + customizable LLM graders. Everything lives in Git — YAML eval files, markdown judge prompts, JSONL results.
+AgentV runs evaluation cases against configured targets and scores them with deterministic code graders + customizable LLM graders. Everything lives in Git — YAML eval files, markdown judge prompts, JSONL results.
 
 ```yaml
 # evals/math.yaml
@@ -38,7 +38,31 @@ agentv eval evals/math.yaml
 - **Version-controlled** — evals, judges, and results all live in Git
 - **Hybrid graders** — deterministic code checks + LLM-based subjective scoring
 - **CI/CD native** — exit codes, JSONL output, threshold flags for pipeline gating
-- **Any agent** — supports Claude, Codex, Copilot, Pi, or any CLI agent
+- **Any target** — run against agents, model providers, gateways, replay targets, CLI wrappers, transcript providers, and future app or service wrappers
+
+## Core vocabulary
+
+- **Suite / imports / tests** are the task corpus: the prompts, cases, datasets, and imported benchmarks you want to evaluate.
+- **Workspace / fixtures / graders** are task-owned context: repos, setup scripts, files, fixtures, deterministic checks, and LLM grading prompts.
+- **Target** is the system under test: an agent, model/provider, gateway, replay target, CLI wrapper, transcript provider, or future app/service wrapper.
+- **Experiment** names comparison intent: target/model, variant, repeats, gates, timeout/runtime policy, and result grouping.
+- **Run** is one concrete execution that writes portable artifacts for readers such as Dashboard, compare, and trend.
+
+```mermaid
+flowchart LR
+  corpus["Suite / imports / tests<br/>task corpus"]
+  context["Workspace / fixtures / graders<br/>task-owned context"]
+  experiment["Experiment<br/>target + variant + runtime policy"]
+  run["Run<br/>concrete execution"]
+  artifacts["Run artifacts<br/>summary.json + index.jsonl + sidecars"]
+  readers["Dashboard / compare / trend<br/>derived readers"]
+
+  corpus --> run
+  context --> run
+  experiment --> run
+  run --> artifacts
+  artifacts --> readers
+```
 
 ## Quick start
 
@@ -48,7 +72,7 @@ npm install -g agentv
 agentv init
 ```
 
-**2. Configure targets** in `.agentv/targets.yaml` — point to your agent or LLM provider.
+**2. Configure targets** in `.agentv/targets.yaml` — point to the system under test, such as an agent, provider, gateway, replay source, or CLI wrapper.
 
 **3. Create an eval** in `evals/`:
 ```yaml
@@ -96,7 +120,7 @@ Run bundle layout:
 
 ```
 .agentv/results/
-└── my-eval/                          # <experiment> — the eval name
+└── my-eval/                          # <experiment> — comparison/run grouping
     └── 2026-06-30T08-30-00-000Z/     # <timestamp> — one run
         └── default/                  # <run-id>
             ├── index.jsonl           # flat per-test results (scripts/CI, `agentv compare`)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ agentv eval evals/math.yaml
 - **CI/CD native** — exit codes, JSONL output, threshold flags for pipeline gating
 - **Any target** — run against agents, model providers, gateways, replay targets, CLI wrappers, transcript providers, and future app or service wrappers
 
-## Core vocabulary
+## Core Concepts
 
 - **Suite / imports / tests** are the task corpus: the prompts, cases, datasets, and imported benchmarks you want to evaluate.
 - **Workspace / fixtures / graders** are task-owned context: repos, setup scripts, files, fixtures, deterministic checks, and LLM grading prompts.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ tests:
         criteria:
           - Implements correct FizzBuzz logic for multiples of 3, 5, and 15
       - type: code-grader
-        command: ./validators/check_syntax.py
+        command: ["python3", "./validators/check_syntax.py"]
       - type: llm-grader
         prompt: ./graders/correctness.md
 ```
@@ -83,26 +83,61 @@ agentv eval evals/my-eval.yaml
 agentv compare .agentv/results/default/<before-timestamp>/index.jsonl .agentv/results/default/<after-timestamp>/index.jsonl
 ```
 
-## Output formats
+## Results
+
+Each run writes a timestamped bundle under `.agentv/results/<experiment>/<timestamp>/`. The flat `index.jsonl` manifest is the portable surface used by scripts, CI, and `agentv compare`:
 
 ```bash
 agentv eval evals/my-eval.yaml --output ./run   # writes ./run/index.jsonl
-cat ./run/index.jsonl                         # JSONL results for scripts/CI
+cat ./run/index.jsonl                            # JSONL results for scripts/CI
+```
+
+Run bundle layout:
+
+```
+.agentv/results/
+└── default/                          # <experiment> — the eval name
+    └── 2026-06-30T08-30-00-000Z/     # <timestamp> — one run
+        ├── index.jsonl               # flat per-test results (scripts/CI, `agentv compare`)
+        ├── summary.json              # run rollup: pass rate, counts, cost
+        └── fizzbuzz/                 # <test-id>
+            ├── summary.json          # per-test rollup across runs
+            ├── task/                 # frozen inputs, for reproducibility
+            │   ├── EVAL.yaml         #   resolved eval spec
+            │   ├── targets.yaml      #   resolved target config
+            │   └── graders/          #   grader files used
+            └── run-1/                # one attempt (run-N for repeats/trials)
+                ├── result.json       # attempt result + score
+                ├── grading.json      # per-assertion grading detail
+                ├── metrics.json      # tokens, cost, tool calls
+                ├── timing.json       # durations
+                ├── transcript.jsonl       # parsed agent transcript
+                ├── transcript-raw.jsonl   # raw agent output (debugging)
+                └── outputs/          # captured stdout and grader outputs
 ```
 
 ## TypeScript SDK
 
-Use AgentV programmatically:
+Use AgentV programmatically. The inline definition mirrors the YAML eval above — same test, same `assertions` (targets come from `.agentv/targets.yaml`):
 
 ```typescript
 import { evaluate } from '@agentv/sdk';
 
 const { results, summary } = await evaluate({
+  threshold: 0.8,
   tests: [
     {
-      id: 'greeting',
-      input: 'Say hello',
-      assertions: [{ type: 'contains', value: 'Hello' }],
+      id: 'fizzbuzz',
+      input: 'Write FizzBuzz in Python',
+      assertions: [
+        { type: 'contains', value: 'fizz' },
+        {
+          type: 'rubrics',
+          criteria: ['Implements correct FizzBuzz logic for multiples of 3, 5, and 15'],
+        },
+        { type: 'code-grader', command: ['python3', './validators/check_syntax.py'] },
+        { type: 'llm-grader', prompt: './graders/correctness.md' },
+      ],
     },
   ],
 });

--- a/packages/core/src/evaluation/validation/eval-file.schema.ts
+++ b/packages/core/src/evaluation/validation/eval-file.schema.ts
@@ -87,6 +87,8 @@ const RubricItemSchema = z.object({
   score_ranges: z.array(ScoreRangeSchema).optional(),
 });
 
+const RubricCriterionSchema = z.union([z.string().min(1), RubricItemSchema]);
+
 // --- Type-specific evaluator schemas ---
 
 const CodeGraderSchema = EvaluatorCommonSchema.extend({
@@ -237,7 +239,7 @@ const EqualsSchema = EvaluatorCommonSchema.extend({
 
 const RubricsSchema = EvaluatorCommonSchema.extend({
   type: z.literal('rubrics'),
-  criteria: z.array(RubricItemSchema).min(1),
+  criteria: z.array(RubricCriterionSchema).min(1),
 });
 
 /** Union of all grader types */

--- a/packages/core/test/evaluation/validation/eval-file-schema.test.ts
+++ b/packages/core/test/evaluation/validation/eval-file-schema.test.ts
@@ -143,6 +143,24 @@ describe('EvalFileSchema input shorthand', () => {
     expect(result.success).toBe(false);
   });
 
+  it('accepts explicit rubrics criteria string shorthand', () => {
+    const result = EvalFileSchema.safeParse({
+      tests: [
+        {
+          ...baseTest,
+          assertions: [
+            {
+              type: 'rubrics',
+              criteria: ['Must be polite', 'Must be accurate'],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it('accepts flatter imports with optional inline tests', () => {
     const result = EvalFileSchema.safeParse({
       name: 'wrapper',

--- a/skills-data/agentv-eval-writer/references/eval-schema.json
+++ b/skills-data/agentv-eval-writer/references/eval-schema.json
@@ -54,12 +54,7 @@
               "properties": {
                 "role": {
                   "type": "string",
-                  "enum": [
-                    "system",
-                    "user",
-                    "assistant",
-                    "tool"
-                  ]
+                  "enum": ["system", "user", "assistant", "tool"]
                 },
                 "content": {
                   "anyOf": [
@@ -78,30 +73,20 @@
                         "properties": {
                           "type": {
                             "type": "string",
-                            "enum": [
-                              "text",
-                              "file",
-                              "image"
-                            ]
+                            "enum": ["text", "file", "image"]
                           },
                           "value": {
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "type",
-                          "value"
-                        ],
+                        "required": ["type", "value"],
                         "additionalProperties": false
                       }
                     }
                   ]
                 }
               },
-              "required": [
-                "role",
-                "content"
-              ],
+              "required": ["role", "content"],
               "additionalProperties": false
             },
             {
@@ -120,12 +105,7 @@
                 "properties": {
                   "role": {
                     "type": "string",
-                    "enum": [
-                      "system",
-                      "user",
-                      "assistant",
-                      "tool"
-                    ]
+                    "enum": ["system", "user", "assistant", "tool"]
                   },
                   "content": {
                     "anyOf": [
@@ -144,30 +124,20 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "text",
-                                "file",
-                                "image"
-                              ]
+                              "enum": ["text", "file", "image"]
                             },
                             "value": {
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "type",
-                            "value"
-                          ],
+                          "required": ["type", "value"],
                           "additionalProperties": false
                         }
                       }
                     ]
                   }
                 },
-                "required": [
-                  "role",
-                  "content"
-                ],
+                "required": ["role", "content"],
                 "additionalProperties": false
               }
             }
@@ -264,11 +234,7 @@
                                         {
                                           "type": "array",
                                           "items": {
-                                            "type": [
-                                              "string",
-                                              "number",
-                                              "boolean"
-                                            ]
+                                            "type": ["string", "number", "boolean"]
                                           },
                                           "minItems": 1
                                         }
@@ -297,12 +263,7 @@
                                   },
                                   "strategy": {
                                     "type": "string",
-                                    "enum": [
-                                      "pass_at_k",
-                                      "pass_all",
-                                      "mean",
-                                      "confidence_interval"
-                                    ]
+                                    "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
                                   },
                                   "cost_limit_usd": {
                                     "type": "number",
@@ -313,9 +274,7 @@
                                     "minimum": 0
                                   }
                                 },
-                                "required": [
-                                  "count"
-                                ],
+                                "required": ["count"],
                                 "additionalProperties": false
                               },
                               "timeout_seconds": {
@@ -332,9 +291,7 @@
                             "additionalProperties": false
                           }
                         },
-                        "required": [
-                          "path"
-                        ],
+                        "required": ["path"],
                         "additionalProperties": false
                       },
                       {
@@ -424,11 +381,7 @@
                                   {
                                     "type": "array",
                                     "items": {
-                                      "type": [
-                                        "string",
-                                        "number",
-                                        "boolean"
-                                      ]
+                                      "type": ["string", "number", "boolean"]
                                     },
                                     "minItems": 1
                                   }
@@ -457,12 +410,7 @@
                             },
                             "strategy": {
                               "type": "string",
-                              "enum": [
-                                "pass_at_k",
-                                "pass_all",
-                                "mean",
-                                "confidence_interval"
-                              ]
+                              "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
                             },
                             "cost_limit_usd": {
                               "type": "number",
@@ -473,9 +421,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "count"
-                          ],
+                          "required": ["count"],
                           "additionalProperties": false
                         },
                         "timeout_seconds": {
@@ -492,9 +438,7 @@
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "path"
-                  ],
+                  "required": ["path"],
                   "additionalProperties": false
                 }
               ]
@@ -581,11 +525,7 @@
                                         {
                                           "type": "array",
                                           "items": {
-                                            "type": [
-                                              "string",
-                                              "number",
-                                              "boolean"
-                                            ]
+                                            "type": ["string", "number", "boolean"]
                                           },
                                           "minItems": 1
                                         }
@@ -614,12 +554,7 @@
                                   },
                                   "strategy": {
                                     "type": "string",
-                                    "enum": [
-                                      "pass_at_k",
-                                      "pass_all",
-                                      "mean",
-                                      "confidence_interval"
-                                    ]
+                                    "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
                                   },
                                   "cost_limit_usd": {
                                     "type": "number",
@@ -630,9 +565,7 @@
                                     "minimum": 0
                                   }
                                 },
-                                "required": [
-                                  "count"
-                                ],
+                                "required": ["count"],
                                 "additionalProperties": false
                               },
                               "timeout_seconds": {
@@ -649,9 +582,7 @@
                             "additionalProperties": false
                           }
                         },
-                        "required": [
-                          "path"
-                        ],
+                        "required": ["path"],
                         "additionalProperties": false
                       },
                       {
@@ -741,11 +672,7 @@
                                   {
                                     "type": "array",
                                     "items": {
-                                      "type": [
-                                        "string",
-                                        "number",
-                                        "boolean"
-                                      ]
+                                      "type": ["string", "number", "boolean"]
                                     },
                                     "minItems": 1
                                   }
@@ -774,12 +701,7 @@
                             },
                             "strategy": {
                               "type": "string",
-                              "enum": [
-                                "pass_at_k",
-                                "pass_all",
-                                "mean",
-                                "confidence_interval"
-                              ]
+                              "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
                             },
                             "cost_limit_usd": {
                               "type": "number",
@@ -790,9 +712,7 @@
                               "minimum": 0
                             }
                           },
-                          "required": [
-                            "count"
-                          ],
+                          "required": ["count"],
                           "additionalProperties": false
                         },
                         "timeout_seconds": {
@@ -809,9 +729,7 @@
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "path"
-                  ],
+                  "required": ["path"],
                   "additionalProperties": false
                 }
               ]
@@ -850,12 +768,7 @@
                             "properties": {
                               "role": {
                                 "type": "string",
-                                "enum": [
-                                  "system",
-                                  "user",
-                                  "assistant",
-                                  "tool"
-                                ]
+                                "enum": ["system", "user", "assistant", "tool"]
                               },
                               "content": {
                                 "anyOf": [
@@ -874,30 +787,20 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "text",
-                                            "file",
-                                            "image"
-                                          ]
+                                          "enum": ["text", "file", "image"]
                                         },
                                         "value": {
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "value"
-                                      ],
+                                      "required": ["type", "value"],
                                       "additionalProperties": false
                                     }
                                   }
                                 ]
                               }
                             },
-                            "required": [
-                              "role",
-                              "content"
-                            ],
+                            "required": ["role", "content"],
                             "additionalProperties": false
                           },
                           {
@@ -916,12 +819,7 @@
                               "properties": {
                                 "role": {
                                   "type": "string",
-                                  "enum": [
-                                    "system",
-                                    "user",
-                                    "assistant",
-                                    "tool"
-                                  ]
+                                  "enum": ["system", "user", "assistant", "tool"]
                                 },
                                 "content": {
                                   "anyOf": [
@@ -940,30 +838,20 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "text",
-                                              "file",
-                                              "image"
-                                            ]
+                                            "enum": ["text", "file", "image"]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       }
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "role",
-                                "content"
-                              ],
+                              "required": ["role", "content"],
                               "additionalProperties": false
                             }
                           }
@@ -992,12 +880,7 @@
                               "properties": {
                                 "role": {
                                   "type": "string",
-                                  "enum": [
-                                    "system",
-                                    "user",
-                                    "assistant",
-                                    "tool"
-                                  ]
+                                  "enum": ["system", "user", "assistant", "tool"]
                                 },
                                 "content": {
                                   "anyOf": [
@@ -1016,30 +899,20 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "text",
-                                              "file",
-                                              "image"
-                                            ]
+                                            "enum": ["text", "file", "image"]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       }
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "role",
-                                "content"
-                              ],
+                              "required": ["role", "content"],
                               "additionalProperties": false
                             }
                           }
@@ -1083,10 +956,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "code-grader",
-                                    "code_grader"
-                                  ]
+                                  "enum": ["code-grader", "code_grader"]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -1160,18 +1030,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type",
-                                "command"
-                              ],
+                              "required": ["type", "command"],
                               "additionalProperties": false
                             },
                             {
@@ -1208,10 +1072,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "llm-grader",
-                                    "llm_grader"
-                                  ]
+                                  "enum": ["llm-grader", "llm_grader"]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -1269,10 +1130,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -1313,10 +1171,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -1367,17 +1222,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -1388,9 +1238,7 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": [
-                                "include"
-                              ],
+                              "required": ["include"],
                               "additionalProperties": false
                             },
                             {
@@ -1453,9 +1301,7 @@
                                           }
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -1471,10 +1317,7 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "threshold"
-                                      ],
+                                      "required": ["type", "threshold"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -1491,10 +1334,7 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "path"
-                                      ],
+                                      "required": ["type", "path"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -1511,18 +1351,13 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "aggregator"
-                              ],
+                              "required": ["type", "aggregator"],
                               "additionalProperties": false
                             },
                             {
@@ -1559,20 +1394,11 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "tool-trajectory",
-                                    "tool_trajectory"
-                                  ]
+                                  "enum": ["tool-trajectory", "tool_trajectory"]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": [
-                                    "any_order",
-                                    "in_order",
-                                    "exact",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -1613,12 +1439,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -1632,12 +1453,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -1648,9 +1464,7 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "tool"
-                                    ],
+                                    "required": ["tool"],
                                     "additionalProperties": false
                                   }
                                 },
@@ -1658,12 +1472,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -1677,12 +1486,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -1693,10 +1497,7 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "mode"
-                              ],
+                              "required": ["type", "mode"],
                               "additionalProperties": false
                             },
                             {
@@ -1733,10 +1534,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "field-accuracy",
-                                    "field_accuracy"
-                                  ]
+                                  "enum": ["field-accuracy", "field_accuracy"]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -1748,11 +1546,7 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "numeric_tolerance",
-                                          "date"
-                                        ]
+                                        "enum": ["exact", "numeric_tolerance", "date"]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -1774,26 +1568,17 @@
                                         }
                                       }
                                     },
-                                    "required": [
-                                      "path",
-                                      "match"
-                                    ],
+                                    "required": ["path", "match"],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": [
-                                    "weighted_average",
-                                    "all_or_nothing"
-                                  ]
+                                  "enum": ["weighted_average", "all_or_nothing"]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "fields"
-                              ],
+                              "required": ["type", "fields"],
                               "additionalProperties": false
                             },
                             {
@@ -1837,10 +1622,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "threshold"
-                              ],
+                              "required": ["type", "threshold"],
                               "additionalProperties": false
                             },
                             {
@@ -1884,10 +1666,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "budget"
-                              ],
+                              "required": ["type", "budget"],
                               "additionalProperties": false
                             },
                             {
@@ -1924,10 +1703,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "token-usage",
-                                    "token_usage"
-                                  ]
+                                  "enum": ["token-usage", "token_usage"]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -1942,9 +1718,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -1981,10 +1755,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "execution-metrics",
-                                    "execution_metrics"
-                                  ]
+                                  "enum": ["execution-metrics", "execution_metrics"]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -2016,9 +1787,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -2061,10 +1830,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -2107,10 +1873,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -2147,15 +1910,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "is-json",
-                                    "is_json"
-                                  ]
+                                  "enum": ["is-json", "is_json"]
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -2198,10 +1956,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -2259,10 +2014,7 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
+                                            "enum": ["correctness", "contradiction"]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -2303,10 +2055,7 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
+                                              "required": ["score_range", "outcome"],
                                               "additionalProperties": false
                                             }
                                           }
@@ -2318,10 +2067,7 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": [
-                                "type",
-                                "criteria"
-                              ],
+                              "required": ["type", "criteria"],
                               "additionalProperties": false
                             }
                           ]
@@ -2365,10 +2111,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "code-grader",
-                                    "code_grader"
-                                  ]
+                                  "enum": ["code-grader", "code_grader"]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -2442,18 +2185,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type",
-                                "command"
-                              ],
+                              "required": ["type", "command"],
                               "additionalProperties": false
                             },
                             {
@@ -2490,10 +2227,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "llm-grader",
-                                    "llm_grader"
-                                  ]
+                                  "enum": ["llm-grader", "llm_grader"]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -2551,10 +2285,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -2595,10 +2326,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -2649,17 +2377,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -2670,9 +2393,7 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": [
-                                "include"
-                              ],
+                              "required": ["include"],
                               "additionalProperties": false
                             },
                             {
@@ -2735,9 +2456,7 @@
                                           }
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -2753,10 +2472,7 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "threshold"
-                                      ],
+                                      "required": ["type", "threshold"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -2773,10 +2489,7 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "path"
-                                      ],
+                                      "required": ["type", "path"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -2793,18 +2506,13 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "aggregator"
-                              ],
+                              "required": ["type", "aggregator"],
                               "additionalProperties": false
                             },
                             {
@@ -2841,20 +2549,11 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "tool-trajectory",
-                                    "tool_trajectory"
-                                  ]
+                                  "enum": ["tool-trajectory", "tool_trajectory"]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": [
-                                    "any_order",
-                                    "in_order",
-                                    "exact",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -2895,12 +2594,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -2914,12 +2608,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -2930,9 +2619,7 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "tool"
-                                    ],
+                                    "required": ["tool"],
                                     "additionalProperties": false
                                   }
                                 },
@@ -2940,12 +2627,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -2959,12 +2641,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -2975,10 +2652,7 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "mode"
-                              ],
+                              "required": ["type", "mode"],
                               "additionalProperties": false
                             },
                             {
@@ -3015,10 +2689,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "field-accuracy",
-                                    "field_accuracy"
-                                  ]
+                                  "enum": ["field-accuracy", "field_accuracy"]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -3030,11 +2701,7 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "numeric_tolerance",
-                                          "date"
-                                        ]
+                                        "enum": ["exact", "numeric_tolerance", "date"]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -3056,26 +2723,17 @@
                                         }
                                       }
                                     },
-                                    "required": [
-                                      "path",
-                                      "match"
-                                    ],
+                                    "required": ["path", "match"],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": [
-                                    "weighted_average",
-                                    "all_or_nothing"
-                                  ]
+                                  "enum": ["weighted_average", "all_or_nothing"]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "fields"
-                              ],
+                              "required": ["type", "fields"],
                               "additionalProperties": false
                             },
                             {
@@ -3119,10 +2777,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "threshold"
-                              ],
+                              "required": ["type", "threshold"],
                               "additionalProperties": false
                             },
                             {
@@ -3166,10 +2821,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "budget"
-                              ],
+                              "required": ["type", "budget"],
                               "additionalProperties": false
                             },
                             {
@@ -3206,10 +2858,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "token-usage",
-                                    "token_usage"
-                                  ]
+                                  "enum": ["token-usage", "token_usage"]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -3224,9 +2873,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -3263,10 +2910,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "execution-metrics",
-                                    "execution_metrics"
-                                  ]
+                                  "enum": ["execution-metrics", "execution_metrics"]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -3298,9 +2942,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -3343,10 +2985,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -3389,10 +3028,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -3429,15 +3065,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "is-json",
-                                    "is_json"
-                                  ]
+                                  "enum": ["is-json", "is_json"]
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -3480,10 +3111,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -3541,10 +3169,7 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
+                                            "enum": ["correctness", "contradiction"]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -3585,10 +3210,7 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
+                                              "required": ["score_range", "outcome"],
                                               "additionalProperties": false
                                             }
                                           }
@@ -3600,10 +3222,7 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": [
-                                "type",
-                                "criteria"
-                              ],
+                              "required": ["type", "criteria"],
                               "additionalProperties": false
                             }
                           ]
@@ -3655,10 +3274,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "code-grader",
-                                        "code_grader"
-                                      ]
+                                      "enum": ["code-grader", "code_grader"]
                                     },
                                     "command": {
                                       "anyOf": [
@@ -3732,18 +3348,12 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "command"
-                                  ],
+                                  "required": ["type", "command"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -3780,10 +3390,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "llm-grader",
-                                        "llm_grader"
-                                      ]
+                                      "enum": ["llm-grader", "llm_grader"]
                                     },
                                     "prompt": {
                                       "anyOf": [
@@ -3841,10 +3448,7 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
+                                            "enum": ["correctness", "contradiction"]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -3885,10 +3489,7 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
+                                              "required": ["score_range", "outcome"],
                                               "additionalProperties": false
                                             }
                                           }
@@ -3939,17 +3540,12 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -3960,9 +3556,7 @@
                                       "minLength": 1
                                     }
                                   },
-                                  "required": [
-                                    "include"
-                                  ],
+                                  "required": ["include"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4025,9 +3619,7 @@
                                               }
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
+                                          "required": ["type"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -4043,10 +3635,7 @@
                                               "maximum": 1
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "threshold"
-                                          ],
+                                          "required": ["type", "threshold"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -4063,10 +3652,7 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "path"
-                                          ],
+                                          "required": ["type", "path"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -4083,18 +3669,13 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
+                                          "required": ["type"],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "aggregator"
-                                  ],
+                                  "required": ["type", "aggregator"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4131,10 +3712,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "tool-trajectory",
-                                        "tool_trajectory"
-                                      ]
+                                      "enum": ["tool-trajectory", "tool_trajectory"]
                                     },
                                     "mode": {
                                       "type": "string",
@@ -4185,12 +3763,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -4204,12 +3777,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -4220,9 +3788,7 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "tool"
-                                        ],
+                                        "required": ["tool"],
                                         "additionalProperties": false
                                       }
                                     },
@@ -4230,12 +3796,7 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
+                                          "enum": ["exact", "ignore", "subset", "superset"]
                                         },
                                         {
                                           "type": "array",
@@ -4249,12 +3810,7 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
+                                          "enum": ["exact", "ignore", "subset", "superset"]
                                         },
                                         {
                                           "type": "array",
@@ -4265,10 +3821,7 @@
                                       ]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "mode"
-                                  ],
+                                  "required": ["type", "mode"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4305,10 +3858,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "field-accuracy",
-                                        "field_accuracy"
-                                      ]
+                                      "enum": ["field-accuracy", "field_accuracy"]
                                     },
                                     "fields": {
                                       "type": "array",
@@ -4320,11 +3870,7 @@
                                           },
                                           "match": {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "numeric_tolerance",
-                                              "date"
-                                            ]
+                                            "enum": ["exact", "numeric_tolerance", "date"]
                                           },
                                           "required": {
                                             "type": "boolean"
@@ -4346,26 +3892,17 @@
                                             }
                                           }
                                         },
-                                        "required": [
-                                          "path",
-                                          "match"
-                                        ],
+                                        "required": ["path", "match"],
                                         "additionalProperties": false
                                       },
                                       "minItems": 1
                                     },
                                     "aggregation": {
                                       "type": "string",
-                                      "enum": [
-                                        "weighted_average",
-                                        "all_or_nothing"
-                                      ]
+                                      "enum": ["weighted_average", "all_or_nothing"]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "fields"
-                                  ],
+                                  "required": ["type", "fields"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4409,10 +3946,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "threshold"
-                                  ],
+                                  "required": ["type", "threshold"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4456,10 +3990,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "budget"
-                                  ],
+                                  "required": ["type", "budget"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4496,10 +4027,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "token-usage",
-                                        "token_usage"
-                                      ]
+                                      "enum": ["token-usage", "token_usage"]
                                     },
                                     "max_total": {
                                       "type": "number",
@@ -4514,9 +4042,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4553,10 +4079,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "execution-metrics",
-                                        "execution_metrics"
-                                      ]
+                                      "enum": ["execution-metrics", "execution_metrics"]
                                     },
                                     "max_tool_calls": {
                                       "type": "number",
@@ -4588,9 +4111,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4633,10 +4154,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4679,10 +4197,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4719,15 +4234,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "is-json",
-                                        "is_json"
-                                      ]
+                                      "enum": ["is-json", "is_json"]
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4770,10 +4280,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4831,10 +4338,7 @@
                                               },
                                               "operator": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "correctness",
-                                                  "contradiction"
-                                                ]
+                                                "enum": ["correctness", "contradiction"]
                                               },
                                               "weight": {
                                                 "type": "number"
@@ -4875,10 +4379,7 @@
                                                       "minLength": 1
                                                     }
                                                   },
-                                                  "required": [
-                                                    "score_range",
-                                                    "outcome"
-                                                  ],
+                                                  "required": ["score_range", "outcome"],
                                                   "additionalProperties": false
                                                 }
                                               }
@@ -4890,10 +4391,7 @@
                                       "minItems": 1
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "criteria"
-                                  ],
+                                  "required": ["type", "criteria"],
                                   "additionalProperties": false
                                 }
                               ]
@@ -4937,10 +4435,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "code-grader",
-                                        "code_grader"
-                                      ]
+                                      "enum": ["code-grader", "code_grader"]
                                     },
                                     "command": {
                                       "anyOf": [
@@ -5014,18 +4509,12 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "command"
-                                  ],
+                                  "required": ["type", "command"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5062,10 +4551,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "llm-grader",
-                                        "llm_grader"
-                                      ]
+                                      "enum": ["llm-grader", "llm_grader"]
                                     },
                                     "prompt": {
                                       "anyOf": [
@@ -5123,10 +4609,7 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
+                                            "enum": ["correctness", "contradiction"]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -5167,10 +4650,7 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
+                                              "required": ["score_range", "outcome"],
                                               "additionalProperties": false
                                             }
                                           }
@@ -5221,17 +4701,12 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5242,9 +4717,7 @@
                                       "minLength": 1
                                     }
                                   },
-                                  "required": [
-                                    "include"
-                                  ],
+                                  "required": ["include"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5307,9 +4780,7 @@
                                               }
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
+                                          "required": ["type"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -5325,10 +4796,7 @@
                                               "maximum": 1
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "threshold"
-                                          ],
+                                          "required": ["type", "threshold"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -5345,10 +4813,7 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "path"
-                                          ],
+                                          "required": ["type", "path"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -5365,18 +4830,13 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
+                                          "required": ["type"],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "aggregator"
-                                  ],
+                                  "required": ["type", "aggregator"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5413,10 +4873,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "tool-trajectory",
-                                        "tool_trajectory"
-                                      ]
+                                      "enum": ["tool-trajectory", "tool_trajectory"]
                                     },
                                     "mode": {
                                       "type": "string",
@@ -5467,12 +4924,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -5486,12 +4938,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -5502,9 +4949,7 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "tool"
-                                        ],
+                                        "required": ["tool"],
                                         "additionalProperties": false
                                       }
                                     },
@@ -5512,12 +4957,7 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
+                                          "enum": ["exact", "ignore", "subset", "superset"]
                                         },
                                         {
                                           "type": "array",
@@ -5531,12 +4971,7 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
+                                          "enum": ["exact", "ignore", "subset", "superset"]
                                         },
                                         {
                                           "type": "array",
@@ -5547,10 +4982,7 @@
                                       ]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "mode"
-                                  ],
+                                  "required": ["type", "mode"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5587,10 +5019,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "field-accuracy",
-                                        "field_accuracy"
-                                      ]
+                                      "enum": ["field-accuracy", "field_accuracy"]
                                     },
                                     "fields": {
                                       "type": "array",
@@ -5602,11 +5031,7 @@
                                           },
                                           "match": {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "numeric_tolerance",
-                                              "date"
-                                            ]
+                                            "enum": ["exact", "numeric_tolerance", "date"]
                                           },
                                           "required": {
                                             "type": "boolean"
@@ -5628,26 +5053,17 @@
                                             }
                                           }
                                         },
-                                        "required": [
-                                          "path",
-                                          "match"
-                                        ],
+                                        "required": ["path", "match"],
                                         "additionalProperties": false
                                       },
                                       "minItems": 1
                                     },
                                     "aggregation": {
                                       "type": "string",
-                                      "enum": [
-                                        "weighted_average",
-                                        "all_or_nothing"
-                                      ]
+                                      "enum": ["weighted_average", "all_or_nothing"]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "fields"
-                                  ],
+                                  "required": ["type", "fields"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5691,10 +5107,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "threshold"
-                                  ],
+                                  "required": ["type", "threshold"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5738,10 +5151,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "budget"
-                                  ],
+                                  "required": ["type", "budget"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5778,10 +5188,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "token-usage",
-                                        "token_usage"
-                                      ]
+                                      "enum": ["token-usage", "token_usage"]
                                     },
                                     "max_total": {
                                       "type": "number",
@@ -5796,9 +5203,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5835,10 +5240,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "execution-metrics",
-                                        "execution_metrics"
-                                      ]
+                                      "enum": ["execution-metrics", "execution_metrics"]
                                     },
                                     "max_tool_calls": {
                                       "type": "number",
@@ -5870,9 +5272,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5915,10 +5315,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5961,10 +5358,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -6001,15 +5395,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "is-json",
-                                        "is_json"
-                                      ]
+                                      "enum": ["is-json", "is_json"]
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -6052,10 +5441,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -6113,10 +5499,7 @@
                                               },
                                               "operator": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "correctness",
-                                                  "contradiction"
-                                                ]
+                                                "enum": ["correctness", "contradiction"]
                                               },
                                               "weight": {
                                                 "type": "number"
@@ -6157,10 +5540,7 @@
                                                       "minLength": 1
                                                     }
                                                   },
-                                                  "required": [
-                                                    "score_range",
-                                                    "outcome"
-                                                  ],
+                                                  "required": ["score_range", "outcome"],
                                                   "additionalProperties": false
                                                 }
                                               }
@@ -6172,10 +5552,7 @@
                                       "minItems": 1
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "criteria"
-                                  ],
+                                  "required": ["type", "criteria"],
                                   "additionalProperties": false
                                 }
                               ]
@@ -6232,12 +5609,7 @@
                               },
                               "strategy": {
                                 "type": "string",
-                                "enum": [
-                                  "pass_at_k",
-                                  "pass_all",
-                                  "mean",
-                                  "confidence_interval"
-                                ]
+                                "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
                               },
                               "cost_limit_usd": {
                                 "type": "number",
@@ -6248,9 +5620,7 @@
                                 "minimum": 0
                               }
                             },
-                            "required": [
-                              "count"
-                            ],
+                            "required": ["count"],
                             "additionalProperties": false
                           },
                           "timeout_seconds": {
@@ -6274,10 +5644,7 @@
                           },
                           "isolation": {
                             "type": "string",
-                            "enum": [
-                              "shared",
-                              "per_case"
-                            ]
+                            "enum": ["shared", "per_case"]
                           },
                           "repos": {
                             "type": "array",
@@ -6359,11 +5726,7 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": [
-                                      "none",
-                                      "fast",
-                                      "strict"
-                                    ]
+                                    "enum": ["none", "fast", "strict"]
                                   }
                                 },
                                 "additionalProperties": false
@@ -6408,11 +5771,7 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": [
-                                      "none",
-                                      "fast",
-                                      "strict"
-                                    ]
+                                    "enum": ["none", "fast", "strict"]
                                   }
                                 },
                                 "additionalProperties": false
@@ -6457,11 +5816,7 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": [
-                                      "none",
-                                      "fast",
-                                      "strict"
-                                    ]
+                                    "enum": ["none", "fast", "strict"]
                                   }
                                 },
                                 "additionalProperties": false
@@ -6506,11 +5861,7 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": [
-                                      "none",
-                                      "fast",
-                                      "strict"
-                                    ]
+                                    "enum": ["none", "fast", "strict"]
                                   }
                                 },
                                 "additionalProperties": false
@@ -6536,9 +5887,7 @@
                                 "minimum": 0.1
                               }
                             },
-                            "required": [
-                              "image"
-                            ],
+                            "required": ["image"],
                             "additionalProperties": false
                           },
                           "env": {
@@ -6582,17 +5931,11 @@
                       },
                       "on_dependency_failure": {
                         "type": "string",
-                        "enum": [
-                          "skip",
-                          "fail",
-                          "run"
-                        ]
+                        "enum": ["skip", "fail", "run"]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": [
-                          "conversation"
-                        ]
+                        "enum": ["conversation"]
                       },
                       "turns": {
                         "type": "array",
@@ -6621,20 +5964,13 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "text",
-                                              "file",
-                                              "image"
-                                            ]
+                                            "enum": ["text", "file", "image"]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       }
                                     }
@@ -6664,20 +6000,13 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "text",
-                                              "file",
-                                              "image"
-                                            ]
+                                            "enum": ["text", "file", "image"]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       }
                                     }
@@ -6728,10 +6057,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "code-grader",
-                                              "code_grader"
-                                            ]
+                                            "enum": ["code-grader", "code_grader"]
                                           },
                                           "command": {
                                             "anyOf": [
@@ -6805,18 +6131,12 @@
                                                   ]
                                                 }
                                               },
-                                              "required": [
-                                                "type",
-                                                "command"
-                                              ],
+                                              "required": ["type", "command"],
                                               "additionalProperties": false
                                             }
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6853,10 +6173,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "llm-grader",
-                                              "llm_grader"
-                                            ]
+                                            "enum": ["llm-grader", "llm_grader"]
                                           },
                                           "prompt": {
                                             "anyOf": [
@@ -6914,10 +6231,7 @@
                                                 },
                                                 "operator": {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "correctness",
-                                                    "contradiction"
-                                                  ]
+                                                  "enum": ["correctness", "contradiction"]
                                                 },
                                                 "weight": {
                                                   "type": "number"
@@ -6958,10 +6272,7 @@
                                                         "minLength": 1
                                                       }
                                                     },
-                                                    "required": [
-                                                      "score_range",
-                                                      "outcome"
-                                                    ],
+                                                    "required": ["score_range", "outcome"],
                                                     "additionalProperties": false
                                                   }
                                                 }
@@ -7012,17 +6323,12 @@
                                                   ]
                                                 }
                                               },
-                                              "required": [
-                                                "type",
-                                                "command"
-                                              ],
+                                              "required": ["type", "command"],
                                               "additionalProperties": false
                                             }
                                           }
                                         },
-                                        "required": [
-                                          "type"
-                                        ],
+                                        "required": ["type"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -7033,9 +6339,7 @@
                                             "minLength": 1
                                           }
                                         },
-                                        "required": [
-                                          "include"
-                                        ],
+                                        "required": ["include"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -7098,9 +6402,7 @@
                                                     }
                                                   }
                                                 },
-                                                "required": [
-                                                  "type"
-                                                ],
+                                                "required": ["type"],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -7116,10 +6418,7 @@
                                                     "maximum": 1
                                                   }
                                                 },
-                                                "required": [
-                                                  "type",
-                                                  "threshold"
-                                                ],
+                                                "required": ["type", "threshold"],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -7136,10 +6435,7 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": [
-                                                  "type",
-                                                  "path"
-                                                ],
+                                                "required": ["type", "path"],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -7156,18 +6452,13 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": [
-                                                  "type"
-                                                ],
+                                                "required": ["type"],
                                                 "additionalProperties": false
                                               }
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "aggregator"
-                                        ],
+                                        "required": ["type", "aggregator"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -7204,10 +6495,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "tool-trajectory",
-                                              "tool_trajectory"
-                                            ]
+                                            "enum": ["tool-trajectory", "tool_trajectory"]
                                           },
                                           "mode": {
                                             "type": "string",
@@ -7293,9 +6581,7 @@
                                                   ]
                                                 }
                                               },
-                                              "required": [
-                                                "tool"
-                                              ],
+                                              "required": ["tool"],
                                               "additionalProperties": false
                                             }
                                           },
@@ -7303,12 +6589,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -7322,12 +6603,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -7338,10 +6614,7 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "mode"
-                                        ],
+                                        "required": ["type", "mode"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -7378,10 +6651,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "field-accuracy",
-                                              "field_accuracy"
-                                            ]
+                                            "enum": ["field-accuracy", "field_accuracy"]
                                           },
                                           "fields": {
                                             "type": "array",
@@ -7393,11 +6663,7 @@
                                                 },
                                                 "match": {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "exact",
-                                                    "numeric_tolerance",
-                                                    "date"
-                                                  ]
+                                                  "enum": ["exact", "numeric_tolerance", "date"]
                                                 },
                                                 "required": {
                                                   "type": "boolean"
@@ -7419,26 +6685,17 @@
                                                   }
                                                 }
                                               },
-                                              "required": [
-                                                "path",
-                                                "match"
-                                              ],
+                                              "required": ["path", "match"],
                                               "additionalProperties": false
                                             },
                                             "minItems": 1
                                           },
                                           "aggregation": {
                                             "type": "string",
-                                            "enum": [
-                                              "weighted_average",
-                                              "all_or_nothing"
-                                            ]
+                                            "enum": ["weighted_average", "all_or_nothing"]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "fields"
-                                        ],
+                                        "required": ["type", "fields"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -7482,10 +6739,7 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "threshold"
-                                        ],
+                                        "required": ["type", "threshold"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -7529,10 +6783,7 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "budget"
-                                        ],
+                                        "required": ["type", "budget"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -7569,10 +6820,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "token-usage",
-                                              "token_usage"
-                                            ]
+                                            "enum": ["token-usage", "token_usage"]
                                           },
                                           "max_total": {
                                             "type": "number",
@@ -7587,9 +6835,7 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": [
-                                          "type"
-                                        ],
+                                        "required": ["type"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -7626,10 +6872,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "execution-metrics",
-                                              "execution_metrics"
-                                            ]
+                                            "enum": ["execution-metrics", "execution_metrics"]
                                           },
                                           "max_tool_calls": {
                                             "type": "number",
@@ -7661,9 +6904,7 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": [
-                                          "type"
-                                        ],
+                                        "required": ["type"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -7706,10 +6947,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -7752,10 +6990,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -7792,15 +7027,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "is-json",
-                                              "is_json"
-                                            ]
+                                            "enum": ["is-json", "is_json"]
                                           }
                                         },
-                                        "required": [
-                                          "type"
-                                        ],
+                                        "required": ["type"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -7843,10 +7073,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -7904,10 +7131,7 @@
                                                     },
                                                     "operator": {
                                                       "type": "string",
-                                                      "enum": [
-                                                        "correctness",
-                                                        "contradiction"
-                                                      ]
+                                                      "enum": ["correctness", "contradiction"]
                                                     },
                                                     "weight": {
                                                       "type": "number"
@@ -7948,10 +7172,7 @@
                                                             "minLength": 1
                                                           }
                                                         },
-                                                        "required": [
-                                                          "score_range",
-                                                          "outcome"
-                                                        ],
+                                                        "required": ["score_range", "outcome"],
                                                         "additionalProperties": false
                                                       }
                                                     }
@@ -7963,10 +7184,7 @@
                                             "minItems": 1
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "criteria"
-                                        ],
+                                        "required": ["type", "criteria"],
                                         "additionalProperties": false
                                       }
                                     ]
@@ -7975,36 +7193,25 @@
                               }
                             }
                           },
-                          "required": [
-                            "input"
-                          ],
+                          "required": ["input"],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": [
-                          "mean",
-                          "min",
-                          "max"
-                        ]
+                        "enum": ["mean", "min", "max"]
                       },
                       "on_turn_failure": {
                         "type": "string",
-                        "enum": [
-                          "continue",
-                          "stop"
-                        ]
+                        "enum": ["continue", "stop"]
                       },
                       "window_size": {
                         "type": "integer",
                         "minimum": 1
                       }
                     },
-                    "required": [
-                      "id"
-                    ],
+                    "required": ["id"],
                     "additionalProperties": false
                   },
                   {
@@ -8016,10 +7223,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "suite",
-                          "tests"
-                        ]
+                        "enum": ["suite", "tests"]
                       },
                       "select": {
                         "anyOf": [
@@ -8090,11 +7294,7 @@
                                     {
                                       "type": "array",
                                       "items": {
-                                        "type": [
-                                          "string",
-                                          "number",
-                                          "boolean"
-                                        ]
+                                        "type": ["string", "number", "boolean"]
                                       },
                                       "minItems": 1
                                     }
@@ -8123,12 +7323,7 @@
                               },
                               "strategy": {
                                 "type": "string",
-                                "enum": [
-                                  "pass_at_k",
-                                  "pass_all",
-                                  "mean",
-                                  "confidence_interval"
-                                ]
+                                "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
                               },
                               "cost_limit_usd": {
                                 "type": "number",
@@ -8139,9 +7334,7 @@
                                 "minimum": 0
                               }
                             },
-                            "required": [
-                              "count"
-                            ],
+                            "required": ["count"],
                             "additionalProperties": false
                           },
                           "timeout_seconds": {
@@ -8158,10 +7351,7 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": [
-                      "include",
-                      "type"
-                    ],
+                    "required": ["include", "type"],
                     "additionalProperties": false
                   },
                   {
@@ -8208,12 +7398,7 @@
                             "properties": {
                               "role": {
                                 "type": "string",
-                                "enum": [
-                                  "system",
-                                  "user",
-                                  "assistant",
-                                  "tool"
-                                ]
+                                "enum": ["system", "user", "assistant", "tool"]
                               },
                               "content": {
                                 "anyOf": [
@@ -8232,30 +7417,20 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "text",
-                                            "file",
-                                            "image"
-                                          ]
+                                          "enum": ["text", "file", "image"]
                                         },
                                         "value": {
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "value"
-                                      ],
+                                      "required": ["type", "value"],
                                       "additionalProperties": false
                                     }
                                   }
                                 ]
                               }
                             },
-                            "required": [
-                              "role",
-                              "content"
-                            ],
+                            "required": ["role", "content"],
                             "additionalProperties": false
                           },
                           {
@@ -8274,12 +7449,7 @@
                               "properties": {
                                 "role": {
                                   "type": "string",
-                                  "enum": [
-                                    "system",
-                                    "user",
-                                    "assistant",
-                                    "tool"
-                                  ]
+                                  "enum": ["system", "user", "assistant", "tool"]
                                 },
                                 "content": {
                                   "anyOf": [
@@ -8298,30 +7468,20 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "text",
-                                              "file",
-                                              "image"
-                                            ]
+                                            "enum": ["text", "file", "image"]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       }
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "role",
-                                "content"
-                              ],
+                              "required": ["role", "content"],
                               "additionalProperties": false
                             }
                           }
@@ -8350,12 +7510,7 @@
                               "properties": {
                                 "role": {
                                   "type": "string",
-                                  "enum": [
-                                    "system",
-                                    "user",
-                                    "assistant",
-                                    "tool"
-                                  ]
+                                  "enum": ["system", "user", "assistant", "tool"]
                                 },
                                 "content": {
                                   "anyOf": [
@@ -8374,30 +7529,20 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "text",
-                                              "file",
-                                              "image"
-                                            ]
+                                            "enum": ["text", "file", "image"]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       }
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "role",
-                                "content"
-                              ],
+                              "required": ["role", "content"],
                               "additionalProperties": false
                             }
                           }
@@ -8441,10 +7586,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "code-grader",
-                                    "code_grader"
-                                  ]
+                                  "enum": ["code-grader", "code_grader"]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -8518,18 +7660,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type",
-                                "command"
-                              ],
+                              "required": ["type", "command"],
                               "additionalProperties": false
                             },
                             {
@@ -8566,10 +7702,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "llm-grader",
-                                    "llm_grader"
-                                  ]
+                                  "enum": ["llm-grader", "llm_grader"]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -8627,10 +7760,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -8671,10 +7801,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -8725,17 +7852,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -8746,9 +7868,7 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": [
-                                "include"
-                              ],
+                              "required": ["include"],
                               "additionalProperties": false
                             },
                             {
@@ -8811,9 +7931,7 @@
                                           }
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -8829,10 +7947,7 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "threshold"
-                                      ],
+                                      "required": ["type", "threshold"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -8849,10 +7964,7 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "path"
-                                      ],
+                                      "required": ["type", "path"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -8869,18 +7981,13 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "aggregator"
-                              ],
+                              "required": ["type", "aggregator"],
                               "additionalProperties": false
                             },
                             {
@@ -8917,20 +8024,11 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "tool-trajectory",
-                                    "tool_trajectory"
-                                  ]
+                                  "enum": ["tool-trajectory", "tool_trajectory"]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": [
-                                    "any_order",
-                                    "in_order",
-                                    "exact",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -8971,12 +8069,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -8990,12 +8083,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -9006,9 +8094,7 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "tool"
-                                    ],
+                                    "required": ["tool"],
                                     "additionalProperties": false
                                   }
                                 },
@@ -9016,12 +8102,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -9035,12 +8116,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -9051,10 +8127,7 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "mode"
-                              ],
+                              "required": ["type", "mode"],
                               "additionalProperties": false
                             },
                             {
@@ -9091,10 +8164,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "field-accuracy",
-                                    "field_accuracy"
-                                  ]
+                                  "enum": ["field-accuracy", "field_accuracy"]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -9106,11 +8176,7 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "numeric_tolerance",
-                                          "date"
-                                        ]
+                                        "enum": ["exact", "numeric_tolerance", "date"]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -9132,26 +8198,17 @@
                                         }
                                       }
                                     },
-                                    "required": [
-                                      "path",
-                                      "match"
-                                    ],
+                                    "required": ["path", "match"],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": [
-                                    "weighted_average",
-                                    "all_or_nothing"
-                                  ]
+                                  "enum": ["weighted_average", "all_or_nothing"]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "fields"
-                              ],
+                              "required": ["type", "fields"],
                               "additionalProperties": false
                             },
                             {
@@ -9195,10 +8252,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "threshold"
-                              ],
+                              "required": ["type", "threshold"],
                               "additionalProperties": false
                             },
                             {
@@ -9242,10 +8296,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "budget"
-                              ],
+                              "required": ["type", "budget"],
                               "additionalProperties": false
                             },
                             {
@@ -9282,10 +8333,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "token-usage",
-                                    "token_usage"
-                                  ]
+                                  "enum": ["token-usage", "token_usage"]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -9300,9 +8348,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -9339,10 +8385,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "execution-metrics",
-                                    "execution_metrics"
-                                  ]
+                                  "enum": ["execution-metrics", "execution_metrics"]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -9374,9 +8417,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -9419,10 +8460,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -9465,10 +8503,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -9505,15 +8540,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "is-json",
-                                    "is_json"
-                                  ]
+                                  "enum": ["is-json", "is_json"]
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -9556,10 +8586,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -9617,10 +8644,7 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
+                                            "enum": ["correctness", "contradiction"]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -9661,10 +8685,7 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
+                                              "required": ["score_range", "outcome"],
                                               "additionalProperties": false
                                             }
                                           }
@@ -9676,10 +8697,7 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": [
-                                "type",
-                                "criteria"
-                              ],
+                              "required": ["type", "criteria"],
                               "additionalProperties": false
                             }
                           ]
@@ -9723,10 +8741,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "code-grader",
-                                    "code_grader"
-                                  ]
+                                  "enum": ["code-grader", "code_grader"]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -9800,18 +8815,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type",
-                                "command"
-                              ],
+                              "required": ["type", "command"],
                               "additionalProperties": false
                             },
                             {
@@ -9848,10 +8857,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "llm-grader",
-                                    "llm_grader"
-                                  ]
+                                  "enum": ["llm-grader", "llm_grader"]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -9909,10 +8915,7 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": [
-                                          "correctness",
-                                          "contradiction"
-                                        ]
+                                        "enum": ["correctness", "contradiction"]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -9953,10 +8956,7 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": [
-                                            "score_range",
-                                            "outcome"
-                                          ],
+                                          "required": ["score_range", "outcome"],
                                           "additionalProperties": false
                                         }
                                       }
@@ -10007,17 +9007,12 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "type",
-                                      "command"
-                                    ],
+                                    "required": ["type", "command"],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -10028,9 +9023,7 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": [
-                                "include"
-                              ],
+                              "required": ["include"],
                               "additionalProperties": false
                             },
                             {
@@ -10093,9 +9086,7 @@
                                           }
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -10111,10 +9102,7 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "threshold"
-                                      ],
+                                      "required": ["type", "threshold"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -10131,10 +9119,7 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type",
-                                        "path"
-                                      ],
+                                      "required": ["type", "path"],
                                       "additionalProperties": false
                                     },
                                     {
@@ -10151,18 +9136,13 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "type"
-                                      ],
+                                      "required": ["type"],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "aggregator"
-                              ],
+                              "required": ["type", "aggregator"],
                               "additionalProperties": false
                             },
                             {
@@ -10199,20 +9179,11 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "tool-trajectory",
-                                    "tool_trajectory"
-                                  ]
+                                  "enum": ["tool-trajectory", "tool_trajectory"]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": [
-                                    "any_order",
-                                    "in_order",
-                                    "exact",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -10253,12 +9224,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -10272,12 +9238,7 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "ignore",
-                                              "subset",
-                                              "superset"
-                                            ]
+                                            "enum": ["exact", "ignore", "subset", "superset"]
                                           },
                                           {
                                             "type": "array",
@@ -10288,9 +9249,7 @@
                                         ]
                                       }
                                     },
-                                    "required": [
-                                      "tool"
-                                    ],
+                                    "required": ["tool"],
                                     "additionalProperties": false
                                   }
                                 },
@@ -10298,12 +9257,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -10317,12 +9271,7 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "exact",
-                                        "ignore",
-                                        "subset",
-                                        "superset"
-                                      ]
+                                      "enum": ["exact", "ignore", "subset", "superset"]
                                     },
                                     {
                                       "type": "array",
@@ -10333,10 +9282,7 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "mode"
-                              ],
+                              "required": ["type", "mode"],
                               "additionalProperties": false
                             },
                             {
@@ -10373,10 +9319,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "field-accuracy",
-                                    "field_accuracy"
-                                  ]
+                                  "enum": ["field-accuracy", "field_accuracy"]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -10388,11 +9331,7 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": [
-                                          "exact",
-                                          "numeric_tolerance",
-                                          "date"
-                                        ]
+                                        "enum": ["exact", "numeric_tolerance", "date"]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -10414,26 +9353,17 @@
                                         }
                                       }
                                     },
-                                    "required": [
-                                      "path",
-                                      "match"
-                                    ],
+                                    "required": ["path", "match"],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": [
-                                    "weighted_average",
-                                    "all_or_nothing"
-                                  ]
+                                  "enum": ["weighted_average", "all_or_nothing"]
                                 }
                               },
-                              "required": [
-                                "type",
-                                "fields"
-                              ],
+                              "required": ["type", "fields"],
                               "additionalProperties": false
                             },
                             {
@@ -10477,10 +9407,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "threshold"
-                              ],
+                              "required": ["type", "threshold"],
                               "additionalProperties": false
                             },
                             {
@@ -10524,10 +9451,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type",
-                                "budget"
-                              ],
+                              "required": ["type", "budget"],
                               "additionalProperties": false
                             },
                             {
@@ -10564,10 +9488,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "token-usage",
-                                    "token_usage"
-                                  ]
+                                  "enum": ["token-usage", "token_usage"]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -10582,9 +9503,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -10621,10 +9540,7 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "execution-metrics",
-                                    "execution_metrics"
-                                  ]
+                                  "enum": ["execution-metrics", "execution_metrics"]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -10656,9 +9572,7 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -10701,10 +9615,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -10747,10 +9658,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -10787,15 +9695,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "is-json",
-                                    "is_json"
-                                  ]
+                                  "enum": ["is-json", "is_json"]
                                 }
                               },
-                              "required": [
-                                "type"
-                              ],
+                              "required": ["type"],
                               "additionalProperties": false
                             },
                             {
@@ -10838,10 +9741,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "type",
-                                "value"
-                              ],
+                              "required": ["type", "value"],
                               "additionalProperties": false
                             },
                             {
@@ -10899,10 +9799,7 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
+                                            "enum": ["correctness", "contradiction"]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -10943,10 +9840,7 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
+                                              "required": ["score_range", "outcome"],
                                               "additionalProperties": false
                                             }
                                           }
@@ -10958,10 +9852,7 @@
                                   "minItems": 1
                                 }
                               },
-                              "required": [
-                                "type",
-                                "criteria"
-                              ],
+                              "required": ["type", "criteria"],
                               "additionalProperties": false
                             }
                           ]
@@ -11013,10 +9904,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "code-grader",
-                                        "code_grader"
-                                      ]
+                                      "enum": ["code-grader", "code_grader"]
                                     },
                                     "command": {
                                       "anyOf": [
@@ -11090,18 +9978,12 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "command"
-                                  ],
+                                  "required": ["type", "command"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11138,10 +10020,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "llm-grader",
-                                        "llm_grader"
-                                      ]
+                                      "enum": ["llm-grader", "llm_grader"]
                                     },
                                     "prompt": {
                                       "anyOf": [
@@ -11199,10 +10078,7 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
+                                            "enum": ["correctness", "contradiction"]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -11243,10 +10119,7 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
+                                              "required": ["score_range", "outcome"],
                                               "additionalProperties": false
                                             }
                                           }
@@ -11297,17 +10170,12 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11318,9 +10186,7 @@
                                       "minLength": 1
                                     }
                                   },
-                                  "required": [
-                                    "include"
-                                  ],
+                                  "required": ["include"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11383,9 +10249,7 @@
                                               }
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
+                                          "required": ["type"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -11401,10 +10265,7 @@
                                               "maximum": 1
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "threshold"
-                                          ],
+                                          "required": ["type", "threshold"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -11421,10 +10282,7 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "path"
-                                          ],
+                                          "required": ["type", "path"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -11441,18 +10299,13 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
+                                          "required": ["type"],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "aggregator"
-                                  ],
+                                  "required": ["type", "aggregator"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11489,10 +10342,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "tool-trajectory",
-                                        "tool_trajectory"
-                                      ]
+                                      "enum": ["tool-trajectory", "tool_trajectory"]
                                     },
                                     "mode": {
                                       "type": "string",
@@ -11543,12 +10393,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -11562,12 +10407,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -11578,9 +10418,7 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "tool"
-                                        ],
+                                        "required": ["tool"],
                                         "additionalProperties": false
                                       }
                                     },
@@ -11588,12 +10426,7 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
+                                          "enum": ["exact", "ignore", "subset", "superset"]
                                         },
                                         {
                                           "type": "array",
@@ -11607,12 +10440,7 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
+                                          "enum": ["exact", "ignore", "subset", "superset"]
                                         },
                                         {
                                           "type": "array",
@@ -11623,10 +10451,7 @@
                                       ]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "mode"
-                                  ],
+                                  "required": ["type", "mode"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11663,10 +10488,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "field-accuracy",
-                                        "field_accuracy"
-                                      ]
+                                      "enum": ["field-accuracy", "field_accuracy"]
                                     },
                                     "fields": {
                                       "type": "array",
@@ -11678,11 +10500,7 @@
                                           },
                                           "match": {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "numeric_tolerance",
-                                              "date"
-                                            ]
+                                            "enum": ["exact", "numeric_tolerance", "date"]
                                           },
                                           "required": {
                                             "type": "boolean"
@@ -11704,26 +10522,17 @@
                                             }
                                           }
                                         },
-                                        "required": [
-                                          "path",
-                                          "match"
-                                        ],
+                                        "required": ["path", "match"],
                                         "additionalProperties": false
                                       },
                                       "minItems": 1
                                     },
                                     "aggregation": {
                                       "type": "string",
-                                      "enum": [
-                                        "weighted_average",
-                                        "all_or_nothing"
-                                      ]
+                                      "enum": ["weighted_average", "all_or_nothing"]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "fields"
-                                  ],
+                                  "required": ["type", "fields"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11767,10 +10576,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "threshold"
-                                  ],
+                                  "required": ["type", "threshold"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11814,10 +10620,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "budget"
-                                  ],
+                                  "required": ["type", "budget"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11854,10 +10657,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "token-usage",
-                                        "token_usage"
-                                      ]
+                                      "enum": ["token-usage", "token_usage"]
                                     },
                                     "max_total": {
                                       "type": "number",
@@ -11872,9 +10672,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11911,10 +10709,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "execution-metrics",
-                                        "execution_metrics"
-                                      ]
+                                      "enum": ["execution-metrics", "execution_metrics"]
                                     },
                                     "max_tool_calls": {
                                       "type": "number",
@@ -11946,9 +10741,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11991,10 +10784,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -12037,10 +10827,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -12077,15 +10864,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "is-json",
-                                        "is_json"
-                                      ]
+                                      "enum": ["is-json", "is_json"]
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -12128,10 +10910,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -12189,10 +10968,7 @@
                                               },
                                               "operator": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "correctness",
-                                                  "contradiction"
-                                                ]
+                                                "enum": ["correctness", "contradiction"]
                                               },
                                               "weight": {
                                                 "type": "number"
@@ -12233,10 +11009,7 @@
                                                       "minLength": 1
                                                     }
                                                   },
-                                                  "required": [
-                                                    "score_range",
-                                                    "outcome"
-                                                  ],
+                                                  "required": ["score_range", "outcome"],
                                                   "additionalProperties": false
                                                 }
                                               }
@@ -12248,10 +11021,7 @@
                                       "minItems": 1
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "criteria"
-                                  ],
+                                  "required": ["type", "criteria"],
                                   "additionalProperties": false
                                 }
                               ]
@@ -12295,10 +11065,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "code-grader",
-                                        "code_grader"
-                                      ]
+                                      "enum": ["code-grader", "code_grader"]
                                     },
                                     "command": {
                                       "anyOf": [
@@ -12372,18 +11139,12 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "command"
-                                  ],
+                                  "required": ["type", "command"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -12420,10 +11181,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "llm-grader",
-                                        "llm_grader"
-                                      ]
+                                      "enum": ["llm-grader", "llm_grader"]
                                     },
                                     "prompt": {
                                       "anyOf": [
@@ -12481,10 +11239,7 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": [
-                                              "correctness",
-                                              "contradiction"
-                                            ]
+                                            "enum": ["correctness", "contradiction"]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -12525,10 +11280,7 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": [
-                                                "score_range",
-                                                "outcome"
-                                              ],
+                                              "required": ["score_range", "outcome"],
                                               "additionalProperties": false
                                             }
                                           }
@@ -12579,17 +11331,12 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -12600,9 +11347,7 @@
                                       "minLength": 1
                                     }
                                   },
-                                  "required": [
-                                    "include"
-                                  ],
+                                  "required": ["include"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -12665,9 +11410,7 @@
                                               }
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
+                                          "required": ["type"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -12683,10 +11426,7 @@
                                               "maximum": 1
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "threshold"
-                                          ],
+                                          "required": ["type", "threshold"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -12703,10 +11443,7 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type",
-                                            "path"
-                                          ],
+                                          "required": ["type", "path"],
                                           "additionalProperties": false
                                         },
                                         {
@@ -12723,18 +11460,13 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "type"
-                                          ],
+                                          "required": ["type"],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "aggregator"
-                                  ],
+                                  "required": ["type", "aggregator"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -12771,10 +11503,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "tool-trajectory",
-                                        "tool_trajectory"
-                                      ]
+                                      "enum": ["tool-trajectory", "tool_trajectory"]
                                     },
                                     "mode": {
                                       "type": "string",
@@ -12825,12 +11554,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -12844,12 +11568,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -12860,9 +11579,7 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "tool"
-                                        ],
+                                        "required": ["tool"],
                                         "additionalProperties": false
                                       }
                                     },
@@ -12870,12 +11587,7 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
+                                          "enum": ["exact", "ignore", "subset", "superset"]
                                         },
                                         {
                                           "type": "array",
@@ -12889,12 +11601,7 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": [
-                                            "exact",
-                                            "ignore",
-                                            "subset",
-                                            "superset"
-                                          ]
+                                          "enum": ["exact", "ignore", "subset", "superset"]
                                         },
                                         {
                                           "type": "array",
@@ -12905,10 +11612,7 @@
                                       ]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "mode"
-                                  ],
+                                  "required": ["type", "mode"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -12945,10 +11649,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "field-accuracy",
-                                        "field_accuracy"
-                                      ]
+                                      "enum": ["field-accuracy", "field_accuracy"]
                                     },
                                     "fields": {
                                       "type": "array",
@@ -12960,11 +11661,7 @@
                                           },
                                           "match": {
                                             "type": "string",
-                                            "enum": [
-                                              "exact",
-                                              "numeric_tolerance",
-                                              "date"
-                                            ]
+                                            "enum": ["exact", "numeric_tolerance", "date"]
                                           },
                                           "required": {
                                             "type": "boolean"
@@ -12986,26 +11683,17 @@
                                             }
                                           }
                                         },
-                                        "required": [
-                                          "path",
-                                          "match"
-                                        ],
+                                        "required": ["path", "match"],
                                         "additionalProperties": false
                                       },
                                       "minItems": 1
                                     },
                                     "aggregation": {
                                       "type": "string",
-                                      "enum": [
-                                        "weighted_average",
-                                        "all_or_nothing"
-                                      ]
+                                      "enum": ["weighted_average", "all_or_nothing"]
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "fields"
-                                  ],
+                                  "required": ["type", "fields"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -13049,10 +11737,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "threshold"
-                                  ],
+                                  "required": ["type", "threshold"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -13096,10 +11781,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "budget"
-                                  ],
+                                  "required": ["type", "budget"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -13136,10 +11818,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "token-usage",
-                                        "token_usage"
-                                      ]
+                                      "enum": ["token-usage", "token_usage"]
                                     },
                                     "max_total": {
                                       "type": "number",
@@ -13154,9 +11833,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -13193,10 +11870,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "execution-metrics",
-                                        "execution_metrics"
-                                      ]
+                                      "enum": ["execution-metrics", "execution_metrics"]
                                     },
                                     "max_tool_calls": {
                                       "type": "number",
@@ -13228,9 +11902,7 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -13273,10 +11945,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -13319,10 +11988,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -13359,15 +12025,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "is-json",
-                                        "is_json"
-                                      ]
+                                      "enum": ["is-json", "is_json"]
                                     }
                                   },
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -13410,10 +12071,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "value"
-                                  ],
+                                  "required": ["type", "value"],
                                   "additionalProperties": false
                                 },
                                 {
@@ -13471,10 +12129,7 @@
                                               },
                                               "operator": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "correctness",
-                                                  "contradiction"
-                                                ]
+                                                "enum": ["correctness", "contradiction"]
                                               },
                                               "weight": {
                                                 "type": "number"
@@ -13515,10 +12170,7 @@
                                                       "minLength": 1
                                                     }
                                                   },
-                                                  "required": [
-                                                    "score_range",
-                                                    "outcome"
-                                                  ],
+                                                  "required": ["score_range", "outcome"],
                                                   "additionalProperties": false
                                                 }
                                               }
@@ -13530,10 +12182,7 @@
                                       "minItems": 1
                                     }
                                   },
-                                  "required": [
-                                    "type",
-                                    "criteria"
-                                  ],
+                                  "required": ["type", "criteria"],
                                   "additionalProperties": false
                                 }
                               ]
@@ -13590,12 +12239,7 @@
                               },
                               "strategy": {
                                 "type": "string",
-                                "enum": [
-                                  "pass_at_k",
-                                  "pass_all",
-                                  "mean",
-                                  "confidence_interval"
-                                ]
+                                "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
                               },
                               "cost_limit_usd": {
                                 "type": "number",
@@ -13606,9 +12250,7 @@
                                 "minimum": 0
                               }
                             },
-                            "required": [
-                              "count"
-                            ],
+                            "required": ["count"],
                             "additionalProperties": false
                           },
                           "timeout_seconds": {
@@ -13632,10 +12274,7 @@
                           },
                           "isolation": {
                             "type": "string",
-                            "enum": [
-                              "shared",
-                              "per_case"
-                            ]
+                            "enum": ["shared", "per_case"]
                           },
                           "repos": {
                             "type": "array",
@@ -13717,11 +12356,7 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": [
-                                      "none",
-                                      "fast",
-                                      "strict"
-                                    ]
+                                    "enum": ["none", "fast", "strict"]
                                   }
                                 },
                                 "additionalProperties": false
@@ -13766,11 +12401,7 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": [
-                                      "none",
-                                      "fast",
-                                      "strict"
-                                    ]
+                                    "enum": ["none", "fast", "strict"]
                                   }
                                 },
                                 "additionalProperties": false
@@ -13815,11 +12446,7 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": [
-                                      "none",
-                                      "fast",
-                                      "strict"
-                                    ]
+                                    "enum": ["none", "fast", "strict"]
                                   }
                                 },
                                 "additionalProperties": false
@@ -13864,11 +12491,7 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": [
-                                      "none",
-                                      "fast",
-                                      "strict"
-                                    ]
+                                    "enum": ["none", "fast", "strict"]
                                   }
                                 },
                                 "additionalProperties": false
@@ -13894,9 +12517,7 @@
                                 "minimum": 0.1
                               }
                             },
-                            "required": [
-                              "image"
-                            ],
+                            "required": ["image"],
                             "additionalProperties": false
                           },
                           "env": {
@@ -13940,17 +12561,11 @@
                       },
                       "on_dependency_failure": {
                         "type": "string",
-                        "enum": [
-                          "skip",
-                          "fail",
-                          "run"
-                        ]
+                        "enum": ["skip", "fail", "run"]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": [
-                          "conversation"
-                        ]
+                        "enum": ["conversation"]
                       },
                       "turns": {
                         "type": "array",
@@ -13979,20 +12594,13 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "text",
-                                              "file",
-                                              "image"
-                                            ]
+                                            "enum": ["text", "file", "image"]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       }
                                     }
@@ -14022,20 +12630,13 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "text",
-                                              "file",
-                                              "image"
-                                            ]
+                                            "enum": ["text", "file", "image"]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       }
                                     }
@@ -14086,10 +12687,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "code-grader",
-                                              "code_grader"
-                                            ]
+                                            "enum": ["code-grader", "code_grader"]
                                           },
                                           "command": {
                                             "anyOf": [
@@ -14163,18 +12761,12 @@
                                                   ]
                                                 }
                                               },
-                                              "required": [
-                                                "type",
-                                                "command"
-                                              ],
+                                              "required": ["type", "command"],
                                               "additionalProperties": false
                                             }
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "command"
-                                        ],
+                                        "required": ["type", "command"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -14211,10 +12803,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "llm-grader",
-                                              "llm_grader"
-                                            ]
+                                            "enum": ["llm-grader", "llm_grader"]
                                           },
                                           "prompt": {
                                             "anyOf": [
@@ -14272,10 +12861,7 @@
                                                 },
                                                 "operator": {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "correctness",
-                                                    "contradiction"
-                                                  ]
+                                                  "enum": ["correctness", "contradiction"]
                                                 },
                                                 "weight": {
                                                   "type": "number"
@@ -14316,10 +12902,7 @@
                                                         "minLength": 1
                                                       }
                                                     },
-                                                    "required": [
-                                                      "score_range",
-                                                      "outcome"
-                                                    ],
+                                                    "required": ["score_range", "outcome"],
                                                     "additionalProperties": false
                                                   }
                                                 }
@@ -14370,17 +12953,12 @@
                                                   ]
                                                 }
                                               },
-                                              "required": [
-                                                "type",
-                                                "command"
-                                              ],
+                                              "required": ["type", "command"],
                                               "additionalProperties": false
                                             }
                                           }
                                         },
-                                        "required": [
-                                          "type"
-                                        ],
+                                        "required": ["type"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -14391,9 +12969,7 @@
                                             "minLength": 1
                                           }
                                         },
-                                        "required": [
-                                          "include"
-                                        ],
+                                        "required": ["include"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -14456,9 +13032,7 @@
                                                     }
                                                   }
                                                 },
-                                                "required": [
-                                                  "type"
-                                                ],
+                                                "required": ["type"],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -14474,10 +13048,7 @@
                                                     "maximum": 1
                                                   }
                                                 },
-                                                "required": [
-                                                  "type",
-                                                  "threshold"
-                                                ],
+                                                "required": ["type", "threshold"],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -14494,10 +13065,7 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": [
-                                                  "type",
-                                                  "path"
-                                                ],
+                                                "required": ["type", "path"],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -14514,18 +13082,13 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": [
-                                                  "type"
-                                                ],
+                                                "required": ["type"],
                                                 "additionalProperties": false
                                               }
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "aggregator"
-                                        ],
+                                        "required": ["type", "aggregator"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -14562,10 +13125,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "tool-trajectory",
-                                              "tool_trajectory"
-                                            ]
+                                            "enum": ["tool-trajectory", "tool_trajectory"]
                                           },
                                           "mode": {
                                             "type": "string",
@@ -14651,9 +13211,7 @@
                                                   ]
                                                 }
                                               },
-                                              "required": [
-                                                "tool"
-                                              ],
+                                              "required": ["tool"],
                                               "additionalProperties": false
                                             }
                                           },
@@ -14661,12 +13219,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -14680,12 +13233,7 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": [
-                                                  "exact",
-                                                  "ignore",
-                                                  "subset",
-                                                  "superset"
-                                                ]
+                                                "enum": ["exact", "ignore", "subset", "superset"]
                                               },
                                               {
                                                 "type": "array",
@@ -14696,10 +13244,7 @@
                                             ]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "mode"
-                                        ],
+                                        "required": ["type", "mode"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -14736,10 +13281,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "field-accuracy",
-                                              "field_accuracy"
-                                            ]
+                                            "enum": ["field-accuracy", "field_accuracy"]
                                           },
                                           "fields": {
                                             "type": "array",
@@ -14751,11 +13293,7 @@
                                                 },
                                                 "match": {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "exact",
-                                                    "numeric_tolerance",
-                                                    "date"
-                                                  ]
+                                                  "enum": ["exact", "numeric_tolerance", "date"]
                                                 },
                                                 "required": {
                                                   "type": "boolean"
@@ -14777,26 +13315,17 @@
                                                   }
                                                 }
                                               },
-                                              "required": [
-                                                "path",
-                                                "match"
-                                              ],
+                                              "required": ["path", "match"],
                                               "additionalProperties": false
                                             },
                                             "minItems": 1
                                           },
                                           "aggregation": {
                                             "type": "string",
-                                            "enum": [
-                                              "weighted_average",
-                                              "all_or_nothing"
-                                            ]
+                                            "enum": ["weighted_average", "all_or_nothing"]
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "fields"
-                                        ],
+                                        "required": ["type", "fields"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -14840,10 +13369,7 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "threshold"
-                                        ],
+                                        "required": ["type", "threshold"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -14887,10 +13413,7 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "budget"
-                                        ],
+                                        "required": ["type", "budget"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -14927,10 +13450,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "token-usage",
-                                              "token_usage"
-                                            ]
+                                            "enum": ["token-usage", "token_usage"]
                                           },
                                           "max_total": {
                                             "type": "number",
@@ -14945,9 +13465,7 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": [
-                                          "type"
-                                        ],
+                                        "required": ["type"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -14984,10 +13502,7 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "execution-metrics",
-                                              "execution_metrics"
-                                            ]
+                                            "enum": ["execution-metrics", "execution_metrics"]
                                           },
                                           "max_tool_calls": {
                                             "type": "number",
@@ -15019,9 +13534,7 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": [
-                                          "type"
-                                        ],
+                                        "required": ["type"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -15064,10 +13577,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -15110,10 +13620,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -15150,15 +13657,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "is-json",
-                                              "is_json"
-                                            ]
+                                            "enum": ["is-json", "is_json"]
                                           }
                                         },
-                                        "required": [
-                                          "type"
-                                        ],
+                                        "required": ["type"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -15201,10 +13703,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "value"
-                                        ],
+                                        "required": ["type", "value"],
                                         "additionalProperties": false
                                       },
                                       {
@@ -15262,10 +13761,7 @@
                                                     },
                                                     "operator": {
                                                       "type": "string",
-                                                      "enum": [
-                                                        "correctness",
-                                                        "contradiction"
-                                                      ]
+                                                      "enum": ["correctness", "contradiction"]
                                                     },
                                                     "weight": {
                                                       "type": "number"
@@ -15306,10 +13802,7 @@
                                                             "minLength": 1
                                                           }
                                                         },
-                                                        "required": [
-                                                          "score_range",
-                                                          "outcome"
-                                                        ],
+                                                        "required": ["score_range", "outcome"],
                                                         "additionalProperties": false
                                                       }
                                                     }
@@ -15321,10 +13814,7 @@
                                             "minItems": 1
                                           }
                                         },
-                                        "required": [
-                                          "type",
-                                          "criteria"
-                                        ],
+                                        "required": ["type", "criteria"],
                                         "additionalProperties": false
                                       }
                                     ]
@@ -15333,36 +13823,25 @@
                               }
                             }
                           },
-                          "required": [
-                            "input"
-                          ],
+                          "required": ["input"],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": [
-                          "mean",
-                          "min",
-                          "max"
-                        ]
+                        "enum": ["mean", "min", "max"]
                       },
                       "on_turn_failure": {
                         "type": "string",
-                        "enum": [
-                          "continue",
-                          "stop"
-                        ]
+                        "enum": ["continue", "stop"]
                       },
                       "window_size": {
                         "type": "integer",
                         "minimum": 1
                       }
                     },
-                    "required": [
-                      "id"
-                    ],
+                    "required": ["id"],
                     "additionalProperties": false
                   },
                   {
@@ -15374,10 +13853,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "suite",
-                          "tests"
-                        ]
+                        "enum": ["suite", "tests"]
                       },
                       "select": {
                         "anyOf": [
@@ -15448,11 +13924,7 @@
                                     {
                                       "type": "array",
                                       "items": {
-                                        "type": [
-                                          "string",
-                                          "number",
-                                          "boolean"
-                                        ]
+                                        "type": ["string", "number", "boolean"]
                                       },
                                       "minItems": 1
                                     }
@@ -15481,12 +13953,7 @@
                               },
                               "strategy": {
                                 "type": "string",
-                                "enum": [
-                                  "pass_at_k",
-                                  "pass_all",
-                                  "mean",
-                                  "confidence_interval"
-                                ]
+                                "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
                               },
                               "cost_limit_usd": {
                                 "type": "number",
@@ -15497,9 +13964,7 @@
                                 "minimum": 0
                               }
                             },
-                            "required": [
-                              "count"
-                            ],
+                            "required": ["count"],
                             "additionalProperties": false
                           },
                           "timeout_seconds": {
@@ -15516,10 +13981,7 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": [
-                      "include",
-                      "type"
-                    ],
+                    "required": ["include", "type"],
                     "additionalProperties": false
                   },
                   {
@@ -15601,9 +14063,7 @@
                         "additionalProperties": {}
                       }
                     },
-                    "required": [
-                      "name"
-                    ],
+                    "required": ["name"],
                     "additionalProperties": false
                   }
                 ]
@@ -15653,10 +14113,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "code-grader",
-                          "code_grader"
-                        ]
+                        "enum": ["code-grader", "code_grader"]
                       },
                       "command": {
                         "anyOf": [
@@ -15730,18 +14187,12 @@
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
+                          "required": ["type", "command"],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": [
-                      "type",
-                      "command"
-                    ],
+                    "required": ["type", "command"],
                     "additionalProperties": false
                   },
                   {
@@ -15778,10 +14229,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "llm-grader",
-                          "llm_grader"
-                        ]
+                        "enum": ["llm-grader", "llm_grader"]
                       },
                       "prompt": {
                         "anyOf": [
@@ -15839,10 +14287,7 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": [
-                                "correctness",
-                                "contradiction"
-                              ]
+                              "enum": ["correctness", "contradiction"]
                             },
                             "weight": {
                               "type": "number"
@@ -15883,10 +14328,7 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": [
-                                  "score_range",
-                                  "outcome"
-                                ],
+                                "required": ["score_range", "outcome"],
                                 "additionalProperties": false
                               }
                             }
@@ -15937,17 +14379,12 @@
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
+                          "required": ["type", "command"],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -15958,9 +14395,7 @@
                         "minLength": 1
                       }
                     },
-                    "required": [
-                      "include"
-                    ],
+                    "required": ["include"],
                     "additionalProperties": false
                   },
                   {
@@ -16023,9 +14458,7 @@
                                 }
                               }
                             },
-                            "required": [
-                              "type"
-                            ],
+                            "required": ["type"],
                             "additionalProperties": false
                           },
                           {
@@ -16041,10 +14474,7 @@
                                 "maximum": 1
                               }
                             },
-                            "required": [
-                              "type",
-                              "threshold"
-                            ],
+                            "required": ["type", "threshold"],
                             "additionalProperties": false
                           },
                           {
@@ -16061,10 +14491,7 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "type",
-                              "path"
-                            ],
+                            "required": ["type", "path"],
                             "additionalProperties": false
                           },
                           {
@@ -16081,18 +14508,13 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "type"
-                            ],
+                            "required": ["type"],
                             "additionalProperties": false
                           }
                         ]
                       }
                     },
-                    "required": [
-                      "type",
-                      "aggregator"
-                    ],
+                    "required": ["type", "aggregator"],
                     "additionalProperties": false
                   },
                   {
@@ -16129,20 +14551,11 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "tool-trajectory",
-                          "tool_trajectory"
-                        ]
+                        "enum": ["tool-trajectory", "tool_trajectory"]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": [
-                          "any_order",
-                          "in_order",
-                          "exact",
-                          "subset",
-                          "superset"
-                        ]
+                        "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                       },
                       "minimums": {
                         "type": "object",
@@ -16183,12 +14596,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -16202,12 +14610,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -16218,9 +14621,7 @@
                               ]
                             }
                           },
-                          "required": [
-                            "tool"
-                          ],
+                          "required": ["tool"],
                           "additionalProperties": false
                         }
                       },
@@ -16228,12 +14629,7 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": [
-                              "exact",
-                              "ignore",
-                              "subset",
-                              "superset"
-                            ]
+                            "enum": ["exact", "ignore", "subset", "superset"]
                           },
                           {
                             "type": "array",
@@ -16247,12 +14643,7 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": [
-                              "exact",
-                              "ignore",
-                              "subset",
-                              "superset"
-                            ]
+                            "enum": ["exact", "ignore", "subset", "superset"]
                           },
                           {
                             "type": "array",
@@ -16263,10 +14654,7 @@
                         ]
                       }
                     },
-                    "required": [
-                      "type",
-                      "mode"
-                    ],
+                    "required": ["type", "mode"],
                     "additionalProperties": false
                   },
                   {
@@ -16303,10 +14691,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "field-accuracy",
-                          "field_accuracy"
-                        ]
+                        "enum": ["field-accuracy", "field_accuracy"]
                       },
                       "fields": {
                         "type": "array",
@@ -16318,11 +14703,7 @@
                             },
                             "match": {
                               "type": "string",
-                              "enum": [
-                                "exact",
-                                "numeric_tolerance",
-                                "date"
-                              ]
+                              "enum": ["exact", "numeric_tolerance", "date"]
                             },
                             "required": {
                               "type": "boolean"
@@ -16344,26 +14725,17 @@
                               }
                             }
                           },
-                          "required": [
-                            "path",
-                            "match"
-                          ],
+                          "required": ["path", "match"],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": [
-                          "weighted_average",
-                          "all_or_nothing"
-                        ]
+                        "enum": ["weighted_average", "all_or_nothing"]
                       }
                     },
-                    "required": [
-                      "type",
-                      "fields"
-                    ],
+                    "required": ["type", "fields"],
                     "additionalProperties": false
                   },
                   {
@@ -16407,10 +14779,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type",
-                      "threshold"
-                    ],
+                    "required": ["type", "threshold"],
                     "additionalProperties": false
                   },
                   {
@@ -16454,10 +14823,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type",
-                      "budget"
-                    ],
+                    "required": ["type", "budget"],
                     "additionalProperties": false
                   },
                   {
@@ -16494,10 +14860,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "token-usage",
-                          "token_usage"
-                        ]
+                        "enum": ["token-usage", "token_usage"]
                       },
                       "max_total": {
                         "type": "number",
@@ -16512,9 +14875,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -16551,10 +14912,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "execution-metrics",
-                          "execution_metrics"
-                        ]
+                        "enum": ["execution-metrics", "execution_metrics"]
                       },
                       "max_tool_calls": {
                         "type": "number",
@@ -16586,9 +14944,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -16631,10 +14987,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
+                    "required": ["type", "value"],
                     "additionalProperties": false
                   },
                   {
@@ -16677,10 +15030,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
+                    "required": ["type", "value"],
                     "additionalProperties": false
                   },
                   {
@@ -16717,15 +15067,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "is-json",
-                          "is_json"
-                        ]
+                        "enum": ["is-json", "is_json"]
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -16768,10 +15113,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
+                    "required": ["type", "value"],
                     "additionalProperties": false
                   },
                   {
@@ -16829,10 +15171,7 @@
                                 },
                                 "operator": {
                                   "type": "string",
-                                  "enum": [
-                                    "correctness",
-                                    "contradiction"
-                                  ]
+                                  "enum": ["correctness", "contradiction"]
                                 },
                                 "weight": {
                                   "type": "number"
@@ -16873,10 +15212,7 @@
                                         "minLength": 1
                                       }
                                     },
-                                    "required": [
-                                      "score_range",
-                                      "outcome"
-                                    ],
+                                    "required": ["score_range", "outcome"],
                                     "additionalProperties": false
                                   }
                                 }
@@ -16888,10 +15224,7 @@
                         "minItems": 1
                       }
                     },
-                    "required": [
-                      "type",
-                      "criteria"
-                    ],
+                    "required": ["type", "criteria"],
                     "additionalProperties": false
                   }
                 ]
@@ -16935,10 +15268,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "code-grader",
-                          "code_grader"
-                        ]
+                        "enum": ["code-grader", "code_grader"]
                       },
                       "command": {
                         "anyOf": [
@@ -17012,18 +15342,12 @@
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
+                          "required": ["type", "command"],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": [
-                      "type",
-                      "command"
-                    ],
+                    "required": ["type", "command"],
                     "additionalProperties": false
                   },
                   {
@@ -17060,10 +15384,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "llm-grader",
-                          "llm_grader"
-                        ]
+                        "enum": ["llm-grader", "llm_grader"]
                       },
                       "prompt": {
                         "anyOf": [
@@ -17121,10 +15442,7 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": [
-                                "correctness",
-                                "contradiction"
-                              ]
+                              "enum": ["correctness", "contradiction"]
                             },
                             "weight": {
                               "type": "number"
@@ -17165,10 +15483,7 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": [
-                                  "score_range",
-                                  "outcome"
-                                ],
+                                "required": ["score_range", "outcome"],
                                 "additionalProperties": false
                               }
                             }
@@ -17219,17 +15534,12 @@
                               ]
                             }
                           },
-                          "required": [
-                            "type",
-                            "command"
-                          ],
+                          "required": ["type", "command"],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -17240,9 +15550,7 @@
                         "minLength": 1
                       }
                     },
-                    "required": [
-                      "include"
-                    ],
+                    "required": ["include"],
                     "additionalProperties": false
                   },
                   {
@@ -17305,9 +15613,7 @@
                                 }
                               }
                             },
-                            "required": [
-                              "type"
-                            ],
+                            "required": ["type"],
                             "additionalProperties": false
                           },
                           {
@@ -17323,10 +15629,7 @@
                                 "maximum": 1
                               }
                             },
-                            "required": [
-                              "type",
-                              "threshold"
-                            ],
+                            "required": ["type", "threshold"],
                             "additionalProperties": false
                           },
                           {
@@ -17343,10 +15646,7 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "type",
-                              "path"
-                            ],
+                            "required": ["type", "path"],
                             "additionalProperties": false
                           },
                           {
@@ -17363,18 +15663,13 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "type"
-                            ],
+                            "required": ["type"],
                             "additionalProperties": false
                           }
                         ]
                       }
                     },
-                    "required": [
-                      "type",
-                      "aggregator"
-                    ],
+                    "required": ["type", "aggregator"],
                     "additionalProperties": false
                   },
                   {
@@ -17411,20 +15706,11 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "tool-trajectory",
-                          "tool_trajectory"
-                        ]
+                        "enum": ["tool-trajectory", "tool_trajectory"]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": [
-                          "any_order",
-                          "in_order",
-                          "exact",
-                          "subset",
-                          "superset"
-                        ]
+                        "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                       },
                       "minimums": {
                         "type": "object",
@@ -17465,12 +15751,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -17484,12 +15765,7 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "ignore",
-                                    "subset",
-                                    "superset"
-                                  ]
+                                  "enum": ["exact", "ignore", "subset", "superset"]
                                 },
                                 {
                                   "type": "array",
@@ -17500,9 +15776,7 @@
                               ]
                             }
                           },
-                          "required": [
-                            "tool"
-                          ],
+                          "required": ["tool"],
                           "additionalProperties": false
                         }
                       },
@@ -17510,12 +15784,7 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": [
-                              "exact",
-                              "ignore",
-                              "subset",
-                              "superset"
-                            ]
+                            "enum": ["exact", "ignore", "subset", "superset"]
                           },
                           {
                             "type": "array",
@@ -17529,12 +15798,7 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": [
-                              "exact",
-                              "ignore",
-                              "subset",
-                              "superset"
-                            ]
+                            "enum": ["exact", "ignore", "subset", "superset"]
                           },
                           {
                             "type": "array",
@@ -17545,10 +15809,7 @@
                         ]
                       }
                     },
-                    "required": [
-                      "type",
-                      "mode"
-                    ],
+                    "required": ["type", "mode"],
                     "additionalProperties": false
                   },
                   {
@@ -17585,10 +15846,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "field-accuracy",
-                          "field_accuracy"
-                        ]
+                        "enum": ["field-accuracy", "field_accuracy"]
                       },
                       "fields": {
                         "type": "array",
@@ -17600,11 +15858,7 @@
                             },
                             "match": {
                               "type": "string",
-                              "enum": [
-                                "exact",
-                                "numeric_tolerance",
-                                "date"
-                              ]
+                              "enum": ["exact", "numeric_tolerance", "date"]
                             },
                             "required": {
                               "type": "boolean"
@@ -17626,26 +15880,17 @@
                               }
                             }
                           },
-                          "required": [
-                            "path",
-                            "match"
-                          ],
+                          "required": ["path", "match"],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": [
-                          "weighted_average",
-                          "all_or_nothing"
-                        ]
+                        "enum": ["weighted_average", "all_or_nothing"]
                       }
                     },
-                    "required": [
-                      "type",
-                      "fields"
-                    ],
+                    "required": ["type", "fields"],
                     "additionalProperties": false
                   },
                   {
@@ -17689,10 +15934,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type",
-                      "threshold"
-                    ],
+                    "required": ["type", "threshold"],
                     "additionalProperties": false
                   },
                   {
@@ -17736,10 +15978,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type",
-                      "budget"
-                    ],
+                    "required": ["type", "budget"],
                     "additionalProperties": false
                   },
                   {
@@ -17776,10 +16015,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "token-usage",
-                          "token_usage"
-                        ]
+                        "enum": ["token-usage", "token_usage"]
                       },
                       "max_total": {
                         "type": "number",
@@ -17794,9 +16030,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -17833,10 +16067,7 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "execution-metrics",
-                          "execution_metrics"
-                        ]
+                        "enum": ["execution-metrics", "execution_metrics"]
                       },
                       "max_tool_calls": {
                         "type": "number",
@@ -17868,9 +16099,7 @@
                         "minimum": 0
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -17913,10 +16142,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
+                    "required": ["type", "value"],
                     "additionalProperties": false
                   },
                   {
@@ -17959,10 +16185,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
+                    "required": ["type", "value"],
                     "additionalProperties": false
                   },
                   {
@@ -17999,15 +16222,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "is-json",
-                          "is_json"
-                        ]
+                        "enum": ["is-json", "is_json"]
                       }
                     },
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "additionalProperties": false
                   },
                   {
@@ -18050,10 +16268,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "value"
-                    ],
+                    "required": ["type", "value"],
                     "additionalProperties": false
                   },
                   {
@@ -18111,10 +16326,7 @@
                                 },
                                 "operator": {
                                   "type": "string",
-                                  "enum": [
-                                    "correctness",
-                                    "contradiction"
-                                  ]
+                                  "enum": ["correctness", "contradiction"]
                                 },
                                 "weight": {
                                   "type": "number"
@@ -18155,10 +16367,7 @@
                                         "minLength": 1
                                       }
                                     },
-                                    "required": [
-                                      "score_range",
-                                      "outcome"
-                                    ],
+                                    "required": ["score_range", "outcome"],
                                     "additionalProperties": false
                                   }
                                 }
@@ -18170,10 +16379,7 @@
                         "minItems": 1
                       }
                     },
-                    "required": [
-                      "type",
-                      "criteria"
-                    ],
+                    "required": ["type", "criteria"],
                     "additionalProperties": false
                   }
                 ]
@@ -18236,12 +16442,7 @@
                 },
                 "strategy": {
                   "type": "string",
-                  "enum": [
-                    "pass_at_k",
-                    "pass_all",
-                    "mean",
-                    "confidence_interval"
-                  ]
+                  "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
                 },
                 "cost_limit_usd": {
                   "type": "number",
@@ -18252,9 +16453,7 @@
                   "minimum": 0
                 }
               },
-              "required": [
-                "count"
-              ],
+              "required": ["count"],
               "additionalProperties": false
             },
             "runs": {
@@ -18313,10 +16512,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "code-grader",
-                      "code_grader"
-                    ]
+                    "enum": ["code-grader", "code_grader"]
                   },
                   "command": {
                     "anyOf": [
@@ -18390,18 +16586,12 @@
                           ]
                         }
                       },
-                      "required": [
-                        "type",
-                        "command"
-                      ],
+                      "required": ["type", "command"],
                       "additionalProperties": false
                     }
                   }
                 },
-                "required": [
-                  "type",
-                  "command"
-                ],
+                "required": ["type", "command"],
                 "additionalProperties": false
               },
               {
@@ -18438,10 +16628,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "llm-grader",
-                      "llm_grader"
-                    ]
+                    "enum": ["llm-grader", "llm_grader"]
                   },
                   "prompt": {
                     "anyOf": [
@@ -18499,10 +16686,7 @@
                         },
                         "operator": {
                           "type": "string",
-                          "enum": [
-                            "correctness",
-                            "contradiction"
-                          ]
+                          "enum": ["correctness", "contradiction"]
                         },
                         "weight": {
                           "type": "number"
@@ -18543,10 +16727,7 @@
                                 "minLength": 1
                               }
                             },
-                            "required": [
-                              "score_range",
-                              "outcome"
-                            ],
+                            "required": ["score_range", "outcome"],
                             "additionalProperties": false
                           }
                         }
@@ -18597,17 +16778,12 @@
                           ]
                         }
                       },
-                      "required": [
-                        "type",
-                        "command"
-                      ],
+                      "required": ["type", "command"],
                       "additionalProperties": false
                     }
                   }
                 },
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "additionalProperties": false
               },
               {
@@ -18618,9 +16794,7 @@
                     "minLength": 1
                   }
                 },
-                "required": [
-                  "include"
-                ],
+                "required": ["include"],
                 "additionalProperties": false
               },
               {
@@ -18683,9 +16857,7 @@
                             }
                           }
                         },
-                        "required": [
-                          "type"
-                        ],
+                        "required": ["type"],
                         "additionalProperties": false
                       },
                       {
@@ -18701,10 +16873,7 @@
                             "maximum": 1
                           }
                         },
-                        "required": [
-                          "type",
-                          "threshold"
-                        ],
+                        "required": ["type", "threshold"],
                         "additionalProperties": false
                       },
                       {
@@ -18721,10 +16890,7 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "type",
-                          "path"
-                        ],
+                        "required": ["type", "path"],
                         "additionalProperties": false
                       },
                       {
@@ -18741,18 +16907,13 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "type"
-                        ],
+                        "required": ["type"],
                         "additionalProperties": false
                       }
                     ]
                   }
                 },
-                "required": [
-                  "type",
-                  "aggregator"
-                ],
+                "required": ["type", "aggregator"],
                 "additionalProperties": false
               },
               {
@@ -18789,20 +16950,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "tool-trajectory",
-                      "tool_trajectory"
-                    ]
+                    "enum": ["tool-trajectory", "tool_trajectory"]
                   },
                   "mode": {
                     "type": "string",
-                    "enum": [
-                      "any_order",
-                      "in_order",
-                      "exact",
-                      "subset",
-                      "superset"
-                    ]
+                    "enum": ["any_order", "in_order", "exact", "subset", "superset"]
                   },
                   "minimums": {
                     "type": "object",
@@ -18843,12 +16995,7 @@
                           "anyOf": [
                             {
                               "type": "string",
-                              "enum": [
-                                "exact",
-                                "ignore",
-                                "subset",
-                                "superset"
-                              ]
+                              "enum": ["exact", "ignore", "subset", "superset"]
                             },
                             {
                               "type": "array",
@@ -18862,12 +17009,7 @@
                           "anyOf": [
                             {
                               "type": "string",
-                              "enum": [
-                                "exact",
-                                "ignore",
-                                "subset",
-                                "superset"
-                              ]
+                              "enum": ["exact", "ignore", "subset", "superset"]
                             },
                             {
                               "type": "array",
@@ -18878,9 +17020,7 @@
                           ]
                         }
                       },
-                      "required": [
-                        "tool"
-                      ],
+                      "required": ["tool"],
                       "additionalProperties": false
                     }
                   },
@@ -18888,12 +17028,7 @@
                     "anyOf": [
                       {
                         "type": "string",
-                        "enum": [
-                          "exact",
-                          "ignore",
-                          "subset",
-                          "superset"
-                        ]
+                        "enum": ["exact", "ignore", "subset", "superset"]
                       },
                       {
                         "type": "array",
@@ -18907,12 +17042,7 @@
                     "anyOf": [
                       {
                         "type": "string",
-                        "enum": [
-                          "exact",
-                          "ignore",
-                          "subset",
-                          "superset"
-                        ]
+                        "enum": ["exact", "ignore", "subset", "superset"]
                       },
                       {
                         "type": "array",
@@ -18923,10 +17053,7 @@
                     ]
                   }
                 },
-                "required": [
-                  "type",
-                  "mode"
-                ],
+                "required": ["type", "mode"],
                 "additionalProperties": false
               },
               {
@@ -18963,10 +17090,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "field-accuracy",
-                      "field_accuracy"
-                    ]
+                    "enum": ["field-accuracy", "field_accuracy"]
                   },
                   "fields": {
                     "type": "array",
@@ -18978,11 +17102,7 @@
                         },
                         "match": {
                           "type": "string",
-                          "enum": [
-                            "exact",
-                            "numeric_tolerance",
-                            "date"
-                          ]
+                          "enum": ["exact", "numeric_tolerance", "date"]
                         },
                         "required": {
                           "type": "boolean"
@@ -19004,26 +17124,17 @@
                           }
                         }
                       },
-                      "required": [
-                        "path",
-                        "match"
-                      ],
+                      "required": ["path", "match"],
                       "additionalProperties": false
                     },
                     "minItems": 1
                   },
                   "aggregation": {
                     "type": "string",
-                    "enum": [
-                      "weighted_average",
-                      "all_or_nothing"
-                    ]
+                    "enum": ["weighted_average", "all_or_nothing"]
                   }
                 },
-                "required": [
-                  "type",
-                  "fields"
-                ],
+                "required": ["type", "fields"],
                 "additionalProperties": false
               },
               {
@@ -19067,10 +17178,7 @@
                     "minimum": 0
                   }
                 },
-                "required": [
-                  "type",
-                  "threshold"
-                ],
+                "required": ["type", "threshold"],
                 "additionalProperties": false
               },
               {
@@ -19114,10 +17222,7 @@
                     "minimum": 0
                   }
                 },
-                "required": [
-                  "type",
-                  "budget"
-                ],
+                "required": ["type", "budget"],
                 "additionalProperties": false
               },
               {
@@ -19154,10 +17259,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "token-usage",
-                      "token_usage"
-                    ]
+                    "enum": ["token-usage", "token_usage"]
                   },
                   "max_total": {
                     "type": "number",
@@ -19172,9 +17274,7 @@
                     "minimum": 0
                   }
                 },
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "additionalProperties": false
               },
               {
@@ -19211,10 +17311,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "execution-metrics",
-                      "execution_metrics"
-                    ]
+                    "enum": ["execution-metrics", "execution_metrics"]
                   },
                   "max_tool_calls": {
                     "type": "number",
@@ -19246,9 +17343,7 @@
                     "minimum": 0
                   }
                 },
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "additionalProperties": false
               },
               {
@@ -19291,10 +17386,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "type",
-                  "value"
-                ],
+                "required": ["type", "value"],
                 "additionalProperties": false
               },
               {
@@ -19337,10 +17429,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "type",
-                  "value"
-                ],
+                "required": ["type", "value"],
                 "additionalProperties": false
               },
               {
@@ -19377,15 +17466,10 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "is-json",
-                      "is_json"
-                    ]
+                    "enum": ["is-json", "is_json"]
                   }
                 },
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "additionalProperties": false
               },
               {
@@ -19428,10 +17512,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "type",
-                  "value"
-                ],
+                "required": ["type", "value"],
                 "additionalProperties": false
               },
               {
@@ -19489,10 +17570,7 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": [
-                                "correctness",
-                                "contradiction"
-                              ]
+                              "enum": ["correctness", "contradiction"]
                             },
                             "weight": {
                               "type": "number"
@@ -19533,10 +17611,7 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": [
-                                  "score_range",
-                                  "outcome"
-                                ],
+                                "required": ["score_range", "outcome"],
                                 "additionalProperties": false
                               }
                             }
@@ -19548,10 +17623,7 @@
                     "minItems": 1
                   }
                 },
-                "required": [
-                  "type",
-                  "criteria"
-                ],
+                "required": ["type", "criteria"],
                 "additionalProperties": false
               }
             ]
@@ -19580,10 +17652,7 @@
                 ]
               }
             },
-            "required": [
-              "type",
-              "command"
-            ],
+            "required": ["type", "command"],
             "additionalProperties": false
           }
         },
@@ -19597,10 +17666,7 @@
                 },
                 "isolation": {
                   "type": "string",
-                  "enum": [
-                    "shared",
-                    "per_case"
-                  ]
+                  "enum": ["shared", "per_case"]
                 },
                 "repos": {
                   "type": "array",
@@ -19682,11 +17748,7 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": [
-                            "none",
-                            "fast",
-                            "strict"
-                          ]
+                          "enum": ["none", "fast", "strict"]
                         }
                       },
                       "additionalProperties": false
@@ -19731,11 +17793,7 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": [
-                            "none",
-                            "fast",
-                            "strict"
-                          ]
+                          "enum": ["none", "fast", "strict"]
                         }
                       },
                       "additionalProperties": false
@@ -19780,11 +17838,7 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": [
-                            "none",
-                            "fast",
-                            "strict"
-                          ]
+                          "enum": ["none", "fast", "strict"]
                         }
                       },
                       "additionalProperties": false
@@ -19829,11 +17883,7 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": [
-                            "none",
-                            "fast",
-                            "strict"
-                          ]
+                          "enum": ["none", "fast", "strict"]
                         }
                       },
                       "additionalProperties": false
@@ -19859,9 +17909,7 @@
                       "minimum": 0.1
                     }
                   },
-                  "required": [
-                    "image"
-                  ],
+                  "required": ["image"],
                   "additionalProperties": false
                 },
                 "env": {

--- a/skills-data/agentv-eval-writer/references/eval-schema.json
+++ b/skills-data/agentv-eval-writer/references/eval-schema.json
@@ -54,7 +54,12 @@
               "properties": {
                 "role": {
                   "type": "string",
-                  "enum": ["system", "user", "assistant", "tool"]
+                  "enum": [
+                    "system",
+                    "user",
+                    "assistant",
+                    "tool"
+                  ]
                 },
                 "content": {
                   "anyOf": [
@@ -73,20 +78,30 @@
                         "properties": {
                           "type": {
                             "type": "string",
-                            "enum": ["text", "file", "image"]
+                            "enum": [
+                              "text",
+                              "file",
+                              "image"
+                            ]
                           },
                           "value": {
                             "type": "string"
                           }
                         },
-                        "required": ["type", "value"],
+                        "required": [
+                          "type",
+                          "value"
+                        ],
                         "additionalProperties": false
                       }
                     }
                   ]
                 }
               },
-              "required": ["role", "content"],
+              "required": [
+                "role",
+                "content"
+              ],
               "additionalProperties": false
             },
             {
@@ -105,7 +120,12 @@
                 "properties": {
                   "role": {
                     "type": "string",
-                    "enum": ["system", "user", "assistant", "tool"]
+                    "enum": [
+                      "system",
+                      "user",
+                      "assistant",
+                      "tool"
+                    ]
                   },
                   "content": {
                     "anyOf": [
@@ -124,20 +144,30 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "enum": ["text", "file", "image"]
+                              "enum": [
+                                "text",
+                                "file",
+                                "image"
+                              ]
                             },
                             "value": {
                               "type": "string"
                             }
                           },
-                          "required": ["type", "value"],
+                          "required": [
+                            "type",
+                            "value"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     ]
                   }
                 },
-                "required": ["role", "content"],
+                "required": [
+                  "role",
+                  "content"
+                ],
                 "additionalProperties": false
               }
             }
@@ -234,7 +264,11 @@
                                         {
                                           "type": "array",
                                           "items": {
-                                            "type": ["string", "number", "boolean"]
+                                            "type": [
+                                              "string",
+                                              "number",
+                                              "boolean"
+                                            ]
                                           },
                                           "minItems": 1
                                         }
@@ -263,7 +297,12 @@
                                   },
                                   "strategy": {
                                     "type": "string",
-                                    "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                                    "enum": [
+                                      "pass_at_k",
+                                      "pass_all",
+                                      "mean",
+                                      "confidence_interval"
+                                    ]
                                   },
                                   "cost_limit_usd": {
                                     "type": "number",
@@ -274,7 +313,9 @@
                                     "minimum": 0
                                   }
                                 },
-                                "required": ["count"],
+                                "required": [
+                                  "count"
+                                ],
                                 "additionalProperties": false
                               },
                               "timeout_seconds": {
@@ -291,7 +332,9 @@
                             "additionalProperties": false
                           }
                         },
-                        "required": ["path"],
+                        "required": [
+                          "path"
+                        ],
                         "additionalProperties": false
                       },
                       {
@@ -381,7 +424,11 @@
                                   {
                                     "type": "array",
                                     "items": {
-                                      "type": ["string", "number", "boolean"]
+                                      "type": [
+                                        "string",
+                                        "number",
+                                        "boolean"
+                                      ]
                                     },
                                     "minItems": 1
                                   }
@@ -410,7 +457,12 @@
                             },
                             "strategy": {
                               "type": "string",
-                              "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                              "enum": [
+                                "pass_at_k",
+                                "pass_all",
+                                "mean",
+                                "confidence_interval"
+                              ]
                             },
                             "cost_limit_usd": {
                               "type": "number",
@@ -421,7 +473,9 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["count"],
+                          "required": [
+                            "count"
+                          ],
                           "additionalProperties": false
                         },
                         "timeout_seconds": {
@@ -438,7 +492,9 @@
                       "additionalProperties": false
                     }
                   },
-                  "required": ["path"],
+                  "required": [
+                    "path"
+                  ],
                   "additionalProperties": false
                 }
               ]
@@ -525,7 +581,11 @@
                                         {
                                           "type": "array",
                                           "items": {
-                                            "type": ["string", "number", "boolean"]
+                                            "type": [
+                                              "string",
+                                              "number",
+                                              "boolean"
+                                            ]
                                           },
                                           "minItems": 1
                                         }
@@ -554,7 +614,12 @@
                                   },
                                   "strategy": {
                                     "type": "string",
-                                    "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                                    "enum": [
+                                      "pass_at_k",
+                                      "pass_all",
+                                      "mean",
+                                      "confidence_interval"
+                                    ]
                                   },
                                   "cost_limit_usd": {
                                     "type": "number",
@@ -565,7 +630,9 @@
                                     "minimum": 0
                                   }
                                 },
-                                "required": ["count"],
+                                "required": [
+                                  "count"
+                                ],
                                 "additionalProperties": false
                               },
                               "timeout_seconds": {
@@ -582,7 +649,9 @@
                             "additionalProperties": false
                           }
                         },
-                        "required": ["path"],
+                        "required": [
+                          "path"
+                        ],
                         "additionalProperties": false
                       },
                       {
@@ -672,7 +741,11 @@
                                   {
                                     "type": "array",
                                     "items": {
-                                      "type": ["string", "number", "boolean"]
+                                      "type": [
+                                        "string",
+                                        "number",
+                                        "boolean"
+                                      ]
                                     },
                                     "minItems": 1
                                   }
@@ -701,7 +774,12 @@
                             },
                             "strategy": {
                               "type": "string",
-                              "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                              "enum": [
+                                "pass_at_k",
+                                "pass_all",
+                                "mean",
+                                "confidence_interval"
+                              ]
                             },
                             "cost_limit_usd": {
                               "type": "number",
@@ -712,7 +790,9 @@
                               "minimum": 0
                             }
                           },
-                          "required": ["count"],
+                          "required": [
+                            "count"
+                          ],
                           "additionalProperties": false
                         },
                         "timeout_seconds": {
@@ -729,7 +809,9 @@
                       "additionalProperties": false
                     }
                   },
-                  "required": ["path"],
+                  "required": [
+                    "path"
+                  ],
                   "additionalProperties": false
                 }
               ]
@@ -768,7 +850,12 @@
                             "properties": {
                               "role": {
                                 "type": "string",
-                                "enum": ["system", "user", "assistant", "tool"]
+                                "enum": [
+                                  "system",
+                                  "user",
+                                  "assistant",
+                                  "tool"
+                                ]
                               },
                               "content": {
                                 "anyOf": [
@@ -787,20 +874,30 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": ["text", "file", "image"]
+                                          "enum": [
+                                            "text",
+                                            "file",
+                                            "image"
+                                          ]
                                         },
                                         "value": {
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type", "value"],
+                                      "required": [
+                                        "type",
+                                        "value"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   }
                                 ]
                               }
                             },
-                            "required": ["role", "content"],
+                            "required": [
+                              "role",
+                              "content"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -819,7 +916,12 @@
                               "properties": {
                                 "role": {
                                   "type": "string",
-                                  "enum": ["system", "user", "assistant", "tool"]
+                                  "enum": [
+                                    "system",
+                                    "user",
+                                    "assistant",
+                                    "tool"
+                                  ]
                                 },
                                 "content": {
                                   "anyOf": [
@@ -838,20 +940,30 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["text", "file", "image"]
+                                            "enum": [
+                                              "text",
+                                              "file",
+                                              "image"
+                                            ]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   ]
                                 }
                               },
-                              "required": ["role", "content"],
+                              "required": [
+                                "role",
+                                "content"
+                              ],
                               "additionalProperties": false
                             }
                           }
@@ -880,7 +992,12 @@
                               "properties": {
                                 "role": {
                                   "type": "string",
-                                  "enum": ["system", "user", "assistant", "tool"]
+                                  "enum": [
+                                    "system",
+                                    "user",
+                                    "assistant",
+                                    "tool"
+                                  ]
                                 },
                                 "content": {
                                   "anyOf": [
@@ -899,20 +1016,30 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["text", "file", "image"]
+                                            "enum": [
+                                              "text",
+                                              "file",
+                                              "image"
+                                            ]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   ]
                                 }
                               },
-                              "required": ["role", "content"],
+                              "required": [
+                                "role",
+                                "content"
+                              ],
                               "additionalProperties": false
                             }
                           }
@@ -956,7 +1083,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["code-grader", "code_grader"]
+                                  "enum": [
+                                    "code-grader",
+                                    "code_grader"
+                                  ]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -1030,12 +1160,18 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type", "command"],
+                              "required": [
+                                "type",
+                                "command"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1072,7 +1208,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["llm-grader", "llm_grader"]
+                                  "enum": [
+                                    "llm-grader",
+                                    "llm_grader"
+                                  ]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -1130,7 +1269,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -1171,7 +1313,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -1222,12 +1367,17 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1238,7 +1388,9 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": ["include"],
+                              "required": [
+                                "include"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1301,7 +1453,9 @@
                                           }
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -1317,7 +1471,10 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": ["type", "threshold"],
+                                      "required": [
+                                        "type",
+                                        "threshold"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -1334,7 +1491,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type", "path"],
+                                      "required": [
+                                        "type",
+                                        "path"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -1351,13 +1511,18 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["type", "aggregator"],
+                              "required": [
+                                "type",
+                                "aggregator"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1394,11 +1559,20 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["tool-trajectory", "tool_trajectory"]
+                                  "enum": [
+                                    "tool-trajectory",
+                                    "tool_trajectory"
+                                  ]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                                  "enum": [
+                                    "any_order",
+                                    "in_order",
+                                    "exact",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -1439,7 +1613,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -1453,7 +1632,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -1464,7 +1648,9 @@
                                         ]
                                       }
                                     },
-                                    "required": ["tool"],
+                                    "required": [
+                                      "tool"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 },
@@ -1472,7 +1658,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -1486,7 +1677,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -1497,7 +1693,10 @@
                                   ]
                                 }
                               },
-                              "required": ["type", "mode"],
+                              "required": [
+                                "type",
+                                "mode"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1534,7 +1733,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["field-accuracy", "field_accuracy"]
+                                  "enum": [
+                                    "field-accuracy",
+                                    "field_accuracy"
+                                  ]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -1546,7 +1748,11 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": ["exact", "numeric_tolerance", "date"]
+                                        "enum": [
+                                          "exact",
+                                          "numeric_tolerance",
+                                          "date"
+                                        ]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -1568,17 +1774,26 @@
                                         }
                                       }
                                     },
-                                    "required": ["path", "match"],
+                                    "required": [
+                                      "path",
+                                      "match"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": ["weighted_average", "all_or_nothing"]
+                                  "enum": [
+                                    "weighted_average",
+                                    "all_or_nothing"
+                                  ]
                                 }
                               },
-                              "required": ["type", "fields"],
+                              "required": [
+                                "type",
+                                "fields"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1622,7 +1837,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "threshold"],
+                              "required": [
+                                "type",
+                                "threshold"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1666,7 +1884,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "budget"],
+                              "required": [
+                                "type",
+                                "budget"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1703,7 +1924,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["token-usage", "token_usage"]
+                                  "enum": [
+                                    "token-usage",
+                                    "token_usage"
+                                  ]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -1718,7 +1942,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1755,7 +1981,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["execution-metrics", "execution_metrics"]
+                                  "enum": [
+                                    "execution-metrics",
+                                    "execution_metrics"
+                                  ]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -1787,7 +2016,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1830,7 +2061,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1873,7 +2107,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1910,10 +2147,15 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["is-json", "is_json"]
+                                  "enum": [
+                                    "is-json",
+                                    "is_json"
+                                  ]
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1956,7 +2198,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -1998,68 +2243,85 @@
                                 "criteria": {
                                   "type": "array",
                                   "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "id": {
-                                        "type": "string"
-                                      },
-                                      "outcome": {
-                                        "type": "string"
-                                      },
-                                      "operator": {
+                                    "anyOf": [
+                                      {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "minLength": 1
                                       },
-                                      "weight": {
-                                        "type": "number"
-                                      },
-                                      "required": {
-                                        "type": "boolean"
-                                      },
-                                      "min_score": {
-                                        "type": "number",
-                                        "exclusiveMinimum": true,
-                                        "minimum": 0,
-                                        "maximum": 1
-                                      },
-                                      "score_ranges": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "object",
-                                          "properties": {
-                                            "score_range": {
-                                              "type": "array",
-                                              "minItems": 2,
-                                              "maxItems": 2,
-                                              "items": [
-                                                {
-                                                  "type": "integer",
-                                                  "minimum": 0,
-                                                  "maximum": 10
-                                                },
-                                                {
-                                                  "type": "integer",
-                                                  "minimum": 0,
-                                                  "maximum": 10
-                                                }
-                                              ]
-                                            },
-                                            "outcome": {
-                                              "type": "string",
-                                              "minLength": 1
-                                            }
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
                                           },
-                                          "required": ["score_range", "outcome"],
-                                          "additionalProperties": false
-                                        }
+                                          "outcome": {
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "type": "string",
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
+                                          },
+                                          "weight": {
+                                            "type": "number"
+                                          },
+                                          "required": {
+                                            "type": "boolean"
+                                          },
+                                          "min_score": {
+                                            "type": "number",
+                                            "exclusiveMinimum": true,
+                                            "minimum": 0,
+                                            "maximum": 1
+                                          },
+                                          "score_ranges": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "score_range": {
+                                                  "type": "array",
+                                                  "minItems": 2,
+                                                  "maxItems": 2,
+                                                  "items": [
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    },
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    }
+                                                  ]
+                                                },
+                                                "outcome": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                }
+                                              },
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false
                                       }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "minItems": 1
                                 }
                               },
-                              "required": ["type", "criteria"],
+                              "required": [
+                                "type",
+                                "criteria"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -2103,7 +2365,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["code-grader", "code_grader"]
+                                  "enum": [
+                                    "code-grader",
+                                    "code_grader"
+                                  ]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -2177,12 +2442,18 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type", "command"],
+                              "required": [
+                                "type",
+                                "command"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2219,7 +2490,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["llm-grader", "llm_grader"]
+                                  "enum": [
+                                    "llm-grader",
+                                    "llm_grader"
+                                  ]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -2277,7 +2551,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -2318,7 +2595,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -2369,12 +2649,17 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2385,7 +2670,9 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": ["include"],
+                              "required": [
+                                "include"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2448,7 +2735,9 @@
                                           }
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -2464,7 +2753,10 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": ["type", "threshold"],
+                                      "required": [
+                                        "type",
+                                        "threshold"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -2481,7 +2773,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type", "path"],
+                                      "required": [
+                                        "type",
+                                        "path"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -2498,13 +2793,18 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["type", "aggregator"],
+                              "required": [
+                                "type",
+                                "aggregator"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2541,11 +2841,20 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["tool-trajectory", "tool_trajectory"]
+                                  "enum": [
+                                    "tool-trajectory",
+                                    "tool_trajectory"
+                                  ]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                                  "enum": [
+                                    "any_order",
+                                    "in_order",
+                                    "exact",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -2586,7 +2895,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -2600,7 +2914,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -2611,7 +2930,9 @@
                                         ]
                                       }
                                     },
-                                    "required": ["tool"],
+                                    "required": [
+                                      "tool"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 },
@@ -2619,7 +2940,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -2633,7 +2959,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -2644,7 +2975,10 @@
                                   ]
                                 }
                               },
-                              "required": ["type", "mode"],
+                              "required": [
+                                "type",
+                                "mode"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2681,7 +3015,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["field-accuracy", "field_accuracy"]
+                                  "enum": [
+                                    "field-accuracy",
+                                    "field_accuracy"
+                                  ]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -2693,7 +3030,11 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": ["exact", "numeric_tolerance", "date"]
+                                        "enum": [
+                                          "exact",
+                                          "numeric_tolerance",
+                                          "date"
+                                        ]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -2715,17 +3056,26 @@
                                         }
                                       }
                                     },
-                                    "required": ["path", "match"],
+                                    "required": [
+                                      "path",
+                                      "match"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": ["weighted_average", "all_or_nothing"]
+                                  "enum": [
+                                    "weighted_average",
+                                    "all_or_nothing"
+                                  ]
                                 }
                               },
-                              "required": ["type", "fields"],
+                              "required": [
+                                "type",
+                                "fields"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2769,7 +3119,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "threshold"],
+                              "required": [
+                                "type",
+                                "threshold"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2813,7 +3166,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "budget"],
+                              "required": [
+                                "type",
+                                "budget"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2850,7 +3206,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["token-usage", "token_usage"]
+                                  "enum": [
+                                    "token-usage",
+                                    "token_usage"
+                                  ]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -2865,7 +3224,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2902,7 +3263,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["execution-metrics", "execution_metrics"]
+                                  "enum": [
+                                    "execution-metrics",
+                                    "execution_metrics"
+                                  ]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -2934,7 +3298,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -2977,7 +3343,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3020,7 +3389,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3057,10 +3429,15 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["is-json", "is_json"]
+                                  "enum": [
+                                    "is-json",
+                                    "is_json"
+                                  ]
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3103,7 +3480,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -3145,68 +3525,85 @@
                                 "criteria": {
                                   "type": "array",
                                   "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "id": {
-                                        "type": "string"
-                                      },
-                                      "outcome": {
-                                        "type": "string"
-                                      },
-                                      "operator": {
+                                    "anyOf": [
+                                      {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "minLength": 1
                                       },
-                                      "weight": {
-                                        "type": "number"
-                                      },
-                                      "required": {
-                                        "type": "boolean"
-                                      },
-                                      "min_score": {
-                                        "type": "number",
-                                        "exclusiveMinimum": true,
-                                        "minimum": 0,
-                                        "maximum": 1
-                                      },
-                                      "score_ranges": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "object",
-                                          "properties": {
-                                            "score_range": {
-                                              "type": "array",
-                                              "minItems": 2,
-                                              "maxItems": 2,
-                                              "items": [
-                                                {
-                                                  "type": "integer",
-                                                  "minimum": 0,
-                                                  "maximum": 10
-                                                },
-                                                {
-                                                  "type": "integer",
-                                                  "minimum": 0,
-                                                  "maximum": 10
-                                                }
-                                              ]
-                                            },
-                                            "outcome": {
-                                              "type": "string",
-                                              "minLength": 1
-                                            }
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
                                           },
-                                          "required": ["score_range", "outcome"],
-                                          "additionalProperties": false
-                                        }
+                                          "outcome": {
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "type": "string",
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
+                                          },
+                                          "weight": {
+                                            "type": "number"
+                                          },
+                                          "required": {
+                                            "type": "boolean"
+                                          },
+                                          "min_score": {
+                                            "type": "number",
+                                            "exclusiveMinimum": true,
+                                            "minimum": 0,
+                                            "maximum": 1
+                                          },
+                                          "score_ranges": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "score_range": {
+                                                  "type": "array",
+                                                  "minItems": 2,
+                                                  "maxItems": 2,
+                                                  "items": [
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    },
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    }
+                                                  ]
+                                                },
+                                                "outcome": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                }
+                                              },
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false
                                       }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "minItems": 1
                                 }
                               },
-                              "required": ["type", "criteria"],
+                              "required": [
+                                "type",
+                                "criteria"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -3258,7 +3655,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["code-grader", "code_grader"]
+                                      "enum": [
+                                        "code-grader",
+                                        "code_grader"
+                                      ]
                                     },
                                     "command": {
                                       "anyOf": [
@@ -3332,12 +3732,18 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": ["type", "command"],
+                                  "required": [
+                                    "type",
+                                    "command"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -3374,7 +3780,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["llm-grader", "llm_grader"]
+                                      "enum": [
+                                        "llm-grader",
+                                        "llm_grader"
+                                      ]
                                     },
                                     "prompt": {
                                       "anyOf": [
@@ -3432,7 +3841,10 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": ["correctness", "contradiction"]
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -3473,7 +3885,10 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": ["score_range", "outcome"],
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
@@ -3524,12 +3939,17 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -3540,7 +3960,9 @@
                                       "minLength": 1
                                     }
                                   },
-                                  "required": ["include"],
+                                  "required": [
+                                    "include"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -3603,7 +4025,9 @@
                                               }
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -3619,7 +4043,10 @@
                                               "maximum": 1
                                             }
                                           },
-                                          "required": ["type", "threshold"],
+                                          "required": [
+                                            "type",
+                                            "threshold"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -3636,7 +4063,10 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["type", "path"],
+                                          "required": [
+                                            "type",
+                                            "path"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -3653,13 +4083,18 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": ["type", "aggregator"],
+                                  "required": [
+                                    "type",
+                                    "aggregator"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -3696,7 +4131,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["tool-trajectory", "tool_trajectory"]
+                                      "enum": [
+                                        "tool-trajectory",
+                                        "tool_trajectory"
+                                      ]
                                     },
                                     "mode": {
                                       "type": "string",
@@ -3747,7 +4185,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -3761,7 +4204,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -3772,7 +4220,9 @@
                                             ]
                                           }
                                         },
-                                        "required": ["tool"],
+                                        "required": [
+                                          "tool"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     },
@@ -3780,7 +4230,12 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": ["exact", "ignore", "subset", "superset"]
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
                                         },
                                         {
                                           "type": "array",
@@ -3794,7 +4249,12 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": ["exact", "ignore", "subset", "superset"]
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
                                         },
                                         {
                                           "type": "array",
@@ -3805,7 +4265,10 @@
                                       ]
                                     }
                                   },
-                                  "required": ["type", "mode"],
+                                  "required": [
+                                    "type",
+                                    "mode"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -3842,7 +4305,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["field-accuracy", "field_accuracy"]
+                                      "enum": [
+                                        "field-accuracy",
+                                        "field_accuracy"
+                                      ]
                                     },
                                     "fields": {
                                       "type": "array",
@@ -3854,7 +4320,11 @@
                                           },
                                           "match": {
                                             "type": "string",
-                                            "enum": ["exact", "numeric_tolerance", "date"]
+                                            "enum": [
+                                              "exact",
+                                              "numeric_tolerance",
+                                              "date"
+                                            ]
                                           },
                                           "required": {
                                             "type": "boolean"
@@ -3876,17 +4346,26 @@
                                             }
                                           }
                                         },
-                                        "required": ["path", "match"],
+                                        "required": [
+                                          "path",
+                                          "match"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       "minItems": 1
                                     },
                                     "aggregation": {
                                       "type": "string",
-                                      "enum": ["weighted_average", "all_or_nothing"]
+                                      "enum": [
+                                        "weighted_average",
+                                        "all_or_nothing"
+                                      ]
                                     }
                                   },
-                                  "required": ["type", "fields"],
+                                  "required": [
+                                    "type",
+                                    "fields"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -3930,7 +4409,10 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type", "threshold"],
+                                  "required": [
+                                    "type",
+                                    "threshold"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -3974,7 +4456,10 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type", "budget"],
+                                  "required": [
+                                    "type",
+                                    "budget"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4011,7 +4496,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["token-usage", "token_usage"]
+                                      "enum": [
+                                        "token-usage",
+                                        "token_usage"
+                                      ]
                                     },
                                     "max_total": {
                                       "type": "number",
@@ -4026,7 +4514,9 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4063,7 +4553,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["execution-metrics", "execution_metrics"]
+                                      "enum": [
+                                        "execution-metrics",
+                                        "execution_metrics"
+                                      ]
                                     },
                                     "max_tool_calls": {
                                       "type": "number",
@@ -4095,7 +4588,9 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4138,7 +4633,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4181,7 +4679,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4218,10 +4719,15 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["is-json", "is_json"]
+                                      "enum": [
+                                        "is-json",
+                                        "is_json"
+                                      ]
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4264,7 +4770,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4306,68 +4815,85 @@
                                     "criteria": {
                                       "type": "array",
                                       "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "id": {
-                                            "type": "string"
-                                          },
-                                          "outcome": {
-                                            "type": "string"
-                                          },
-                                          "operator": {
+                                        "anyOf": [
+                                          {
                                             "type": "string",
-                                            "enum": ["correctness", "contradiction"]
+                                            "minLength": 1
                                           },
-                                          "weight": {
-                                            "type": "number"
-                                          },
-                                          "required": {
-                                            "type": "boolean"
-                                          },
-                                          "min_score": {
-                                            "type": "number",
-                                            "exclusiveMinimum": true,
-                                            "minimum": 0,
-                                            "maximum": 1
-                                          },
-                                          "score_ranges": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object",
-                                              "properties": {
-                                                "score_range": {
-                                                  "type": "array",
-                                                  "minItems": 2,
-                                                  "maxItems": 2,
-                                                  "items": [
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    },
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    }
-                                                  ]
-                                                },
-                                                "outcome": {
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                }
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "string"
                                               },
-                                              "required": ["score_range", "outcome"],
-                                              "additionalProperties": false
-                                            }
+                                              "outcome": {
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "correctness",
+                                                  "contradiction"
+                                                ]
+                                              },
+                                              "weight": {
+                                                "type": "number"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "min_score": {
+                                                "type": "number",
+                                                "exclusiveMinimum": true,
+                                                "minimum": 0,
+                                                "maximum": 1
+                                              },
+                                              "score_ranges": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "score_range": {
+                                                      "type": "array",
+                                                      "minItems": 2,
+                                                      "maxItems": 2,
+                                                      "items": [
+                                                        {
+                                                          "type": "integer",
+                                                          "minimum": 0,
+                                                          "maximum": 10
+                                                        },
+                                                        {
+                                                          "type": "integer",
+                                                          "minimum": 0,
+                                                          "maximum": 10
+                                                        }
+                                                      ]
+                                                    },
+                                                    "outcome": {
+                                                      "type": "string",
+                                                      "minLength": 1
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "score_range",
+                                                    "outcome"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              }
+                                            },
+                                            "additionalProperties": false
                                           }
-                                        },
-                                        "additionalProperties": false
+                                        ]
                                       },
                                       "minItems": 1
                                     }
                                   },
-                                  "required": ["type", "criteria"],
+                                  "required": [
+                                    "type",
+                                    "criteria"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -4411,7 +4937,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["code-grader", "code_grader"]
+                                      "enum": [
+                                        "code-grader",
+                                        "code_grader"
+                                      ]
                                     },
                                     "command": {
                                       "anyOf": [
@@ -4485,12 +5014,18 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": ["type", "command"],
+                                  "required": [
+                                    "type",
+                                    "command"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4527,7 +5062,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["llm-grader", "llm_grader"]
+                                      "enum": [
+                                        "llm-grader",
+                                        "llm_grader"
+                                      ]
                                     },
                                     "prompt": {
                                       "anyOf": [
@@ -4585,7 +5123,10 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": ["correctness", "contradiction"]
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -4626,7 +5167,10 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": ["score_range", "outcome"],
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
@@ -4677,12 +5221,17 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4693,7 +5242,9 @@
                                       "minLength": 1
                                     }
                                   },
-                                  "required": ["include"],
+                                  "required": [
+                                    "include"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4756,7 +5307,9 @@
                                               }
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -4772,7 +5325,10 @@
                                               "maximum": 1
                                             }
                                           },
-                                          "required": ["type", "threshold"],
+                                          "required": [
+                                            "type",
+                                            "threshold"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -4789,7 +5345,10 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["type", "path"],
+                                          "required": [
+                                            "type",
+                                            "path"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -4806,13 +5365,18 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": ["type", "aggregator"],
+                                  "required": [
+                                    "type",
+                                    "aggregator"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4849,7 +5413,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["tool-trajectory", "tool_trajectory"]
+                                      "enum": [
+                                        "tool-trajectory",
+                                        "tool_trajectory"
+                                      ]
                                     },
                                     "mode": {
                                       "type": "string",
@@ -4900,7 +5467,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -4914,7 +5486,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -4925,7 +5502,9 @@
                                             ]
                                           }
                                         },
-                                        "required": ["tool"],
+                                        "required": [
+                                          "tool"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     },
@@ -4933,7 +5512,12 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": ["exact", "ignore", "subset", "superset"]
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
                                         },
                                         {
                                           "type": "array",
@@ -4947,7 +5531,12 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": ["exact", "ignore", "subset", "superset"]
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
                                         },
                                         {
                                           "type": "array",
@@ -4958,7 +5547,10 @@
                                       ]
                                     }
                                   },
-                                  "required": ["type", "mode"],
+                                  "required": [
+                                    "type",
+                                    "mode"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4995,7 +5587,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["field-accuracy", "field_accuracy"]
+                                      "enum": [
+                                        "field-accuracy",
+                                        "field_accuracy"
+                                      ]
                                     },
                                     "fields": {
                                       "type": "array",
@@ -5007,7 +5602,11 @@
                                           },
                                           "match": {
                                             "type": "string",
-                                            "enum": ["exact", "numeric_tolerance", "date"]
+                                            "enum": [
+                                              "exact",
+                                              "numeric_tolerance",
+                                              "date"
+                                            ]
                                           },
                                           "required": {
                                             "type": "boolean"
@@ -5029,17 +5628,26 @@
                                             }
                                           }
                                         },
-                                        "required": ["path", "match"],
+                                        "required": [
+                                          "path",
+                                          "match"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       "minItems": 1
                                     },
                                     "aggregation": {
                                       "type": "string",
-                                      "enum": ["weighted_average", "all_or_nothing"]
+                                      "enum": [
+                                        "weighted_average",
+                                        "all_or_nothing"
+                                      ]
                                     }
                                   },
-                                  "required": ["type", "fields"],
+                                  "required": [
+                                    "type",
+                                    "fields"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5083,7 +5691,10 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type", "threshold"],
+                                  "required": [
+                                    "type",
+                                    "threshold"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5127,7 +5738,10 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type", "budget"],
+                                  "required": [
+                                    "type",
+                                    "budget"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5164,7 +5778,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["token-usage", "token_usage"]
+                                      "enum": [
+                                        "token-usage",
+                                        "token_usage"
+                                      ]
                                     },
                                     "max_total": {
                                       "type": "number",
@@ -5179,7 +5796,9 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5216,7 +5835,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["execution-metrics", "execution_metrics"]
+                                      "enum": [
+                                        "execution-metrics",
+                                        "execution_metrics"
+                                      ]
                                     },
                                     "max_tool_calls": {
                                       "type": "number",
@@ -5248,7 +5870,9 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5291,7 +5915,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5334,7 +5961,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5371,10 +6001,15 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["is-json", "is_json"]
+                                      "enum": [
+                                        "is-json",
+                                        "is_json"
+                                      ]
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5417,7 +6052,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -5459,68 +6097,85 @@
                                     "criteria": {
                                       "type": "array",
                                       "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "id": {
-                                            "type": "string"
-                                          },
-                                          "outcome": {
-                                            "type": "string"
-                                          },
-                                          "operator": {
+                                        "anyOf": [
+                                          {
                                             "type": "string",
-                                            "enum": ["correctness", "contradiction"]
+                                            "minLength": 1
                                           },
-                                          "weight": {
-                                            "type": "number"
-                                          },
-                                          "required": {
-                                            "type": "boolean"
-                                          },
-                                          "min_score": {
-                                            "type": "number",
-                                            "exclusiveMinimum": true,
-                                            "minimum": 0,
-                                            "maximum": 1
-                                          },
-                                          "score_ranges": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object",
-                                              "properties": {
-                                                "score_range": {
-                                                  "type": "array",
-                                                  "minItems": 2,
-                                                  "maxItems": 2,
-                                                  "items": [
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    },
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    }
-                                                  ]
-                                                },
-                                                "outcome": {
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                }
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "string"
                                               },
-                                              "required": ["score_range", "outcome"],
-                                              "additionalProperties": false
-                                            }
+                                              "outcome": {
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "correctness",
+                                                  "contradiction"
+                                                ]
+                                              },
+                                              "weight": {
+                                                "type": "number"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "min_score": {
+                                                "type": "number",
+                                                "exclusiveMinimum": true,
+                                                "minimum": 0,
+                                                "maximum": 1
+                                              },
+                                              "score_ranges": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "score_range": {
+                                                      "type": "array",
+                                                      "minItems": 2,
+                                                      "maxItems": 2,
+                                                      "items": [
+                                                        {
+                                                          "type": "integer",
+                                                          "minimum": 0,
+                                                          "maximum": 10
+                                                        },
+                                                        {
+                                                          "type": "integer",
+                                                          "minimum": 0,
+                                                          "maximum": 10
+                                                        }
+                                                      ]
+                                                    },
+                                                    "outcome": {
+                                                      "type": "string",
+                                                      "minLength": 1
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "score_range",
+                                                    "outcome"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              }
+                                            },
+                                            "additionalProperties": false
                                           }
-                                        },
-                                        "additionalProperties": false
+                                        ]
                                       },
                                       "minItems": 1
                                     }
                                   },
-                                  "required": ["type", "criteria"],
+                                  "required": [
+                                    "type",
+                                    "criteria"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -5577,7 +6232,12 @@
                               },
                               "strategy": {
                                 "type": "string",
-                                "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                                "enum": [
+                                  "pass_at_k",
+                                  "pass_all",
+                                  "mean",
+                                  "confidence_interval"
+                                ]
                               },
                               "cost_limit_usd": {
                                 "type": "number",
@@ -5588,7 +6248,9 @@
                                 "minimum": 0
                               }
                             },
-                            "required": ["count"],
+                            "required": [
+                              "count"
+                            ],
                             "additionalProperties": false
                           },
                           "timeout_seconds": {
@@ -5612,7 +6274,10 @@
                           },
                           "isolation": {
                             "type": "string",
-                            "enum": ["shared", "per_case"]
+                            "enum": [
+                              "shared",
+                              "per_case"
+                            ]
                           },
                           "repos": {
                             "type": "array",
@@ -5694,7 +6359,11 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": ["none", "fast", "strict"]
+                                    "enum": [
+                                      "none",
+                                      "fast",
+                                      "strict"
+                                    ]
                                   }
                                 },
                                 "additionalProperties": false
@@ -5739,7 +6408,11 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": ["none", "fast", "strict"]
+                                    "enum": [
+                                      "none",
+                                      "fast",
+                                      "strict"
+                                    ]
                                   }
                                 },
                                 "additionalProperties": false
@@ -5784,7 +6457,11 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": ["none", "fast", "strict"]
+                                    "enum": [
+                                      "none",
+                                      "fast",
+                                      "strict"
+                                    ]
                                   }
                                 },
                                 "additionalProperties": false
@@ -5829,7 +6506,11 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": ["none", "fast", "strict"]
+                                    "enum": [
+                                      "none",
+                                      "fast",
+                                      "strict"
+                                    ]
                                   }
                                 },
                                 "additionalProperties": false
@@ -5855,7 +6536,9 @@
                                 "minimum": 0.1
                               }
                             },
-                            "required": ["image"],
+                            "required": [
+                              "image"
+                            ],
                             "additionalProperties": false
                           },
                           "env": {
@@ -5899,11 +6582,17 @@
                       },
                       "on_dependency_failure": {
                         "type": "string",
-                        "enum": ["skip", "fail", "run"]
+                        "enum": [
+                          "skip",
+                          "fail",
+                          "run"
+                        ]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": ["conversation"]
+                        "enum": [
+                          "conversation"
+                        ]
                       },
                       "turns": {
                         "type": "array",
@@ -5932,13 +6621,20 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["text", "file", "image"]
+                                            "enum": [
+                                              "text",
+                                              "file",
+                                              "image"
+                                            ]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
@@ -5968,13 +6664,20 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["text", "file", "image"]
+                                            "enum": [
+                                              "text",
+                                              "file",
+                                              "image"
+                                            ]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
@@ -6025,7 +6728,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["code-grader", "code_grader"]
+                                            "enum": [
+                                              "code-grader",
+                                              "code_grader"
+                                            ]
                                           },
                                           "command": {
                                             "anyOf": [
@@ -6099,12 +6805,18 @@
                                                   ]
                                                 }
                                               },
-                                              "required": ["type", "command"],
+                                              "required": [
+                                                "type",
+                                                "command"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6141,7 +6853,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["llm-grader", "llm_grader"]
+                                            "enum": [
+                                              "llm-grader",
+                                              "llm_grader"
+                                            ]
                                           },
                                           "prompt": {
                                             "anyOf": [
@@ -6199,7 +6914,10 @@
                                                 },
                                                 "operator": {
                                                   "type": "string",
-                                                  "enum": ["correctness", "contradiction"]
+                                                  "enum": [
+                                                    "correctness",
+                                                    "contradiction"
+                                                  ]
                                                 },
                                                 "weight": {
                                                   "type": "number"
@@ -6240,7 +6958,10 @@
                                                         "minLength": 1
                                                       }
                                                     },
-                                                    "required": ["score_range", "outcome"],
+                                                    "required": [
+                                                      "score_range",
+                                                      "outcome"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 }
@@ -6291,12 +7012,17 @@
                                                   ]
                                                 }
                                               },
-                                              "required": ["type", "command"],
+                                              "required": [
+                                                "type",
+                                                "command"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6307,7 +7033,9 @@
                                             "minLength": 1
                                           }
                                         },
-                                        "required": ["include"],
+                                        "required": [
+                                          "include"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6370,7 +7098,9 @@
                                                     }
                                                   }
                                                 },
-                                                "required": ["type"],
+                                                "required": [
+                                                  "type"
+                                                ],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -6386,7 +7116,10 @@
                                                     "maximum": 1
                                                   }
                                                 },
-                                                "required": ["type", "threshold"],
+                                                "required": [
+                                                  "type",
+                                                  "threshold"
+                                                ],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -6403,7 +7136,10 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["type", "path"],
+                                                "required": [
+                                                  "type",
+                                                  "path"
+                                                ],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -6420,13 +7156,18 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["type"],
+                                                "required": [
+                                                  "type"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
                                           }
                                         },
-                                        "required": ["type", "aggregator"],
+                                        "required": [
+                                          "type",
+                                          "aggregator"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6463,7 +7204,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["tool-trajectory", "tool_trajectory"]
+                                            "enum": [
+                                              "tool-trajectory",
+                                              "tool_trajectory"
+                                            ]
                                           },
                                           "mode": {
                                             "type": "string",
@@ -6549,7 +7293,9 @@
                                                   ]
                                                 }
                                               },
-                                              "required": ["tool"],
+                                              "required": [
+                                                "tool"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           },
@@ -6557,7 +7303,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -6571,7 +7322,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -6582,7 +7338,10 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "mode"],
+                                        "required": [
+                                          "type",
+                                          "mode"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6619,7 +7378,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["field-accuracy", "field_accuracy"]
+                                            "enum": [
+                                              "field-accuracy",
+                                              "field_accuracy"
+                                            ]
                                           },
                                           "fields": {
                                             "type": "array",
@@ -6631,7 +7393,11 @@
                                                 },
                                                 "match": {
                                                   "type": "string",
-                                                  "enum": ["exact", "numeric_tolerance", "date"]
+                                                  "enum": [
+                                                    "exact",
+                                                    "numeric_tolerance",
+                                                    "date"
+                                                  ]
                                                 },
                                                 "required": {
                                                   "type": "boolean"
@@ -6653,17 +7419,26 @@
                                                   }
                                                 }
                                               },
-                                              "required": ["path", "match"],
+                                              "required": [
+                                                "path",
+                                                "match"
+                                              ],
                                               "additionalProperties": false
                                             },
                                             "minItems": 1
                                           },
                                           "aggregation": {
                                             "type": "string",
-                                            "enum": ["weighted_average", "all_or_nothing"]
+                                            "enum": [
+                                              "weighted_average",
+                                              "all_or_nothing"
+                                            ]
                                           }
                                         },
-                                        "required": ["type", "fields"],
+                                        "required": [
+                                          "type",
+                                          "fields"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6707,7 +7482,10 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": ["type", "threshold"],
+                                        "required": [
+                                          "type",
+                                          "threshold"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6751,7 +7529,10 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": ["type", "budget"],
+                                        "required": [
+                                          "type",
+                                          "budget"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6788,7 +7569,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["token-usage", "token_usage"]
+                                            "enum": [
+                                              "token-usage",
+                                              "token_usage"
+                                            ]
                                           },
                                           "max_total": {
                                             "type": "number",
@@ -6803,7 +7587,9 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6840,7 +7626,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["execution-metrics", "execution_metrics"]
+                                            "enum": [
+                                              "execution-metrics",
+                                              "execution_metrics"
+                                            ]
                                           },
                                           "max_tool_calls": {
                                             "type": "number",
@@ -6872,7 +7661,9 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6915,7 +7706,10 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6958,7 +7752,10 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -6995,10 +7792,15 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["is-json", "is_json"]
+                                            "enum": [
+                                              "is-json",
+                                              "is_json"
+                                            ]
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -7041,7 +7843,10 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -7083,68 +7888,85 @@
                                           "criteria": {
                                             "type": "array",
                                             "items": {
-                                              "type": "object",
-                                              "properties": {
-                                                "id": {
-                                                  "type": "string"
-                                                },
-                                                "outcome": {
-                                                  "type": "string"
-                                                },
-                                                "operator": {
+                                              "anyOf": [
+                                                {
                                                   "type": "string",
-                                                  "enum": ["correctness", "contradiction"]
+                                                  "minLength": 1
                                                 },
-                                                "weight": {
-                                                  "type": "number"
-                                                },
-                                                "required": {
-                                                  "type": "boolean"
-                                                },
-                                                "min_score": {
-                                                  "type": "number",
-                                                  "exclusiveMinimum": true,
-                                                  "minimum": 0,
-                                                  "maximum": 1
-                                                },
-                                                "score_ranges": {
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                      "score_range": {
-                                                        "type": "array",
-                                                        "minItems": 2,
-                                                        "maxItems": 2,
-                                                        "items": [
-                                                          {
-                                                            "type": "integer",
-                                                            "minimum": 0,
-                                                            "maximum": 10
-                                                          },
-                                                          {
-                                                            "type": "integer",
-                                                            "minimum": 0,
-                                                            "maximum": 10
-                                                          }
-                                                        ]
-                                                      },
-                                                      "outcome": {
-                                                        "type": "string",
-                                                        "minLength": 1
-                                                      }
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "id": {
+                                                      "type": "string"
                                                     },
-                                                    "required": ["score_range", "outcome"],
-                                                    "additionalProperties": false
-                                                  }
+                                                    "outcome": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "correctness",
+                                                        "contradiction"
+                                                      ]
+                                                    },
+                                                    "weight": {
+                                                      "type": "number"
+                                                    },
+                                                    "required": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "min_score": {
+                                                      "type": "number",
+                                                      "exclusiveMinimum": true,
+                                                      "minimum": 0,
+                                                      "maximum": 1
+                                                    },
+                                                    "score_ranges": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "score_range": {
+                                                            "type": "array",
+                                                            "minItems": 2,
+                                                            "maxItems": 2,
+                                                            "items": [
+                                                              {
+                                                                "type": "integer",
+                                                                "minimum": 0,
+                                                                "maximum": 10
+                                                              },
+                                                              {
+                                                                "type": "integer",
+                                                                "minimum": 0,
+                                                                "maximum": 10
+                                                              }
+                                                            ]
+                                                          },
+                                                          "outcome": {
+                                                            "type": "string",
+                                                            "minLength": 1
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "score_range",
+                                                          "outcome"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    }
+                                                  },
+                                                  "additionalProperties": false
                                                 }
-                                              },
-                                              "additionalProperties": false
+                                              ]
                                             },
                                             "minItems": 1
                                           }
                                         },
-                                        "required": ["type", "criteria"],
+                                        "required": [
+                                          "type",
+                                          "criteria"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     ]
@@ -7153,25 +7975,36 @@
                               }
                             }
                           },
-                          "required": ["input"],
+                          "required": [
+                            "input"
+                          ],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": ["mean", "min", "max"]
+                        "enum": [
+                          "mean",
+                          "min",
+                          "max"
+                        ]
                       },
                       "on_turn_failure": {
                         "type": "string",
-                        "enum": ["continue", "stop"]
+                        "enum": [
+                          "continue",
+                          "stop"
+                        ]
                       },
                       "window_size": {
                         "type": "integer",
                         "minimum": 1
                       }
                     },
-                    "required": ["id"],
+                    "required": [
+                      "id"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -7183,7 +8016,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["suite", "tests"]
+                        "enum": [
+                          "suite",
+                          "tests"
+                        ]
                       },
                       "select": {
                         "anyOf": [
@@ -7254,7 +8090,11 @@
                                     {
                                       "type": "array",
                                       "items": {
-                                        "type": ["string", "number", "boolean"]
+                                        "type": [
+                                          "string",
+                                          "number",
+                                          "boolean"
+                                        ]
                                       },
                                       "minItems": 1
                                     }
@@ -7283,7 +8123,12 @@
                               },
                               "strategy": {
                                 "type": "string",
-                                "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                                "enum": [
+                                  "pass_at_k",
+                                  "pass_all",
+                                  "mean",
+                                  "confidence_interval"
+                                ]
                               },
                               "cost_limit_usd": {
                                 "type": "number",
@@ -7294,7 +8139,9 @@
                                 "minimum": 0
                               }
                             },
-                            "required": ["count"],
+                            "required": [
+                              "count"
+                            ],
                             "additionalProperties": false
                           },
                           "timeout_seconds": {
@@ -7311,7 +8158,10 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["include", "type"],
+                    "required": [
+                      "include",
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -7358,7 +8208,12 @@
                             "properties": {
                               "role": {
                                 "type": "string",
-                                "enum": ["system", "user", "assistant", "tool"]
+                                "enum": [
+                                  "system",
+                                  "user",
+                                  "assistant",
+                                  "tool"
+                                ]
                               },
                               "content": {
                                 "anyOf": [
@@ -7377,20 +8232,30 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": ["text", "file", "image"]
+                                          "enum": [
+                                            "text",
+                                            "file",
+                                            "image"
+                                          ]
                                         },
                                         "value": {
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type", "value"],
+                                      "required": [
+                                        "type",
+                                        "value"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   }
                                 ]
                               }
                             },
-                            "required": ["role", "content"],
+                            "required": [
+                              "role",
+                              "content"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -7409,7 +8274,12 @@
                               "properties": {
                                 "role": {
                                   "type": "string",
-                                  "enum": ["system", "user", "assistant", "tool"]
+                                  "enum": [
+                                    "system",
+                                    "user",
+                                    "assistant",
+                                    "tool"
+                                  ]
                                 },
                                 "content": {
                                   "anyOf": [
@@ -7428,20 +8298,30 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["text", "file", "image"]
+                                            "enum": [
+                                              "text",
+                                              "file",
+                                              "image"
+                                            ]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   ]
                                 }
                               },
-                              "required": ["role", "content"],
+                              "required": [
+                                "role",
+                                "content"
+                              ],
                               "additionalProperties": false
                             }
                           }
@@ -7470,7 +8350,12 @@
                               "properties": {
                                 "role": {
                                   "type": "string",
-                                  "enum": ["system", "user", "assistant", "tool"]
+                                  "enum": [
+                                    "system",
+                                    "user",
+                                    "assistant",
+                                    "tool"
+                                  ]
                                 },
                                 "content": {
                                   "anyOf": [
@@ -7489,20 +8374,30 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["text", "file", "image"]
+                                            "enum": [
+                                              "text",
+                                              "file",
+                                              "image"
+                                            ]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   ]
                                 }
                               },
-                              "required": ["role", "content"],
+                              "required": [
+                                "role",
+                                "content"
+                              ],
                               "additionalProperties": false
                             }
                           }
@@ -7546,7 +8441,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["code-grader", "code_grader"]
+                                  "enum": [
+                                    "code-grader",
+                                    "code_grader"
+                                  ]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -7620,12 +8518,18 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type", "command"],
+                              "required": [
+                                "type",
+                                "command"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -7662,7 +8566,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["llm-grader", "llm_grader"]
+                                  "enum": [
+                                    "llm-grader",
+                                    "llm_grader"
+                                  ]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -7720,7 +8627,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -7761,7 +8671,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -7812,12 +8725,17 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -7828,7 +8746,9 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": ["include"],
+                              "required": [
+                                "include"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -7891,7 +8811,9 @@
                                           }
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -7907,7 +8829,10 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": ["type", "threshold"],
+                                      "required": [
+                                        "type",
+                                        "threshold"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -7924,7 +8849,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type", "path"],
+                                      "required": [
+                                        "type",
+                                        "path"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -7941,13 +8869,18 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["type", "aggregator"],
+                              "required": [
+                                "type",
+                                "aggregator"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -7984,11 +8917,20 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["tool-trajectory", "tool_trajectory"]
+                                  "enum": [
+                                    "tool-trajectory",
+                                    "tool_trajectory"
+                                  ]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                                  "enum": [
+                                    "any_order",
+                                    "in_order",
+                                    "exact",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -8029,7 +8971,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -8043,7 +8990,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -8054,7 +9006,9 @@
                                         ]
                                       }
                                     },
-                                    "required": ["tool"],
+                                    "required": [
+                                      "tool"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 },
@@ -8062,7 +9016,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -8076,7 +9035,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -8087,7 +9051,10 @@
                                   ]
                                 }
                               },
-                              "required": ["type", "mode"],
+                              "required": [
+                                "type",
+                                "mode"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8124,7 +9091,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["field-accuracy", "field_accuracy"]
+                                  "enum": [
+                                    "field-accuracy",
+                                    "field_accuracy"
+                                  ]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -8136,7 +9106,11 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": ["exact", "numeric_tolerance", "date"]
+                                        "enum": [
+                                          "exact",
+                                          "numeric_tolerance",
+                                          "date"
+                                        ]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -8158,17 +9132,26 @@
                                         }
                                       }
                                     },
-                                    "required": ["path", "match"],
+                                    "required": [
+                                      "path",
+                                      "match"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": ["weighted_average", "all_or_nothing"]
+                                  "enum": [
+                                    "weighted_average",
+                                    "all_or_nothing"
+                                  ]
                                 }
                               },
-                              "required": ["type", "fields"],
+                              "required": [
+                                "type",
+                                "fields"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8212,7 +9195,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "threshold"],
+                              "required": [
+                                "type",
+                                "threshold"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8256,7 +9242,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "budget"],
+                              "required": [
+                                "type",
+                                "budget"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8293,7 +9282,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["token-usage", "token_usage"]
+                                  "enum": [
+                                    "token-usage",
+                                    "token_usage"
+                                  ]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -8308,7 +9300,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8345,7 +9339,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["execution-metrics", "execution_metrics"]
+                                  "enum": [
+                                    "execution-metrics",
+                                    "execution_metrics"
+                                  ]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -8377,7 +9374,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8420,7 +9419,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8463,7 +9465,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8500,10 +9505,15 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["is-json", "is_json"]
+                                  "enum": [
+                                    "is-json",
+                                    "is_json"
+                                  ]
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8546,7 +9556,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8588,68 +9601,85 @@
                                 "criteria": {
                                   "type": "array",
                                   "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "id": {
-                                        "type": "string"
-                                      },
-                                      "outcome": {
-                                        "type": "string"
-                                      },
-                                      "operator": {
+                                    "anyOf": [
+                                      {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "minLength": 1
                                       },
-                                      "weight": {
-                                        "type": "number"
-                                      },
-                                      "required": {
-                                        "type": "boolean"
-                                      },
-                                      "min_score": {
-                                        "type": "number",
-                                        "exclusiveMinimum": true,
-                                        "minimum": 0,
-                                        "maximum": 1
-                                      },
-                                      "score_ranges": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "object",
-                                          "properties": {
-                                            "score_range": {
-                                              "type": "array",
-                                              "minItems": 2,
-                                              "maxItems": 2,
-                                              "items": [
-                                                {
-                                                  "type": "integer",
-                                                  "minimum": 0,
-                                                  "maximum": 10
-                                                },
-                                                {
-                                                  "type": "integer",
-                                                  "minimum": 0,
-                                                  "maximum": 10
-                                                }
-                                              ]
-                                            },
-                                            "outcome": {
-                                              "type": "string",
-                                              "minLength": 1
-                                            }
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
                                           },
-                                          "required": ["score_range", "outcome"],
-                                          "additionalProperties": false
-                                        }
+                                          "outcome": {
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "type": "string",
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
+                                          },
+                                          "weight": {
+                                            "type": "number"
+                                          },
+                                          "required": {
+                                            "type": "boolean"
+                                          },
+                                          "min_score": {
+                                            "type": "number",
+                                            "exclusiveMinimum": true,
+                                            "minimum": 0,
+                                            "maximum": 1
+                                          },
+                                          "score_ranges": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "score_range": {
+                                                  "type": "array",
+                                                  "minItems": 2,
+                                                  "maxItems": 2,
+                                                  "items": [
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    },
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    }
+                                                  ]
+                                                },
+                                                "outcome": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                }
+                                              },
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false
                                       }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "minItems": 1
                                 }
                               },
-                              "required": ["type", "criteria"],
+                              "required": [
+                                "type",
+                                "criteria"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -8693,7 +9723,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["code-grader", "code_grader"]
+                                  "enum": [
+                                    "code-grader",
+                                    "code_grader"
+                                  ]
                                 },
                                 "command": {
                                   "anyOf": [
@@ -8767,12 +9800,18 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type", "command"],
+                              "required": [
+                                "type",
+                                "command"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8809,7 +9848,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["llm-grader", "llm_grader"]
+                                  "enum": [
+                                    "llm-grader",
+                                    "llm_grader"
+                                  ]
                                 },
                                 "prompt": {
                                   "anyOf": [
@@ -8867,7 +9909,10 @@
                                       },
                                       "operator": {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "enum": [
+                                          "correctness",
+                                          "contradiction"
+                                        ]
                                       },
                                       "weight": {
                                         "type": "number"
@@ -8908,7 +9953,10 @@
                                               "minLength": 1
                                             }
                                           },
-                                          "required": ["score_range", "outcome"],
+                                          "required": [
+                                            "score_range",
+                                            "outcome"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       }
@@ -8959,12 +10007,17 @@
                                         ]
                                       }
                                     },
-                                    "required": ["type", "command"],
+                                    "required": [
+                                      "type",
+                                      "command"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -8975,7 +10028,9 @@
                                   "minLength": 1
                                 }
                               },
-                              "required": ["include"],
+                              "required": [
+                                "include"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9038,7 +10093,9 @@
                                           }
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -9054,7 +10111,10 @@
                                           "maximum": 1
                                         }
                                       },
-                                      "required": ["type", "threshold"],
+                                      "required": [
+                                        "type",
+                                        "threshold"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -9071,7 +10131,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type", "path"],
+                                      "required": [
+                                        "type",
+                                        "path"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -9088,13 +10151,18 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["type", "aggregator"],
+                              "required": [
+                                "type",
+                                "aggregator"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9131,11 +10199,20 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["tool-trajectory", "tool_trajectory"]
+                                  "enum": [
+                                    "tool-trajectory",
+                                    "tool_trajectory"
+                                  ]
                                 },
                                 "mode": {
                                   "type": "string",
-                                  "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                                  "enum": [
+                                    "any_order",
+                                    "in_order",
+                                    "exact",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 "minimums": {
                                   "type": "object",
@@ -9176,7 +10253,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -9190,7 +10272,12 @@
                                         "anyOf": [
                                           {
                                             "type": "string",
-                                            "enum": ["exact", "ignore", "subset", "superset"]
+                                            "enum": [
+                                              "exact",
+                                              "ignore",
+                                              "subset",
+                                              "superset"
+                                            ]
                                           },
                                           {
                                             "type": "array",
@@ -9201,7 +10288,9 @@
                                         ]
                                       }
                                     },
-                                    "required": ["tool"],
+                                    "required": [
+                                      "tool"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 },
@@ -9209,7 +10298,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -9223,7 +10317,12 @@
                                   "anyOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["exact", "ignore", "subset", "superset"]
+                                      "enum": [
+                                        "exact",
+                                        "ignore",
+                                        "subset",
+                                        "superset"
+                                      ]
                                     },
                                     {
                                       "type": "array",
@@ -9234,7 +10333,10 @@
                                   ]
                                 }
                               },
-                              "required": ["type", "mode"],
+                              "required": [
+                                "type",
+                                "mode"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9271,7 +10373,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["field-accuracy", "field_accuracy"]
+                                  "enum": [
+                                    "field-accuracy",
+                                    "field_accuracy"
+                                  ]
                                 },
                                 "fields": {
                                   "type": "array",
@@ -9283,7 +10388,11 @@
                                       },
                                       "match": {
                                         "type": "string",
-                                        "enum": ["exact", "numeric_tolerance", "date"]
+                                        "enum": [
+                                          "exact",
+                                          "numeric_tolerance",
+                                          "date"
+                                        ]
                                       },
                                       "required": {
                                         "type": "boolean"
@@ -9305,17 +10414,26 @@
                                         }
                                       }
                                     },
-                                    "required": ["path", "match"],
+                                    "required": [
+                                      "path",
+                                      "match"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   "minItems": 1
                                 },
                                 "aggregation": {
                                   "type": "string",
-                                  "enum": ["weighted_average", "all_or_nothing"]
+                                  "enum": [
+                                    "weighted_average",
+                                    "all_or_nothing"
+                                  ]
                                 }
                               },
-                              "required": ["type", "fields"],
+                              "required": [
+                                "type",
+                                "fields"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9359,7 +10477,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "threshold"],
+                              "required": [
+                                "type",
+                                "threshold"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9403,7 +10524,10 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type", "budget"],
+                              "required": [
+                                "type",
+                                "budget"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9440,7 +10564,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["token-usage", "token_usage"]
+                                  "enum": [
+                                    "token-usage",
+                                    "token_usage"
+                                  ]
                                 },
                                 "max_total": {
                                   "type": "number",
@@ -9455,7 +10582,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9492,7 +10621,10 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["execution-metrics", "execution_metrics"]
+                                  "enum": [
+                                    "execution-metrics",
+                                    "execution_metrics"
+                                  ]
                                 },
                                 "max_tool_calls": {
                                   "type": "number",
@@ -9524,7 +10656,9 @@
                                   "minimum": 0
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9567,7 +10701,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9610,7 +10747,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9647,10 +10787,15 @@
                                 },
                                 "type": {
                                   "type": "string",
-                                  "enum": ["is-json", "is_json"]
+                                  "enum": [
+                                    "is-json",
+                                    "is_json"
+                                  ]
                                 }
                               },
-                              "required": ["type"],
+                              "required": [
+                                "type"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9693,7 +10838,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["type", "value"],
+                              "required": [
+                                "type",
+                                "value"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9735,68 +10883,85 @@
                                 "criteria": {
                                   "type": "array",
                                   "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "id": {
-                                        "type": "string"
-                                      },
-                                      "outcome": {
-                                        "type": "string"
-                                      },
-                                      "operator": {
+                                    "anyOf": [
+                                      {
                                         "type": "string",
-                                        "enum": ["correctness", "contradiction"]
+                                        "minLength": 1
                                       },
-                                      "weight": {
-                                        "type": "number"
-                                      },
-                                      "required": {
-                                        "type": "boolean"
-                                      },
-                                      "min_score": {
-                                        "type": "number",
-                                        "exclusiveMinimum": true,
-                                        "minimum": 0,
-                                        "maximum": 1
-                                      },
-                                      "score_ranges": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "object",
-                                          "properties": {
-                                            "score_range": {
-                                              "type": "array",
-                                              "minItems": 2,
-                                              "maxItems": 2,
-                                              "items": [
-                                                {
-                                                  "type": "integer",
-                                                  "minimum": 0,
-                                                  "maximum": 10
-                                                },
-                                                {
-                                                  "type": "integer",
-                                                  "minimum": 0,
-                                                  "maximum": 10
-                                                }
-                                              ]
-                                            },
-                                            "outcome": {
-                                              "type": "string",
-                                              "minLength": 1
-                                            }
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
                                           },
-                                          "required": ["score_range", "outcome"],
-                                          "additionalProperties": false
-                                        }
+                                          "outcome": {
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "type": "string",
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
+                                          },
+                                          "weight": {
+                                            "type": "number"
+                                          },
+                                          "required": {
+                                            "type": "boolean"
+                                          },
+                                          "min_score": {
+                                            "type": "number",
+                                            "exclusiveMinimum": true,
+                                            "minimum": 0,
+                                            "maximum": 1
+                                          },
+                                          "score_ranges": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "score_range": {
+                                                  "type": "array",
+                                                  "minItems": 2,
+                                                  "maxItems": 2,
+                                                  "items": [
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    },
+                                                    {
+                                                      "type": "integer",
+                                                      "minimum": 0,
+                                                      "maximum": 10
+                                                    }
+                                                  ]
+                                                },
+                                                "outcome": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                }
+                                              },
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false
                                       }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                   },
                                   "minItems": 1
                                 }
                               },
-                              "required": ["type", "criteria"],
+                              "required": [
+                                "type",
+                                "criteria"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -9848,7 +11013,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["code-grader", "code_grader"]
+                                      "enum": [
+                                        "code-grader",
+                                        "code_grader"
+                                      ]
                                     },
                                     "command": {
                                       "anyOf": [
@@ -9922,12 +11090,18 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": ["type", "command"],
+                                  "required": [
+                                    "type",
+                                    "command"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -9964,7 +11138,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["llm-grader", "llm_grader"]
+                                      "enum": [
+                                        "llm-grader",
+                                        "llm_grader"
+                                      ]
                                     },
                                     "prompt": {
                                       "anyOf": [
@@ -10022,7 +11199,10 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": ["correctness", "contradiction"]
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -10063,7 +11243,10 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": ["score_range", "outcome"],
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
@@ -10114,12 +11297,17 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10130,7 +11318,9 @@
                                       "minLength": 1
                                     }
                                   },
-                                  "required": ["include"],
+                                  "required": [
+                                    "include"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10193,7 +11383,9 @@
                                               }
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -10209,7 +11401,10 @@
                                               "maximum": 1
                                             }
                                           },
-                                          "required": ["type", "threshold"],
+                                          "required": [
+                                            "type",
+                                            "threshold"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -10226,7 +11421,10 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["type", "path"],
+                                          "required": [
+                                            "type",
+                                            "path"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -10243,13 +11441,18 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": ["type", "aggregator"],
+                                  "required": [
+                                    "type",
+                                    "aggregator"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10286,7 +11489,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["tool-trajectory", "tool_trajectory"]
+                                      "enum": [
+                                        "tool-trajectory",
+                                        "tool_trajectory"
+                                      ]
                                     },
                                     "mode": {
                                       "type": "string",
@@ -10337,7 +11543,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -10351,7 +11562,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -10362,7 +11578,9 @@
                                             ]
                                           }
                                         },
-                                        "required": ["tool"],
+                                        "required": [
+                                          "tool"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     },
@@ -10370,7 +11588,12 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": ["exact", "ignore", "subset", "superset"]
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
                                         },
                                         {
                                           "type": "array",
@@ -10384,7 +11607,12 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": ["exact", "ignore", "subset", "superset"]
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
                                         },
                                         {
                                           "type": "array",
@@ -10395,7 +11623,10 @@
                                       ]
                                     }
                                   },
-                                  "required": ["type", "mode"],
+                                  "required": [
+                                    "type",
+                                    "mode"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10432,7 +11663,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["field-accuracy", "field_accuracy"]
+                                      "enum": [
+                                        "field-accuracy",
+                                        "field_accuracy"
+                                      ]
                                     },
                                     "fields": {
                                       "type": "array",
@@ -10444,7 +11678,11 @@
                                           },
                                           "match": {
                                             "type": "string",
-                                            "enum": ["exact", "numeric_tolerance", "date"]
+                                            "enum": [
+                                              "exact",
+                                              "numeric_tolerance",
+                                              "date"
+                                            ]
                                           },
                                           "required": {
                                             "type": "boolean"
@@ -10466,17 +11704,26 @@
                                             }
                                           }
                                         },
-                                        "required": ["path", "match"],
+                                        "required": [
+                                          "path",
+                                          "match"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       "minItems": 1
                                     },
                                     "aggregation": {
                                       "type": "string",
-                                      "enum": ["weighted_average", "all_or_nothing"]
+                                      "enum": [
+                                        "weighted_average",
+                                        "all_or_nothing"
+                                      ]
                                     }
                                   },
-                                  "required": ["type", "fields"],
+                                  "required": [
+                                    "type",
+                                    "fields"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10520,7 +11767,10 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type", "threshold"],
+                                  "required": [
+                                    "type",
+                                    "threshold"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10564,7 +11814,10 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type", "budget"],
+                                  "required": [
+                                    "type",
+                                    "budget"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10601,7 +11854,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["token-usage", "token_usage"]
+                                      "enum": [
+                                        "token-usage",
+                                        "token_usage"
+                                      ]
                                     },
                                     "max_total": {
                                       "type": "number",
@@ -10616,7 +11872,9 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10653,7 +11911,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["execution-metrics", "execution_metrics"]
+                                      "enum": [
+                                        "execution-metrics",
+                                        "execution_metrics"
+                                      ]
                                     },
                                     "max_tool_calls": {
                                       "type": "number",
@@ -10685,7 +11946,9 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10728,7 +11991,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10771,7 +12037,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10808,10 +12077,15 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["is-json", "is_json"]
+                                      "enum": [
+                                        "is-json",
+                                        "is_json"
+                                      ]
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10854,7 +12128,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10896,68 +12173,85 @@
                                     "criteria": {
                                       "type": "array",
                                       "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "id": {
-                                            "type": "string"
-                                          },
-                                          "outcome": {
-                                            "type": "string"
-                                          },
-                                          "operator": {
+                                        "anyOf": [
+                                          {
                                             "type": "string",
-                                            "enum": ["correctness", "contradiction"]
+                                            "minLength": 1
                                           },
-                                          "weight": {
-                                            "type": "number"
-                                          },
-                                          "required": {
-                                            "type": "boolean"
-                                          },
-                                          "min_score": {
-                                            "type": "number",
-                                            "exclusiveMinimum": true,
-                                            "minimum": 0,
-                                            "maximum": 1
-                                          },
-                                          "score_ranges": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object",
-                                              "properties": {
-                                                "score_range": {
-                                                  "type": "array",
-                                                  "minItems": 2,
-                                                  "maxItems": 2,
-                                                  "items": [
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    },
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    }
-                                                  ]
-                                                },
-                                                "outcome": {
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                }
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "string"
                                               },
-                                              "required": ["score_range", "outcome"],
-                                              "additionalProperties": false
-                                            }
+                                              "outcome": {
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "correctness",
+                                                  "contradiction"
+                                                ]
+                                              },
+                                              "weight": {
+                                                "type": "number"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "min_score": {
+                                                "type": "number",
+                                                "exclusiveMinimum": true,
+                                                "minimum": 0,
+                                                "maximum": 1
+                                              },
+                                              "score_ranges": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "score_range": {
+                                                      "type": "array",
+                                                      "minItems": 2,
+                                                      "maxItems": 2,
+                                                      "items": [
+                                                        {
+                                                          "type": "integer",
+                                                          "minimum": 0,
+                                                          "maximum": 10
+                                                        },
+                                                        {
+                                                          "type": "integer",
+                                                          "minimum": 0,
+                                                          "maximum": 10
+                                                        }
+                                                      ]
+                                                    },
+                                                    "outcome": {
+                                                      "type": "string",
+                                                      "minLength": 1
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "score_range",
+                                                    "outcome"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              }
+                                            },
+                                            "additionalProperties": false
                                           }
-                                        },
-                                        "additionalProperties": false
+                                        ]
                                       },
                                       "minItems": 1
                                     }
                                   },
-                                  "required": ["type", "criteria"],
+                                  "required": [
+                                    "type",
+                                    "criteria"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -11001,7 +12295,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["code-grader", "code_grader"]
+                                      "enum": [
+                                        "code-grader",
+                                        "code_grader"
+                                      ]
                                     },
                                     "command": {
                                       "anyOf": [
@@ -11075,12 +12372,18 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": ["type", "command"],
+                                  "required": [
+                                    "type",
+                                    "command"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11117,7 +12420,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["llm-grader", "llm_grader"]
+                                      "enum": [
+                                        "llm-grader",
+                                        "llm_grader"
+                                      ]
                                     },
                                     "prompt": {
                                       "anyOf": [
@@ -11175,7 +12481,10 @@
                                           },
                                           "operator": {
                                             "type": "string",
-                                            "enum": ["correctness", "contradiction"]
+                                            "enum": [
+                                              "correctness",
+                                              "contradiction"
+                                            ]
                                           },
                                           "weight": {
                                             "type": "number"
@@ -11216,7 +12525,10 @@
                                                   "minLength": 1
                                                 }
                                               },
-                                              "required": ["score_range", "outcome"],
+                                              "required": [
+                                                "score_range",
+                                                "outcome"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
@@ -11267,12 +12579,17 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11283,7 +12600,9 @@
                                       "minLength": 1
                                     }
                                   },
-                                  "required": ["include"],
+                                  "required": [
+                                    "include"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11346,7 +12665,9 @@
                                               }
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -11362,7 +12683,10 @@
                                               "maximum": 1
                                             }
                                           },
-                                          "required": ["type", "threshold"],
+                                          "required": [
+                                            "type",
+                                            "threshold"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -11379,7 +12703,10 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["type", "path"],
+                                          "required": [
+                                            "type",
+                                            "path"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -11396,13 +12723,18 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": ["type", "aggregator"],
+                                  "required": [
+                                    "type",
+                                    "aggregator"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11439,7 +12771,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["tool-trajectory", "tool_trajectory"]
+                                      "enum": [
+                                        "tool-trajectory",
+                                        "tool_trajectory"
+                                      ]
                                     },
                                     "mode": {
                                       "type": "string",
@@ -11490,7 +12825,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -11504,7 +12844,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -11515,7 +12860,9 @@
                                             ]
                                           }
                                         },
-                                        "required": ["tool"],
+                                        "required": [
+                                          "tool"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     },
@@ -11523,7 +12870,12 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": ["exact", "ignore", "subset", "superset"]
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
                                         },
                                         {
                                           "type": "array",
@@ -11537,7 +12889,12 @@
                                       "anyOf": [
                                         {
                                           "type": "string",
-                                          "enum": ["exact", "ignore", "subset", "superset"]
+                                          "enum": [
+                                            "exact",
+                                            "ignore",
+                                            "subset",
+                                            "superset"
+                                          ]
                                         },
                                         {
                                           "type": "array",
@@ -11548,7 +12905,10 @@
                                       ]
                                     }
                                   },
-                                  "required": ["type", "mode"],
+                                  "required": [
+                                    "type",
+                                    "mode"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11585,7 +12945,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["field-accuracy", "field_accuracy"]
+                                      "enum": [
+                                        "field-accuracy",
+                                        "field_accuracy"
+                                      ]
                                     },
                                     "fields": {
                                       "type": "array",
@@ -11597,7 +12960,11 @@
                                           },
                                           "match": {
                                             "type": "string",
-                                            "enum": ["exact", "numeric_tolerance", "date"]
+                                            "enum": [
+                                              "exact",
+                                              "numeric_tolerance",
+                                              "date"
+                                            ]
                                           },
                                           "required": {
                                             "type": "boolean"
@@ -11619,17 +12986,26 @@
                                             }
                                           }
                                         },
-                                        "required": ["path", "match"],
+                                        "required": [
+                                          "path",
+                                          "match"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       "minItems": 1
                                     },
                                     "aggregation": {
                                       "type": "string",
-                                      "enum": ["weighted_average", "all_or_nothing"]
+                                      "enum": [
+                                        "weighted_average",
+                                        "all_or_nothing"
+                                      ]
                                     }
                                   },
-                                  "required": ["type", "fields"],
+                                  "required": [
+                                    "type",
+                                    "fields"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11673,7 +13049,10 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type", "threshold"],
+                                  "required": [
+                                    "type",
+                                    "threshold"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11717,7 +13096,10 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type", "budget"],
+                                  "required": [
+                                    "type",
+                                    "budget"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11754,7 +13136,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["token-usage", "token_usage"]
+                                      "enum": [
+                                        "token-usage",
+                                        "token_usage"
+                                      ]
                                     },
                                     "max_total": {
                                       "type": "number",
@@ -11769,7 +13154,9 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11806,7 +13193,10 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["execution-metrics", "execution_metrics"]
+                                      "enum": [
+                                        "execution-metrics",
+                                        "execution_metrics"
+                                      ]
                                     },
                                     "max_tool_calls": {
                                       "type": "number",
@@ -11838,7 +13228,9 @@
                                       "minimum": 0
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11881,7 +13273,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11924,7 +13319,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -11961,10 +13359,15 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["is-json", "is_json"]
+                                      "enum": [
+                                        "is-json",
+                                        "is_json"
+                                      ]
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -12007,7 +13410,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["type", "value"],
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -12049,68 +13455,85 @@
                                     "criteria": {
                                       "type": "array",
                                       "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "id": {
-                                            "type": "string"
-                                          },
-                                          "outcome": {
-                                            "type": "string"
-                                          },
-                                          "operator": {
+                                        "anyOf": [
+                                          {
                                             "type": "string",
-                                            "enum": ["correctness", "contradiction"]
+                                            "minLength": 1
                                           },
-                                          "weight": {
-                                            "type": "number"
-                                          },
-                                          "required": {
-                                            "type": "boolean"
-                                          },
-                                          "min_score": {
-                                            "type": "number",
-                                            "exclusiveMinimum": true,
-                                            "minimum": 0,
-                                            "maximum": 1
-                                          },
-                                          "score_ranges": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object",
-                                              "properties": {
-                                                "score_range": {
-                                                  "type": "array",
-                                                  "minItems": 2,
-                                                  "maxItems": 2,
-                                                  "items": [
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    },
-                                                    {
-                                                      "type": "integer",
-                                                      "minimum": 0,
-                                                      "maximum": 10
-                                                    }
-                                                  ]
-                                                },
-                                                "outcome": {
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                }
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "string"
                                               },
-                                              "required": ["score_range", "outcome"],
-                                              "additionalProperties": false
-                                            }
+                                              "outcome": {
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "correctness",
+                                                  "contradiction"
+                                                ]
+                                              },
+                                              "weight": {
+                                                "type": "number"
+                                              },
+                                              "required": {
+                                                "type": "boolean"
+                                              },
+                                              "min_score": {
+                                                "type": "number",
+                                                "exclusiveMinimum": true,
+                                                "minimum": 0,
+                                                "maximum": 1
+                                              },
+                                              "score_ranges": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "score_range": {
+                                                      "type": "array",
+                                                      "minItems": 2,
+                                                      "maxItems": 2,
+                                                      "items": [
+                                                        {
+                                                          "type": "integer",
+                                                          "minimum": 0,
+                                                          "maximum": 10
+                                                        },
+                                                        {
+                                                          "type": "integer",
+                                                          "minimum": 0,
+                                                          "maximum": 10
+                                                        }
+                                                      ]
+                                                    },
+                                                    "outcome": {
+                                                      "type": "string",
+                                                      "minLength": 1
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "score_range",
+                                                    "outcome"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              }
+                                            },
+                                            "additionalProperties": false
                                           }
-                                        },
-                                        "additionalProperties": false
+                                        ]
                                       },
                                       "minItems": 1
                                     }
                                   },
-                                  "required": ["type", "criteria"],
+                                  "required": [
+                                    "type",
+                                    "criteria"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -12167,7 +13590,12 @@
                               },
                               "strategy": {
                                 "type": "string",
-                                "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                                "enum": [
+                                  "pass_at_k",
+                                  "pass_all",
+                                  "mean",
+                                  "confidence_interval"
+                                ]
                               },
                               "cost_limit_usd": {
                                 "type": "number",
@@ -12178,7 +13606,9 @@
                                 "minimum": 0
                               }
                             },
-                            "required": ["count"],
+                            "required": [
+                              "count"
+                            ],
                             "additionalProperties": false
                           },
                           "timeout_seconds": {
@@ -12202,7 +13632,10 @@
                           },
                           "isolation": {
                             "type": "string",
-                            "enum": ["shared", "per_case"]
+                            "enum": [
+                              "shared",
+                              "per_case"
+                            ]
                           },
                           "repos": {
                             "type": "array",
@@ -12284,7 +13717,11 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": ["none", "fast", "strict"]
+                                    "enum": [
+                                      "none",
+                                      "fast",
+                                      "strict"
+                                    ]
                                   }
                                 },
                                 "additionalProperties": false
@@ -12329,7 +13766,11 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": ["none", "fast", "strict"]
+                                    "enum": [
+                                      "none",
+                                      "fast",
+                                      "strict"
+                                    ]
                                   }
                                 },
                                 "additionalProperties": false
@@ -12374,7 +13815,11 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": ["none", "fast", "strict"]
+                                    "enum": [
+                                      "none",
+                                      "fast",
+                                      "strict"
+                                    ]
                                   }
                                 },
                                 "additionalProperties": false
@@ -12419,7 +13864,11 @@
                                   },
                                   "reset": {
                                     "type": "string",
-                                    "enum": ["none", "fast", "strict"]
+                                    "enum": [
+                                      "none",
+                                      "fast",
+                                      "strict"
+                                    ]
                                   }
                                 },
                                 "additionalProperties": false
@@ -12445,7 +13894,9 @@
                                 "minimum": 0.1
                               }
                             },
-                            "required": ["image"],
+                            "required": [
+                              "image"
+                            ],
                             "additionalProperties": false
                           },
                           "env": {
@@ -12489,11 +13940,17 @@
                       },
                       "on_dependency_failure": {
                         "type": "string",
-                        "enum": ["skip", "fail", "run"]
+                        "enum": [
+                          "skip",
+                          "fail",
+                          "run"
+                        ]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": ["conversation"]
+                        "enum": [
+                          "conversation"
+                        ]
                       },
                       "turns": {
                         "type": "array",
@@ -12522,13 +13979,20 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["text", "file", "image"]
+                                            "enum": [
+                                              "text",
+                                              "file",
+                                              "image"
+                                            ]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
@@ -12558,13 +14022,20 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["text", "file", "image"]
+                                            "enum": [
+                                              "text",
+                                              "file",
+                                              "image"
+                                            ]
                                           },
                                           "value": {
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     }
@@ -12615,7 +14086,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["code-grader", "code_grader"]
+                                            "enum": [
+                                              "code-grader",
+                                              "code_grader"
+                                            ]
                                           },
                                           "command": {
                                             "anyOf": [
@@ -12689,12 +14163,18 @@
                                                   ]
                                                 }
                                               },
-                                              "required": ["type", "command"],
+                                              "required": [
+                                                "type",
+                                                "command"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
                                         },
-                                        "required": ["type", "command"],
+                                        "required": [
+                                          "type",
+                                          "command"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -12731,7 +14211,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["llm-grader", "llm_grader"]
+                                            "enum": [
+                                              "llm-grader",
+                                              "llm_grader"
+                                            ]
                                           },
                                           "prompt": {
                                             "anyOf": [
@@ -12789,7 +14272,10 @@
                                                 },
                                                 "operator": {
                                                   "type": "string",
-                                                  "enum": ["correctness", "contradiction"]
+                                                  "enum": [
+                                                    "correctness",
+                                                    "contradiction"
+                                                  ]
                                                 },
                                                 "weight": {
                                                   "type": "number"
@@ -12830,7 +14316,10 @@
                                                         "minLength": 1
                                                       }
                                                     },
-                                                    "required": ["score_range", "outcome"],
+                                                    "required": [
+                                                      "score_range",
+                                                      "outcome"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 }
@@ -12881,12 +14370,17 @@
                                                   ]
                                                 }
                                               },
-                                              "required": ["type", "command"],
+                                              "required": [
+                                                "type",
+                                                "command"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -12897,7 +14391,9 @@
                                             "minLength": 1
                                           }
                                         },
-                                        "required": ["include"],
+                                        "required": [
+                                          "include"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -12960,7 +14456,9 @@
                                                     }
                                                   }
                                                 },
-                                                "required": ["type"],
+                                                "required": [
+                                                  "type"
+                                                ],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -12976,7 +14474,10 @@
                                                     "maximum": 1
                                                   }
                                                 },
-                                                "required": ["type", "threshold"],
+                                                "required": [
+                                                  "type",
+                                                  "threshold"
+                                                ],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -12993,7 +14494,10 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["type", "path"],
+                                                "required": [
+                                                  "type",
+                                                  "path"
+                                                ],
                                                 "additionalProperties": false
                                               },
                                               {
@@ -13010,13 +14514,18 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["type"],
+                                                "required": [
+                                                  "type"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
                                           }
                                         },
-                                        "required": ["type", "aggregator"],
+                                        "required": [
+                                          "type",
+                                          "aggregator"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13053,7 +14562,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["tool-trajectory", "tool_trajectory"]
+                                            "enum": [
+                                              "tool-trajectory",
+                                              "tool_trajectory"
+                                            ]
                                           },
                                           "mode": {
                                             "type": "string",
@@ -13139,7 +14651,9 @@
                                                   ]
                                                 }
                                               },
-                                              "required": ["tool"],
+                                              "required": [
+                                                "tool"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           },
@@ -13147,7 +14661,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -13161,7 +14680,12 @@
                                             "anyOf": [
                                               {
                                                 "type": "string",
-                                                "enum": ["exact", "ignore", "subset", "superset"]
+                                                "enum": [
+                                                  "exact",
+                                                  "ignore",
+                                                  "subset",
+                                                  "superset"
+                                                ]
                                               },
                                               {
                                                 "type": "array",
@@ -13172,7 +14696,10 @@
                                             ]
                                           }
                                         },
-                                        "required": ["type", "mode"],
+                                        "required": [
+                                          "type",
+                                          "mode"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13209,7 +14736,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["field-accuracy", "field_accuracy"]
+                                            "enum": [
+                                              "field-accuracy",
+                                              "field_accuracy"
+                                            ]
                                           },
                                           "fields": {
                                             "type": "array",
@@ -13221,7 +14751,11 @@
                                                 },
                                                 "match": {
                                                   "type": "string",
-                                                  "enum": ["exact", "numeric_tolerance", "date"]
+                                                  "enum": [
+                                                    "exact",
+                                                    "numeric_tolerance",
+                                                    "date"
+                                                  ]
                                                 },
                                                 "required": {
                                                   "type": "boolean"
@@ -13243,17 +14777,26 @@
                                                   }
                                                 }
                                               },
-                                              "required": ["path", "match"],
+                                              "required": [
+                                                "path",
+                                                "match"
+                                              ],
                                               "additionalProperties": false
                                             },
                                             "minItems": 1
                                           },
                                           "aggregation": {
                                             "type": "string",
-                                            "enum": ["weighted_average", "all_or_nothing"]
+                                            "enum": [
+                                              "weighted_average",
+                                              "all_or_nothing"
+                                            ]
                                           }
                                         },
-                                        "required": ["type", "fields"],
+                                        "required": [
+                                          "type",
+                                          "fields"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13297,7 +14840,10 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": ["type", "threshold"],
+                                        "required": [
+                                          "type",
+                                          "threshold"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13341,7 +14887,10 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": ["type", "budget"],
+                                        "required": [
+                                          "type",
+                                          "budget"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13378,7 +14927,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["token-usage", "token_usage"]
+                                            "enum": [
+                                              "token-usage",
+                                              "token_usage"
+                                            ]
                                           },
                                           "max_total": {
                                             "type": "number",
@@ -13393,7 +14945,9 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13430,7 +14984,10 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["execution-metrics", "execution_metrics"]
+                                            "enum": [
+                                              "execution-metrics",
+                                              "execution_metrics"
+                                            ]
                                           },
                                           "max_tool_calls": {
                                             "type": "number",
@@ -13462,7 +15019,9 @@
                                             "minimum": 0
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13505,7 +15064,10 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13548,7 +15110,10 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13585,10 +15150,15 @@
                                           },
                                           "type": {
                                             "type": "string",
-                                            "enum": ["is-json", "is_json"]
+                                            "enum": [
+                                              "is-json",
+                                              "is_json"
+                                            ]
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13631,7 +15201,10 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["type", "value"],
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
                                         "additionalProperties": false
                                       },
                                       {
@@ -13673,68 +15246,85 @@
                                           "criteria": {
                                             "type": "array",
                                             "items": {
-                                              "type": "object",
-                                              "properties": {
-                                                "id": {
-                                                  "type": "string"
-                                                },
-                                                "outcome": {
-                                                  "type": "string"
-                                                },
-                                                "operator": {
+                                              "anyOf": [
+                                                {
                                                   "type": "string",
-                                                  "enum": ["correctness", "contradiction"]
+                                                  "minLength": 1
                                                 },
-                                                "weight": {
-                                                  "type": "number"
-                                                },
-                                                "required": {
-                                                  "type": "boolean"
-                                                },
-                                                "min_score": {
-                                                  "type": "number",
-                                                  "exclusiveMinimum": true,
-                                                  "minimum": 0,
-                                                  "maximum": 1
-                                                },
-                                                "score_ranges": {
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                      "score_range": {
-                                                        "type": "array",
-                                                        "minItems": 2,
-                                                        "maxItems": 2,
-                                                        "items": [
-                                                          {
-                                                            "type": "integer",
-                                                            "minimum": 0,
-                                                            "maximum": 10
-                                                          },
-                                                          {
-                                                            "type": "integer",
-                                                            "minimum": 0,
-                                                            "maximum": 10
-                                                          }
-                                                        ]
-                                                      },
-                                                      "outcome": {
-                                                        "type": "string",
-                                                        "minLength": 1
-                                                      }
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "id": {
+                                                      "type": "string"
                                                     },
-                                                    "required": ["score_range", "outcome"],
-                                                    "additionalProperties": false
-                                                  }
+                                                    "outcome": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "correctness",
+                                                        "contradiction"
+                                                      ]
+                                                    },
+                                                    "weight": {
+                                                      "type": "number"
+                                                    },
+                                                    "required": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "min_score": {
+                                                      "type": "number",
+                                                      "exclusiveMinimum": true,
+                                                      "minimum": 0,
+                                                      "maximum": 1
+                                                    },
+                                                    "score_ranges": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "score_range": {
+                                                            "type": "array",
+                                                            "minItems": 2,
+                                                            "maxItems": 2,
+                                                            "items": [
+                                                              {
+                                                                "type": "integer",
+                                                                "minimum": 0,
+                                                                "maximum": 10
+                                                              },
+                                                              {
+                                                                "type": "integer",
+                                                                "minimum": 0,
+                                                                "maximum": 10
+                                                              }
+                                                            ]
+                                                          },
+                                                          "outcome": {
+                                                            "type": "string",
+                                                            "minLength": 1
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "score_range",
+                                                          "outcome"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    }
+                                                  },
+                                                  "additionalProperties": false
                                                 }
-                                              },
-                                              "additionalProperties": false
+                                              ]
                                             },
                                             "minItems": 1
                                           }
                                         },
-                                        "required": ["type", "criteria"],
+                                        "required": [
+                                          "type",
+                                          "criteria"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     ]
@@ -13743,25 +15333,36 @@
                               }
                             }
                           },
-                          "required": ["input"],
+                          "required": [
+                            "input"
+                          ],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": ["mean", "min", "max"]
+                        "enum": [
+                          "mean",
+                          "min",
+                          "max"
+                        ]
                       },
                       "on_turn_failure": {
                         "type": "string",
-                        "enum": ["continue", "stop"]
+                        "enum": [
+                          "continue",
+                          "stop"
+                        ]
                       },
                       "window_size": {
                         "type": "integer",
                         "minimum": 1
                       }
                     },
-                    "required": ["id"],
+                    "required": [
+                      "id"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -13773,7 +15374,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["suite", "tests"]
+                        "enum": [
+                          "suite",
+                          "tests"
+                        ]
                       },
                       "select": {
                         "anyOf": [
@@ -13844,7 +15448,11 @@
                                     {
                                       "type": "array",
                                       "items": {
-                                        "type": ["string", "number", "boolean"]
+                                        "type": [
+                                          "string",
+                                          "number",
+                                          "boolean"
+                                        ]
                                       },
                                       "minItems": 1
                                     }
@@ -13873,7 +15481,12 @@
                               },
                               "strategy": {
                                 "type": "string",
-                                "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                                "enum": [
+                                  "pass_at_k",
+                                  "pass_all",
+                                  "mean",
+                                  "confidence_interval"
+                                ]
                               },
                               "cost_limit_usd": {
                                 "type": "number",
@@ -13884,7 +15497,9 @@
                                 "minimum": 0
                               }
                             },
-                            "required": ["count"],
+                            "required": [
+                              "count"
+                            ],
                             "additionalProperties": false
                           },
                           "timeout_seconds": {
@@ -13901,7 +15516,10 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["include", "type"],
+                    "required": [
+                      "include",
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -13983,7 +15601,9 @@
                         "additionalProperties": {}
                       }
                     },
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "additionalProperties": false
                   }
                 ]
@@ -14033,7 +15653,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["code-grader", "code_grader"]
+                        "enum": [
+                          "code-grader",
+                          "code_grader"
+                        ]
                       },
                       "command": {
                         "anyOf": [
@@ -14107,12 +15730,18 @@
                               ]
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": ["type", "command"],
+                    "required": [
+                      "type",
+                      "command"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14149,7 +15778,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["llm-grader", "llm_grader"]
+                        "enum": [
+                          "llm-grader",
+                          "llm_grader"
+                        ]
                       },
                       "prompt": {
                         "anyOf": [
@@ -14207,7 +15839,10 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": ["correctness", "contradiction"]
+                              "enum": [
+                                "correctness",
+                                "contradiction"
+                              ]
                             },
                             "weight": {
                               "type": "number"
@@ -14248,7 +15883,10 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": ["score_range", "outcome"],
+                                "required": [
+                                  "score_range",
+                                  "outcome"
+                                ],
                                 "additionalProperties": false
                               }
                             }
@@ -14299,12 +15937,17 @@
                               ]
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14315,7 +15958,9 @@
                         "minLength": 1
                       }
                     },
-                    "required": ["include"],
+                    "required": [
+                      "include"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14378,7 +16023,9 @@
                                 }
                               }
                             },
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -14394,7 +16041,10 @@
                                 "maximum": 1
                               }
                             },
-                            "required": ["type", "threshold"],
+                            "required": [
+                              "type",
+                              "threshold"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -14411,7 +16061,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["type", "path"],
+                            "required": [
+                              "type",
+                              "path"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -14428,13 +16081,18 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "additionalProperties": false
                           }
                         ]
                       }
                     },
-                    "required": ["type", "aggregator"],
+                    "required": [
+                      "type",
+                      "aggregator"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14471,11 +16129,20 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["tool-trajectory", "tool_trajectory"]
+                        "enum": [
+                          "tool-trajectory",
+                          "tool_trajectory"
+                        ]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                        "enum": [
+                          "any_order",
+                          "in_order",
+                          "exact",
+                          "subset",
+                          "superset"
+                        ]
                       },
                       "minimums": {
                         "type": "object",
@@ -14516,7 +16183,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -14530,7 +16202,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -14541,7 +16218,9 @@
                               ]
                             }
                           },
-                          "required": ["tool"],
+                          "required": [
+                            "tool"
+                          ],
                           "additionalProperties": false
                         }
                       },
@@ -14549,7 +16228,12 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": ["exact", "ignore", "subset", "superset"]
+                            "enum": [
+                              "exact",
+                              "ignore",
+                              "subset",
+                              "superset"
+                            ]
                           },
                           {
                             "type": "array",
@@ -14563,7 +16247,12 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": ["exact", "ignore", "subset", "superset"]
+                            "enum": [
+                              "exact",
+                              "ignore",
+                              "subset",
+                              "superset"
+                            ]
                           },
                           {
                             "type": "array",
@@ -14574,7 +16263,10 @@
                         ]
                       }
                     },
-                    "required": ["type", "mode"],
+                    "required": [
+                      "type",
+                      "mode"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14611,7 +16303,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["field-accuracy", "field_accuracy"]
+                        "enum": [
+                          "field-accuracy",
+                          "field_accuracy"
+                        ]
                       },
                       "fields": {
                         "type": "array",
@@ -14623,7 +16318,11 @@
                             },
                             "match": {
                               "type": "string",
-                              "enum": ["exact", "numeric_tolerance", "date"]
+                              "enum": [
+                                "exact",
+                                "numeric_tolerance",
+                                "date"
+                              ]
                             },
                             "required": {
                               "type": "boolean"
@@ -14645,17 +16344,26 @@
                               }
                             }
                           },
-                          "required": ["path", "match"],
+                          "required": [
+                            "path",
+                            "match"
+                          ],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": ["weighted_average", "all_or_nothing"]
+                        "enum": [
+                          "weighted_average",
+                          "all_or_nothing"
+                        ]
                       }
                     },
-                    "required": ["type", "fields"],
+                    "required": [
+                      "type",
+                      "fields"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14699,7 +16407,10 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type", "threshold"],
+                    "required": [
+                      "type",
+                      "threshold"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14743,7 +16454,10 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type", "budget"],
+                    "required": [
+                      "type",
+                      "budget"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14780,7 +16494,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["token-usage", "token_usage"]
+                        "enum": [
+                          "token-usage",
+                          "token_usage"
+                        ]
                       },
                       "max_total": {
                         "type": "number",
@@ -14795,7 +16512,9 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14832,7 +16551,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["execution-metrics", "execution_metrics"]
+                        "enum": [
+                          "execution-metrics",
+                          "execution_metrics"
+                        ]
                       },
                       "max_tool_calls": {
                         "type": "number",
@@ -14864,7 +16586,9 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14907,7 +16631,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14950,7 +16677,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -14987,10 +16717,15 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["is-json", "is_json"]
+                        "enum": [
+                          "is-json",
+                          "is_json"
+                        ]
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15033,7 +16768,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15075,68 +16813,85 @@
                       "criteria": {
                         "type": "array",
                         "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "outcome": {
-                              "type": "string"
-                            },
-                            "operator": {
+                          "anyOf": [
+                            {
                               "type": "string",
-                              "enum": ["correctness", "contradiction"]
+                              "minLength": 1
                             },
-                            "weight": {
-                              "type": "number"
-                            },
-                            "required": {
-                              "type": "boolean"
-                            },
-                            "min_score": {
-                              "type": "number",
-                              "exclusiveMinimum": true,
-                              "minimum": 0,
-                              "maximum": 1
-                            },
-                            "score_ranges": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "score_range": {
-                                    "type": "array",
-                                    "minItems": 2,
-                                    "maxItems": 2,
-                                    "items": [
-                                      {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "maximum": 10
-                                      },
-                                      {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "maximum": 10
-                                      }
-                                    ]
-                                  },
-                                  "outcome": {
-                                    "type": "string",
-                                    "minLength": 1
-                                  }
+                            {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
                                 },
-                                "required": ["score_range", "outcome"],
-                                "additionalProperties": false
-                              }
+                                "outcome": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string",
+                                  "enum": [
+                                    "correctness",
+                                    "contradiction"
+                                  ]
+                                },
+                                "weight": {
+                                  "type": "number"
+                                },
+                                "required": {
+                                  "type": "boolean"
+                                },
+                                "min_score": {
+                                  "type": "number",
+                                  "exclusiveMinimum": true,
+                                  "minimum": 0,
+                                  "maximum": 1
+                                },
+                                "score_ranges": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "score_range": {
+                                        "type": "array",
+                                        "minItems": 2,
+                                        "maxItems": 2,
+                                        "items": [
+                                          {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 10
+                                          },
+                                          {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 10
+                                          }
+                                        ]
+                                      },
+                                      "outcome": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      }
+                                    },
+                                    "required": [
+                                      "score_range",
+                                      "outcome"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                }
+                              },
+                              "additionalProperties": false
                             }
-                          },
-                          "additionalProperties": false
+                          ]
                         },
                         "minItems": 1
                       }
                     },
-                    "required": ["type", "criteria"],
+                    "required": [
+                      "type",
+                      "criteria"
+                    ],
                     "additionalProperties": false
                   }
                 ]
@@ -15180,7 +16935,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["code-grader", "code_grader"]
+                        "enum": [
+                          "code-grader",
+                          "code_grader"
+                        ]
                       },
                       "command": {
                         "anyOf": [
@@ -15254,12 +17012,18 @@
                               ]
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": ["type", "command"],
+                    "required": [
+                      "type",
+                      "command"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15296,7 +17060,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["llm-grader", "llm_grader"]
+                        "enum": [
+                          "llm-grader",
+                          "llm_grader"
+                        ]
                       },
                       "prompt": {
                         "anyOf": [
@@ -15354,7 +17121,10 @@
                             },
                             "operator": {
                               "type": "string",
-                              "enum": ["correctness", "contradiction"]
+                              "enum": [
+                                "correctness",
+                                "contradiction"
+                              ]
                             },
                             "weight": {
                               "type": "number"
@@ -15395,7 +17165,10 @@
                                     "minLength": 1
                                   }
                                 },
-                                "required": ["score_range", "outcome"],
+                                "required": [
+                                  "score_range",
+                                  "outcome"
+                                ],
                                 "additionalProperties": false
                               }
                             }
@@ -15446,12 +17219,17 @@
                               ]
                             }
                           },
-                          "required": ["type", "command"],
+                          "required": [
+                            "type",
+                            "command"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15462,7 +17240,9 @@
                         "minLength": 1
                       }
                     },
-                    "required": ["include"],
+                    "required": [
+                      "include"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15525,7 +17305,9 @@
                                 }
                               }
                             },
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -15541,7 +17323,10 @@
                                 "maximum": 1
                               }
                             },
-                            "required": ["type", "threshold"],
+                            "required": [
+                              "type",
+                              "threshold"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -15558,7 +17343,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["type", "path"],
+                            "required": [
+                              "type",
+                              "path"
+                            ],
                             "additionalProperties": false
                           },
                           {
@@ -15575,13 +17363,18 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "additionalProperties": false
                           }
                         ]
                       }
                     },
-                    "required": ["type", "aggregator"],
+                    "required": [
+                      "type",
+                      "aggregator"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15618,11 +17411,20 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["tool-trajectory", "tool_trajectory"]
+                        "enum": [
+                          "tool-trajectory",
+                          "tool_trajectory"
+                        ]
                       },
                       "mode": {
                         "type": "string",
-                        "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                        "enum": [
+                          "any_order",
+                          "in_order",
+                          "exact",
+                          "subset",
+                          "superset"
+                        ]
                       },
                       "minimums": {
                         "type": "object",
@@ -15663,7 +17465,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -15677,7 +17484,12 @@
                               "anyOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["exact", "ignore", "subset", "superset"]
+                                  "enum": [
+                                    "exact",
+                                    "ignore",
+                                    "subset",
+                                    "superset"
+                                  ]
                                 },
                                 {
                                   "type": "array",
@@ -15688,7 +17500,9 @@
                               ]
                             }
                           },
-                          "required": ["tool"],
+                          "required": [
+                            "tool"
+                          ],
                           "additionalProperties": false
                         }
                       },
@@ -15696,7 +17510,12 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": ["exact", "ignore", "subset", "superset"]
+                            "enum": [
+                              "exact",
+                              "ignore",
+                              "subset",
+                              "superset"
+                            ]
                           },
                           {
                             "type": "array",
@@ -15710,7 +17529,12 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": ["exact", "ignore", "subset", "superset"]
+                            "enum": [
+                              "exact",
+                              "ignore",
+                              "subset",
+                              "superset"
+                            ]
                           },
                           {
                             "type": "array",
@@ -15721,7 +17545,10 @@
                         ]
                       }
                     },
-                    "required": ["type", "mode"],
+                    "required": [
+                      "type",
+                      "mode"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15758,7 +17585,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["field-accuracy", "field_accuracy"]
+                        "enum": [
+                          "field-accuracy",
+                          "field_accuracy"
+                        ]
                       },
                       "fields": {
                         "type": "array",
@@ -15770,7 +17600,11 @@
                             },
                             "match": {
                               "type": "string",
-                              "enum": ["exact", "numeric_tolerance", "date"]
+                              "enum": [
+                                "exact",
+                                "numeric_tolerance",
+                                "date"
+                              ]
                             },
                             "required": {
                               "type": "boolean"
@@ -15792,17 +17626,26 @@
                               }
                             }
                           },
-                          "required": ["path", "match"],
+                          "required": [
+                            "path",
+                            "match"
+                          ],
                           "additionalProperties": false
                         },
                         "minItems": 1
                       },
                       "aggregation": {
                         "type": "string",
-                        "enum": ["weighted_average", "all_or_nothing"]
+                        "enum": [
+                          "weighted_average",
+                          "all_or_nothing"
+                        ]
                       }
                     },
-                    "required": ["type", "fields"],
+                    "required": [
+                      "type",
+                      "fields"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15846,7 +17689,10 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type", "threshold"],
+                    "required": [
+                      "type",
+                      "threshold"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15890,7 +17736,10 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type", "budget"],
+                    "required": [
+                      "type",
+                      "budget"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15927,7 +17776,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["token-usage", "token_usage"]
+                        "enum": [
+                          "token-usage",
+                          "token_usage"
+                        ]
                       },
                       "max_total": {
                         "type": "number",
@@ -15942,7 +17794,9 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -15979,7 +17833,10 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["execution-metrics", "execution_metrics"]
+                        "enum": [
+                          "execution-metrics",
+                          "execution_metrics"
+                        ]
                       },
                       "max_tool_calls": {
                         "type": "number",
@@ -16011,7 +17868,9 @@
                         "minimum": 0
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -16054,7 +17913,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -16097,7 +17959,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -16134,10 +17999,15 @@
                       },
                       "type": {
                         "type": "string",
-                        "enum": ["is-json", "is_json"]
+                        "enum": [
+                          "is-json",
+                          "is_json"
+                        ]
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -16180,7 +18050,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "value"],
+                    "required": [
+                      "type",
+                      "value"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -16222,68 +18095,85 @@
                       "criteria": {
                         "type": "array",
                         "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "outcome": {
-                              "type": "string"
-                            },
-                            "operator": {
+                          "anyOf": [
+                            {
                               "type": "string",
-                              "enum": ["correctness", "contradiction"]
+                              "minLength": 1
                             },
-                            "weight": {
-                              "type": "number"
-                            },
-                            "required": {
-                              "type": "boolean"
-                            },
-                            "min_score": {
-                              "type": "number",
-                              "exclusiveMinimum": true,
-                              "minimum": 0,
-                              "maximum": 1
-                            },
-                            "score_ranges": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "score_range": {
-                                    "type": "array",
-                                    "minItems": 2,
-                                    "maxItems": 2,
-                                    "items": [
-                                      {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "maximum": 10
-                                      },
-                                      {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "maximum": 10
-                                      }
-                                    ]
-                                  },
-                                  "outcome": {
-                                    "type": "string",
-                                    "minLength": 1
-                                  }
+                            {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
                                 },
-                                "required": ["score_range", "outcome"],
-                                "additionalProperties": false
-                              }
+                                "outcome": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string",
+                                  "enum": [
+                                    "correctness",
+                                    "contradiction"
+                                  ]
+                                },
+                                "weight": {
+                                  "type": "number"
+                                },
+                                "required": {
+                                  "type": "boolean"
+                                },
+                                "min_score": {
+                                  "type": "number",
+                                  "exclusiveMinimum": true,
+                                  "minimum": 0,
+                                  "maximum": 1
+                                },
+                                "score_ranges": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "score_range": {
+                                        "type": "array",
+                                        "minItems": 2,
+                                        "maxItems": 2,
+                                        "items": [
+                                          {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 10
+                                          },
+                                          {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 10
+                                          }
+                                        ]
+                                      },
+                                      "outcome": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      }
+                                    },
+                                    "required": [
+                                      "score_range",
+                                      "outcome"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                }
+                              },
+                              "additionalProperties": false
                             }
-                          },
-                          "additionalProperties": false
+                          ]
                         },
                         "minItems": 1
                       }
                     },
-                    "required": ["type", "criteria"],
+                    "required": [
+                      "type",
+                      "criteria"
+                    ],
                     "additionalProperties": false
                   }
                 ]
@@ -16346,7 +18236,12 @@
                 },
                 "strategy": {
                   "type": "string",
-                  "enum": ["pass_at_k", "pass_all", "mean", "confidence_interval"]
+                  "enum": [
+                    "pass_at_k",
+                    "pass_all",
+                    "mean",
+                    "confidence_interval"
+                  ]
                 },
                 "cost_limit_usd": {
                   "type": "number",
@@ -16357,7 +18252,9 @@
                   "minimum": 0
                 }
               },
-              "required": ["count"],
+              "required": [
+                "count"
+              ],
               "additionalProperties": false
             },
             "runs": {
@@ -16416,7 +18313,10 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["code-grader", "code_grader"]
+                    "enum": [
+                      "code-grader",
+                      "code_grader"
+                    ]
                   },
                   "command": {
                     "anyOf": [
@@ -16490,12 +18390,18 @@
                           ]
                         }
                       },
-                      "required": ["type", "command"],
+                      "required": [
+                        "type",
+                        "command"
+                      ],
                       "additionalProperties": false
                     }
                   }
                 },
-                "required": ["type", "command"],
+                "required": [
+                  "type",
+                  "command"
+                ],
                 "additionalProperties": false
               },
               {
@@ -16532,7 +18438,10 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["llm-grader", "llm_grader"]
+                    "enum": [
+                      "llm-grader",
+                      "llm_grader"
+                    ]
                   },
                   "prompt": {
                     "anyOf": [
@@ -16590,7 +18499,10 @@
                         },
                         "operator": {
                           "type": "string",
-                          "enum": ["correctness", "contradiction"]
+                          "enum": [
+                            "correctness",
+                            "contradiction"
+                          ]
                         },
                         "weight": {
                           "type": "number"
@@ -16631,7 +18543,10 @@
                                 "minLength": 1
                               }
                             },
-                            "required": ["score_range", "outcome"],
+                            "required": [
+                              "score_range",
+                              "outcome"
+                            ],
                             "additionalProperties": false
                           }
                         }
@@ -16682,12 +18597,17 @@
                           ]
                         }
                       },
-                      "required": ["type", "command"],
+                      "required": [
+                        "type",
+                        "command"
+                      ],
                       "additionalProperties": false
                     }
                   }
                 },
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "additionalProperties": false
               },
               {
@@ -16698,7 +18618,9 @@
                     "minLength": 1
                   }
                 },
-                "required": ["include"],
+                "required": [
+                  "include"
+                ],
                 "additionalProperties": false
               },
               {
@@ -16761,7 +18683,9 @@
                             }
                           }
                         },
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "additionalProperties": false
                       },
                       {
@@ -16777,7 +18701,10 @@
                             "maximum": 1
                           }
                         },
-                        "required": ["type", "threshold"],
+                        "required": [
+                          "type",
+                          "threshold"
+                        ],
                         "additionalProperties": false
                       },
                       {
@@ -16794,7 +18721,10 @@
                             "type": "string"
                           }
                         },
-                        "required": ["type", "path"],
+                        "required": [
+                          "type",
+                          "path"
+                        ],
                         "additionalProperties": false
                       },
                       {
@@ -16811,13 +18741,18 @@
                             "type": "string"
                           }
                         },
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "additionalProperties": false
                       }
                     ]
                   }
                 },
-                "required": ["type", "aggregator"],
+                "required": [
+                  "type",
+                  "aggregator"
+                ],
                 "additionalProperties": false
               },
               {
@@ -16854,11 +18789,20 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["tool-trajectory", "tool_trajectory"]
+                    "enum": [
+                      "tool-trajectory",
+                      "tool_trajectory"
+                    ]
                   },
                   "mode": {
                     "type": "string",
-                    "enum": ["any_order", "in_order", "exact", "subset", "superset"]
+                    "enum": [
+                      "any_order",
+                      "in_order",
+                      "exact",
+                      "subset",
+                      "superset"
+                    ]
                   },
                   "minimums": {
                     "type": "object",
@@ -16899,7 +18843,12 @@
                           "anyOf": [
                             {
                               "type": "string",
-                              "enum": ["exact", "ignore", "subset", "superset"]
+                              "enum": [
+                                "exact",
+                                "ignore",
+                                "subset",
+                                "superset"
+                              ]
                             },
                             {
                               "type": "array",
@@ -16913,7 +18862,12 @@
                           "anyOf": [
                             {
                               "type": "string",
-                              "enum": ["exact", "ignore", "subset", "superset"]
+                              "enum": [
+                                "exact",
+                                "ignore",
+                                "subset",
+                                "superset"
+                              ]
                             },
                             {
                               "type": "array",
@@ -16924,7 +18878,9 @@
                           ]
                         }
                       },
-                      "required": ["tool"],
+                      "required": [
+                        "tool"
+                      ],
                       "additionalProperties": false
                     }
                   },
@@ -16932,7 +18888,12 @@
                     "anyOf": [
                       {
                         "type": "string",
-                        "enum": ["exact", "ignore", "subset", "superset"]
+                        "enum": [
+                          "exact",
+                          "ignore",
+                          "subset",
+                          "superset"
+                        ]
                       },
                       {
                         "type": "array",
@@ -16946,7 +18907,12 @@
                     "anyOf": [
                       {
                         "type": "string",
-                        "enum": ["exact", "ignore", "subset", "superset"]
+                        "enum": [
+                          "exact",
+                          "ignore",
+                          "subset",
+                          "superset"
+                        ]
                       },
                       {
                         "type": "array",
@@ -16957,7 +18923,10 @@
                     ]
                   }
                 },
-                "required": ["type", "mode"],
+                "required": [
+                  "type",
+                  "mode"
+                ],
                 "additionalProperties": false
               },
               {
@@ -16994,7 +18963,10 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["field-accuracy", "field_accuracy"]
+                    "enum": [
+                      "field-accuracy",
+                      "field_accuracy"
+                    ]
                   },
                   "fields": {
                     "type": "array",
@@ -17006,7 +18978,11 @@
                         },
                         "match": {
                           "type": "string",
-                          "enum": ["exact", "numeric_tolerance", "date"]
+                          "enum": [
+                            "exact",
+                            "numeric_tolerance",
+                            "date"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -17028,17 +19004,26 @@
                           }
                         }
                       },
-                      "required": ["path", "match"],
+                      "required": [
+                        "path",
+                        "match"
+                      ],
                       "additionalProperties": false
                     },
                     "minItems": 1
                   },
                   "aggregation": {
                     "type": "string",
-                    "enum": ["weighted_average", "all_or_nothing"]
+                    "enum": [
+                      "weighted_average",
+                      "all_or_nothing"
+                    ]
                   }
                 },
-                "required": ["type", "fields"],
+                "required": [
+                  "type",
+                  "fields"
+                ],
                 "additionalProperties": false
               },
               {
@@ -17082,7 +19067,10 @@
                     "minimum": 0
                   }
                 },
-                "required": ["type", "threshold"],
+                "required": [
+                  "type",
+                  "threshold"
+                ],
                 "additionalProperties": false
               },
               {
@@ -17126,7 +19114,10 @@
                     "minimum": 0
                   }
                 },
-                "required": ["type", "budget"],
+                "required": [
+                  "type",
+                  "budget"
+                ],
                 "additionalProperties": false
               },
               {
@@ -17163,7 +19154,10 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["token-usage", "token_usage"]
+                    "enum": [
+                      "token-usage",
+                      "token_usage"
+                    ]
                   },
                   "max_total": {
                     "type": "number",
@@ -17178,7 +19172,9 @@
                     "minimum": 0
                   }
                 },
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "additionalProperties": false
               },
               {
@@ -17215,7 +19211,10 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["execution-metrics", "execution_metrics"]
+                    "enum": [
+                      "execution-metrics",
+                      "execution_metrics"
+                    ]
                   },
                   "max_tool_calls": {
                     "type": "number",
@@ -17247,7 +19246,9 @@
                     "minimum": 0
                   }
                 },
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "additionalProperties": false
               },
               {
@@ -17290,7 +19291,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["type", "value"],
+                "required": [
+                  "type",
+                  "value"
+                ],
                 "additionalProperties": false
               },
               {
@@ -17333,7 +19337,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["type", "value"],
+                "required": [
+                  "type",
+                  "value"
+                ],
                 "additionalProperties": false
               },
               {
@@ -17370,10 +19377,15 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["is-json", "is_json"]
+                    "enum": [
+                      "is-json",
+                      "is_json"
+                    ]
                   }
                 },
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "additionalProperties": false
               },
               {
@@ -17416,7 +19428,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["type", "value"],
+                "required": [
+                  "type",
+                  "value"
+                ],
                 "additionalProperties": false
               },
               {
@@ -17458,68 +19473,85 @@
                   "criteria": {
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string"
-                        },
-                        "outcome": {
-                          "type": "string"
-                        },
-                        "operator": {
+                      "anyOf": [
+                        {
                           "type": "string",
-                          "enum": ["correctness", "contradiction"]
+                          "minLength": 1
                         },
-                        "weight": {
-                          "type": "number"
-                        },
-                        "required": {
-                          "type": "boolean"
-                        },
-                        "min_score": {
-                          "type": "number",
-                          "exclusiveMinimum": true,
-                          "minimum": 0,
-                          "maximum": 1
-                        },
-                        "score_ranges": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "score_range": {
-                                "type": "array",
-                                "minItems": 2,
-                                "maxItems": 2,
-                                "items": [
-                                  {
-                                    "type": "integer",
-                                    "minimum": 0,
-                                    "maximum": 10
-                                  },
-                                  {
-                                    "type": "integer",
-                                    "minimum": 0,
-                                    "maximum": 10
-                                  }
-                                ]
-                              },
-                              "outcome": {
-                                "type": "string",
-                                "minLength": 1
-                              }
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
                             },
-                            "required": ["score_range", "outcome"],
-                            "additionalProperties": false
-                          }
+                            "outcome": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "type": "string",
+                              "enum": [
+                                "correctness",
+                                "contradiction"
+                              ]
+                            },
+                            "weight": {
+                              "type": "number"
+                            },
+                            "required": {
+                              "type": "boolean"
+                            },
+                            "min_score": {
+                              "type": "number",
+                              "exclusiveMinimum": true,
+                              "minimum": 0,
+                              "maximum": 1
+                            },
+                            "score_ranges": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "score_range": {
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "maxItems": 2,
+                                    "items": [
+                                      {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 10
+                                      },
+                                      {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 10
+                                      }
+                                    ]
+                                  },
+                                  "outcome": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  }
+                                },
+                                "required": [
+                                  "score_range",
+                                  "outcome"
+                                ],
+                                "additionalProperties": false
+                              }
+                            }
+                          },
+                          "additionalProperties": false
                         }
-                      },
-                      "additionalProperties": false
+                      ]
                     },
                     "minItems": 1
                   }
                 },
-                "required": ["type", "criteria"],
+                "required": [
+                  "type",
+                  "criteria"
+                ],
                 "additionalProperties": false
               }
             ]
@@ -17548,7 +19580,10 @@
                 ]
               }
             },
-            "required": ["type", "command"],
+            "required": [
+              "type",
+              "command"
+            ],
             "additionalProperties": false
           }
         },
@@ -17562,7 +19597,10 @@
                 },
                 "isolation": {
                   "type": "string",
-                  "enum": ["shared", "per_case"]
+                  "enum": [
+                    "shared",
+                    "per_case"
+                  ]
                 },
                 "repos": {
                   "type": "array",
@@ -17644,7 +19682,11 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": ["none", "fast", "strict"]
+                          "enum": [
+                            "none",
+                            "fast",
+                            "strict"
+                          ]
                         }
                       },
                       "additionalProperties": false
@@ -17689,7 +19731,11 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": ["none", "fast", "strict"]
+                          "enum": [
+                            "none",
+                            "fast",
+                            "strict"
+                          ]
                         }
                       },
                       "additionalProperties": false
@@ -17734,7 +19780,11 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": ["none", "fast", "strict"]
+                          "enum": [
+                            "none",
+                            "fast",
+                            "strict"
+                          ]
                         }
                       },
                       "additionalProperties": false
@@ -17779,7 +19829,11 @@
                         },
                         "reset": {
                           "type": "string",
-                          "enum": ["none", "fast", "strict"]
+                          "enum": [
+                            "none",
+                            "fast",
+                            "strict"
+                          ]
                         }
                       },
                       "additionalProperties": false
@@ -17805,7 +19859,9 @@
                       "minimum": 0.1
                     }
                   },
-                  "required": ["image"],
+                  "required": [
+                    "image"
+                  ],
                   "additionalProperties": false
                 },
                 "env": {


### PR DESCRIPTION
## Summary
- Replace the README opening install/YAML block and separate "What it does" section with a shorter outcome-focused intro for AgentV's broader target scope.
- Rename "Why AgentV?" to "Why?" and tighten Core Concepts around eval suites, path-derived category, workspace context, target/model, policy, experiment as the named run condition, and concrete runs.
- Promote the current quick start authoring shape to top-level `name`, top-level `target`, top-level `model`, and `policy`; `experiment` remains the result/run concept, not a top-level eval YAML or `defineEval()` field.
- Keep public `policy` examples to `runs`, `timeout_seconds`/`timeoutSeconds`, `threshold`, and `budget_usd`/`budgetUsd`, matching PR #1576.
- Keep YAML and TypeScript examples on `assertions`, including string shorthand plus `contains`, `code-grader`, `llm-grader`, and threshold usage.
- Clarify the Results layout around `.agentv/results/<experiment>/<timestamp>/`, resolved target identity subfolders such as `copilot-sdk--claude-sonnet-4.6`, `index.jsonl`, `summary.json`, and per-test artifacts/sidecars.
- Rename the README tree's generated source snapshot from `task/` to `test/` for reader-facing terminology; tracked follow-up `av-2ac7` covers the compatibility-safe code/artifact rename.
- Add a compact Core Concepts Mermaid diagram covering eval suites/imports/tests, path-derived categories, workspace fixtures/graders, experiment conditions, target/model, policy, concrete runs, run artifacts, and Dashboard/compare/trend readers.
- Expand the TypeScript SDK section with both paths: `evaluate()` for application-owned runs and `defineEval()` for TypeScript eval files that AgentV runs through the normal runner.
- Update the eval-file validation schema and generated `eval-schema.json` so explicit `type: rubrics` accepts string shorthand criteria, matching runtime parsing and public docs.

## Verification
- Ran `bun run generate:schema` from `packages/core`.
- Ran `bun run lint`.
- Ran `bun test packages/core/test/evaluation/validation/eval-file-schema.test.ts packages/core/test/evaluation/validation/eval-schema-sync.test.ts`.
- Ran `bun test packages/core/test/evaluation/loaders/grader-parser.test.ts --test-name-pattern "string shorthand|criteria"`.
- Validated the earlier README quick start YAML snippet against `EvalFileSchema` before the later target/policy README guidance update.
- Ran `git diff --check` after the target/model/policy/workspace-isolation/runs README updates.
- Ran `git diff --check` after the `name` + target/model/policy README correction.
- Earlier in this PR: ran a one-case mock-provider eval and verified current generated artifacts include `result.json`, `grading.json`, `metrics.json`, `timing.json`, transcripts, and outputs.

## Notes
- This README PR should be read with implementation PR #1576. PR #1576 currently rejects top-level `experiment` authoring and accepts `name` + `target` + `model` + `policy`.
- `experiment` remains the result namespace/run condition concept used by `.agentv/results/<experiment>/<timestamp>/`, compare, Dashboard, and application-owned `evaluate()` calls.
- The code-level rename from `task/` / `task_dir` to `test/` / `test_dir` is intentionally tracked separately in Bead `av-2ac7` because it touches the public artifact contract and readers.