### PR TITLE
fix(eval): reject mixed criteria assertions

### DIFF
--- a/apps/cli/src/commands/pipeline/input.ts
+++ b/apps/cli/src/commands/pipeline/input.ts
@@ -22,7 +22,7 @@ import { readFile } from 'node:fs/promises';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join, relative, resolve } from 'node:path';
 
-import type { GraderConfig, LlmGraderConfig, ScriptGraderConfig } from '@agentv/core';
+import type { GraderConfig, LlmBackedGraderConfig, ScriptGraderConfig } from '@agentv/core';
 
 /** Assertion types that can be graded deterministically without external scripts or LLMs. */
 const BUILTIN_ASSERTION_TYPES = new Set([
@@ -150,6 +150,7 @@ export const evalInputCommand = command({
       await writeJson(join(testDir, 'input.json'), {
         input: inputMessages,
         input_files: test.file_paths,
+        ...(test.description ? { description: test.description } : {}),
         metadata: test.metadata ?? {},
       });
 
@@ -266,12 +267,12 @@ async function writeGraderConfigs(
         weight: config.weight ?? 1.0,
         config: config.config ?? {},
       });
-    } else if (assertion.type === 'llm-grader') {
+    } else if (assertion.type === 'llm-grader' || assertion.type === 'llm-rubric') {
       if (!hasLlmGraders) {
         await mkdir(llmGradersDir, { recursive: true });
         hasLlmGraders = true;
       }
-      const config = assertion as LlmGraderConfig;
+      const config = assertion as LlmBackedGraderConfig;
       let promptContent = '';
 
       if (config.resolvedPromptPath) {
@@ -286,7 +287,7 @@ async function writeGraderConfigs(
 
       // For rubrics assertions, include the criteria array directly
       // so grader subagents can evaluate without needing a prompt file.
-      const rubrics = (config as LlmGraderConfig).rubrics;
+      const rubrics = config.rubrics;
       const rubricsData = rubrics?.map((r) => ({
         id: r.id,
         outcome: r.outcome,
@@ -298,7 +299,11 @@ async function writeGraderConfigs(
 
       await writeJson(join(llmGradersDir, `${config.name}.json`), {
         name: config.name,
+        type: config.type,
         prompt_content: promptContent,
+        ...(config.type === 'llm-rubric' && config.value !== undefined
+          ? { value: config.value }
+          : {}),
         ...(rubricsData && rubricsData.length > 0 ? { rubrics: rubricsData } : {}),
         weight: config.weight ?? 1.0,
         threshold: 0.5,

--- a/apps/cli/src/commands/pipeline/run.ts
+++ b/apps/cli/src/commands/pipeline/run.ts
@@ -18,7 +18,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join, relative, resolve } from 'node:path';
 
 import { deriveCategory, loadTestSuite } from '@agentv/core';
-import type { GraderConfig, LlmGraderConfig, ScriptGraderConfig } from '@agentv/core';
+import type { GraderConfig, LlmBackedGraderConfig, ScriptGraderConfig } from '@agentv/core';
 import { command, number, oneOf, option, optional, positional, string } from 'cmd-ts';
 
 import { buildDefaultRunDir } from '../eval/result-layout.js';
@@ -174,6 +174,7 @@ export const evalRunCommand = command({
       await writeJson(join(testDir, 'input.json'), {
         input: inputMessages,
         input_files: test.file_paths,
+        ...(test.description ? { description: test.description } : {}),
         metadata: test.metadata ?? {},
       });
 
@@ -463,12 +464,12 @@ async function writeGraderConfigs(
         weight: config.weight ?? 1.0,
         config: config.config ?? {},
       });
-    } else if (assertion.type === 'llm-grader') {
+    } else if (assertion.type === 'llm-grader' || assertion.type === 'llm-rubric') {
       if (!hasLlmGraders) {
         await mkdir(llmGradersDir, { recursive: true });
         hasLlmGraders = true;
       }
-      const config = assertion as LlmGraderConfig;
+      const config = assertion as LlmBackedGraderConfig;
       let promptContent = '';
       if (config.resolvedPromptPath) {
         try {
@@ -480,7 +481,7 @@ async function writeGraderConfigs(
         promptContent = config.prompt;
       }
       // For rubrics assertions, include the criteria array directly
-      const rubrics = (config as LlmGraderConfig).rubrics;
+      const rubrics = config.rubrics;
       const rubricsData = rubrics?.map((r) => ({
         id: r.id,
         outcome: r.outcome,
@@ -492,7 +493,11 @@ async function writeGraderConfigs(
 
       await writeJson(join(llmGradersDir, `${config.name}.json`), {
         name: config.name,
+        type: config.type,
         prompt_content: promptContent,
+        ...(config.type === 'llm-rubric' && config.value !== undefined
+          ? { value: config.value }
+          : {}),
         ...(rubricsData && rubricsData.length > 0 ? { rubrics: rubricsData } : {}),
         weight: config.weight ?? 1.0,
         threshold: 0.5,

--- a/apps/cli/test/commands/eval/pipeline/fixtures/builtin-test.eval.yaml
+++ b/apps/cli/test/commands/eval/pipeline/fixtures/builtin-test.eval.yaml
@@ -3,8 +3,10 @@ prompts:
   - "{{ input }}"
 tests:
   - id: test-01
-    criteria: Response echoes the input
     assert:
+      - metric: echoes_input
+        type: llm-rubric
+        value: Response echoes the input
       - metric: has_hello
         type: contains
         value: hello

--- a/apps/cli/test/commands/eval/pipeline/fixtures/input-test.eval.yaml
+++ b/apps/cli/test/commands/eval/pipeline/fixtures/input-test.eval.yaml
@@ -3,8 +3,10 @@ prompts:
   - "{{ input }}"
 tests:
   - id: test-01
-    criteria: Response echoes the input
     assert:
+      - metric: echoes_input
+        type: llm-rubric
+        value: Response echoes the input
       - metric: contains_hello
         type: script
         command: node grader-score-1.js

--- a/apps/cli/test/commands/eval/pipeline/fixtures/no-name.eval.yaml
+++ b/apps/cli/test/commands/eval/pipeline/fixtures/no-name.eval.yaml
@@ -2,8 +2,10 @@ prompts:
   - "{{ input }}"
 tests:
   - id: test-01
-    criteria: Response echoes the input
     assert:
+      - metric: echoes_input
+        type: llm-rubric
+        value: Response echoes the input
       - metric: contains_hello
         type: contains
         value: hello

--- a/apps/cli/test/commands/eval/pipeline/input.test.ts
+++ b/apps/cli/test/commands/eval/pipeline/input.test.ts
@@ -45,8 +45,20 @@ describe('pipeline input', () => {
     expect(llmGrader.prompt_content).toBeDefined();
     expect(llmGrader.name).toBe('relevance');
 
+    const rubricGrader = JSON.parse(
+      await readFile(
+        join(OUT_DIR, 'input-test', 'test-01', 'llm_graders', 'echoes_input.json'),
+        'utf8',
+      ),
+    );
+    expect(rubricGrader.name).toBe('echoes_input');
+    expect(rubricGrader.type).toBe('llm-rubric');
+    expect(rubricGrader.value).toBe('Response echoes the input');
+
     const criteria = await readFile(join(OUT_DIR, 'input-test', 'test-01', 'criteria.md'), 'utf8');
-    expect(criteria).toContain('Response echoes the input');
+    expect(criteria).toBe('');
+    expect(input.description).toBeUndefined();
+    expect(input.metadata).toEqual({});
 
     const invoke = JSON.parse(
       await readFile(join(OUT_DIR, 'input-test', 'test-01', 'invoke.json'), 'utf8'),

--- a/packages/core/src/evaluation/evaluate.ts
+++ b/packages/core/src/evaluation/evaluate.ts
@@ -98,6 +98,8 @@ import { loadTestSuite } from './yaml-parser.js';
 export interface EvalTestInput {
   /** Unique test identifier */
   readonly id: string;
+  /** Optional human-readable test description */
+  readonly description?: string;
   /** What the response should accomplish */
   readonly criteria?: string;
   /** Per-test prompt variables used by config.prompts templates. */
@@ -649,6 +651,7 @@ function buildInlineEvalTests(
           id: promptId ? `${test.id}__${promptId}` : test.id,
           suite: suiteName,
           category: options.category,
+          ...(test.description !== undefined ? { description: test.description } : {}),
           criteria: test.criteria ?? '',
           question: String(question),
           input,

--- a/packages/core/src/evaluation/loaders/eval-yaml-transpiler.ts
+++ b/packages/core/src/evaluation/loaders/eval-yaml-transpiler.ts
@@ -384,6 +384,16 @@ export function transpileEvalYaml(suite: unknown, source = 'EVAL.yaml'): Transpi
     const rawCase = tests[idx];
     const caseAssertions = rawCase.assert ?? [];
 
+    if (
+      typeof rawCase.criteria === 'string' &&
+      rawCase.criteria.trim() &&
+      rawCase.assert !== undefined
+    ) {
+      throw new Error(
+        `Invalid EVAL.yaml test '${rawCase.id ?? idx + 1}' in '${source}': do not combine test-level 'criteria' with 'assert'. Put human-readable case descriptions in 'description', or express grading text as an explicit assertion such as { type: 'llm-rubric', value: ... }.`,
+      );
+    }
+
     // Collect NL assertions (not skill-trigger)
     const nlAssertions: string[] = [];
 

--- a/packages/core/src/evaluation/types.ts
+++ b/packages/core/src/evaluation/types.ts
@@ -1046,6 +1046,7 @@ export interface EvalTest {
   readonly suite?: string;
   readonly category?: string;
   readonly conversation_id?: string;
+  readonly description?: string;
   readonly prompt?: EvalPromptIdentity;
   readonly question: string;
   readonly input: readonly TestMessage[];

--- a/packages/core/src/evaluation/validation/eval-validator.ts
+++ b/packages/core/src/evaluation/validation/eval-validator.ts
@@ -592,6 +592,14 @@ export async function validateEvalFile(filePath: string): Promise<ValidationResu
         location: `${location}.criteria`,
         message: "Invalid 'criteria' field (must be a non-empty string if provided)",
       });
+    } else if (criteria !== undefined && evalCase.assert !== undefined) {
+      errors.push({
+        severity: 'error',
+        filePath: absolutePath,
+        location: `${location}.criteria`,
+        message:
+          "Do not combine test-level 'criteria' with 'assert'. Put human-readable case descriptions in tests[].description, or express grading text as an explicit assertion such as { type: 'llm-rubric', value: ... }.",
+      });
     }
 
     // input field (string/object shorthand or message array). When omitted,

--- a/packages/core/src/evaluation/yaml-parser.ts
+++ b/packages/core/src/evaluation/yaml-parser.ts
@@ -329,6 +329,9 @@ function interpolateRawEvalCase(
   return {
     ...raw,
     ...(raw.id !== undefined ? { id: interpolateCaseField(raw.id, vars, filters) } : {}),
+    ...(raw.description !== undefined
+      ? { description: interpolateCaseField(raw.description, vars, filters) }
+      : {}),
     ...(raw.criteria !== undefined
       ? { criteria: interpolateCaseField(raw.criteria, vars, filters) }
       : {}),
@@ -1537,6 +1540,9 @@ async function loadTestsFromParsedYamlValue(
         suite: suiteName,
         category,
         conversation_id: conversationId,
+        ...(typeof renderedCase.description === 'string'
+          ? { description: renderedCase.description }
+          : {}),
         ...(promptIdentity ? { prompt: promptIdentity } : {}),
         question: question,
         input: inputMessages,

--- a/packages/core/test/evaluation/loaders/eval-yaml-transpiler.test.ts
+++ b/packages/core/test/evaluation/loaders/eval-yaml-transpiler.test.ts
@@ -13,7 +13,6 @@ const SINGLE_SKILL_SUITE = {
   tests: [
     {
       id: 'csv-top-months',
-      criteria: 'Agent finds the top 3 months by revenue',
       input: [
         {
           role: 'user',
@@ -30,6 +29,7 @@ const SINGLE_SKILL_SUITE = {
         'The top 3 months by revenue are November ($22,500), September ($20,100), and December ($19,400).',
       assert: [
         { type: 'skill-trigger', skill: 'csv-analyzer', should_trigger: true },
+        { type: 'llm-rubric', value: 'Agent finds the top 3 months by revenue' },
         { type: 'llm-rubric', value: 'Output identifies November as the highest revenue month' },
         { type: 'contains', value: '$22,500' },
       ],
@@ -152,10 +152,56 @@ describe('transpileEvalYaml — skill-trigger', () => {
 // ---------------------------------------------------------------------------
 
 describe('transpileEvalYaml — NL assertions', () => {
-  it('prepends criteria to assertions', () => {
+  it('converts explicit llm-rubric assertions', () => {
     const { files } = transpileEvalYaml(SINGLE_SKILL_SUITE);
     const evals = files.get('csv-analyzer')?.evals;
     expect(evals[0].assertions[0]).toBe('Agent finds the top 3 months by revenue');
+  });
+
+  it('rejects test-level criteria combined with assert entries', () => {
+    expect(() =>
+      transpileEvalYaml(
+        {
+          tests: [
+            {
+              id: 'mixed',
+              criteria: 'Describe the expected behavior',
+              input: 'test',
+              assert: [{ type: 'contains', value: 'ok' }],
+            },
+          ],
+        },
+        'mixed.eval.yaml',
+      ),
+    ).toThrow(
+      "do not combine test-level 'criteria' with 'assert'. Put human-readable case descriptions in 'description'",
+    );
+  });
+
+  it('accepts description with assert entries without adding a grading assertion', () => {
+    const { files } = transpileEvalYaml({
+      tests: [
+        {
+          id: 'described',
+          description: 'Human-facing case label',
+          input: 'test',
+          assert: [{ type: 'llm-rubric', value: 'Answer clearly' }],
+        },
+      ],
+    });
+
+    const evals = files.get('_no-skill')?.evals;
+    expect(evals[0].assertions).toEqual(['Answer clearly']);
+    expect(evals[0].assertions).not.toContain('Human-facing case label');
+  });
+
+  it('keeps legacy criteria-only tests as natural-language assertions', () => {
+    const { files } = transpileEvalYaml({
+      tests: [{ id: 'legacy', criteria: 'Answer clearly', input: 'test' }],
+    });
+
+    const evals = files.get('_no-skill')?.evals;
+    expect(evals[0].assertions).toEqual(['Answer clearly']);
   });
 
   it('converts rubrics type to criteria string', () => {

--- a/packages/core/test/evaluation/validation/eval-validator.test.ts
+++ b/packages/core/test/evaluation/validation/eval-validator.test.ts
@@ -40,6 +40,61 @@ describe('validateEvalFile', () => {
     );
   });
 
+  it('rejects test-level criteria combined with explicit assert entries', async () => {
+    const filePath = path.join(tempDir, 'criteria-with-assert.yaml');
+    await writeFile(
+      filePath,
+      `prompts:
+  - "{{ prompt }}"
+tests:
+  - id: mixed
+    vars:
+      prompt: "Hello"
+    criteria: Response echoes the input
+    assert:
+      - type: contains
+        value: hello
+`,
+    );
+
+    const result = await validateEvalFile(filePath);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        severity: 'error',
+        location: 'tests[0].criteria',
+        message: expect.stringContaining("Do not combine test-level 'criteria' with 'assert'"),
+      }),
+    );
+    expect(result.errors[0].message).toContain('tests[].description');
+    expect(result.errors[0].message).toContain('type:');
+    expect(result.errors[0].message).toContain('llm-rubric');
+  });
+
+  it('accepts test-level description combined with explicit assert entries', async () => {
+    const filePath = path.join(tempDir, 'description-with-assert.yaml');
+    await writeFile(
+      filePath,
+      `prompts:
+  - "{{ prompt }}"
+tests:
+  - id: described
+    description: Human-facing case label
+    vars:
+      prompt: "Hello"
+    assert:
+      - type: contains
+        value: hello
+`,
+    );
+
+    const result = await validateEvalFile(filePath);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
   it('validates top-level target and run controls with flatter import entries', async () => {
     const filePath = path.join(tempDir, 'run-controls-include.yaml');
     await writeFile(
@@ -1235,7 +1290,6 @@ tests:
   - "{{ prompt }}"
 tests:
   - id: finance-summary
-    criteria: Keep supported facts and avoid contradictions
     vars:
       prompt: Summarize the finance note
     assert:

--- a/skills-data/agentv-bench/agents/grader.md
+++ b/skills-data/agentv-bench/agents/grader.md
@@ -63,7 +63,7 @@ For each assertion in the test's `assertions[]`, evaluate it natively based on i
 
 | Type | How to evaluate |
 |------|----------------|
-| `llm-rubric` | Read the `prompt` field. Evaluate the response against those criteria. Score 0.0-1.0 with evidence. |
+| `llm-rubric` | Read `value` for free-form criteria, `rubrics` for itemized criteria, or `prompt_content`/`prompt` for a custom grading prompt. Evaluate the response against those criteria. Score 0.0-1.0 with evidence. |
 | `rubric` / `rubrics` | Read rubric items/criteria. Score each item 0.0-1.0. Aggregate as weighted average. |
 
 For LLM-graded types: be rigorous and fair. Score based on substance, not exact wording. If a `criteria` field exists on the test case, use it as additional context for your evaluation. If `expected_output` exists, use it as a reference answer (not as the only correct answer).

--- a/skills-data/agentv-bench/references/eval-yaml-spec.md
+++ b/skills-data/agentv-bench/references/eval-yaml-spec.md
@@ -183,8 +183,8 @@ Same as contains variants but explicitly case-insensitive.
 
 #### `llm-rubric`
 
-- **Fields:** `prompt` (string, required — either inline text or path to .md file)
-- **Recipe:** Read the prompt. Evaluate the response against the criteria using your own reasoning. Produce score (0.0-1.0) with evidence.
+- **Fields:** `value` (free-form or structured criteria), `rubrics` (itemized criteria), or `prompt` / exported `prompt_content` (custom grading prompt)
+- **Recipe:** Read the rubric value, rubric items, or prompt. Evaluate the response against those criteria using your own reasoning. Produce score (0.0-1.0) with evidence.
 - **PASS:** score >= 0.5 (configurable via `threshold`).
 
 #### `rubric` / `rubrics`
@@ -304,7 +304,7 @@ Extracts inputs, target commands, and grader configs from an eval YAML file.
 │   ├── criteria.md             ← human-readable success criteria
 │   ├── expected_output.json    ← (if present)
 │   ├── script_graders/<name>.json   ← {name, command, weight, config?}
-│   └── llm_graders/<name>.json    ← {name, weight, threshold?, prompt_content}
+│   └── llm_graders/<name>.json    ← {name, type, weight, threshold?, prompt_content, value?, rubrics?}
 ```
 
 **`manifest.json` format:**

--- a/skills-data/agentv-bench/references/subagent-pipeline.md
+++ b/skills-data/agentv-bench/references/subagent-pipeline.md
@@ -136,8 +136,8 @@ agentv results validate <run-dir>
 
 ## LLM Grading JSON Format
 
-The agent reads `llm_graders/<name>.json` for each test, grades the response using the prompt
-content, and produces a scores JSON:
+The agent reads `llm_graders/<name>.json` for each test, grades the response using
+`value`, `rubrics`, or prompt content from the config, and produces a scores JSON:
 
 ```json
 {
@@ -175,7 +175,7 @@ the eval.yaml. The target is recorded in `manifest.json` — one run = one targe
         ├── response.md              ← target/agent output
         ├── timing.json              ← execution timing
         ├── script_graders/<name>.json     ← grader configs written by `pipeline input`: script-grader scripts AND built-in types (contains, regex, equals, etc.)
-        ├── llm_graders/<name>.json      ← LLM grader configs
+        ├── llm_graders/<name>.json      ← LLM grader configs with prompt_content, value, or rubrics
         ├── script_grader_results/<name>.json  ← script grader results
         ├── llm_grader_results/<name>.json   ← LLM grader results (written by grader subagents; one file per grader)
         └── grading.json              ← merged grading (written by `pipeline bench` — do NOT write here directly)


### PR DESCRIPTION
## Summary

Authored eval YAML now rejects the ambiguous case where test-level `criteria` appears beside explicit `assert` entries. Human-readable case text should live in `description`, and grading text should live in an assertion such as `type: llm-rubric`.

The pipeline fixtures that were using `criteria` as a description now use first-class test `description`, and pipeline input bundles preserve it as `input.json.description` instead of treating it as arbitrary metadata or grader criteria.

## Validation

- `bun run build`
- `bun test packages/core/test/evaluation/loaders/eval-yaml-transpiler.test.ts packages/core/test/evaluation/validation/eval-validator.test.ts apps/cli/test/commands/eval/pipeline/input.test.ts`
- `bun run lint`
- `bun run typecheck`
- Promptfoo local reference: `/home/entity/projects/promptfoo/promptfoo` at `6bfc5a0c7f16f9c4717ac731d276b578e63d0769`; `TestCaseSchema` exposes `description`, `assert`, and `metadata`, with no generic test-level `criteria` field, and `defaultTest` omits `description`.

## Related

Related: av-kfik.42

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
