### PR TITLE
fix(web): show docs version selector on mobile

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -62,6 +62,7 @@ export default defineConfig({
         alt: 'AgentV mark',
       },
       components: {
+        Header: './src/components/Header.astro',
         SiteTitle: './src/components/StarlightSiteTitle.astro',
         LanguageSelect: './src/components/VersionSelect.astro',
         Sidebar: './src/components/VersionedSidebar.astro',

--- a/apps/web/src/components/Header.astro
+++ b/apps/web/src/components/Header.astro
@@ -1,0 +1,97 @@
+---
+import LanguageSelect from 'virtual:starlight/components/LanguageSelect';
+import Search from 'virtual:starlight/components/Search';
+import SiteTitle from 'virtual:starlight/components/SiteTitle';
+import SocialIcons from 'virtual:starlight/components/SocialIcons';
+import ThemeSelect from 'virtual:starlight/components/ThemeSelect';
+import config from 'virtual:starlight/user-config';
+
+const shouldRenderSearch =
+  config.pagefind || config.components.Search !== '@astrojs/starlight/components/Search.astro';
+---
+
+<div class="header">
+  <div class="title-wrapper sl-flex">
+    <SiteTitle />
+  </div>
+  <div class="mobile-version md:sl-hidden print:hidden">
+    <LanguageSelect />
+  </div>
+  <div class="sl-flex print:hidden">
+    {shouldRenderSearch && <Search />}
+  </div>
+  <div class="sl-hidden md:sl-flex print:hidden right-group">
+    <div class="sl-flex social-icons">
+      <SocialIcons />
+    </div>
+    <ThemeSelect />
+    <LanguageSelect />
+  </div>
+</div>
+
+<style>
+  @layer starlight.core {
+    .header {
+      display: flex;
+      gap: 0.625rem;
+      justify-content: space-between;
+      align-items: center;
+      height: 100%;
+    }
+
+    .title-wrapper {
+      overflow: clip;
+      padding: 0.25rem;
+      margin: -0.25rem;
+      min-width: 0;
+    }
+
+    .mobile-version {
+      display: flex;
+      align-items: center;
+      flex: 0 0 auto;
+    }
+
+    .right-group,
+    .social-icons {
+      gap: 1rem;
+      align-items: center;
+    }
+
+    .social-icons::after {
+      content: '';
+      height: 2rem;
+      border-inline-end: 1px solid var(--sl-color-gray-5);
+    }
+
+    @media (min-width: 50rem) {
+      :global(:root[data-has-sidebar]) {
+        --__sidebar-pad: calc(2 * var(--sl-nav-pad-x));
+      }
+
+      :global(:root:not([data-has-toc])) {
+        --__toc-width: 0rem;
+      }
+
+      .header {
+        --__sidebar-width: max(0rem, var(--sl-content-inline-start, 0rem) - var(--sl-nav-pad-x));
+        --__main-column-fr: calc(
+          (
+              100% + var(--__sidebar-pad, 0rem) - var(--__toc-width, var(--sl-sidebar-width)) -
+                (2 * var(--__toc-width, var(--sl-nav-pad-x))) - var(--sl-content-inline-start, 0rem) -
+                var(--sl-content-width)
+            ) / 2
+        );
+        display: grid;
+        grid-template-columns:
+          minmax(
+            calc(var(--__sidebar-width) + max(0rem, var(--__main-column-fr) - var(--sl-nav-gap))),
+            auto
+          )
+          1fr
+          auto;
+        align-content: center;
+      }
+    }
+  }
+</style>

--- a/apps/web/src/styles/custom.css
+++ b/apps/web/src/styles/custom.css
@@ -82,7 +82,7 @@ a[aria-current="page"] {
 }
 
 .version-select select {
-  max-width: 11.5rem;
+  max-width: min(11.5rem, 28vw);
   min-height: 2rem;
   border: 1px solid var(--sl-color-gray-5);
   border-radius: 0.375rem;
@@ -91,6 +91,10 @@ a[aria-current="page"] {
   background: var(--sl-color-gray-6);
   font: inherit;
   font-size: 0.8125rem;
+}
+
+.mobile-version .version-select select {
+  max-width: 7.25rem;
 }
 
 .version-select select:focus {


### PR DESCRIPTION
## Summary
Docs users on mobile can now switch versions from the top header instead of losing the version picker entirely. The desktop header keeps the existing right-side version selector, while the mobile header gets a compact selector sized to sit beside the AgentV wordmark and search/menu controls.

Related: av-kfik.26

## Validation
- `bun --filter @agentv/web build`
- `bun --filter @agentv/web check:routes`
- `git diff --check origin/main..HEAD`
- Served the built docs with `bun --cwd apps/web preview --host 127.0.0.1 --port 4322`
- Captured Chromium screenshots at 390x844 and 1280x900 for `/docs/v4.42.4/targets/llm-providers/`; mobile shows the `v4.42.4` selector in the header, desktop keeps it in the top-right controls.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.5_high-000000)
