### PR TITLE
fix(dashboard): include execution errors in run-list totals

### DIFF
--- a/apps/dashboard/src/components/RunList.mobile.spec.tsx
+++ b/apps/dashboard/src/components/RunList.mobile.spec.tsx
@@ -18,7 +18,7 @@ function runMeta(overrides: Partial<RunMeta> = {}): RunMeta {
 }
 
 describe('buildRunListItemView', () => {
-  it('deducts execution errors from quality totals for both table and mobile views', () => {
+  it('keeps displayed totals distinct from quality totals when execution errors are present', () => {
     const view = buildRunListItemView(
       runMeta({
         execution_error_count: 2,
@@ -27,6 +27,7 @@ describe('buildRunListItemView', () => {
     );
 
     expect(view.errors).toBe(2);
+    expect(view.totalCount).toBe(10);
     expect(view.qualityCount).toBe(8);
     expect(view.passedCount).toBe(6);
     expect(view.failedCount).toBe(2);

--- a/apps/dashboard/src/components/RunList.tsx
+++ b/apps/dashboard/src/components/RunList.tsx
@@ -3,7 +3,7 @@
  *
  * Displays all available runs with a pass/fail status dot, human-readable name,
  * a per-run "on remote" indicator (whether the run is backed up to the
- * configured results branch), date, quality test count, execution-error count,
+ * configured results branch), date, total test count, execution-error count,
  * and coloured pass-rate pill. Clicking a row navigates to the run detail view.
  *
  * On phone-width viewports the rows collapse to dense cards so right-side table
@@ -73,6 +73,7 @@ interface RunListItemView {
   label: string;
   display: RunDisplay;
   errors: number;
+  totalCount: number;
   qualityCount: number;
   passing: boolean;
   passedCount: number;
@@ -108,6 +109,7 @@ export function buildRunListItemView(run: RunMeta, passThreshold: number): RunLi
   const display = formatRunDisplay(run, { includePassRate: false });
   const label = display.label;
   const errors = executionErrorCount(run);
+  const totalCount = run.test_count;
   const qualityCount = Math.max(0, run.test_count - errors);
   const passing = qualityCount > 0 ? run.pass_rate >= passThreshold : errors === 0;
   const passedCount = Math.round(run.pass_rate * qualityCount);
@@ -127,6 +129,7 @@ export function buildRunListItemView(run: RunMeta, passThreshold: number): RunLi
     label,
     display,
     errors,
+    totalCount,
     qualityCount,
     passing,
     passedCount,
@@ -431,7 +434,7 @@ export function RunList({
             label,
             display,
             errors,
-            qualityCount,
+            totalCount,
             passedCount,
             failedCount,
             experimentNamespace,
@@ -495,7 +498,7 @@ export function RunList({
                   <PassRatePill rate={run.pass_rate} />
                 </MobileRunMetric>
                 <MobileRunMetric label="Total" valueClassName="text-gray-300">
-                  {qualityCount}
+                  {totalCount}
                 </MobileRunMetric>
                 <MobileRunMetric label="Passed" valueClassName="text-emerald-300">
                   {passedCount}
@@ -548,7 +551,7 @@ export function RunList({
                 label,
                 display,
                 errors,
-                qualityCount,
+                totalCount,
                 passedCount,
                 failedCount,
                 experimentNamespace,
@@ -637,9 +640,7 @@ export function RunList({
                       <span className="text-gray-600">0</span>
                     )}
                   </td>
-                  <td className="px-4 py-3 text-right tabular-nums text-gray-400">
-                    {qualityCount}
-                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums text-gray-400">{totalCount}</td>
 
                   {/* Pass rate pill */}
                   <td className="px-4 py-3">


### PR DESCRIPTION
## Summary
Dashboard run lists now make the Total column/card reconcile with the run detail totals when a run has execution errors. Pass rate, passed, and failure counts still use the graded quality denominator, but Total now shows the full `test_count`, so rows like 45 passed, 24 failures, and 11 errors display Total 80 instead of 69.

## Validation
- `bun run lint`
- `bun test apps/dashboard/src/components/RunList.mobile.spec.tsx apps/dashboard/src/components/StatsCards.test.tsx apps/dashboard/src/lib/result-summary.test.ts`
- `bun test apps/dashboard/src/components/RunList.mobile.spec.tsx`
- `cd apps/dashboard && bun run build`
- Browser UAT with the av-2s7.21 remote-results scenario matrix confirmed desktop and mobile run lists now show the density run as Passed 45, Failures 24, Errors 11, Total 80.
- GitHub Actions on PR #1638 are passing.

## Related
Related: av-2s7.21

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
