### PR TITLE
fix(dashboard): contain transcript detail on mobile

### DIFF
--- a/apps/dashboard/src/components/EvalDetail.tsx
+++ b/apps/dashboard/src/components/EvalDetail.tsx
@@ -171,10 +171,10 @@ export function EvalDetail({
   };
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <div className="flex h-full min-h-0 min-w-0 flex-col">
       {/* Tab navigation — at the top so Files tab editor fills maximum height */}
-      <div className="border-b border-gray-800">
-        <div className="flex gap-1 px-4">
+      <div className="min-w-0 border-b border-gray-800">
+        <div className="flex min-w-0 gap-1 overflow-x-auto px-4">
           {tabs.map((tab) => (
             <button
               type="button"
@@ -193,9 +193,9 @@ export function EvalDetail({
       </div>
 
       {/* Tab content */}
-      <div className="min-h-0 flex-1 overflow-hidden">
+      <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
         {activeTab === 'checks' && (
-          <div className="overflow-auto p-4">
+          <div className="min-w-0 overflow-auto p-4">
             {showAggregateRepeat ? (
               <RepeatAggregateChecksTab
                 result={result}
@@ -227,7 +227,7 @@ export function EvalDetail({
           </div>
         )}
         {activeTab === 'transcript' && (
-          <div className="overflow-auto p-4">
+          <div className="min-w-0 overflow-auto p-4">
             {showAggregateRepeat ? (
               <RepeatAggregateTranscriptTab
                 result={result}
@@ -255,7 +255,7 @@ export function EvalDetail({
           </div>
         )}
         {activeTab === 'source' && (
-          <div className="overflow-auto p-4">
+          <div className="min-w-0 overflow-auto p-4">
             <SourceTab result={detailResult} />
           </div>
         )}

--- a/apps/dashboard/src/components/ResultTable.tsx
+++ b/apps/dashboard/src/components/ResultTable.tsx
@@ -420,7 +420,9 @@ export function ResultTable({
 
       <div
         className={
-          selectedRow ? 'grid min-w-0 gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(360px,42rem)]' : ''
+          selectedRow
+            ? 'grid min-w-0 max-w-full gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(360px,42rem)]'
+            : ''
         }
       >
         <div className="min-w-0">
@@ -1013,7 +1015,7 @@ function ResultDetailPanel({
     <aside
       key={panelScrollKey}
       ref={scrollPanelIntoView}
-      className="min-w-0 rounded-lg border border-gray-800 bg-gray-950/80 xl:sticky xl:top-4 xl:max-h-[calc(100vh-2rem)]"
+      className="min-w-0 max-w-full overflow-hidden rounded-lg border border-gray-800 bg-gray-950/80 xl:sticky xl:top-4 xl:max-h-[calc(100vh-2rem)]"
     >
       <div className="flex min-w-0 items-start justify-between gap-3 border-b border-gray-800 px-4 py-3">
         <div className="min-w-0">
@@ -1042,7 +1044,7 @@ function ResultDetailPanel({
           </button>
         </div>
       </div>
-      <div className="h-[36rem] min-h-[28rem] overflow-hidden xl:h-[calc(100vh-9rem)]">
+      <div className="h-[36rem] min-h-[28rem] min-w-0 overflow-hidden xl:h-[calc(100vh-9rem)]">
         <EvalDetail
           key={`${row.key}:${selectedTrialPath ?? 'aggregate'}:${initialFilePath ?? ''}`}
           eval={row.result}

--- a/apps/dashboard/src/components/TranscriptTimeline.tsx
+++ b/apps/dashboard/src/components/TranscriptTimeline.tsx
@@ -510,7 +510,7 @@ function JsonBlock({
 }: { label: string; value: unknown; tone?: 'default' | 'error' }) {
   if (!hasValue(value)) return null;
   return (
-    <div className="space-y-1">
+    <div className="min-w-0 space-y-1">
       <div
         className={
           tone === 'error'
@@ -520,7 +520,7 @@ function JsonBlock({
       >
         {label}
       </div>
-      <pre className="max-h-80 overflow-auto rounded-md border border-gray-800 bg-gray-950 p-3 text-xs text-gray-200">
+      <pre className="max-h-80 max-w-full overflow-auto rounded-md border border-gray-800 bg-gray-950 p-3 text-xs text-gray-200">
         <code>{formatUnknown(value)}</code>
       </pre>
     </div>
@@ -529,7 +529,7 @@ function JsonBlock({
 
 function MetadataPill({ children }: { children: ReactNode }) {
   return (
-    <span className="rounded-md border border-gray-800 bg-gray-950 px-2 py-0.5 text-xs text-gray-400">
+    <span className="inline-flex min-w-0 max-w-full break-all rounded-md border border-gray-800 bg-gray-950 px-2 py-0.5 text-xs text-gray-400">
       {children}
     </span>
   );
@@ -586,7 +586,7 @@ function ToolCallDetails({
 
   return (
     <details
-      className="rounded-md border border-gray-800 bg-gray-950/80 p-3"
+      className="min-w-0 rounded-md border border-gray-800 bg-gray-950/80 p-3"
       open={expanded}
       data-testid={`tool-call-${callId ?? index}`}
       data-expanded={expanded ? 'true' : 'false'}
@@ -594,7 +594,7 @@ function ToolCallDetails({
         onToggle(toolCall.id, event.currentTarget.open)
       }
     >
-      <summary className="cursor-pointer list-none text-sm font-medium text-gray-200">
+      <summary className="min-w-0 cursor-pointer list-none text-sm font-medium text-gray-200">
         <span className="inline-flex min-w-0 flex-wrap items-center gap-2">
           <span className="text-xs text-gray-500">{expanded ? '-' : '+'}</span>
           <span>Tool call</span>
@@ -605,7 +605,7 @@ function ToolCallDetails({
           {duration && <span className="tabular-nums text-xs text-gray-500">{duration}</span>}
         </span>
       </summary>
-      <div className="mt-3 space-y-3">
+      <div className="mt-3 min-w-0 space-y-3">
         <div className="flex flex-wrap gap-2">
           {callId && <MetadataPill>id: {callId}</MetadataPill>}
           {duration && <MetadataPill>duration: {duration}</MetadataPill>}
@@ -624,12 +624,12 @@ function ToolResultDetails({ line }: { line: TranscriptJsonLine }) {
   const duration = formatDurationMs(line.duration_ms);
   const tokenUsage = formatTokenUsage(line.token_usage);
   return (
-    <details className="rounded-md border border-amber-900/50 bg-gray-950/60 p-3">
+    <details className="min-w-0 rounded-md border border-amber-900/50 bg-gray-950/60 p-3">
       <summary className="cursor-pointer text-sm font-medium text-amber-300">
         {line.name ? `Tool result · ${line.name}` : 'Tool result'}
         {duration && <span className="ml-2 tabular-nums text-xs text-gray-500">{duration}</span>}
       </summary>
-      <div className="mt-3 space-y-3">
+      <div className="mt-3 min-w-0 space-y-3">
         <div className="flex flex-wrap gap-2">
           {line.name && <MetadataPill>name: {line.name}</MetadataPill>}
           {duration && <MetadataPill>duration: {duration}</MetadataPill>}
@@ -660,7 +660,7 @@ function TranscriptMessageCard({
   return (
     <details
       id={message.anchorId}
-      className={`scroll-mt-6 rounded-lg border ${roleStyle.container}`}
+      className={`min-w-0 scroll-mt-6 rounded-lg border ${roleStyle.container}`}
       open={expanded}
       data-testid={`message-row-${ordinal + 1}`}
       data-expanded={expanded ? 'true' : 'false'}
@@ -668,7 +668,7 @@ function TranscriptMessageCard({
         onToggleMessage(message.id, event.currentTarget.open)
       }
     >
-      <summary className="cursor-pointer list-none px-4 py-3">
+      <summary className="min-w-0 cursor-pointer list-none px-4 py-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex min-w-0 flex-wrap items-center gap-2">
             <span className="text-xs text-gray-500">{expanded ? '-' : '+'}</span>
@@ -707,7 +707,7 @@ function TranscriptMessageCard({
         {line.role === 'tool' || line.role === 'function' ? (
           <ToolResultDetails line={line} />
         ) : content.trim().length > 0 ? (
-          <pre className="whitespace-pre-wrap break-words text-sm leading-6 text-gray-200">
+          <pre className="max-w-full whitespace-pre-wrap break-words text-sm leading-6 text-gray-200">
             {content}
           </pre>
         ) : (
@@ -728,7 +728,7 @@ function TranscriptMessageCard({
         )}
 
         {line.metadata && line.role !== 'tool' && line.role !== 'function' && (
-          <details className="rounded-md border border-gray-800 bg-gray-950/60 p-3">
+          <details className="min-w-0 rounded-md border border-gray-800 bg-gray-950/60 p-3">
             <summary className="cursor-pointer text-xs font-medium text-gray-400">
               Message metadata
             </summary>
@@ -757,7 +757,7 @@ function TranscriptSummary({
   const toolCounts = summarizeToolCounts(messages);
 
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex min-w-0 flex-wrap gap-2">
       <MetadataPill>{messages.length} messages</MetadataPill>
       {Array.from(roleCounts.entries()).map(([role, count]) => (
         <MetadataPill key={role}>
@@ -905,37 +905,37 @@ export function TranscriptTimeline({
   }
 
   return (
-    <div className="space-y-4">
+    <div className="min-w-0 space-y-4">
       {hasCanonicalAnswer && (
-        <section className="rounded-lg border border-emerald-900/50 bg-emerald-950/20 p-4">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div>
+        <section className="min-w-0 rounded-lg border border-emerald-900/50 bg-emerald-950/20 p-4">
+          <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
+            <div className="min-w-0">
               <h3 className="text-sm font-medium text-emerald-300">Final answer</h3>
               <p className="mt-1 text-xs text-gray-500">
                 Highlighted from canonical <code>outputs/answer.md</code>; transcript context stays
                 below.
               </p>
             </div>
-            <div className="flex flex-wrap items-center gap-2">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
               <OpenFileButton path={answerPath} onOpenFile={onOpenFile}>
                 Open answer.md in Files
               </OpenFileButton>
               <ActionLink href={answerHref}>Open answer.md</ActionLink>
             </div>
           </div>
-          <pre className="mt-3 max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-md border border-emerald-900/40 bg-gray-950/80 p-3 text-sm leading-6 text-gray-100">
+          <pre className="mt-3 max-h-64 max-w-full overflow-auto whitespace-pre-wrap break-words rounded-md border border-emerald-900/40 bg-gray-950/80 p-3 text-sm leading-6 text-gray-100">
             {finalAnswer && finalAnswer.trim().length > 0 ? finalAnswer : 'answer.md is empty.'}
           </pre>
         </section>
       )}
 
-      <section className="rounded-lg border border-gray-800 bg-gray-900 p-4">
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div className="space-y-2">
+      <section className="min-w-0 rounded-lg border border-gray-800 bg-gray-900 p-4">
+        <div className="flex min-w-0 flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0 space-y-2">
             <h3 className="text-sm font-medium text-gray-300">Transcript timeline</h3>
             <TranscriptSummary messages={messages} transcriptPath={transcriptPath} />
           </div>
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
             <OpenFileButton path={transcriptPath} onOpenFile={onOpenFile}>
               Open transcript.json in Files
             </OpenFileButton>
@@ -947,9 +947,9 @@ export function TranscriptTimeline({
         </div>
       </section>
 
-      <section className="rounded-lg border border-gray-800 bg-gray-900 p-3">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex flex-wrap gap-2">
+      <section className="min-w-0 rounded-lg border border-gray-800 bg-gray-900 p-3">
+        <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
+          <div className="flex min-w-0 flex-wrap gap-2">
             <FilterButton
               active={filter === 'all'}
               count={messages.length}
@@ -980,7 +980,7 @@ export function TranscriptTimeline({
             </FilterButton>
           </div>
           {allToolIds.length > 0 && (
-            <div className="flex flex-wrap gap-2">
+            <div className="flex min-w-0 flex-wrap gap-2">
               <button
                 type="button"
                 onClick={expandAllToolCalls}

--- a/apps/dashboard/src/components/transcript-timeline.test.tsx
+++ b/apps/dashboard/src/components/transcript-timeline.test.tsx
@@ -189,4 +189,22 @@ describe('TranscriptTimeline', () => {
     expect(html).toContain('Download normalized JSON');
     expect(html).toContain('{&quot;answer&quot;:42,&quot;source&quot;:&quot;src/app.ts&quot;}');
   });
+
+  it('keeps long transcript artifact labels and JSON blocks constrained for narrow panels', () => {
+    const parsed = parseTranscriptJsonl(structuredTranscriptJsonl);
+    const html = renderToStaticMarkup(
+      <TranscriptTimeline
+        entries={parsed.entries}
+        transcriptPath="very-long-project-name/very-long-test-case-name/sample-1/transcript.json"
+        transcriptHref="/api/raw-transcript"
+        transcriptDownloadHref="/api/download-transcript"
+      />,
+    );
+
+    expect(html).toContain('break-all');
+    expect(html).toContain('max-w-full overflow-auto');
+    expect(html).toContain(
+      'very-long-project-name/very-long-test-case-name/sample-1/transcript.json',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

At a 390px-wide viewport, run detail transcript inspection now stays inside the Dashboard content area instead of letting the selected row detail or transcript controls widen the page. The result tables still keep their intentional contained horizontal scrolling, but opening a row detail, switching to Transcript, using transcript controls, and scrolling message cards no longer creates incoherent page-level clipping.

This keeps the fix scoped to the run-detail/transcript layout: `EvalDetail` and `TranscriptTimeline` now consistently allow flex and scroll descendants to shrink, and long transcript artifact labels wrap within the panel.

Related: av-2s7.24

## Validation

- `bun install`
- `bun --filter @agentv/core build`
- `bun --filter @agentv/sdk build`
- `bun test ./src/components/transcript-timeline.test.tsx ./src/components/ResultTable.test.tsx ./src/components/EvalDetail.test.ts` from `apps/dashboard`
- `bun --filter @agentv/dashboard test`
- `bun run lint apps/dashboard/src/components/ResultTable.tsx apps/dashboard/src/components/EvalDetail.tsx apps/dashboard/src/components/TranscriptTimeline.tsx apps/dashboard/src/components/transcript-timeline.test.tsx`
- `bun --filter @agentv/dashboard build`
- Browser UAT with `agent-browser` against `http://localhost:3139`:
  - 390x844: opened run detail for `remote::replay-contract`, opened row detail, switched to Transcript, verified controls and message anchors.
  - 390x844 width check: `bodyScrollWidth=382`, `mainScrollWidth=374`, `detailScrollWidth=324`, `detailClientWidth=324`.
  - 1280x900 sanity: `mainScrollWidth=1016`, `detailScrollWidth=670`.

Private evidence: `EntityProcess/agentv-private` branch `evidence/av-2s7-24-transcript-mobile`, commit `306c2cc`.

Evidence files:

- `dogfood/av-2s7-24-transcript-mobile/mobile-transcript-controls-390x844.png`
- `dogfood/av-2s7-24-transcript-mobile/mobile-transcript-messages-390x844.png`
- `dogfood/av-2s7-24-transcript-mobile/desktop-transcript-sanity-1280x900.png`

## Review Notes

`ce-code-review` could not be run through its normal subagent path because this Codex session exposes subagents with a tool-level restriction against spawning unless the user explicitly requested delegation. I performed a manual diff review instead; no actionable findings remain.

## Post-Deploy Monitoring & Validation

No additional production monitoring required. This is a local Dashboard layout-only fix; validation is browser UAT on the affected run-detail transcript workflow plus Dashboard tests/build.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
