### PR TITLE
fix(artifacts): keep run status in agentv format

### DIFF
--- a/apps/cli/test/commands/eval/artifact-writer.test.ts
+++ b/apps/cli/test/commands/eval/artifact-writer.test.ts
@@ -1010,7 +1010,7 @@ describe('writeArtifactsFromResults', () => {
     expect(indexLine.runtime_source).toEqual(runtimeSource);
   });
 
-  it('writes repeat runs in Vercel-compatible case and run folders', async () => {
+  it('writes repeat runs in AgentV case and run folders', async () => {
     const results = [
       makeResult({
         testId: 'repeat-case',
@@ -1146,7 +1146,8 @@ describe('writeArtifactsFromResults', () => {
       ),
     ) as Record<string, unknown>;
     expect(runOneResult).toMatchObject({
-      status: 'failed',
+      execution_status: 'quality_failure',
+      verdict: 'fail',
       duration_ms: 2000,
       duration_seconds: 2,
       model: 'test-target',
@@ -1159,6 +1160,7 @@ describe('writeArtifactsFromResults', () => {
         duration_ms: 2000,
       },
     });
+    expect(runOneResult).not.toHaveProperty('status');
 
     const runTwoAnswer = await readFile(
       path.join(paths.testArtifactDir, repeatRowDir, 'run-2', 'outputs', 'answer.md'),
@@ -1173,6 +1175,8 @@ describe('writeArtifactsFromResults', () => {
       ),
     ) as Record<string, unknown>;
     expect(runTwoResult).toMatchObject({
+      execution_status: 'ok',
+      verdict: 'pass',
       grading_path: './grading.json',
       metrics_path: './metrics.json',
       transcript_path: './transcript.jsonl',
@@ -1181,6 +1185,7 @@ describe('writeArtifactsFromResults', () => {
         duration_ms: 4000,
       },
     });
+    expect(runTwoResult).not.toHaveProperty('status');
   });
 
   it('handles empty results array', async () => {
@@ -1358,7 +1363,7 @@ describe('writeArtifactsFromResults', () => {
     expect(indexLine.artifact_pointers).toBeUndefined();
   });
 
-  it('writes AgentV metrics as Agent Skills and Vercel-style behavior projections', async () => {
+  it('writes AgentV metrics as Agent Skills and executor behavior projections', async () => {
     const input = [{ role: 'user' as const, content: 'Inspect the repo and fetch context' }];
     const output = [
       {

--- a/apps/web/src/content/docs/docs/reference/result-artifacts.mdx
+++ b/apps/web/src/content/docs/docs/reference/result-artifacts.mdx
@@ -82,7 +82,7 @@ query.
 | --- | --- | --- |
 | `summary.json` | Aggregate run metadata and rollups: run id, experiment metadata, counts, pass rate, score summaries, duration, token/cost totals, and writer metadata. | Listing runs, CI summaries, quick dashboards, trend cards, and validating that a run is complete enough to inspect. |
 | `index.jsonl` | Canonical row index: one row per result, attempt, or case-level aggregate, with identity fields, filter metadata, scores, status, and explicit run-relative paths to sidecars. | Filtering, compare/trend inputs, Dashboard detail routing, rerun/resume lookup, export adapters, and artifact discovery. |
-| `result.json` | Compact per-attempt manifest for one attempt directory. | Loading one attempt without scanning the whole run index. |
+| `result.json` | Compact per-attempt manifest for one attempt directory, including AgentV `execution_status` and `verdict`. | Loading one attempt without scanning the whole run index. |
 | `grading.json` | Grader outputs, assertions, rubric evidence, execution-metric grader facts, and scoring provenance. | Explaining why a row passed or failed. |
 | `metrics.json` | Derived executor behavior summary, such as tool calls, files touched, shell commands, errors, turns, and output sizes. | Dashboard behavior views, metric-style graders, adapter projections, and lightweight analysis. |
 | `outputs/file_changes.diff` | Full unified diff of workspace file changes when file changes are captured. | Human review and external artifact inspection; LLM and code graders still receive the same full diff through `file_changes`. |

--- a/apps/web/src/content/docs/docs/tools/results.mdx
+++ b/apps/web/src/content/docs/docs/tools/results.mdx
@@ -132,8 +132,8 @@ Every case uses aggregate `summary.json`, then stores attempt details under
 `grading.json`, `metrics.json`, `timing.json`, `transcript.jsonl`,
 `transcript-raw.jsonl`, `outputs/answer.md`, and `outputs/file_changes.diff`
 when workspace changes were captured. The `result.json` file carries
-`grading_path`, `metrics_path`, transcript, output, and `file_changes_path`
-paths.
+AgentV `execution_status` and `verdict` fields plus `grading_path`,
+`metrics_path`, transcript, output, and `file_changes_path` paths.
 
 `transcript-raw.jsonl` preserves native provider or harness transcript bytes
 when they are available, while `transcript.jsonl` is the normalized
@@ -152,12 +152,12 @@ labels such as `provider_reported`, `token_estimated`, `aggregate`, or
 `unavailable`.
 
 The `metrics` section aligns with Claude Agent Skills `metrics.json`
-while adding AgentV/Vercel-style detail:
+while adding AgentV executor detail:
 
 | Field group | Purpose |
 |-------------|---------|
 | `tool_calls`, `total_tool_calls`, `total_steps`, `errors_encountered`, `output_chars`, `transcript_chars`, `files_created`, `files_deleted` | Agent Skills-compatible executor metrics |
-| `tool_call_events`, `tool_call_counts`, `tool_category_counts`, `shell_commands`, `files_read`, `files_modified`, `web_fetches`, `errors`, `reasoning_blocks`, `thinking_blocks`, `total_turns` | AgentV/Vercel-style behavior summary when source data includes it |
+| `tool_call_events`, `tool_call_counts`, `tool_category_counts`, `shell_commands`, `files_read`, `files_modified`, `web_fetches`, `errors`, `reasoning_blocks`, `thinking_blocks`, `total_turns` | AgentV behavior summary when source data includes it |
 
 Vercel `@vercel/agent-eval` `results.o11y` maps into AgentV like this:
 

--- a/docs/adr/0011-result-output-artifact-contract.md
+++ b/docs/adr/0011-result-output-artifact-contract.md
@@ -65,6 +65,10 @@ An AgentV result output is a run-centric bundle with this root contract:
         file_changes.diff     # when workspace file changes exist
 ```
 
+`run-N/result.json` uses AgentV-owned status fields: `execution_status` carries
+the attempt execution classification and `verdict` carries the grader verdict.
+It does not export external runner status enums.
+
 `summary.json` and `index.jsonl` are complementary:
 
 - `summary.json` owns aggregate run metadata and rollups: counts, pass rate,

--- a/packages/core/src/evaluation/metrics.ts
+++ b/packages/core/src/evaluation/metrics.ts
@@ -3,7 +3,7 @@
  *
  * This is a derived per-case executor metrics projection over `EvaluationResult`
  * and the internal trace envelope. It aligns with AgentV's case-local `metrics.json`
- * while carrying the compact Vercel-style observability fields. It is not the
+ * while carrying compact executor observability fields. It is not the
  * canonical trace store; portable transcript detail stays in `transcript.jsonl`, and
  * duration/token/cost usage stays in `timing.json`.
  */

--- a/packages/core/src/evaluation/run-artifacts.ts
+++ b/packages/core/src/evaluation/run-artifacts.ts
@@ -508,8 +508,9 @@ export interface AdditionalResultArtifactsContext {
   readonly sourceTestsById: ReadonlyMap<string, EvalTest>;
 }
 
-export interface VercelRunResultArtifact {
-  readonly status: 'passed' | 'failed' | 'error';
+export interface AgentVRunResultArtifact {
+  readonly execution_status: EvaluationResult['executionStatus'];
+  readonly verdict: TrialResult['verdict'];
   readonly duration_ms?: number;
   readonly duration_seconds: number;
   readonly model: string;
@@ -890,23 +891,13 @@ function buildRepeatCaseSummaryArtifact(
   };
 }
 
-function toVercelRunStatus(
-  trial: TrialResult,
-  result: EvaluationResult,
-): VercelRunResultArtifact['status'] {
-  if (trial.executionStatus === 'execution_error' || result.executionStatus === 'execution_error') {
-    return 'error';
-  }
-  return trial.verdict === 'pass' ? 'passed' : 'failed';
-}
-
 function toFilePathList(entries: readonly unknown[]): readonly string[] {
   return entries
     .map((entry) => (isRecord(entry) && typeof entry.path === 'string' ? entry.path : undefined))
     .filter((entry): entry is string => entry !== undefined);
 }
 
-function buildVercelRunResultArtifact(params: {
+function buildAgentVRunResultArtifact(params: {
   readonly trial: TrialResult;
   readonly result: EvaluationResult;
   readonly metricsArtifact: ReturnType<typeof buildMetricsArtifact> & {
@@ -915,13 +906,14 @@ function buildVercelRunResultArtifact(params: {
   readonly hasTranscript: boolean;
   readonly hasOutput: boolean;
   readonly hasFileChanges: boolean;
-}): VercelRunResultArtifact {
+}): AgentVRunResultArtifact {
   const metrics = params.metricsArtifact.metrics;
   const fileChangesPath = params.hasFileChanges
     ? `./${CANONICAL_FILE_CHANGES_ARTIFACT_PATH}`
     : undefined;
   return dropUndefined({
-    status: toVercelRunStatus(params.trial, params.result),
+    execution_status: params.trial.executionStatus ?? params.result.executionStatus,
+    verdict: params.trial.verdict,
     duration_ms: resultDurationMs(params.result),
     duration_seconds: resultDurationSeconds(params.result),
     model: params.result.target ?? 'unknown',
@@ -950,7 +942,7 @@ function buildVercelRunResultArtifact(params: {
           })
         : undefined,
     timing: params.metricsArtifact.timing,
-  }) as unknown as VercelRunResultArtifact;
+  }) as unknown as AgentVRunResultArtifact;
 }
 
 function singleRunTrial(result: EvaluationResult): TrialResult {
@@ -1050,7 +1042,7 @@ async function writeTrialRunArtifacts(params: {
   await writeFile(
     path.join(runDir, 'result.json'),
     `${JSON.stringify(
-      buildVercelRunResultArtifact({
+      buildAgentVRunResultArtifact({
         trial: params.trial,
         result,
         metricsArtifact,

--- a/packages/core/src/evaluation/types.ts
+++ b/packages/core/src/evaluation/types.ts
@@ -1084,7 +1084,7 @@ export interface TrialResult {
   /** Machine-readable failure reason code */
   readonly failureReasonCode?: string;
   /**
-   * Full per-attempt result used by artifact writers to materialize Vercel-style
+   * Full per-attempt result used by artifact writers to materialize AgentV
    * run-N folders. This is intentionally omitted from wire trial summaries.
    */
   readonly result?: EvaluationResult;


### PR DESCRIPTION
## Summary

AgentV attempt manifests now keep AgentV's own run status format instead of projecting status into Vercel's `passed`/`failed`/`error` enum. This follows up on #1581, which was already merged before the status-format correction could be pushed to that PR.

`run-N/result.json` now records `execution_status` and `verdict` as the source-of-truth status fields. The result artifact docs and tests now describe and enforce that AgentV-owned shape.

## Validation

- `bun --filter @agentv/core build`
- `bun test apps/cli/test/commands/eval/artifact-writer.test.ts`
- `bun run lint`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
