### PR TITLE
fix(runtime): unblock SDK provider live matrix for av-t2o5.6

### DIFF
--- a/apps/web/src/content/docs/docs/next/targets/coding-agents.mdx
+++ b/apps/web/src/content/docs/docs/next/targets/coding-agents.mdx
@@ -130,7 +130,7 @@ for the provider you use:
 
 ```bash
 bun add --optional @openai/codex-sdk
-bun add --optional @earendil-works/pi-coding-agent
+bun add --optional @earendil-works/pi-coding-agent @earendil-works/pi-ai
 bun add --optional @anthropic-ai/claude-agent-sdk
 bun add --optional @github/copilot-sdk
 ```

--- a/apps/web/src/content/docs/docs/v4.42.4/targets/coding-agents.mdx
+++ b/apps/web/src/content/docs/docs/v4.42.4/targets/coding-agents.mdx
@@ -132,7 +132,7 @@ for the provider you use:
 
 ```bash
 bun add --optional @openai/codex-sdk
-bun add --optional @earendil-works/pi-coding-agent
+bun add --optional @earendil-works/pi-coding-agent @earendil-works/pi-ai
 bun add --optional @anthropic-ai/claude-agent-sdk
 bun add --optional @github/copilot-sdk
 ```

--- a/bun.lock
+++ b/bun.lock
@@ -16,10 +16,17 @@
         "typescript": "5.8.3",
         "yaml": "^2.8.3",
       },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.89",
+        "@earendil-works/pi-ai": "^0.74.0",
+        "@earendil-works/pi-coding-agent": "^0.74.0",
+        "@github/copilot-sdk": "^1.0.3",
+        "@openai/codex-sdk": "^0.136.0",
+      },
     },
     "apps/cli": {
       "name": "agentv",
-      "version": "5.0.0-next.1",
+      "version": "5.1.0-next.1",
       "bin": {
         "agentv": "./dist/cli.js",
       },
@@ -94,7 +101,7 @@
     },
     "packages/core": {
       "name": "@agentv/core",
-      "version": "5.0.0-next.1",
+      "version": "5.1.0-next.1",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",
         "@earendil-works/pi-ai": "^0.74.0",
@@ -131,7 +138,7 @@
     },
     "packages/sdk": {
       "name": "@agentv/sdk",
-      "version": "5.0.0-next.1",
+      "version": "5.1.0-next.1",
       "dependencies": {
         "@agentv/core": "5.0.0-next.1",
         "yaml": "^2.8.3",
@@ -326,7 +333,7 @@
 
     "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.74.2", "", { "dependencies": { "@earendil-works/pi-ai": "^0.74.2", "ignore": "^7.0.5", "typebox": "^1.1.24", "yaml": "^2.8.2" } }, "sha512-RPlB3bi2z+VQK0HRhBK73kXOQI1fFmRgWzzT6+ihB7JYfh29jb7eAfYvpx8rlf248gUAYaLQ8JYa+43l09rPmQ=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.74.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.91.1", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "^2.2.0", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "typebox": "^1.1.24", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.74.2", "", { "dependencies": { "@anthropic-ai/sdk": "^0.91.1", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "^2.2.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "openai": "6.26.0", "partial-json": "^0.1.7", "typebox": "^1.1.24" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-ukQBHGDm20k9ZUS2cGjNN9vDJp/48r35xmvgSx3paCaC06r2N/PLuRZoJmwQ1ZM7f8T3072odv9YPWn+77w0LA=="],
 
     "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.74.2", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.74.2", "@earendil-works/pi-ai": "^0.74.2", "@earendil-works/pi-tui": "^0.74.2", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "diff": "^8.0.2", "glob": "^13.0.1", "highlight.js": "^10.7.3", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "jiti": "^2.7.0", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "typebox": "^1.1.24", "undici": "^7.19.1", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.6" }, "bin": { "pi": "dist/cli.js" } }, "sha512-4Ey/ZgKw8Rq/cLhKtam7ze+LrTg+cNGRMCcAm0HCteHyVbYGbYqbbV8KzXW6fD/X64+213E9PJvIiPfpKJ1kOw=="],
 
@@ -2090,6 +2097,8 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@agentv/core/@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.74.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.91.1", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "^2.2.0", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "typebox": "^1.1.24", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw=="],
+
     "@anthropic-ai/claude-agent-sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@astrojs/mdx/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
@@ -2118,11 +2127,7 @@
 
     "@babel/traverse/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
