### PR TITLE
feat(eval): author experiment as promptfoo-style tags.experiment (av-4hzh)

### DIFF
--- a/apps/cli/src/commands/eval/artifact-writer.ts
+++ b/apps/cli/src/commands/eval/artifact-writer.ts
@@ -223,6 +223,7 @@ export async function writePerTestArtifacts(
     taskBundleTargets?: readonly TaskBundleTargetSelection[];
     additionalArtifacts?: AdditionalResultArtifactsWriter;
     runtimeSource?: RunRuntimeSourceMetadata;
+    tags?: Record<string, string>;
   },
 ): Promise<void> {
   await writeCorePerTestArtifacts(results, outputDir, {
@@ -233,6 +234,7 @@ export async function writePerTestArtifacts(
     sourceTests: options?.sourceTests,
     additionalArtifacts: options?.additionalArtifacts ?? createTaskBundleArtifactsWriter(options),
     runtimeSource: options?.runtimeSource,
+    tags: options?.tags,
   });
 }
 
@@ -253,6 +255,7 @@ export async function writeArtifactsFromResults(
     taskBundleTargets?: readonly TaskBundleTargetSelection[];
     additionalArtifacts?: AdditionalResultArtifactsWriter;
     runtimeSource?: RunRuntimeSourceMetadata;
+    tags?: Record<string, string>;
   },
 ): Promise<{
   testArtifactDir: string;
@@ -270,5 +273,6 @@ export async function writeArtifactsFromResults(
     sourceTests: options?.sourceTests,
     additionalArtifacts: options?.additionalArtifacts ?? createTaskBundleArtifactsWriter(options),
     runtimeSource: options?.runtimeSource,
+    tags: options?.tags,
   });
 }

