### PR TITLE
docs(readme): document experiment eval contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ agentv init
 
 **3. Create an eval** in `evals/`:
 ```yaml
-name: backend-with-skills
+experiment: backend-with-skills
 description: Code generation quality
 target: copilot-sdk
 model: claude-sonnet-4.6
@@ -67,6 +67,7 @@ workspace:
 
 policy:
   runs: 3
+  early_exit: false
   timeout_seconds: 600
   threshold: 0.8
   budget_usd: 5
@@ -96,7 +97,7 @@ agentv compare .agentv/results/backend-without-skills/<timestamp>/copilot-sdk--c
 
 ## Results
 
-Each run writes a timestamped invocation directory under `.agentv/results/<experiment>/<timestamp>/`. In this example, `name: backend-with-skills` names the condition being measured, `target: copilot-sdk` selects the system under test, and `model: claude-sonnet-4.6` overrides that target's default model. The resolved target identity is still `copilot-sdk--claude-sonnet-4.6` so CI baselines can distinguish model changes. The flat `index.jsonl` manifest is the portable surface used by scripts, CI, and `agentv compare`:
+Each run writes a timestamped invocation directory under `.agentv/results/<experiment>/<timestamp>/`. In this example, `experiment: backend-with-skills` names the condition being measured, `target: copilot-sdk` selects the system under test, and `model: claude-sonnet-4.6` overrides that target's default model. The resolved target identity is still `copilot-sdk--claude-sonnet-4.6` so CI baselines can distinguish model changes. The flat `index.jsonl` manifest is the portable surface used by scripts, CI, and `agentv compare`:
 
 ```bash
 agentv eval evals/my-eval.yaml
@@ -162,12 +163,13 @@ Use `defineEval()` when you want AgentV to run the TypeScript eval file:
 import { defineEval } from '@agentv/sdk';
 
 export default defineEval({
-  name: 'backend-with-skills',
+  experiment: 'backend-with-skills',
   description: 'Code generation quality',
   target: 'copilot-sdk',
   model: 'claude-sonnet-4.6',
   policy: {
     runs: 3,
+    earlyExit: false,
     timeoutSeconds: 600,
     threshold: 0.8,
     budgetUsd: 5,


### PR DESCRIPTION
## Summary

- updates the README eval contract example to use top-level `experiment` instead of `name`
- includes `policy.early_exit` in YAML and `policy.earlyExit` in the TypeScript `defineEval()` example
- updates the Results wording so the experiment result directory is tied to the `experiment` field

## Notes

This PR documents the intended public contract for review before implementation is complete. Runtime/schema/SDK support is tracked separately in Bead `av-61mn` and assigned to the `av-61mn-experiment-contract` worker.

## Verification

- `git diff --check`