-    "@earendil-works/pi-agent-core/@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.74.2", "", { "dependencies": { "@anthropic-ai/sdk": "^0.91.1", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "^2.2.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "openai": "6.26.0", "partial-json": "^0.1.7", "typebox": "^1.1.24" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-ukQBHGDm20k9ZUS2cGjNN9vDJp/48r35xmvgSx3paCaC06r2N/PLuRZoJmwQ1ZM7f8T3072odv9YPWn+77w0LA=="],
-
     "@earendil-works/pi-ai/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
-
-    "@earendil-works/pi-coding-agent/@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.74.2", "", { "dependencies": { "@anthropic-ai/sdk": "^0.91.1", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "^2.2.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "openai": "6.26.0", "partial-json": "^0.1.7", "typebox": "^1.1.24" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-ukQBHGDm20k9ZUS2cGjNN9vDJp/48r35xmvgSx3paCaC06r2N/PLuRZoJmwQ1ZM7f8T3072odv9YPWn+77w0LA=="],
 
     "@github/copilot-sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -2167,6 +2172,8 @@
     "@types/babel__template/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@types/babel__traverse/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "agentv/@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.74.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.91.1", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "^2.2.0", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "typebox": "^1.1.24", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw=="],
 
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -2236,15 +2243,15 @@
 
     "vite/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
+    "@agentv/core/@earendil-works/pi-ai/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
+
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
-    "@earendil-works/pi-agent-core/@earendil-works/pi-ai/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
-
-    "@earendil-works/pi-coding-agent/@earendil-works/pi-ai/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
-
     "@tanstack/router-plugin/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "agentv/@earendil-works/pi-ai/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
 
     "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/package.json
+++ b/package.json
@@ -40,5 +40,12 @@
     "tsup": "8.3.5",
     "typescript": "5.8.3",
     "yaml": "^2.8.3"
+  },
+  "optionalDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.89",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@github/copilot-sdk": "^1.0.3",
+    "@openai/codex-sdk": "^0.136.0"
   }
 }

--- a/packages/core/src/evaluation/providers/claude-sdk.ts
+++ b/packages/core/src/evaluation/providers/claude-sdk.ts
@@ -28,9 +28,11 @@ async function loadClaudeSdk(): Promise<typeof import('@anthropic-ai/claude-agen
     try {
       claudeSdkModule = await import('@anthropic-ai/claude-agent-sdk');
     } catch (error) {
-      throw new Error(
+      const missing = new Error(
         `Failed to load @anthropic-ai/claude-agent-sdk. AgentV declares SDK beta packages as optional dependencies; run bun install to hydrate optional dependencies, or install this SDK explicitly:\n  bun add --optional @anthropic-ai/claude-agent-sdk\n  npm install @anthropic-ai/claude-agent-sdk\n\nOriginal error: ${error instanceof Error ? error.message : String(error)}`,
       );
+      missing.name = 'MissingSdkDependency';
+      throw missing;
     }
   }
   return claudeSdkModule;

--- a/packages/core/src/evaluation/providers/claude.ts
+++ b/packages/core/src/evaluation/providers/claude.ts
@@ -27,9 +27,11 @@ async function loadClaudeSdk(): Promise<typeof import('@anthropic-ai/claude-agen
     try {
       claudeSdkModule = await import('@anthropic-ai/claude-agent-sdk');
     } catch (error) {
-      throw new Error(
-        `Failed to load @anthropic-ai/claude-agent-sdk. Please install it:\n  npm install @anthropic-ai/claude-agent-sdk\n\nOriginal error: ${error instanceof Error ? error.message : String(error)}`,
+      const missing = new Error(
+        `Failed to load @anthropic-ai/claude-agent-sdk. AgentV declares SDK beta packages as optional dependencies; run bun install to hydrate optional dependencies, or install this SDK explicitly:\n  bun add --optional @anthropic-ai/claude-agent-sdk\n  npm install @anthropic-ai/claude-agent-sdk\n\nOriginal error: ${error instanceof Error ? error.message : String(error)}`,
       );
+      missing.name = 'MissingSdkDependency';
+      throw missing;
     }
   }
   return claudeSdkModule;

--- a/packages/core/src/evaluation/providers/codex.ts
+++ b/packages/core/src/evaluation/providers/codex.ts
@@ -28,9 +28,11 @@ async function loadCodexSdk(): Promise<any> {
     try {
       codexSdkModule = await import('@openai/codex-sdk');
     } catch (error) {
-      throw new Error(
+      const missing = new Error(
         `Failed to load @openai/codex-sdk. AgentV declares SDK beta packages as optional dependencies; run bun install to hydrate optional dependencies, or install this SDK explicitly:\n  bun add --optional @openai/codex-sdk\n  npm install @openai/codex-sdk\n\nOriginal error: ${error instanceof Error ? error.message : String(error)}`,
       );
+      missing.name = 'MissingSdkDependency';
+      throw missing;
     }
   }
   return codexSdkModule;

--- a/packages/core/src/evaluation/providers/copilot-sdk.ts
+++ b/packages/core/src/evaluation/providers/copilot-sdk.ts
@@ -46,9 +46,11 @@ async function loadCopilotSdk(): Promise<any> {
             '  Set provider: copilot-cli in your eval YAML',
         );
       }
-      throw new Error(
+      const missing = new Error(
         `Failed to load @github/copilot-sdk. AgentV declares SDK beta packages as optional dependencies; run bun install to hydrate optional dependencies, or install this SDK explicitly:\n  bun add --optional @github/copilot-sdk\n  npm install @github/copilot-sdk\n\nOriginal error: ${message}`,
       );
+      missing.name = 'MissingSdkDependency';
+      throw missing;
     }
   }
   return copilotSdkModule;

--- a/packages/core/src/evaluation/providers/pi-coding-agent.ts
+++ b/packages/core/src/evaluation/providers/pi-coding-agent.ts
@@ -224,9 +224,11 @@ async function doLoadSdkModules(): Promise<void> {
     }
   }
 