--- a/apps/cli/src/commands/eval/commands/run.ts
+++ b/apps/cli/src/commands/eval/commands/run.ts
@@ -214,7 +214,8 @@ export const evalRunCommand = command({
     tag: multioption({
       type: array(string),
       long: 'tag',
-      description: 'Only run eval files that have this tag (repeatable, AND logic)',
+      description:
+        'Repeatable. `--tag name` filters to eval files with that tag (AND logic). `--tag key=value` sets a promptfoo-shaped run tag; `--tag experiment=<name>` labels the experiment (CLI > project config > eval tags).',
     }),
     excludeTag: multioption({
       type: array(string),

--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -149,6 +149,8 @@ interface NormalizedOptions {
   readonly cliThreshold?: number;
   readonly tags: readonly string[];
   readonly excludeTags: readonly string[];
+  /** Promptfoo-shaped `--tag key=value` entries (CLI layer of the tags map). */
+  readonly tagMap: Record<string, string>;
   readonly transcript?: string;
   readonly recordReplay?: string;
   readonly recordReplayVariant?: string;
@@ -339,6 +341,92 @@ export function matchesTagFilters(
 }
 
 /**
+ * Split repeatable `--tag` values into two shapes, mirroring the suite-level
+ * `tags` union (selection list vs promptfoo map):
+ *
+ * - `--tag key=value` (contains `=`) -> a `Record<string,string>` tag-map entry
+ *   (promptfoo-shaped run metadata; the reserved `experiment` key feeds the
+ *   experiment namespace).
+ * - `--tag name` (no `=`) -> a bare selection tag, preserving the existing
+ *   file-level `--tag`/`--exclude-tag` AND-filter behavior.
+ *
+ * On repeated `key=value` for the same key, the last value wins. An empty value
+ * (`--tag experiment=`) is kept as an explicit empty string so callers can
+ * detect an intentional clear.
+ */
+export function splitCliTags(value: unknown): {
+  selectionTags: readonly string[];
+  tagMap: Record<string, string>;
+} {
+  const selectionTags: string[] = [];
+  const tagMap: Record<string, string> = {};
+  for (const entry of normalizeStringArray(value)) {
+    const eq = entry.indexOf('=');
+    if (eq === -1) {
+      selectionTags.push(entry);
+      continue;
+    }
+    const key = entry.slice(0, eq).trim();
+    if (key.length === 0) {
+      continue;
+    }
+    tagMap[key] = entry.slice(eq + 1).trim();
+  }
+  return { selectionTags, tagMap };
+}
+
+/**
+ * Resolve the effective promptfoo-shaped tags map for a run by merging layers
+ * with precedence CLI `--tag key=value` > project config `tags` > eval `tags`.
+ * Returns undefined when no layer contributes any entry.
+ */
+export function resolveEffectiveTags(layers: {
+  evalTags?: Record<string, string>;
+  configTags?: Record<string, string>;
+  cliTags?: Record<string, string>;
+}): Record<string, string> | undefined {
+  const merged: Record<string, string> = {
+    ...(layers.evalTags ?? {}),
+    ...(layers.configTags ?? {}),
+    ...(layers.cliTags ?? {}),
+  };
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+/**
+ * Resolve the experiment namespace and its provenance for a run.
+ *
+ * Precedence: `--experiment` (CLI) > `tags.experiment` (resolved tags map) >
+ * the eval-derived default (multi-eval label, suite `metadata.name`, or eval
+ * filename). This keeps `--experiment` authoritative while letting a
+ * promptfoo-shaped `tags.experiment` label a run, and preserves the existing
+ * default fallback when neither is set.
+ */
+export function resolveExperimentNamespace(params: {
+  cliExperiment?: string;
+  tagsExperiment?: string;
+  isMultiEval: boolean;
+  suiteName?: string;
+  resultGroupName: string;
+}): {
+  experiment: string;
+  source: RunRuntimeSourceMetadata['experiment_namespace_source'];
+} {
+  if (params.cliExperiment) {
+    return { experiment: params.cliExperiment, source: 'cli' };
+  }
+  if (params.tagsExperiment) {
+    return { experiment: params.tagsExperiment, source: 'tags' };
+  }
+  const source: RunRuntimeSourceMetadata['experiment_namespace_source'] = params.isMultiEval
+    ? 'multi_eval'
+    : params.suiteName
+      ? 'eval_metadata'
+      : 'eval_filename';
+  return { experiment: params.resultGroupName, source };
+}
+
+/**
  * Normalize --output-messages value. Accepts a number (>= 1) or "all".
  * Defaults to 1 (last assistant message only).
  */
@@ -458,6 +546,7 @@ function normalizeOptions(
     ...(resultsPush || resultsNoPush ? { auto_push: resultsPush && !resultsNoPush } : {}),
     ...(resultsRequirePush ? { require_push: true } : {}),
   };
+  const cliTags = splitCliTags(rawOptions.tag);
 
   return {
     target: singleTarget,
@@ -515,8 +604,9 @@ function normalizeOptions(
     outputMessages: normalizeOutputMessages(normalizeString(rawOptions.outputMessages)),
     threshold: cliThreshold,
     cliThreshold,
-    tags: normalizeStringArray(rawOptions.tag),
+    tags: cliTags.selectionTags,
     excludeTags: normalizeStringArray(rawOptions.excludeTag),
+    tagMap: cliTags.tagMap,
     transcript: normalizeString(rawOptions.transcript),
     recordReplay: normalizeString(rawOptions.recordReplay),
     recordReplayVariant: normalizeString(rawOptions.recordReplayVariant),
@@ -1620,18 +1710,34 @@ export async function runEvalCommand(
     resolvedTestFiles.length === 1
       ? (primarySuite?.metadata?.name ?? fallbackResultGroupName)
       : fallbackResultGroupName;
-  const experimentNamespaceSource: RunRuntimeSourceMetadata['experiment_namespace_source'] =
-    resolvedExperiment.name
-      ? 'cli'
-      : resolvedTestFiles.length > 1
-        ? 'multi_eval'
-        : primarySuite?.metadata?.name
-          ? 'eval_metadata'
-          : 'eval_filename';
+  // Resolve the promptfoo-shaped tags map: eval `tags` < project config `tags`
+  // < CLI `--tag key=value`. The reserved `experiment` key feeds the namespace
+  // between an explicit --experiment (CLI) and the eval-derived default.
+  const resolvedTags = resolveEffectiveTags({
+    evalTags: primarySuite?.tags,
+    configTags: yamlConfig?.tags,
+    cliTags: options.tagMap,
+  });
+  const { experiment: resolvedExperimentNamespace, source: experimentNamespaceSource } =
+    resolveExperimentNamespace({
+      cliExperiment: resolvedExperiment.name,
+      tagsExperiment: normalizeString(resolvedTags?.experiment),
+      isMultiEval: resolvedTestFiles.length > 1,
+      suiteName: primarySuite?.metadata?.name,
+      resultGroupName,
+    });
   options = {
     ...options,
-    experiment: resolvedExperiment.name ?? resultGroupName,
+    experiment: resolvedExperimentNamespace,
   };
+  // When a tags map is emitted, keep its `experiment` key in lockstep with the
+  // resolved namespace so the row's `experiment` field and `tags.experiment`
+  // never disagree (e.g. a `--experiment` override still reflects in the map).
+  // A run with no authored tags emits no map — the namespace lives only in the
+  // `experiment` field, preserving the minimal default-run shape.
+  const emittedTags = resolvedTags
+    ? { ...resolvedTags, experiment: normalizeExperimentName(resolvedExperimentNamespace) }
+    : undefined;
   const hasCliRuntimeConfig = hasCliRuntimeSource(input.rawOptions);
 
   if (!process.env.AGENTV_EXPERIMENT) {
@@ -2120,6 +2226,7 @@ export async function runEvalCommand(
       runId: path.basename(runDir),
       experimentMetadata: runExperimentMetadata,
       runtimeSource: runtimeSourceMetadata,
+      tags: emittedTags,
     });
   }
 
@@ -2396,6 +2503,7 @@ export async function runEvalCommand(
           sourceTests,
           taskBundleTargets,
           runtimeSource: runtimeSourceMetadata,
+          tags: emittedTags,
         });
         const { summaryPath } = await aggregateRunDir(runDir, {
           evalFile,
@@ -2403,6 +2511,7 @@ export async function runEvalCommand(
           runId: path.basename(runDir),
           experimentMetadata: runExperimentMetadata,
           runtimeSource: runtimeSourceMetadata,
+          tags: emittedTags,
         });
         const indexPath = path.join(runDir, RESULT_INDEX_FILENAME);
         console.log(`Artifact bundle updated: ${runDir}`);
@@ -2424,6 +2533,7 @@ export async function runEvalCommand(
             sourceTests,
             taskBundleTargets,
             runtimeSource: runtimeSourceMetadata,
+            tags: emittedTags,
           },
         );
         console.log(`Artifact bundle written to: ${runDir}`);

--- a/apps/cli/src/commands/eval/run-eval.ts
+++ b/apps/cli/src/commands/eval/run-eval.ts
@@ -394,6 +394,27 @@ export function resolveEffectiveTags(layers: {
 }
 
 /**
+ * Keep an emitted tags map's `experiment` key in lockstep with the resolved
+ * experiment namespace so a row's `experiment` field and `tags.experiment` never
+ * disagree — but only when an experiment was intentionally set (`--experiment`,
+ * i.e. `experimentIsIntentional`, or an authored `tags.experiment`). A tags map
+ * that carries no experiment (e.g. only `--tag team=core`) must not gain an
+ * eval-default experiment key, and no tags map means nothing to emit.
+ */
+export function syncTagsExperiment(
+  resolvedTags: Record<string, string> | undefined,
+  options: { experimentIsIntentional: boolean; normalizedExperiment: string },
+): Record<string, string> | undefined {
+  if (!resolvedTags) {
+    return undefined;
+  }
+  if (!options.experimentIsIntentional && resolvedTags.experiment === undefined) {
+    return resolvedTags;
+  }
+  return { ...resolvedTags, experiment: options.normalizedExperiment };
+}
+
+/**
  * Resolve the experiment namespace and its provenance for a run.
  *
  * Precedence: `--experiment` (CLI) > `tags.experiment` (resolved tags map) >
@@ -1726,22 +1747,26 @@ export async function runEvalCommand(
       suiteName: primarySuite?.metadata?.name,
       resultGroupName,
     });
+  // Normalize once so the row `experiment` field, AGENTV_EXPERIMENT, and the
+  // emitted tags map all agree (and any invalid-name error surfaces in one place).
+  const normalizedExperiment = normalizeExperimentName(resolvedExperimentNamespace);
   options = {
     ...options,
     experiment: resolvedExperimentNamespace,
   };
-  // When a tags map is emitted, keep its `experiment` key in lockstep with the
-  // resolved namespace so the row's `experiment` field and `tags.experiment`
-  // never disagree (e.g. a `--experiment` override still reflects in the map).
-  // A run with no authored tags emits no map — the namespace lives only in the
-  // `experiment` field, preserving the minimal default-run shape.
-  const emittedTags = resolvedTags
-    ? { ...resolvedTags, experiment: normalizeExperimentName(resolvedExperimentNamespace) }
-    : undefined;
+  // Keep the emitted tags map's `experiment` key in lockstep with the resolved
+  // namespace ONLY when an experiment was intentionally set — via `--experiment`
+  // or an authored `tags.experiment`. A run whose tags map carries no experiment
+  // (e.g. only `--tag team=core`) must not gain an eval-default experiment key,
+  // and a run with no tags at all emits no map.
+  const emittedTags = syncTagsExperiment(resolvedTags, {
+    experimentIsIntentional: resolvedExperiment.name !== undefined,
+    normalizedExperiment,
+  });
   const hasCliRuntimeConfig = hasCliRuntimeSource(input.rawOptions);
 
   if (!process.env.AGENTV_EXPERIMENT) {
-    process.env.AGENTV_EXPERIMENT = normalizeExperimentName(options.experiment);
+    process.env.AGENTV_EXPERIMENT = normalizedExperiment;
   }
 
   // Validate --grader-target / --model combinations

--- a/apps/cli/src/commands/results/report.ts
+++ b/apps/cli/src/commands/results/report.ts
@@ -150,6 +150,8 @@ function formatNamespaceSourceLabel(
   switch (source) {
     case 'cli':
       return 'CLI namespace';
+    case 'tags':
+      return 'Tags namespace';
     case 'eval_metadata':
       return 'Eval metadata namespace';
     case 'eval_filename':

--- a/apps/cli/test/commands/eval/artifact-writer.test.ts
+++ b/apps/cli/test/commands/eval/artifact-writer.test.ts
@@ -476,6 +476,26 @@ describe('buildRunSummaryArtifact', () => {
     expect(summary.cost_usd).toBeDefined();
     expect(summary.cost_usd?.mean).toBe(0.075);
   });
+
+  it('records the resolved promptfoo tags map on run metadata', () => {
+    const benchmark = buildRunSummaryArtifact(
+      [makeResult({})],
+      'test.eval.yaml',
+      'baseline-v2',
+      'run-1',
+      undefined,
+      undefined,
+      undefined,
+      { experiment: 'baseline-v2', team: 'compliance' },
+    );
+
+    expect(benchmark.metadata.tags).toEqual({ experiment: 'baseline-v2', team: 'compliance' });
+  });
+
+  it('omits the tags map when no tags are resolved', () => {
+    const benchmark = buildRunSummaryArtifact([makeResult({})], 'test.eval.yaml');
+    expect(benchmark.metadata.tags).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1020,6 +1040,24 @@ describe('writeArtifactsFromResults', () => {
 
     expect(summary.metadata.runtime_source).toEqual(runtimeSource);
     expect(indexLine.runtime_source).toEqual(runtimeSource);
+  });
+
+  it('emits the resolved tags map to summary metadata and every index row', async () => {
+    const tags = { experiment: 'baseline-v2', team: 'compliance' };
+    const paths = await writeArtifactsFromResults(
+      [makeResult({ testId: 'alpha' }), makeResult({ testId: 'beta' })],
+      testDir,
+      { evalFile: 'evals/smoke.eval.yaml', experiment: 'baseline-v2', tags },
+    );
+
+    const summary: RunSummaryArtifact = JSON.parse(await readFile(paths.summaryPath, 'utf8'));
+    expect(summary.metadata.tags).toEqual(tags);
+
+    const indexLines = await readIndexLines(paths.indexPath);
+    expect(indexLines).toHaveLength(2);
+    for (const line of indexLines) {
+      expect(line.tags).toEqual(tags);
+    }
   });
 
   it('writes repeat runs in AgentV case and run folders', async () => {

--- a/apps/cli/test/commands/eval/tag-filtering.test.ts
+++ b/apps/cli/test/commands/eval/tag-filtering.test.ts
@@ -5,6 +5,7 @@ import {
   resolveEffectiveTags,
   resolveExperimentNamespace,
   splitCliTags,
+  syncTagsExperiment,
 } from '../../../src/commands/eval/run-eval.js';
 
 describe('matchesTagFilters', () => {
@@ -183,5 +184,40 @@ describe('resolveExperimentNamespace', () => {
         resultGroupName: 'multi-eval',
       }),
     ).toEqual({ experiment: 'tag-exp', source: 'tags' });
+  });
+});
+
+describe('syncTagsExperiment', () => {
+  it('returns undefined when there is no tags map', () => {
+    expect(
+      syncTagsExperiment(undefined, { experimentIsIntentional: true, normalizedExperiment: 'x' }),
+    ).toBeUndefined();
+  });
+
+  it('does not inject a default experiment when only non-experiment tags are set', () => {
+    expect(
+      syncTagsExperiment(
+        { team: 'core' },
+        { experimentIsIntentional: false, normalizedExperiment: 'my-suite' },
+      ),
+    ).toEqual({ team: 'core' });
+  });
+
+  it('syncs the experiment key when it was authored in the tags map', () => {
+    expect(
+      syncTagsExperiment(
+        { experiment: 'baseline', team: 'core' },
+        { experimentIsIntentional: false, normalizedExperiment: 'baseline' },
+      ),
+    ).toEqual({ experiment: 'baseline', team: 'core' });
+  });
+
+  it('syncs the experiment key to a --experiment override alongside other tags', () => {
+    expect(
+      syncTagsExperiment(
+        { team: 'core' },
+        { experimentIsIntentional: true, normalizedExperiment: 'cli-wins' },
+      ),
+    ).toEqual({ team: 'core', experiment: 'cli-wins' });
   });
 });

--- a/apps/cli/test/commands/eval/tag-filtering.test.ts
+++ b/apps/cli/test/commands/eval/tag-filtering.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'bun:test';
 
-import { matchesTagFilters } from '../../../src/commands/eval/run-eval.js';
+import {
+  matchesTagFilters,
+  resolveEffectiveTags,
+  resolveExperimentNamespace,
+  splitCliTags,
+} from '../../../src/commands/eval/run-eval.js';
 
 describe('matchesTagFilters', () => {
   describe('no filters', () => {
@@ -69,5 +74,114 @@ describe('matchesTagFilters', () => {
     it('rejects file not matching include even if not matching exclude', () => {
       expect(matchesTagFilters(['fast'], ['agent'], ['slow'])).toBe(false);
     });
+  });
+});
+
+describe('splitCliTags', () => {
+  it('routes bare values to selection tags and key=value to the tag map', () => {
+    const { selectionTags, tagMap } = splitCliTags([
+      'agent',
+      'experiment=baseline-v2',
+      'slow',
+      'team=compliance',
+    ]);
+    expect(selectionTags).toEqual(['agent', 'slow']);
+    expect(tagMap).toEqual({ experiment: 'baseline-v2', team: 'compliance' });
+  });
+
+  it('keeps an explicit empty value (--tag experiment=)', () => {
+    const { selectionTags, tagMap } = splitCliTags(['experiment=']);
+    expect(selectionTags).toEqual([]);
+    expect(tagMap).toEqual({ experiment: '' });
+  });
+
+  it('lets the last value win for a repeated key', () => {
+    expect(splitCliTags(['experiment=a', 'experiment=b']).tagMap).toEqual({ experiment: 'b' });
+  });
+
+  it('ignores entries with an empty key', () => {
+    expect(splitCliTags(['=value']).tagMap).toEqual({});
+  });
+
+  it('returns empty shapes for undefined input', () => {
+    expect(splitCliTags(undefined)).toEqual({ selectionTags: [], tagMap: {} });
+  });
+});
+
+describe('resolveEffectiveTags', () => {
+  it('merges eval < project config < CLI with CLI winning', () => {
+    expect(
+      resolveEffectiveTags({
+        evalTags: { experiment: 'eval', team: 'a' },
+        configTags: { experiment: 'config' },
+        cliTags: { experiment: 'cli' },
+      }),
+    ).toEqual({ experiment: 'cli', team: 'a' });
+  });
+
+  it('lets project config override eval when no CLI value is present', () => {
+    expect(
+      resolveEffectiveTags({
+        evalTags: { experiment: 'eval' },
+        configTags: { experiment: 'config' },
+      }),
+    ).toEqual({ experiment: 'config' });
+  });
+
+  it('returns undefined when no layer contributes', () => {
+    expect(resolveEffectiveTags({})).toBeUndefined();
+  });
+});
+
+describe('resolveExperimentNamespace', () => {
+  const base = {
+    isMultiEval: false,
+    suiteName: 'my-suite',
+    resultGroupName: 'my-suite',
+  };
+
+  it('prefers an explicit --experiment over tags.experiment and the default', () => {
+    expect(
+      resolveExperimentNamespace({ ...base, cliExperiment: 'cli-exp', tagsExperiment: 'tag-exp' }),
+    ).toEqual({ experiment: 'cli-exp', source: 'cli' });
+  });
+
+  it('uses tags.experiment when no --experiment is given', () => {
+    expect(resolveExperimentNamespace({ ...base, tagsExperiment: 'tag-exp' })).toEqual({
+      experiment: 'tag-exp',
+      source: 'tags',
+    });
+  });
+
+  it('falls back to the eval-metadata default when neither is set (e.g. --tag experiment=)', () => {
+    expect(resolveExperimentNamespace({ ...base })).toEqual({
+      experiment: 'my-suite',
+      source: 'eval_metadata',
+    });
+  });
+
+  it('falls back to the eval filename when there is no suite name', () => {
+    expect(
+      resolveExperimentNamespace({
+        isMultiEval: false,
+        resultGroupName: 'dataset',
+      }),
+    ).toEqual({ experiment: 'dataset', source: 'eval_filename' });
+  });
+
+  it('labels multi-eval runs when no CLI/tags experiment is set', () => {
+    expect(
+      resolveExperimentNamespace({ isMultiEval: true, resultGroupName: 'multi-eval' }),
+    ).toEqual({ experiment: 'multi-eval', source: 'multi_eval' });
+  });
+
+  it('lets tags.experiment win over the multi-eval default', () => {
+    expect(
+      resolveExperimentNamespace({
+        isMultiEval: true,
+        tagsExperiment: 'tag-exp',
+        resultGroupName: 'multi-eval',
+      }),
+    ).toEqual({ experiment: 'tag-exp', source: 'tags' });
   });
 });

--- a/apps/web/src/content/docs/docs/evaluation/experiments.mdx
+++ b/apps/web/src/content/docs/docs/evaluation/experiments.mdx
@@ -246,10 +246,36 @@ Eval runs write to a direct run bundle:
 .agentv/results/<run_id>/
 ```
 
-CLI `--experiment` sets the experiment label explicitly. Without that flag, AgentV uses
-top-level `experiment`, then top-level `name`, then the eval filename. The
-Dashboard uses "Experiment" for the comparison and result grouping concept;
-folder names are only storage allocation and must not define result semantics.
+CLI `--experiment` sets the experiment label explicitly. Without that flag, AgentV
+uses a reserved `tags.experiment` key (see below), then top-level `experiment`,
+then top-level `name`, then the eval filename. The precedence is
+`--experiment` > `tags.experiment` > default. The Dashboard uses "Experiment" for
+the comparison and result grouping concept; folder names are only storage
+allocation and must not define result semantics.
+
+### Tags as run metadata (`tags.experiment`)
+
+Suite-level `tags` accepts either the existing selection form (a string or list of
+strings that drives `select.tags` / `--tag name` filtering) **or** a
+promptfoo-shaped map:
+
+```yaml
+tags:
+  experiment: baseline-v2
+  team: compliance
+```
+
+The map form is run metadata, not selection. The reserved `experiment` key feeds
+the experiment namespace, and the full map is emitted to
+`summary.json.metadata.tags` and every `index.jsonl` row so the Dashboard can group
+trend/compare views by `tags.experiment`.
+
+Set or override map tags from the CLI with a repeatable `--tag key=value` flag
+(`--tag experiment=baseline-v2 --tag team=compliance`); bare `--tag name` keeps its
+existing file-selection meaning. Tags merge with precedence
+**CLI `--tag key=value` > project config `tags` > eval `tags`**. `--experiment`
+still wins over `tags.experiment` for the namespace, and an explicit
+`--tag experiment=` clears the label back to the default.
 
 Imported source suite metadata appears in `index.jsonl` rows and manifests.
 Use `index.jsonl` fields such as `eval_path`, `test_id`, `target`, and

--- a/apps/web/src/content/docs/docs/reference/result-artifacts.mdx
+++ b/apps/web/src/content/docs/docs/reference/result-artifacts.mdx
@@ -122,6 +122,7 @@ Example row:
   "timestamp": "2026-06-30T08:15:00.000Z",
   "run_id": "2026-06-30T08-15-00-000Z",
   "experiment": "with_skills",
+  "tags": { "experiment": "with_skills", "team": "support" },
   "eval_path": "evals/support/refunds.eval.yaml",
   "test_id": "refund-eligibility",
   "target": "codex-gpt5",
@@ -149,6 +150,12 @@ manual `prepare`/`grade` attempts, or imported provider sessions. That is why
 `experiment`, `eval_path`, `test_id`, `target`, `variant`, `attempt`, and
 source metadata belong in `index.jsonl`: tools can filter dynamically without
 requiring every run to be pre-split into semantic folders.
+
+When a run resolves a promptfoo-shaped tags map (from suite `tags`, project
+config `tags`, or `--tag key=value`), the resolved map is emitted as `tags` on
+each row and as `summary.json.metadata.tags`. Its reserved `experiment` key
+matches the row `experiment` field, so trend/compare views can group by
+`tags.experiment`.
 
 The `run-1/`, `run-2/`, and later folders under a result directory are artifact
 attempt/execution folders. Do not treat those folder names as the comparison

--- a/docs/adr/0013-experiment-is-metadata-expressed-as-tags-experiment.md
+++ b/docs/adr/0013-experiment-is-metadata-expressed-as-tags-experiment.md
@@ -1,0 +1,128 @@
+# 13. Experiment is metadata expressed as `tags.experiment`
+
+Date: 2026-07-01
+
+## Status
+
+Accepted
+
+Extends [ADR 0009](0009-eval-path-result-identity-and-default-experiment.md) and
+builds on [ADR 0012](0012-finalize-run-artifact-layout.md), which established
+that `experiment` is a mutable run-grouping label recorded in run metadata
+rather than a storage-path segment. This ADR closes the `experiment.name`
+source loop by giving evals a promptfoo-compatible way to author it.
+
+## Context
+
+AgentV already treats `experiment` as run-grouping metadata: it is written to
+`summary.json.metadata.experiment` and each `index.jsonl` row, with provenance
+in `runtime_source.experiment_namespace_source`. Until now an eval could only
+influence the namespace through the CLI `--experiment` flag or by falling back
+to the suite `metadata.name` / eval filename. There was no first-class,
+in-eval way to label the experiment.
+
+promptfoo — a widely used lowest-common-denominator eval contract — expresses
+run labels through `tags: Record<string,string>` with no first-class
+`experiment` field; the convention is a reserved `experiment` tag key. AgentV's
+`tags`, by contrast, is a string **list** that drives selection through
+`tagsMatch` / `select.tags` and the file-level `--tag` / `--exclude-tag`
+filters. The two shapes collide: `tags: {experiment: v1}` (map) does not fit the
+existing list shape.
+
+This is the one remaining promptfoo-compat item after deciding to keep
+`targets` (promptfoo natively accepts `targets` as a first-class, non-deprecated
+alias for `providers`, so no provider/label aliasing is needed).
+
+## Decision
+
+Accept suite-level `tags` as a **union**: the existing string / string-list form
+**or** a promptfoo-shaped `Record<string,string>` map. The forms are
+additive and non-breaking.
+
+- **List/string form** keeps its exact selection semantics. It continues to
+  flow into `metadata.tags`, drive `tagsMatch` / `select.tags`, and back the
+  file-level `--tag` / `--exclude-tag` AND-filters. Nothing about selection
+  changes.
+- **Map form** is promptfoo-shaped run metadata. It is surfaced on the parsed
+  suite as `EvalSuiteResult.tags` and is **not** inherited as per-case selection
+  tags. The reserved key `experiment` participates in namespace resolution.
+
+The resolved tags map is merged across three layers with precedence
+**CLI `--tag key=value` > project config `tags` > eval `tags`**.
+
+`--tag` is dual-mode, mirroring the suite-level union at the CLI boundary:
+
+- `--tag name` (no `=`) — a bare selection tag (existing file-filter behavior).
+- `--tag key=value` (contains `=`) — a promptfoo-shaped run-tag entry.
+  `--tag experiment=<name>` labels the experiment; `--tag experiment=` is an
+  explicit empty value that clears the tag and falls back to the default.
+
+The experiment namespace is resolved with precedence:
+
+```text
+--experiment (CLI)  >  tags.experiment  >  default (multi-eval / suite name / filename)
+```
+
+`experiment_namespace_source` gains a new `tags` value for provenance, joining
+the existing `cli`, `eval_metadata`, `eval_filename`, `multi_eval`, and
+`unknown` values. The `experiment_namespace` / `experiment_namespace_source`
+contract is otherwise unchanged.
+
+The resolved tags map is emitted to `summary.json.metadata.tags` and to each
+`index.jsonl` row (mirroring promptfoo's `evals_to_tags`) so Dashboard
+trend/compare can group by `tags.experiment`. Experiment stays metadata: there
+is **no** path segment — post-[ADR 0012](0012-finalize-run-artifact-layout.md)
+runs already write at the results root.
+
+## Compatibility
+
+Additive and non-breaking. Existing list-form `tags` and the `--tag` selection
+filter behave exactly as before. A map-form `tags` on a named suite no longer
+throws in metadata validation — the list form still feeds `metadata.tags`, and
+the map form is carried separately.
+
+## Consequences
+
+Positive:
+
+- Evals can author their experiment label inline in a promptfoo-compatible way.
+- Run grouping is explicit, self-describing metadata on both the summary and
+  every row, so Dashboard/compare can group without path inference.
+- The `--tag key=value` surface matches promptfoo's shared vocabulary.
+
+Negative:
+
+- `--tag` is overloaded (selection vs metadata). The `=` split keeps this
+  unambiguous in practice — selection tags are identifiers that do not contain
+  `=` — but the two meanings must be documented together.
+- `tags` now has two authored shapes. This is an intentional union to stay
+  non-breaking; a future bead may split selection into its own `labels` field
+  and make `tags` map-only to match promptfoo exactly.
+
+## Alternatives Considered
+
+### Add a separate CLI flag instead of overloading `--tag`
+
+Rejected. `--tag key=value` is the promptfoo-aligned surface, and the `=` split
+mirrors the same list-vs-map union already accepted at the suite level. A second
+flag would fragment the vocabulary.
+
+### Make `tags` map-only now and move selection to `labels`
+
+Deferred, not rejected. This is the cleaner long-term shape and matches
+promptfoo exactly, but it is a breaking change for every eval that uses list
+`tags` for selection. It is noted here as a possible follow-up bead and is
+explicitly out of scope.
+
+### Store experiment as a path segment again
+
+Rejected. [ADR 0012](0012-finalize-run-artifact-layout.md) already established
+that experiment is mutable grouping metadata, not storage identity.
+
+## Non-Goals
+
+- No `provider` / `providers` alias — `targets` stays (promptfoo accepts it).
+- No entry-shape aliasing (`id` / `label` / nested `config`); that belongs in
+  the friendly-YAML → promptfooconfig converter, not the parser.
+- No repo-wide rename and no run-artifact layout change.
+- Splitting selection tags into a map-only `tags` + `labels` field.

--- a/packages/core/src/evaluation/loaders/config-loader.ts
+++ b/packages/core/src/evaluation/loaders/config-loader.ts
@@ -200,6 +200,7 @@ function parseConfigObject(
     );
     const results = parseResultsConfig((parsed as Record<string, unknown>).results, configPath);
     const hooks = parseHooksConfig((parsed as Record<string, unknown>).hooks, configPath);
+    const tags = parseTagsConfig((parsed as Record<string, unknown>).tags, configPath);
 
     return {
       required_version: requiredVersion as string | undefined,
@@ -207,6 +208,7 @@ function parseConfigObject(
       execution: executionDefaults,
       results,
       ...(hooks && { hooks }),
+      ...(tags && { tags }),
     };
   } catch (error) {
     logWarning(`Could not parse AgentV config at ${configPath}: ${(error as Error).message}`);
@@ -681,6 +683,34 @@ export function parseHooksConfig(raw: unknown, configPath: string): HooksConfig 
   }
 
   return undefined;
+}
+
+/**
+ * Parse the optional project-config `tags` map (promptfoo-shaped
+ * `Record<string,string>`). Non-string entries are dropped with a warning; a
+ * non-object value is rejected. Returns undefined when no valid entry remains.
+ */
+export function parseTagsConfig(
+  raw: unknown,
+  configPath: string,
+): Record<string, string> | undefined {
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    logWarning(`Invalid tags in ${configPath}, expected a key=value map of strings`);
+    return undefined;
+  }
+
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value === 'string') {
+      out[key] = value;
+    } else {
+      logWarning(`Ignoring non-string tag "${key}" in ${configPath}`);
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 function logWarning(message: string): void {

--- a/packages/core/src/evaluation/loaders/config-loader.ts
+++ b/packages/core/src/evaluation/loaders/config-loader.ts
@@ -71,6 +71,12 @@ export type AgentVConfig = {
   readonly execution?: ExecutionDefaults;
   readonly results?: ResultsConfig;
   readonly hooks?: HooksConfig;
+  /**
+   * Promptfoo-shaped tags map applied to every run. Merged between eval `tags`
+   * and CLI `--tag key=value` (precedence CLI > project config > eval). The
+   * reserved key `experiment` participates in experiment-namespace resolution.
+   */
+  readonly tags?: Record<string, string>;
 };
 
 /**

--- a/packages/core/src/evaluation/metadata.ts
+++ b/packages/core/src/evaluation/metadata.ts
@@ -22,6 +22,27 @@ const MetadataSchema = z.object({
 
 export type EvalMetadata = z.infer<typeof MetadataSchema>;
 
+/**
+ * Resolve suite `tags` for selection metadata. `tags` may be authored as the
+ * existing string list (selection) or a promptfoo-shaped `Record<string,string>`
+ * map (run metadata carried separately via EvalSuiteResult.tags). The list form
+ * is validated by the schema here; the map form is intentionally not selection
+ * metadata and returns undefined. Any other shape (scalar/number) is rejected
+ * loudly rather than silently dropped.
+ */
+function selectionTagsForMetadata(tags: unknown): unknown {
+  if (tags === undefined) {
+    return undefined;
+  }
+  if (Array.isArray(tags)) {
+    return tags;
+  }
+  if (typeof tags === 'object' && tags !== null) {
+    return undefined;
+  }
+  throw new Error('Invalid `tags`: expected a list of strings or a key=value map of strings.');
+}
+
 export function parseMetadata(suite: JsonObject): EvalMetadata | undefined {
   if (typeof suite.name !== 'string') {
     return undefined;
@@ -32,10 +53,7 @@ export function parseMetadata(suite: JsonObject): EvalMetadata | undefined {
     description: suite.description,
     version: suite.version,
     author: suite.author,
-    // `tags` may be authored as a promptfoo-shaped `Record<string,string>` map
-    // (carried separately as run metadata via EvalSuiteResult.tags). Only the
-    // list form drives selection metadata here; the map form is ignored.
-    tags: Array.isArray(suite.tags) ? suite.tags : undefined,
+    tags: selectionTagsForMetadata(suite.tags),
     license: suite.license,
     requires: suite.requires,
   });

--- a/packages/core/src/evaluation/metadata.ts
+++ b/packages/core/src/evaluation/metadata.ts
@@ -32,7 +32,10 @@ export function parseMetadata(suite: JsonObject): EvalMetadata | undefined {
     description: suite.description,
     version: suite.version,
     author: suite.author,
-    tags: suite.tags,
+    // `tags` may be authored as a promptfoo-shaped `Record<string,string>` map
+    // (carried separately as run metadata via EvalSuiteResult.tags). Only the
+    // list form drives selection metadata here; the map form is ignored.
+    tags: Array.isArray(suite.tags) ? suite.tags : undefined,
     license: suite.license,
     requires: suite.requires,
   });

--- a/packages/core/src/evaluation/run-artifacts.ts
+++ b/packages/core/src/evaluation/run-artifacts.ts
@@ -276,7 +276,7 @@ async function readRunSummaryMetadata(summaryPath: string): Promise<{
 /**
  * Coerce an unknown value into a `Record<string,string>`, dropping non-string
  * entries. Returns undefined when the value is not a plain object or has no
- * string entries. Shared by summary reads and tag-map resolution.
+ * string entries. Used when reading a prior run summary's `tags` on resume.
  */
 export function normalizeStringRecord(value: unknown): Record<string, string> | undefined {
   if (!isRecord(value)) {

--- a/packages/core/src/evaluation/run-artifacts.ts
+++ b/packages/core/src/evaluation/run-artifacts.ts
@@ -75,6 +75,7 @@ export type RunRuntimeConfigSource = 'defaults' | 'inline_experiment' | 'cli_fla
 
 export type ExperimentNamespaceSource =
   | 'cli'
+  | 'tags'
   | 'eval_metadata'
   | 'eval_filename'
   | 'multi_eval'
@@ -164,6 +165,7 @@ export async function aggregateRunDir(
     plannedTestCount?: number;
     experimentMetadata?: ExperimentArtifactMetadata;
     runtimeSource?: RunRuntimeSourceMetadata;
+    tags?: Record<string, string>;
   },
 ): Promise<{ summaryPath: string; testCount: number; targetCount: number }> {
   const indexPath =
@@ -175,6 +177,7 @@ export async function aggregateRunDir(
   const previousMetadata = await readRunSummaryMetadata(path.join(runDir, RUN_SUMMARY_FILENAME));
   const plannedTestCount = options?.plannedTestCount ?? previousMetadata.plannedTestCount;
   const runtimeSource = options?.runtimeSource ?? previousMetadata.runtimeSource;
+  const tags = options?.tags ?? previousMetadata.tags;
 
   const summary = buildRunSummaryArtifact(
     results,
@@ -184,6 +187,7 @@ export async function aggregateRunDir(
     plannedTestCount,
     options?.experimentMetadata,
     runtimeSource,
+    tags,
   );
   const summaryPath = path.join(runDir, RUN_SUMMARY_FILENAME);
   await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
@@ -241,6 +245,7 @@ async function resolveExistingResultManifestPath(runDir: string): Promise<string
 async function readRunSummaryMetadata(summaryPath: string): Promise<{
   plannedTestCount?: number;
   runtimeSource?: RunRuntimeSourceMetadata;
+  tags?: Record<string, string>;
 }> {
   try {
     const raw = await readFile(summaryPath, 'utf8');
@@ -248,6 +253,7 @@ async function readRunSummaryMetadata(summaryPath: string): Promise<{
       metadata?: {
         planned_test_count?: number;
         runtime_source?: RunRuntimeSourceMetadata;
+        tags?: unknown;
       };
     };
     const value = parsed.metadata?.planned_test_count;
@@ -256,13 +262,33 @@ async function readRunSummaryMetadata(summaryPath: string): Promise<{
     const runtimeSource = isRunRuntimeSourceMetadata(parsed.metadata?.runtime_source)
       ? parsed.metadata.runtime_source
       : undefined;
+    const tags = normalizeStringRecord(parsed.metadata?.tags);
     return {
       ...(plannedTestCount !== undefined && { plannedTestCount }),
       ...(runtimeSource !== undefined && { runtimeSource }),
+      ...(tags !== undefined && { tags }),
     };
   } catch {
     return {};
   }
+}
+
+/**
+ * Coerce an unknown value into a `Record<string,string>`, dropping non-string
+ * entries. Returns undefined when the value is not a plain object or has no
+ * string entries. Shared by summary reads and tag-map resolution.
+ */
+export function normalizeStringRecord(value: unknown): Record<string, string> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const out: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry === 'string') {
+      out[key] = entry;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 function isRunRuntimeSourceMetadata(value: unknown): value is RunRuntimeSourceMetadata {
@@ -281,6 +307,7 @@ function isRunRuntimeSourceMetadata(value: unknown): value is RunRuntimeSourceMe
       candidate.config_source === 'mixed') &&
     typeof candidate.experiment_namespace === 'string' &&
     (candidate.experiment_namespace_source === 'cli' ||
+      candidate.experiment_namespace_source === 'tags' ||
       candidate.experiment_namespace_source === 'eval_metadata' ||
       candidate.experiment_namespace_source === 'eval_filename' ||
       candidate.experiment_namespace_source === 'multi_eval' ||
@@ -404,6 +431,12 @@ export interface RunSummaryArtifact {
     readonly experiment_config?: ExperimentArtifactMetadata;
     readonly runtime_source?: RunRuntimeSourceMetadata;
     readonly planned_test_count?: number;
+    /**
+     * Resolved promptfoo-shaped suite tags map (`Record<string,string>`), merged
+     * CLI > project config > eval `tags`. The reserved key `experiment` feeds the
+     * experiment namespace. Absent when no map-form tags were resolved.
+     */
+    readonly tags?: Record<string, string>;
   };
   readonly run_summary: Record<
     string,
@@ -442,6 +475,8 @@ export interface IndexArtifactEntry {
   readonly category?: string;
   readonly conversation_id?: string;
   readonly experiment?: string;
+  /** Resolved promptfoo-shaped suite tags map for this run (grouping/compare). */
+  readonly tags?: Record<string, string>;
   readonly score: number;
   readonly target: string;
   readonly variant?: string;
@@ -1297,6 +1332,7 @@ export function buildRunSummaryArtifact(
   plannedTestCount?: number,
   experimentMetadata?: ExperimentArtifactMetadata,
   runtimeSource?: RunRuntimeSourceMetadata,
+  tags?: Record<string, string>,
 ): RunSummaryArtifact {
   const targetSet = new Set<string>();
   const variantSet = new Set<string>();
@@ -1398,6 +1434,7 @@ export function buildRunSummaryArtifact(
       experiment_config: experimentMetadata,
       runtime_source: runtimeSource,
       planned_test_count: plannedTestCount,
+      tags: tags && Object.keys(tags).length > 0 ? tags : undefined,
     },
     run_summary: runSummary,
     per_grader_summary: perEvaluatorSummary,
@@ -1415,6 +1452,7 @@ export async function writeInitialRunSummaryArtifact(
     runId?: string;
     experimentMetadata?: ExperimentArtifactMetadata;
     runtimeSource?: RunRuntimeSourceMetadata;
+    tags?: Record<string, string>;
   },
 ): Promise<void> {
   await mkdir(runDir, { recursive: true });
@@ -1426,6 +1464,7 @@ export async function writeInitialRunSummaryArtifact(
     options.plannedTestCount,
     options.experimentMetadata,
     options.runtimeSource,
+    options.tags,
   );
   const summaryPath = path.join(runDir, RUN_SUMMARY_FILENAME);
   await writeFile(summaryPath, `${JSON.stringify(stub, null, 2)}\n`, 'utf8');
@@ -2226,10 +2265,13 @@ export async function writePerTestArtifacts(
     sourceTests?: readonly EvalTest[];
     additionalArtifacts?: AdditionalResultArtifactsWriter;
     runtimeSource?: RunRuntimeSourceMetadata;
+    tags?: Record<string, string>;
   },
 ): Promise<void> {
   await mkdir(outputDir, { recursive: true });
   const duplicatePolicy = options?.duplicatePolicy ?? 'update';
+  const resolvedTags =
+    options?.tags && Object.keys(options.tags).length > 0 ? options.tags : undefined;
   const testByTestId = buildSourceTestLookup(options?.sourceTests);
   const indexRecords: ResultIndexArtifact[] = [];
 
@@ -2325,6 +2367,7 @@ export async function writePerTestArtifacts(
         duplicatePolicy,
       }),
       experiment: options?.experiment,
+      ...(resolvedTags ? { tags: resolvedTags } : {}),
     });
   }
 
@@ -2345,6 +2388,7 @@ export async function writeArtifactsFromResults(
     sourceTests?: readonly EvalTest[];
     additionalArtifacts?: AdditionalResultArtifactsWriter;
     runtimeSource?: RunRuntimeSourceMetadata;
+    tags?: Record<string, string>;
   },
 ): Promise<{
   testArtifactDir: string;
@@ -2356,6 +2400,8 @@ export async function writeArtifactsFromResults(
   const indexPath = path.join(outputDir, RESULT_INDEX_FILENAME);
   await mkdir(outputDir, { recursive: true });
   const duplicatePolicy = options?.duplicatePolicy ?? 'update';
+  const resolvedTags =
+    options?.tags && Object.keys(options.tags).length > 0 ? options.tags : undefined;
   const existingRecords = await readExistingIndexRecords(outputDir);
   const existingByIdentity = existingRecordsByProjectionIdentity(existingRecords);
   const indexRecords: unknown[] = [];
@@ -2503,6 +2549,7 @@ export async function writeArtifactsFromResults(
         duplicatePolicy,
       }),
       experiment: options?.experiment,
+      ...(resolvedTags ? { tags: resolvedTags } : {}),
     };
     if (duplicatePolicy === 'update' && emittedIdentityIds.has(identityId)) {
       const existingIndex = indexRecords.findIndex(
@@ -2520,6 +2567,7 @@ export async function writeArtifactsFromResults(
   const previousMetadata = await readRunSummaryMetadata(summaryPath);
   const plannedTestCount = options?.plannedTestCount ?? previousMetadata.plannedTestCount;
   const runtimeSource = options?.runtimeSource ?? previousMetadata.runtimeSource;
+  const summaryTags = resolvedTags ?? previousMetadata.tags;
   const summary = buildRunSummaryArtifact(
     results,
     options?.evalFile,
@@ -2528,6 +2576,7 @@ export async function writeArtifactsFromResults(
     plannedTestCount,
     options?.experimentMetadata,
     runtimeSource,
+    summaryTags,
   );
   await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
 

--- a/packages/core/src/evaluation/yaml-parser.ts
+++ b/packages/core/src/evaluation/yaml-parser.ts
@@ -348,6 +348,14 @@ export type EvalSuiteResult = {
   readonly cacheConfig?: import('./loaders/config-loader.js').CacheConfig;
   /** Suite-level metadata (name, description, version, etc.) */
   readonly metadata?: import('./metadata.js').EvalMetadata;
+  /**
+   * Promptfoo-shaped suite tags map (`Record<string,string>`) when `tags:` is
+   * authored as a map rather than a selection list. The reserved key
+   * `experiment` feeds the experiment namespace; the full map is carried as run
+   * metadata. Absent when `tags:` is a string/list (that form drives selection
+   * via `metadata.tags`).
+   */
+  readonly tags?: Record<string, string>;
   /** Suite-level total cost budget in USD */
   readonly budgetUsd?: number;
   /** Execution error tolerance from project/CLI runtime surfaces. */
@@ -869,6 +877,7 @@ function buildEvalSuiteResult(parsed: JsonObject, tests: readonly EvalTest[]): E
   const failOnError = extractFailOnError(parsed);
   const threshold = extractThreshold(parsed);
   const experimentConfig = normalizeSuiteExperimentConfig(parsed);
+  const tags = extractSuiteTagMap(parsed);
 
   return {
     tests,
@@ -882,7 +891,37 @@ function buildEvalSuiteResult(parsed: JsonObject, tests: readonly EvalTest[]): E
     ...(failOnError !== undefined && { failOnError }),
     ...(threshold !== undefined && { threshold }),
     ...(experimentConfig !== undefined && { experimentConfig }),
+    ...(tags !== undefined && { tags }),
   };
+}
+
+/**
+ * Extract the promptfoo-shaped suite tags map when `tags:` (or `metadata.tags:`)
+ * is authored as a `Record<string,string>`. The list/string form is a selection
+ * construct and is intentionally ignored here (it flows through `metadata.tags`).
+ * Top-level `tags:` wins over `metadata.tags` on key collisions.
+ */
+function extractSuiteTagMap(suite: JsonObject): Record<string, string> | undefined {
+  const metadata = (suite as RawTestSuite).metadata;
+  const metadataTags = isJsonObject(metadata) ? metadata.tags : undefined;
+  const merged: Record<string, string> = {
+    ...tagMapEntries(metadataTags),
+    ...tagMapEntries((suite as RawTestSuite).tags),
+  };
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function tagMapEntries(value: unknown): Record<string, string> {
+  if (!isJsonObject(value)) {
+    return {};
+  }
+  const out: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry === 'string') {
+      out[key] = entry;
+    }
+  }
+  return out;
 }
 
 function rejectAuthoredWorkers(parsed: JsonObject): void {
@@ -2149,12 +2188,19 @@ function asString(value: unknown): string | undefined {
  * `metadata.governance:` so existing governance evals keep their precedence.
  */
 function extractSuiteMetadataPayload(suite: RawTestSuite): Record<string, unknown> | undefined {
-  const payload = isJsonObject(suite.metadata)
-    ? ({ ...(suite.metadata as Record<string, unknown>) } as Record<string, unknown>)
+  const rawMetadata = isJsonObject(suite.metadata)
+    ? (suite.metadata as Record<string, unknown>)
     : {};
+  // `tags` is handled explicitly: the list form is inherited as per-case
+  // selection metadata, while the map form (promptfoo-shaped) is carried on the
+  // suite via EvalSuiteResult.tags and is intentionally dropped here so it does
+  // not pollute per-case selection tags.
+  const payload: Record<string, unknown> = Object.fromEntries(
+    Object.entries(rawMetadata).filter(([key]) => key !== 'tags'),
+  );
 
   const suiteTags = readMetadataTags(suite.tags);
-  const metadataTags = readMetadataTags(payload.tags);
+  const metadataTags = readMetadataTags(rawMetadata.tags);
   if (suiteTags.length > 0 || metadataTags.length > 0) {
     payload.tags = dedupeMetadataArray([...suiteTags, ...metadataTags]);
   }

--- a/packages/core/test/evaluation/loaders/config-loader.test.ts
+++ b/packages/core/test/evaluation/loaders/config-loader.test.ts
@@ -13,6 +13,7 @@ import {
   loadConfig,
   parseExecutionDefaults,
   parseResultsConfig,
+  parseTagsConfig,
   resolveResultsConfigForProject,
 } from '../../../src/evaluation/loaders/config-loader.js';
 import type { JsonObject } from '../../../src/evaluation/types.js';
@@ -57,6 +58,26 @@ describe('loadConfig', () => {
         expect(config?.eval_patterns).toEqual(['**/*.global.eval.yaml']);
         expect(config?.execution).toEqual({ verbose: true });
       });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('propagates a project-config tags map through loadConfig', async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'agentv-tags-config-'));
+    try {
+      const projectDir = path.join(tempDir, 'project');
+      const evalDir = path.join(projectDir, 'evals');
+      const localConfigDir = path.join(projectDir, '.agentv');
+      mkdirSync(evalDir, { recursive: true });
+      mkdirSync(localConfigDir, { recursive: true });
+      writeFileSync(
+        path.join(localConfigDir, 'config.yaml'),
+        'tags:\n  experiment: staging\n  team: core\n',
+      );
+
+      const config = await loadConfig(path.join(evalDir, 'suite.eval.yaml'), projectDir);
+      expect(config?.tags).toEqual({ experiment: 'staging', team: 'core' });
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -318,6 +339,33 @@ describe('loadConfig', () => {
       warnSpy.mockRestore();
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('parseTagsConfig', () => {
+  it('parses a valid string map', () => {
+    expect(
+      parseTagsConfig({ experiment: 'staging', team: 'core' }, '/tmp/.agentv/config.yaml'),
+    ).toEqual({
+      experiment: 'staging',
+      team: 'core',
+    });
+  });
+
+  it('drops non-string entries and keeps the rest', () => {
+    expect(
+      parseTagsConfig({ experiment: 'staging', count: 3 }, '/tmp/.agentv/config.yaml'),
+    ).toEqual({ experiment: 'staging' });
+  });
+
+  it('returns undefined for a non-object value', () => {
+    expect(parseTagsConfig('nope', '/tmp/.agentv/config.yaml')).toBeUndefined();
+    expect(parseTagsConfig(['a', 'b'], '/tmp/.agentv/config.yaml')).toBeUndefined();
+  });
+
+  it('returns undefined when nothing valid remains', () => {
+    expect(parseTagsConfig({ count: 3 }, '/tmp/.agentv/config.yaml')).toBeUndefined();
+    expect(parseTagsConfig(undefined, '/tmp/.agentv/config.yaml')).toBeUndefined();
   });
 });
 

--- a/packages/core/test/evaluation/yaml-parser-tags-map.test.ts
+++ b/packages/core/test/evaluation/yaml-parser-tags-map.test.ts
@@ -87,6 +87,19 @@ tests:
     expect(suite.tests[0].metadata?.tags).toBeUndefined();
   });
 
+  it('rejects a malformed scalar tags value loudly rather than dropping it', async () => {
+    const { filePath, dir } = createTempYaml(`
+name: scalar-tags
+tags: not-a-list
+tests:
+  - id: test-1
+    input: "Hi"
+    criteria: "Greet"
+`);
+
+    await expect(loadTestSuite(filePath, dir)).rejects.toThrow(/Invalid .*tags/);
+  });
+
   it('lets top-level tags override metadata-block tags on key collisions', async () => {
     const { filePath, dir } = createTempYaml(`
 name: collision-eval

--- a/packages/core/test/evaluation/yaml-parser-tags-map.test.ts
+++ b/packages/core/test/evaluation/yaml-parser-tags-map.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { loadTestSuite } from '../../src/evaluation/yaml-parser.js';
+
+function createTempYaml(content: string): { filePath: string; dir: string } {
+  const dir = mkdtempSync(path.join(tmpdir(), 'tags-map-test-'));
+  const filePath = path.join(dir, 'dataset.eval.yaml');
+  writeFileSync(filePath, content);
+  return { filePath, dir };
+}
+
+describe('loadTestSuite - promptfoo-shaped tags map', () => {
+  it('parses map-form tags into EvalSuiteResult.tags and exposes the experiment key', async () => {
+    const { filePath, dir } = createTempYaml(`
+name: mapped-eval
+description: A map-form tags eval
+tags:
+  experiment: baseline-v2
+  team: compliance
+tests:
+  - id: test-1
+    input: "Hello"
+    criteria: "Greet"
+`);
+
+    const suite = await loadTestSuite(filePath, dir);
+    expect(suite.tags).toEqual({ experiment: 'baseline-v2', team: 'compliance' });
+    // The map form must NOT populate the selection list on metadata.
+    expect(suite.metadata?.tags).toBeUndefined();
+    // The map form must NOT be inherited as case selection tags.
+    expect(suite.tests[0].metadata?.tags).toBeUndefined();
+  });
+
+  it('does not crash when a named suite authors map-form tags', async () => {
+    const { filePath, dir } = createTempYaml(`
+name: named-eval
+tags:
+  experiment: run-a
+tests:
+  - id: test-1
+    input: "Hi"
+    criteria: "Greet"
+`);
+
+    const suite = await loadTestSuite(filePath, dir);
+    expect(suite.tags).toEqual({ experiment: 'run-a' });
+    expect(suite.metadata?.name).toBe('named-eval');
+  });
+
+  it('keeps list-form tags as a selection list, with no tags map', async () => {
+    const { filePath, dir } = createTempYaml(`
+name: listed-eval
+tags:
+  - unit
+  - smoke
+tests:
+  - id: test-1
+    input: "Hello"
+    criteria: "Greet"
+`);
+
+    const suite = await loadTestSuite(filePath, dir);
+    // List form still drives selection via metadata.tags (unchanged behavior).
+    expect(suite.metadata?.tags).toEqual(['unit', 'smoke']);
+    expect(suite.tests[0].metadata?.tags).toEqual(['unit', 'smoke']);
+    // No promptfoo map for the list form.
+    expect(suite.tags).toBeUndefined();
+  });
+
+  it('reads a tags map authored under the metadata block', async () => {
+    const { filePath, dir } = createTempYaml(`
+name: metadata-mapped
+metadata:
+  tags:
+    experiment: from-metadata
+tests:
+  - id: test-1
+    input: "Hi"
+    criteria: "Greet"
+`);
+
+    const suite = await loadTestSuite(filePath, dir);
+    expect(suite.tags).toEqual({ experiment: 'from-metadata' });
+    expect(suite.tests[0].metadata?.tags).toBeUndefined();
+  });
+
+  it('lets top-level tags override metadata-block tags on key collisions', async () => {
+    const { filePath, dir } = createTempYaml(`
+name: collision-eval
+tags:
+  experiment: top-level
+metadata:
+  tags:
+    experiment: metadata-block
+    team: compliance
+tests:
+  - id: test-1
+    input: "Hi"
+    criteria: "Greet"
+`);
+
+    const suite = await loadTestSuite(filePath, dir);
+    expect(suite.tags).toEqual({ experiment: 'top-level', team: 'compliance' });
+  });
+});


### PR DESCRIPTION
## Summary

Lets an AgentV eval express its experiment via a flat, promptfoo-shaped
`tags.experiment` key. Suite-level `tags` now accepts a `Record<string,string>`
**map** in addition to the existing `string | string[]` **selection list** — the
two forms are additive and non-breaking. Implements bead **av-4hzh**.

- **Union `tags` shape.** List/string form keeps its exact selection semantics
  (`tagsMatch` / `select.tags` / file-level `--tag name` filtering, unchanged).
  Map form is promptfoo-shaped run metadata surfaced as `EvalSuiteResult.tags`;
  the reserved `experiment` key feeds the experiment namespace and the map is
  **not** inherited as per-case selection tags.
- **Precedence.** Experiment namespace resolves `--experiment` (CLI) >
  `tags.experiment` > eval-derived default. A new `experiment_namespace_source`
  value `tags` records the provenance.
- **`--tag key=value`.** `--tag` is dual-mode: `key=value` sets a promptfoo run
  tag (`--tag experiment=<name>` labels the run; `--tag experiment=` clears it),
  bare `--tag name` keeps its file-selection meaning. Tags merge
  **CLI > project config `tags` > eval `tags`**.
- **Emission.** The resolved tags map is written to `summary.json.metadata.tags`
  and every `index.jsonl` row so Dashboard trend/compare can group by
  `tags.experiment`. The emitted map's `experiment` key stays in lockstep with
  the resolved namespace. Experiment stays metadata — no path segment (runs
  already write at the results root, per #1583 / ADR 0012).
- **Docs/ADR.** Adds ADR 0013 (extends ADR 0009, closes the `experiment.name`
  source loop / #1575) and documents the feature in the experiments and
  result-artifacts docs.

## Non-goals

No `provider`/`providers` alias (kept `targets`), no entry-shape aliasing, no
repo-wide rename, no run-artifact layout change, and no split of selection tags
into a `labels` field (possible follow-up).

## Tests

- Parser: map-form parse, list-form selection preserved, metadata-block map,
  top-level-over-metadata precedence.
- CLI helpers: `splitCliTags` (bare vs `key=value`, empty value, last-wins),
  `resolveEffectiveTags` (layer precedence), `resolveExperimentNamespace`
  (`--experiment` > `tags.experiment` > default, multi-eval, filename).
- Emission: `buildRunSummaryArtifact` metadata tags + `writeArtifactsFromResults`
  summary + per-row tags.

## Verification

Lint + typecheck + `@agentv/core` (1982) and `apps/cli` eval/results suites green.
Dogfooded live via a real OpenAI-compatible provider + LLM grader (map-form
`tags.experiment` → `summary.metadata.tags` + rows + `experiment_namespace_source:
tags`; `--experiment` override; `--tag experiment=` precedence). Private evidence
kept local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)