### PR TITLE
fix(dashboard): clarify repeat attempt rows

### DIFF
--- a/apps/dashboard/src/components/EvalDetail.tsx
+++ b/apps/dashboard/src/components/EvalDetail.tsx
@@ -66,6 +66,19 @@ function caseTrialPath(trial: EvalCaseTrial, index = 0): string {
   return trial.attempt_path ?? trial.run_path ?? `attempt-${trial.attempt ?? index + 1}`;
 }
 
+function trialNumber(trial: EvalCaseTrial, index = 0): number {
+  if (typeof trial.sample_index === 'number') return trial.sample_index;
+  if (typeof trial.attempt === 'number') return trial.attempt + 1;
+  return index + 1;
+}
+
+function trialDisplayLabel(trial: EvalCaseTrial, index = 0): string {
+  const label = `Attempt ${trialNumber(trial, index)}`;
+  return typeof trial.retry_index === 'number' && trial.retry_index > 0
+    ? `${label} retry ${trial.retry_index}`
+    : label;
+}
+
 function caseTrialTokenTotal(trial: EvalCaseTrial): number | undefined {
   if (trial.total_tokens != null) return trial.total_tokens;
   const usage = trial.token_usage;
@@ -564,10 +577,16 @@ function TrialActionRow({
   onSelectTrial?: (trial: EvalCaseTrial, initialTab?: Tab) => void;
 }) {
   const label = caseTrialPath(trial, index);
+  const displayLabel = trialDisplayLabel(trial, index);
   return (
     <div className="grid gap-2 rounded-md border border-gray-800 bg-gray-950/50 p-3 text-sm md:grid-cols-[minmax(8rem,1fr)_auto] md:items-center">
       <div className="min-w-0">
-        <div className="font-medium text-gray-200">{label}</div>
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <span className="font-medium text-gray-200">{displayLabel}</span>
+          <span className="rounded-md border border-gray-800 px-1.5 py-0.5 text-[11px] font-medium text-gray-500">
+            {label}
+          </span>
+        </div>
         <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-gray-500">
           <span>{formatPercent(trial.score)} score</span>
           <span>{trial.verdict ?? 'unknown'}</span>
@@ -608,14 +627,20 @@ function RepeatAggregateChecksTab({
   return (
     <div className="space-y-6">
       <div className="rounded-lg border border-gray-800 bg-gray-900 p-4">
+        <p className="mb-3 text-sm text-gray-400">
+          Aggregate across {group.trialCount} attempts for this test case.
+        </p>
         <div className="grid gap-3 md:grid-cols-4">
           <RunMetricRow label="Attempt success" value={formatPercent(group.passRate)} />
           <RunMetricRow label="Mean score" value={formatPercent(group.meanScore)} />
           <RunMetricRow
-            label="Passed attempts"
+            label="Attempts passed"
             value={`${group.passedTrials}/${group.trialCount}`}
           />
-          <RunMetricRow label="Assertions" value={formatPercent(group.assertionPassRate)} />
+          <RunMetricRow label="Assertion pass" value={formatPercent(group.assertionPassRate)} />
+          {group.executionErrorTrials > 0 ? (
+            <RunMetricRow label="Execution errors" value={String(group.executionErrorTrials)} />
+          ) : null}
         </div>
       </div>
 
@@ -806,6 +831,7 @@ function RepeatAggregateTranscriptTab({
       </h4>
       {group.trials.map((trial, index) => {
         const runLabel = caseTrialPath(trial, index);
+        const displayLabel = trialDisplayLabel(trial, index);
         const transcriptPath = trial.transcript_path;
         const transcriptHref = transcriptPath
           ? artifactFileContentUrl({
@@ -823,7 +849,12 @@ function RepeatAggregateTranscriptTab({
             className="grid gap-2 rounded-md border border-gray-800 bg-gray-950/50 p-3 text-sm md:grid-cols-[minmax(8rem,1fr)_auto] md:items-center"
           >
             <div className="min-w-0">
-              <div className="font-medium text-gray-200">{runLabel}</div>
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                <span className="font-medium text-gray-200">{displayLabel}</span>
+                <span className="rounded-md border border-gray-800 px-1.5 py-0.5 text-[11px] font-medium text-gray-500">
+                  {runLabel}
+                </span>
+              </div>
               <div className="mt-1 truncate font-mono text-xs text-gray-500" title={transcriptPath}>
                 {transcriptPath ?? 'No transcript artifact'}
               </div>

--- a/apps/dashboard/src/components/ResultTable.test.tsx
+++ b/apps/dashboard/src/components/ResultTable.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { buildResultTableModel } from '~/lib/result-table';
+import type { EvalResult } from '~/lib/types';
+
+import { ResultRowsTable, ResultTable } from './ResultTable';
+
+function repeatResult(overrides: Partial<EvalResult> = {}): EvalResult {
+  return {
+    testId: 'refund-policy-flaky',
+    target: 'codex',
+    score: 0.67,
+    executionStatus: 'quality_failure',
+    eval_path: 'evals/refund-policy.eval.yaml',
+    timestamp: '2026-07-04T10:00:00.000Z',
+    scores: [{ name: 'rubric', type: 'llm-rubric', score: 0.67, verdict: 'fail' }],
+    attempts: [
+      {
+        attempt: 0,
+        sample_index: 1,
+        attempt_path: 'sample-1',
+        score: 1,
+        verdict: 'pass',
+        duration_ms: 4400,
+        total_tokens: 830,
+        cost_usd: 0.0021,
+      },
+      {
+        attempt: 1,
+        sample_index: 2,
+        attempt_path: 'sample-2',
+        score: 0.51,
+        verdict: 'fail',
+        duration_ms: 5200,
+        total_tokens: 910,
+        cost_usd: 0.0024,
+      },
+      {
+        attempt: 2,
+        sample_index: 3,
+        attempt_path: 'sample-3',
+        score: 0,
+        verdict: 'fail',
+        execution_status: 'execution_error',
+        error: 'target timed out',
+        duration_ms: 15000,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('ResultTable repeat-run rendering', () => {
+  it('renders repeat runs as a collapsed aggregate case by default', () => {
+    const html = renderToStaticMarkup(
+      <ResultTable results={[repeatResult()]} runId="repeat-run-2026-07-04" passThreshold={0.8} />,
+    );
+
+    expect(html).toContain('Aggregate case');
+    expect(html).toContain('Flaky');
+    expect(html).toContain('1/3 attempts passed');
+    expect(html).toContain('Attempt success');
+    expect(html).toContain('Mean score');
+    expect(html).toContain('Expand attempts for refund-policy-flaky');
+    expect(html).not.toContain('Under refund-policy-flaky');
+    expect(html).not.toContain('sample-1');
+  });
+
+  it('renders expanded attempts as subordinate rows under the aggregate case', () => {
+    const model = buildResultTableModel({
+      results: [repeatResult()],
+      passThreshold: 0.8,
+    });
+    const row = model.filteredRows[0];
+    const html = renderToStaticMarkup(
+      <ResultRowsTable
+        rows={model.filteredRows}
+        visibleColumns={model.visibleColumns}
+        passThreshold={0.8}
+        selectedRowKey={null}
+        selectedTrialPath={null}
+        repeatGroupsByRowKey={new Map(model.repeatGroups.map((group) => [group.row.key, group]))}
+        expandedRepeatRows={new Set([row.key])}
+        onToggleRepeatGroup={() => undefined}
+        onOpenDetail={() => undefined}
+        onOpenTrialDetail={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('Aggregate case');
+    expect(html).toContain('Collapse attempts for refund-policy-flaky');
+    expect(html).toContain('Attempt 1');
+    expect(html).toContain('Attempt 2');
+    expect(html).toContain('Attempt 3');
+    expect(html).toContain('Under refund-policy-flaky');
+    expect(html).toContain('sample-1');
+    expect(html).toContain('target timed out');
+  });
+});

--- a/apps/dashboard/src/components/ResultTable.tsx
+++ b/apps/dashboard/src/components/ResultTable.tsx
@@ -191,7 +191,7 @@ export function ResultTable({
   const [selectedTrialPath, setSelectedTrialPath] = useState<string | null>(null);
   const [selectedDetailFilePath, setSelectedDetailFilePath] = useState<string | null>(null);
   const [selectedDetailTab, setSelectedDetailTab] = useState<DetailTab>('checks');
-  const [collapsedRepeatRows, setCollapsedRepeatRows] = useState<ReadonlySet<string>>(
+  const [expandedRepeatRows, setExpandedRepeatRows] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
   const model = useMemo(
@@ -292,7 +292,7 @@ export function ResultTable({
   }
 
   function toggleRepeatGroup(rowKey: string) {
-    setCollapsedRepeatRows((current) => {
+    setExpandedRepeatRows((current) => {
       const next = new Set(current);
       if (next.has(rowKey)) next.delete(rowKey);
       else next.add(rowKey);
@@ -439,7 +439,7 @@ export function ResultTable({
               selectedRowKey={selectedRowKey}
               selectedTrialPath={selectedTrialPath}
               repeatGroupsByRowKey={repeatGroupsByRowKey}
-              collapsedRepeatRows={collapsedRepeatRows}
+              expandedRepeatRows={expandedRepeatRows}
               onToggleRepeatGroup={toggleRepeatGroup}
               onOpenDetail={openRowDetail}
               onOpenTrialDetail={openTrialDetail}
@@ -468,14 +468,14 @@ export function ResultTable({
   );
 }
 
-function ResultRowsTable({
+export function ResultRowsTable({
   rows,
   visibleColumns,
   passThreshold,
   selectedRowKey,
   selectedTrialPath,
   repeatGroupsByRowKey,
-  collapsedRepeatRows,
+  expandedRepeatRows,
   onToggleRepeatGroup,
   onOpenDetail,
   onOpenTrialDetail,
@@ -486,7 +486,7 @@ function ResultRowsTable({
   selectedRowKey: string | null;
   selectedTrialPath: string | null;
   repeatGroupsByRowKey: ReadonlyMap<string, RepeatRunGroup>;
-  collapsedRepeatRows: ReadonlySet<string>;
+  expandedRepeatRows: ReadonlySet<string>;
   onToggleRepeatGroup: (rowKey: string) => void;
   onOpenDetail: (rowKey: string) => void;
   onOpenTrialDetail: (rowKey: string, trial: EvalCaseTrial) => void;
@@ -516,13 +516,13 @@ function ResultRowsTable({
           {rows.map((row) => {
             const repeatGroup = repeatGroupsByRowKey.get(row.key);
             const isSelected = selectedRowKey === row.key && !selectedTrialPath;
-            const collapsed = repeatGroup ? collapsedRepeatRows.has(row.key) : true;
+            const expanded = repeatGroup ? expandedRepeatRows.has(row.key) : false;
             return (
               <Fragment key={row.key}>
                 <tr
                   className={`cursor-pointer transition-colors ${
                     isSelected ? 'bg-cyan-950/20' : 'hover:bg-gray-900/30'
-                  }`}
+                  } ${repeatGroup ? 'bg-gray-950/20' : ''}`}
                   onClick={() => onOpenDetail(row.key)}
                   onKeyDown={(event) => {
                     if (event.key === 'Enter' || event.key === ' ') {
@@ -542,7 +542,7 @@ function ResultRowsTable({
                         column={column}
                         row={row}
                         repeatGroup={repeatGroup}
-                        repeatCollapsed={collapsed}
+                        repeatExpanded={expanded}
                         passThreshold={passThreshold}
                         isSelected={isSelected}
                         onToggleRepeatGroup={onToggleRepeatGroup}
@@ -550,7 +550,7 @@ function ResultRowsTable({
                     </td>
                   ))}
                 </tr>
-                {repeatGroup && !collapsed
+                {repeatGroup && expanded
                   ? repeatGroup.trials.map((trial, index) => {
                       const trialPath = caseTrialPath(trial, index);
                       const trialSelected =
@@ -558,9 +558,10 @@ function ResultRowsTable({
                       return (
                         <tr
                           key={`${row.key}:${trialPath}`}
-                          className={`cursor-pointer bg-gray-950/40 transition-colors ${
+                          className={`cursor-pointer bg-gray-950/60 transition-colors ${
                             trialSelected ? 'bg-cyan-950/20' : 'hover:bg-gray-900/50'
                           }`}
+                          aria-label={`${trialDisplayLabel(trial, index)} for ${row.testId}`}
                           onClick={() => onOpenTrialDetail(row.key, trial)}
                           onKeyDown={(event) => {
                             if (event.key === 'Enter' || event.key === ' ') {
@@ -602,6 +603,19 @@ function caseTrialPassed(trial: EvalCaseTrial, passThreshold: number): boolean {
   if (trial.verdict === 'pass') return true;
   if (trial.verdict === 'fail') return false;
   return typeof trial.score === 'number' ? trial.score >= passThreshold : false;
+}
+
+function trialNumber(trial: EvalCaseTrial, index = 0): number {
+  if (typeof trial.sample_index === 'number') return trial.sample_index;
+  if (typeof trial.attempt === 'number') return trial.attempt + 1;
+  return index + 1;
+}
+
+function trialDisplayLabel(trial: EvalCaseTrial, index = 0): string {
+  const label = `Attempt ${trialNumber(trial, index)}`;
+  return typeof trial.retry_index === 'number' && trial.retry_index > 0
+    ? `${label} retry ${trial.retry_index}`
+    : label;
 }
 
 function primaryTrialArtifactPath(trial: EvalCaseTrial): string | null {
@@ -652,15 +666,23 @@ function TrialResultCell({
   const isExecutionError = trial.execution_status === 'execution_error';
   const status = isExecutionError ? 'error' : passed ? 'passing' : 'failing';
   const statusLabel = isExecutionError ? 'Error' : passed ? 'Passing' : 'Failing';
-  const label = caseTrialPath(trial, index);
+  const label = trialDisplayLabel(trial, index);
+  const artifactLabel = caseTrialPath(trial, index);
 
   switch (column.id) {
     case 'status':
       return <ResultStatusSymbol status={status} label={statusLabel} />;
     case 'expander':
-      return <span aria-hidden="true" className="block h-5" />;
+      return <span aria-hidden="true" className="mx-auto block h-7 w-px bg-gray-800" />;
     case 'test':
-      return <TrialTestCell label={label} trial={trial} />;
+      return (
+        <TrialTestCell
+          label={label}
+          artifactLabel={artifactLabel}
+          parentTestId={row.testId}
+          trial={trial}
+        />
+      );
     case 'target':
       return <TargetCell target={row.targetLabel} tone="text-gray-500" />;
     case 'score':
@@ -687,11 +709,32 @@ function TrialResultCell({
   }
 }
 
-function TrialTestCell({ label, trial }: { label: string; trial: EvalCaseTrial }) {
+function TrialTestCell({
+  label,
+  artifactLabel,
+  parentTestId,
+  trial,
+}: {
+  label: string;
+  artifactLabel: string;
+  parentTestId: string;
+  trial: EvalCaseTrial;
+}) {
   return (
-    <div className="max-w-[24rem] min-w-0 pl-6">
-      <div className="truncate font-medium text-gray-300" title={label}>
-        {label}
+    <div className="max-w-[28rem] min-w-0 border-l border-gray-800 pl-3">
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="rounded-md border border-gray-800 bg-gray-900 px-1.5 py-0.5 text-[11px] font-medium text-gray-500">
+          Attempt
+        </span>
+        <span className="truncate font-medium text-gray-300" title={label}>
+          {label}
+        </span>
+      </div>
+      <div
+        className="mt-0.5 truncate text-xs text-gray-600"
+        title={`${parentTestId} · ${artifactLabel}`}
+      >
+        Under {parentTestId} · {artifactLabel}
       </div>
       <div className="mt-0.5 flex min-w-0 flex-wrap gap-x-3 gap-y-0.5 text-xs text-gray-600">
         {trial.total_tool_calls != null ? <span>{trial.total_tool_calls} tool calls</span> : null}
@@ -735,31 +778,60 @@ function RepeatStatusCell({
 }
 
 function RepeatSummaryText({ group }: { group: RepeatRunGroup }) {
+  const classification =
+    group.passedTrials === group.trialCount
+      ? 'Stable pass'
+      : group.passedTrials === 0
+        ? 'Stable fail'
+        : 'Flaky';
   const parts = [
-    `${group.trialCount} attempts`,
-    `${formatPercent(group.passRate)} attempt success`,
+    `${group.passedTrials}/${group.trialCount} attempts passed`,
+    `${formatPercent(group.passRate)} success`,
     `${formatPercent(group.meanScore)} mean score`,
+    group.executionErrorTrials > 0 ? `${group.executionErrorTrials} execution errors` : undefined,
     group.assertionPassRate != null
-      ? `${formatPercent(group.assertionPassRate)} assertions (${group.passedAssertions}/${group.assertionCount})`
+      ? `${group.passedAssertions}/${group.assertionCount} assertions`
       : undefined,
-    group.totalToolCalls != null ? `${group.totalToolCalls} tool calls` : undefined,
-    group.artifactCount > 0 ? `${group.artifactCount} artifacts` : undefined,
   ].filter((part): part is string => Boolean(part));
   return (
-    <div className="mt-0.5 truncate text-xs text-gray-500" title={parts.join(' · ')}>
-      {parts.join(' · ')}
+    <div className="mt-1 flex max-w-[34rem] flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+      <span className="rounded-md border border-cyan-900/60 bg-cyan-950/30 px-1.5 py-0.5 font-medium text-cyan-300">
+        Aggregate case
+      </span>
+      <span
+        className={
+          classification === 'Stable pass'
+            ? 'text-emerald-300'
+            : classification === 'Stable fail'
+              ? 'text-red-300'
+              : 'text-yellow-300'
+        }
+      >
+        {classification}
+      </span>
+      <span className="min-w-0 truncate text-gray-500" title={parts.join(' · ')}>
+        {parts.join(' · ')}
+      </span>
     </div>
   );
 }
 
 function RepeatScoreCell({ group }: { group: RepeatRunGroup }) {
-  return <PassRatePill rate={group.meanScore} />;
+  return (
+    <div className="flex min-w-0 flex-col items-end gap-1">
+      <PassRatePill rate={group.passRate} />
+      <div className="text-xs text-gray-500">Attempt success</div>
+      <div className="text-xs tabular-nums text-gray-600">
+        Mean score {formatPercent(group.meanScore)}
+      </div>
+    </div>
+  );
 }
 
 function RepeatDurationCell({ group, row }: { group: RepeatRunGroup; row: ResultTableRow }) {
   return (
     <span className="text-gray-400">
-      {formatDuration(group.meanDurationMs ?? row.result.durationMs)}
+      Avg {formatDuration(group.meanDurationMs ?? row.result.durationMs)}
     </span>
   );
 }
@@ -801,7 +873,7 @@ function ResultCell({
   column,
   row,
   repeatGroup,
-  repeatCollapsed,
+  repeatExpanded,
   passThreshold,
   isSelected,
   onToggleRepeatGroup,
@@ -809,7 +881,7 @@ function ResultCell({
   column: ResultTableColumn;
   row: ReturnType<typeof buildResultTableModel>['filteredRows'][number];
   repeatGroup?: RepeatRunGroup;
-  repeatCollapsed: boolean;
+  repeatExpanded: boolean;
   passThreshold: number;
   isSelected: boolean;
   onToggleRepeatGroup: (rowKey: string) => void;
@@ -832,7 +904,7 @@ function ResultCell({
       return repeatGroup ? (
         <ExpanderCell
           row={row}
-          repeatCollapsed={repeatCollapsed}
+          repeatExpanded={repeatExpanded}
           onToggleRepeatGroup={onToggleRepeatGroup}
         />
       ) : (
@@ -933,7 +1005,7 @@ function ResultDetailPanel({
     resultDir: row.result.result_dir,
     evalPath: row.result.eval_path,
   });
-  const title = selectedTrialPath ? `${row.testId} · ${selectedTrialPath}` : row.testId;
+  const title = selectedTrial ? `${row.testId} · ${trialDisplayLabel(selectedTrial)}` : row.testId;
   const showAggregateRepeatDetail = repeatGroup && !selectedTrial;
   const panelScrollKey = `${row.key}:${selectedTrialPath ?? ''}:${initialTab}`;
 
@@ -997,11 +1069,11 @@ function TargetCell({ target, tone = 'text-gray-300' }: { target: string; tone?:
 
 function ExpanderCell({
   row,
-  repeatCollapsed,
+  repeatExpanded,
   onToggleRepeatGroup,
 }: {
   row: ResultTableRow;
-  repeatCollapsed: boolean;
+  repeatExpanded: boolean;
   onToggleRepeatGroup: (rowKey: string) => void;
 }) {
   return (
@@ -1012,10 +1084,10 @@ function ExpanderCell({
         onToggleRepeatGroup(row.key);
       }}
       className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-gray-800 text-xs text-gray-400 transition-colors hover:border-gray-700 hover:text-gray-200"
-      aria-expanded={!repeatCollapsed}
-      aria-label={`${repeatCollapsed ? 'Expand' : 'Collapse'} ${row.testId}`}
+      aria-expanded={repeatExpanded}
+      aria-label={`${repeatExpanded ? 'Collapse' : 'Expand'} attempts for ${row.testId}`}
     >
-      {repeatCollapsed ? '+' : '-'}
+      {repeatExpanded ? '-' : '+'}
     </button>
   );
 }

--- a/apps/dashboard/src/lib/result-table.test.ts
+++ b/apps/dashboard/src/lib/result-table.test.ts
@@ -143,6 +143,51 @@ describe('result-table model', () => {
       trialCount: 2,
       passedTrials: 1,
       failedTrials: 1,
+      executionErrorTrials: 0,
+    });
+  });
+
+  it('keeps execution-error attempts visible in repeat-run aggregates', () => {
+    const model = buildResultTableModel({
+      passThreshold: 0.8,
+      results: [
+        result({
+          testId: 'flaky-repeat-case',
+          score: 0.5,
+          attempts: [
+            {
+              attempt: 0,
+              attempt_path: 'sample-1',
+              score: 1,
+              verdict: 'pass',
+              duration_ms: 4200,
+            },
+            {
+              attempt: 1,
+              attempt_path: 'sample-2',
+              score: 0.42,
+              verdict: 'fail',
+              duration_ms: 5100,
+            },
+            {
+              attempt: 2,
+              attempt_path: 'sample-3',
+              score: 0,
+              verdict: 'fail',
+              execution_status: 'execution_error',
+              error: 'target timed out',
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(model.repeatGroups[0]).toMatchObject({
+      trialCount: 3,
+      passedTrials: 1,
+      failedTrials: 2,
+      executionErrorTrials: 1,
+      passRate: 1 / 3,
     });
   });
 

--- a/apps/dashboard/src/lib/result-table.ts
+++ b/apps/dashboard/src/lib/result-table.ts
@@ -74,6 +74,7 @@ export interface RepeatRunGroup {
   readonly trialCount: number;
   readonly passedTrials: number;
   readonly failedTrials: number;
+  readonly executionErrorTrials: number;
   readonly passRate: number;
   readonly meanScore: number;
   readonly assertionCount: number;
@@ -300,6 +301,9 @@ function buildRepeatGroup(row: ResultTableRow, passThreshold: number): RepeatRun
   if (trials.length <= 1) return undefined;
 
   const passedTrials = trials.filter((trial) => caseTrialPassed(trial, passThreshold)).length;
+  const executionErrorTrials = trials.filter(
+    (trial) => trial.execution_status === 'execution_error',
+  ).length;
   const durationValues = numeric(trials.map((trial) => trial.duration_ms));
   const scoreValues = numeric(trials.map((trial) => trial.score));
   const toolCallValues = numeric(trials.map((trial) => trial.total_tool_calls));
@@ -317,6 +321,7 @@ function buildRepeatGroup(row: ResultTableRow, passThreshold: number): RepeatRun
     trialCount: trials.length,
     passedTrials,
     failedTrials: trials.length - passedTrials,
+    executionErrorTrials,
     passRate: trials.length > 0 ? passedTrials / trials.length : 0,
     meanScore:
       scoreValues.length > 0

--- a/apps/dashboard/src/lib/types.ts
+++ b/apps/dashboard/src/lib/types.ts
@@ -128,6 +128,8 @@ export interface AssertionEntry {
 
 export interface EvalCaseTrial {
   attempt?: number;
+  sample_index?: number;
+  retry_index?: number;
   attempt_path?: string;
   run_path?: string;
   score?: number;


### PR DESCRIPTION
## Summary
Repeat-run results now read as one logical test case first, with aggregate reliability metrics visible in the collapsed row and individual attempts clearly nested underneath when expanded.

The table defaults repeat groups to the aggregate view, labels the parent as an aggregate case, and shows attempt success, mean score, attempts passed, execution-error attempts, and assertion coverage without flattening attempts into peer test cases. Expanded rows now use Attempt N labels, parent-case context, and sample artifact paths so per-attempt score, duration, cost, token, and error values stay readable but visually subordinate. The detail panel uses the same aggregate-first vocabulary and exposes execution-error counts in the aggregate metrics.

## Validation
- `bunx biome check apps/dashboard/src/components/ResultTable.tsx apps/dashboard/src/components/EvalDetail.tsx apps/dashboard/src/components/ResultTable.test.tsx apps/dashboard/src/lib/result-table.ts apps/dashboard/src/lib/result-table.test.ts apps/dashboard/src/lib/types.ts`
- `bun test ./apps/dashboard/src/lib/result-table.test.ts ./apps/dashboard/src/components/ResultTable.test.tsx`
- `bun --filter @agentv/dashboard test`
- `bun --filter @agentv/dashboard build`
- Browser UAT with a local realistic repeat-run fixture containing three attempts: pass, quality fail, and execution error. Checked desktop expanded detail and 390px mobile-ish viewport against `agentv dashboard --dir . --single --port 3127`.

## Evidence
Private evidence branch: `EntityProcess/agentv-private:evidence/dashboard-repeat-ui-polish` at `507c77f`.

- `desktop-expanded-detail.png`: expanded attempts with aggregate detail panel on desktop.
- `mobile-expanded-detail.png`: 390px viewport with expanded attempts and aggregate detail.

## Related
Related: Bead `av-i0l.4`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
