### PR TITLE
test(cli): cover Agent Skills expectations criteria

### DIFF
--- a/apps/cli/test/commands/convert/convert-evals-json.test.ts
+++ b/apps/cli/test/commands/convert/convert-evals-json.test.ts
@@ -104,6 +104,38 @@ describe('convertEvalsJsonToYaml', () => {
     });
   });
 
+  it('accepts expectations as Agent Skills criteria without assertions', () => {
+    const filePath = writeTempJson({
+      skill_name: 'test-skill',
+      evals: [
+        {
+          id: 1,
+          prompt: 'Check this paragraph for style issues',
+          expectations: ['Flags "please" as unnecessary', 'Flags "below" as positional'],
+        },
+      ],
+    });
+
+    const yamlObject = agentSkillsToAgentVYamlObject(readAgentSkillsEvalsFile(filePath));
+
+    expect(yamlObject.tests?.[0]?.assert?.[0]).toMatchObject({
+      metric: 'agent-skills-criteria',
+      type: 'llm-rubric',
+      value: [
+        {
+          id: 'expectation-1',
+          outcome: 'Flags "please" as unnecessary',
+          required: true,
+        },
+        {
+          id: 'expectation-2',
+          outcome: 'Flags "below" as positional',
+          required: true,
+        },
+      ],
+    });
+  });
+
   it('throws on invalid format', () => {
     const filePath = writeTempJson({ not_evals: true });
     expect(() => convertEvalsJsonToYaml(filePath)).toThrow(


### PR DESCRIPTION
## Summary

- Adds regression coverage for Agent Skills evals.json cases that use `expectations` without `assertions`.
- Verifies the read adapter emits `agent-skills-criteria` llm-rubric entries with stable `expectation-N` IDs and `required: true`.

## Notes

Latest `origin/main` already moved Agent Skills evals.json support out of the removed core loader and into the CLI read adapter, and it already parses `expectations`. This PR preserves that behavior with focused expectations-only coverage.

## Verification

- `bun test apps/cli/test/commands/convert/convert-evals-json.test.ts` - pass
- `bun run lint` - pass
- `git diff --check` - pass
- `bun test packages/core/test/evaluation/orchestrator.test.ts -t "applies exponential backoff between retries"` - pass after full-suite timing failure
- `bun run test` - one timing-sensitive failure in `packages/core/test/evaluation/orchestrator.test.ts` (`applies exponential backoff between retries`); reran that exact test successfully

## Review

Subagent review reported no findings. Residual gap noted: this new case exercises the read-adapter object path; the existing basic conversion test already covers serialized YAML for `expectations` when `assertions` are also present.

Closes av-p60u.