-  throw new Error(
-    'pi-coding-agent SDK is not installed. AgentV declares SDK beta packages as optional dependencies; run bun install to hydrate optional dependencies, or install this SDK explicitly:\n  bun add --optional @earendil-works/pi-coding-agent\n  npm install @earendil-works/pi-coding-agent',
+  const missing = new Error(
+    'pi-coding-agent SDK dependencies are not installed. AgentV declares SDK beta packages as optional dependencies; run bun install to hydrate optional dependencies, or install the Pi SDK packages explicitly:\n  bun add --optional @earendil-works/pi-coding-agent @earendil-works/pi-ai\n  npm install @earendil-works/pi-coding-agent @earendil-works/pi-ai',
   );
+  missing.name = 'MissingSdkDependency';
+  throw missing;
 }
 
 async function loadSdkModules() {


### PR DESCRIPTION
## Summary

SDK provider dogfood no longer depends on incidental workspace install state: the source checkout now hydrates the optional SDK packages that the child runner needs, while the published package surfaces keep the SDKs optional and lazy-loaded inside the child process.

This PR keeps `codex-sdk`, `pi-sdk`, `claude-sdk`, and `copilot-sdk` behind `SdkChildProvider`; it does not move any SDK provider in-process. Missing SDK package failures now surface as `MissingSdkDependency` child errors with install guidance, and the Pi SDK docs now name both required Pi packages.

## Provider Status

| Provider | Status | Evidence |
| --- | --- | --- |
| `codex-sdk` | PASS | Live host child-runner run `2026-07-05T07-45-12-754Z` passed at 100%. |
| `pi-sdk` | PASS | Live host child-runner run `2026-07-05T07-45-45-388Z` passed at 100%. |
| `claude-sdk` | PASS | Live host child-runner run `2026-07-05T07-46-19-822Z` passed at 100%. |
| `copilot-sdk` | BLOCKED | Dependency loads and child runner starts, but Copilot CLI server exits with `BYOK providers require an explicit model` in runs `2026-07-05T07-46-47-294Z` and `2026-07-05T07-49-34-192Z`, including after adding `model_id` and `wire_model`. |

Private evidence: `EntityProcess/agentv-private` branch `evidence/av-t2o5-6-sdk-provider-live-unblock`, commit `dc9a3c4`.

## Validation

- `bun install --frozen-lockfile`
- `bun -e` import probe for `@openai/codex-sdk`, `@anthropic-ai/claude-agent-sdk`, `@github/copilot-sdk`, `@earendil-works/pi-coding-agent`, and `@earendil-works/pi-ai`
- `bun test packages/core/test/evaluation/providers/sdk-child-provider.test.ts`
- `bun test packages/core/test/evaluation/providers/pi-runtime.test.ts packages/core/test/evaluation/providers/claude-provider-aliases.test.ts packages/core/test/evaluation/providers/copilot-cli.test.ts`
- `bun test packages/core/test/evaluation/providers/copilot-sdk.test.ts packages/core/test/evaluation/providers/claude.test.ts`
- `bun run build`
- Live SDK matrix commands with `bun apps/cli/src/cli.ts eval run ... --workers 1 --threshold 0.8 --keep-workspaces`
- `git diff --check`

## Related

Related: av-t2o5.6. Beads remain the source of truth for final provider status, evidence, and residual blockers.
