### PR TITLE
feat(dashboard): render component grading artifacts

### DIFF
--- a/apps/dashboard/src/components/EvalDetail.test.ts
+++ b/apps/dashboard/src/components/EvalDetail.test.ts
@@ -1,31 +1,154 @@
 import { describe, expect, it } from 'bun:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 
-import { parseGradingArtifact } from './EvalDetail';
+import { GradingArtifactView, parseGradingArtifact } from './EvalDetail';
 
 describe('parseGradingArtifact', () => {
-  it('reads assertion_results with legacy assertions fallback', () => {
-    const current = parseGradingArtifact(
+  it('reads aggregate pass, score, reason, named_scores, and metadata', () => {
+    const parsed = parseGradingArtifact(
       JSON.stringify({
-        assertion_results: [
-          { text: 'Current evidence row', passed: true, evidence: 'from assertion_results' },
+        pass: false,
+        score: 0.42,
+        reason: 'One authored assertion failed.',
+        named_scores: { correctness: 0.5, style: 0.34, ignored: 'not a number' },
+        metadata: { grader_target: 'azure-llm', run_kind: 'sample' },
+      }),
+    );
+
+    expect(parsed?.result).toMatchObject({
+      pass: false,
+      score: 0.42,
+      reason: 'One authored assertion failed.',
+      namedScores: { correctness: 0.5, style: 0.34 },
+      metadata: { grader_target: 'azure-llm', run_kind: 'sample' },
+      componentResults: [],
+    });
+  });
+
+  it('reads single, multiple, and nested component_results with assertion metadata', () => {
+    const parsed = parseGradingArtifact(
+      JSON.stringify({
+        pass: false,
+        score: 0.66,
+        reason: 'Nested rubric failed.',
+        component_results: [
+          {
+            pass: true,
+            score: 1,
+            reason: 'Valid JSON.',
+            assertion: { type: 'is-json', metric: 'validity' },
+          },
+          {
+            pass: false,
+            score: 0.32,
+            reason: 'Rubric partially matched.',
+            assertion: { type: 'llm-rubric', metric: 'correctness', value: 'must cite policy' },
+            component_results: [
+              {
+                pass: false,
+                score: 0,
+                reason: 'Missing citation.',
+                assertion: { type: 'contains', value: 'POL-123' },
+              },
+            ],
+          },
         ],
-        assertions: [{ text: 'Legacy row ignored when current shape exists', passed: false }],
-        summary: { passed: 1, failed: 0, total: 1, pass_rate: 1 },
       }),
     );
 
-    expect(current?.assertions).toEqual([
-      { text: 'Current evidence row', passed: true, evidence: 'from assertion_results' },
-    ]);
+    expect(parsed?.result?.componentResults).toHaveLength(2);
+    expect(parsed?.result?.componentResults[0]).toMatchObject({
+      pass: true,
+      score: 1,
+      reason: 'Valid JSON.',
+      assertion: { type: 'is-json', metric: 'validity' },
+      componentResults: [],
+    });
+    expect(parsed?.result?.componentResults[1]?.componentResults[0]).toMatchObject({
+      pass: false,
+      score: 0,
+      reason: 'Missing citation.',
+      assertion: { type: 'contains', value: 'POL-123' },
+      componentResults: [],
+    });
+  });
 
-    const legacy = parseGradingArtifact(
+  it('does not require or display old public grading fields', () => {
+    const parsed = parseGradingArtifact(
       JSON.stringify({
-        assertions: [{ text: 'Legacy evidence row', passed: false, evidence: 'from assertions' }],
+        pass: true,
+        score: 1,
+        reason: 'Aggregate result is the source of truth.',
+        assertion_results: [
+          { text: 'stale assertion_results row', passed: false, evidence: 'old evidence' },
+        ],
+        evidence: 'old top-level evidence',
+        graders: [{ name: 'old grader' }],
+        checks: [{ text: 'old check' }],
       }),
     );
 
-    expect(legacy?.assertions).toEqual([
-      { text: 'Legacy evidence row', passed: false, evidence: 'from assertions' },
-    ]);
+    expect(parsed?.result).toMatchObject({
+      pass: true,
+      score: 1,
+      reason: 'Aggregate result is the source of truth.',
+      componentResults: [],
+    });
+    expect(JSON.stringify(parsed)).not.toContain('stale assertion_results row');
+    expect(JSON.stringify(parsed)).not.toContain('old evidence');
+    expect(JSON.stringify(parsed)).not.toContain('old grader');
+    expect(JSON.stringify(parsed)).not.toContain('old check');
+  });
+
+  it('reports missing, empty, and failed-parse artifact states', () => {
+    expect(parseGradingArtifact(undefined)).toBeNull();
+    expect(parseGradingArtifact('')).toBeNull();
+    expect(parseGradingArtifact('[]')?.error).toBe('grading.json must contain a JSON object.');
+    expect(parseGradingArtifact('{')?.error).toContain('JSON');
+  });
+});
+
+describe('GradingArtifactView', () => {
+  it('renders aggregate grading before recursive component details without empty clutter', () => {
+    const parsed = parseGradingArtifact(
+      JSON.stringify({
+        pass: false,
+        score: 0.5,
+        reason: 'One component failed.',
+        named_scores: { correctness: 0.5 },
+        metadata: { grader_target: 'azure-llm' },
+        component_results: [
+          {
+            pass: false,
+            score: 0.5,
+            reason: 'Authored rubric failed.',
+            assertion: { type: 'llm-rubric', metric: 'correctness', value: 'cite policy' },
+            component_results: [
+              {
+                pass: true,
+                score: 1,
+                reason: 'Required structure present.',
+                assertion: { type: 'is-json' },
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    if (!parsed?.result) throw new Error('expected parsed grading result');
+
+    const html = renderToStaticMarkup(
+      createElement(GradingArtifactView, { result: parsed.result }),
+    );
+
+    expect(html.indexOf('Aggregate score')).toBeLessThan(html.indexOf('Component Results'));
+    expect(html).toContain('One component failed.');
+    expect(html).toContain('correctness');
+    expect(html).toContain('value: cite policy');
+    expect(html).toContain('Authored rubric failed.');
+    expect(html).toContain('Required structure present.');
+    expect(html).not.toContain('No assertion steps recorded');
   });
 });

--- a/apps/dashboard/src/components/EvalDetail.tsx
+++ b/apps/dashboard/src/components/EvalDetail.tsx
@@ -1,9 +1,8 @@
 /**
- * Eval detail view with checks, source traceability, artifact files, and artifacts.
+ * Eval detail view with grading, source traceability, artifact files, and artifacts.
  *
  * Layout: compact header → tabs → full-height content area.
- * Scores and assertions are only visible in the Checks tab.
- * Assertions are grouped by grader name.
+ * Scores and assertions are only visible in the Grading tab.
  */
 
 import { useEffect, useMemo, useState } from 'react';
@@ -63,7 +62,7 @@ function findFirstFile(nodes: FileNode[]): string | null {
 }
 
 function caseTrialPath(trial: EvalCaseTrial, index = 0): string {
-  return trial.attempt_path ?? trial.run_path ?? `attempt-${trial.attempt ?? index + 1}`;
+  return trial.sample_path ?? trial.attempt_path ?? trial.run_path ?? `sample-${index + 1}`;
 }
 
 function trialNumber(trial: EvalCaseTrial, index = 0): number {
@@ -160,7 +159,7 @@ export function EvalDetail({
   }, [initialTab, initialSelectedFilePath]);
 
   const tabs: { id: Tab; label: string }[] = [
-    { id: 'checks', label: 'Checks' },
+    { id: 'checks', label: 'Grading' },
     { id: 'transcript', label: 'Transcript' },
     { id: 'source', label: 'Source' },
     { id: 'files', label: 'Files' },
@@ -204,9 +203,16 @@ export function EvalDetail({
                 onSelectTrial={onSelectTrial}
               />
             ) : selectedTrial ? (
-              <TrialChecksTab
+              <ArtifactGradingTab
                 result={detailResult}
                 trial={selectedTrial}
+                runId={runId}
+                projectId={projectId}
+                onOpenFile={openFile}
+              />
+            ) : detailResult.grading_path ? (
+              <ArtifactGradingTab
+                result={detailResult}
                 runId={runId}
                 projectId={projectId}
                 onOpenFile={openFile}
@@ -601,7 +607,7 @@ function TrialActionRow({
           onClick={() => onSelectTrial?.(trial, 'checks')}
           className="rounded-md border border-gray-700 px-2.5 py-1 text-xs text-gray-300 transition-colors hover:border-cyan-900/60 hover:text-cyan-300"
         >
-          Checks
+          Grading
         </button>
         <button
           type="button"
@@ -678,49 +684,300 @@ function RepeatAggregateChecksTab({
   );
 }
 
-type ParsedGradingArtifact = {
-  assertions: AssertionEntry[];
-  summary?: {
-    passed?: number;
-    failed?: number;
-    total?: number;
-    pass_rate?: number;
-  };
+type GradingJsonObject = Record<string, unknown>;
+
+export type GradingAssertionMetadata = {
+  type?: string;
+  metric?: string;
+  value?: unknown;
+} & Record<string, unknown>;
+
+export type GradingComponentResult = {
+  pass?: boolean;
+  score?: number;
+  reason?: string;
+  assertion?: GradingAssertionMetadata;
+  namedScores?: Record<string, number>;
+  metadata?: GradingJsonObject;
+  componentResults: GradingComponentResult[];
+};
+
+export type ParsedGradingArtifact = {
+  result?: GradingComponentResult;
   error?: string;
 };
+
+function isObject(value: unknown): value is GradingJsonObject {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stringField(source: GradingJsonObject, key: string): string | undefined {
+  const value = source[key];
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+function numberField(source: GradingJsonObject, key: string): number | undefined {
+  const value = source[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function booleanField(source: GradingJsonObject, key: string): boolean | undefined {
+  const value = source[key];
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function parseNamedScores(value: unknown): Record<string, number> | undefined {
+  if (!isObject(value)) return undefined;
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, number] => typeof entry[1] === 'number' && Number.isFinite(entry[1]),
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function parseAssertionMetadata(value: unknown): GradingAssertionMetadata | undefined {
+  if (!isObject(value)) return undefined;
+  return Object.keys(value).length > 0 ? (value as GradingAssertionMetadata) : undefined;
+}
+
+function parseComponentResult(value: unknown): GradingComponentResult | null {
+  if (!isObject(value)) return null;
+  const componentResults = Array.isArray(value.component_results)
+    ? value.component_results.flatMap((component) => {
+        const parsed = parseComponentResult(component);
+        return parsed ? [parsed] : [];
+      })
+    : [];
+  const namedScores = parseNamedScores(value.named_scores);
+  const metadata =
+    isObject(value.metadata) && Object.keys(value.metadata).length > 0 ? value.metadata : undefined;
+  return {
+    pass: booleanField(value, 'pass'),
+    score: numberField(value, 'score'),
+    reason: stringField(value, 'reason'),
+    assertion: parseAssertionMetadata(value.assertion),
+    namedScores,
+    metadata,
+    componentResults,
+  };
+}
 
 export function parseGradingArtifact(content: string | undefined): ParsedGradingArtifact | null {
   if (!content) return null;
   try {
-    const parsed = JSON.parse(content) as Record<string, unknown>;
-    const rawAssertions = Array.isArray(parsed.assertion_results)
-      ? parsed.assertion_results
-      : Array.isArray(parsed.assertions)
-        ? parsed.assertions
-        : [];
-    const assertions = rawAssertions.flatMap((value): AssertionEntry[] => {
-      if (!value || typeof value !== 'object') return [];
-      const assertion = value as Record<string, unknown>;
-      if (typeof assertion.text !== 'string' || typeof assertion.passed !== 'boolean') {
-        return [];
-      }
-      return [
-        {
-          text: assertion.text,
-          passed: assertion.passed,
-          evidence: typeof assertion.evidence === 'string' ? assertion.evidence : undefined,
-        },
-      ];
-    });
-    const summary =
-      parsed.summary && typeof parsed.summary === 'object' ? parsed.summary : undefined;
-    return { assertions, summary: summary as ParsedGradingArtifact['summary'] };
+    const result = parseComponentResult(JSON.parse(content));
+    return result ? { result } : { error: 'grading.json must contain a JSON object.' };
   } catch (error) {
-    return { assertions: [], error: error instanceof Error ? error.message : String(error) };
+    return { error: error instanceof Error ? error.message : String(error) };
   }
 }
 
-function TrialChecksTab({
+function formatJsonValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return JSON.stringify(value);
+}
+
+function gradingVerdictLabel(pass: boolean | undefined): string {
+  if (pass === true) return 'Pass';
+  if (pass === false) return 'Fail';
+  return 'Unknown';
+}
+
+function gradingVerdictClass(pass: boolean | undefined): string {
+  if (pass === true) return 'border-emerald-900/50 bg-emerald-950/20 text-emerald-300';
+  if (pass === false) return 'border-red-900/50 bg-red-950/20 text-red-300';
+  return 'border-gray-800 bg-gray-950/50 text-gray-300';
+}
+
+function assertionLabel(
+  assertion: GradingAssertionMetadata | undefined,
+  fallback: string,
+): { title: string; details: string[] } {
+  if (!assertion) return { title: fallback, details: [] };
+  const title =
+    (typeof assertion.metric === 'string' && assertion.metric) ||
+    (typeof assertion.type === 'string' && assertion.type) ||
+    fallback;
+  const details: string[] = [];
+  if (typeof assertion.type === 'string' && assertion.type !== title) {
+    details.push(`type: ${assertion.type}`);
+  }
+  if (typeof assertion.metric === 'string' && assertion.metric !== title) {
+    details.push(`metric: ${assertion.metric}`);
+  }
+  if (assertion.value !== undefined) {
+    details.push(`value: ${formatJsonValue(assertion.value)}`);
+  }
+  return { title, details };
+}
+
+function NamedScoresGrid({ scores }: { scores: Record<string, number> | undefined }) {
+  if (!scores || Object.keys(scores).length === 0) return null;
+  return (
+    <div className="grid gap-3 md:grid-cols-3">
+      {Object.entries(scores).map(([name, value]) => (
+        <RunMetricRow key={name} label={name} value={formatPercent(value)} />
+      ))}
+    </div>
+  );
+}
+
+function MetadataBlock({ metadata }: { metadata: GradingJsonObject | undefined }) {
+  if (!metadata || Object.keys(metadata).length === 0) return null;
+  return (
+    <details className="rounded-lg border border-gray-800 bg-gray-950/50 p-3">
+      <summary className="cursor-pointer text-sm font-medium text-gray-300">Metadata</summary>
+      <pre className="mt-3 max-h-64 overflow-auto text-xs text-gray-300">
+        {JSON.stringify(metadata, null, 2)}
+      </pre>
+    </details>
+  );
+}
+
+function OptionalScoreBar({ score }: { score: number | undefined }) {
+  if (score == null) {
+    return <div className="h-2 rounded-full bg-gray-800" />;
+  }
+  return <ScoreBar score={score} />;
+}
+
+function GradingAggregateSummary({ result }: { result: GradingComponentResult }) {
+  return (
+    <div className="space-y-4 rounded-lg border border-gray-800 bg-gray-900 p-4">
+      <div className="grid gap-3 md:grid-cols-[minmax(9rem,12rem)_1fr] md:items-center">
+        <div
+          className={`rounded-lg border px-3 py-2 text-sm font-medium ${gradingVerdictClass(
+            result.pass,
+          )}`}
+        >
+          {gradingVerdictLabel(result.pass)}
+        </div>
+        <div className="min-w-0">
+          <div className="mb-1 flex items-center justify-between gap-3 text-xs text-gray-500">
+            <span>Aggregate score</span>
+            <span className="font-mono">{formatPercent(result.score)}</span>
+          </div>
+          <OptionalScoreBar score={result.score} />
+        </div>
+      </div>
+      {result.reason ? <p className="text-sm text-gray-300">{result.reason}</p> : null}
+      <NamedScoresGrid scores={result.namedScores} />
+      <MetadataBlock metadata={result.metadata} />
+    </div>
+  );
+}
+
+function GradingComponentTree({
+  components,
+}: {
+  components: readonly GradingComponentResult[];
+}) {
+  if (components.length === 0) return null;
+  return (
+    <section className="space-y-3">
+      <h4 className="text-xs font-semibold uppercase tracking-wider text-gray-300">
+        Component Results
+      </h4>
+      <div className="space-y-2">
+        {components.map((component, index) => (
+          <GradingComponentNode
+            key={`${component.reason ?? 'component'}-${index}`}
+            component={component}
+            index={index}
+            depth={0}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function GradingArtifactView({ result }: { result: GradingComponentResult }) {
+  return (
+    <div className="space-y-6">
+      <GradingAggregateSummary result={result} />
+      <GradingComponentTree components={result.componentResults} />
+    </div>
+  );
+}
+
+function GradingComponentNode({
+  component,
+  index,
+  depth,
+}: {
+  component: GradingComponentResult;
+  index: number;
+  depth: number;
+}) {
+  const label = assertionLabel(component.assertion, `Component ${index + 1}`);
+  const hasChildren = component.componentResults.length > 0;
+  const summary = (
+    <div className="min-w-0 flex-1">
+      <div className="grid gap-3 md:grid-cols-[minmax(10rem,1fr)_minmax(8rem,12rem)] md:items-center">
+        <div className="min-w-0">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <span className="font-medium text-gray-200">{label.title}</span>
+            <span
+              className={`rounded-md border px-1.5 py-0.5 text-[11px] font-medium ${gradingVerdictClass(
+                component.pass,
+              )}`}
+            >
+              {gradingVerdictLabel(component.pass)}
+            </span>
+          </div>
+          {label.details.length > 0 ? (
+            <div className="mt-1 flex flex-wrap gap-2 text-xs text-gray-500">
+              {label.details.map((detail) => (
+                <span key={detail}>{detail}</span>
+              ))}
+            </div>
+          ) : null}
+        </div>
+        <div className="min-w-0">
+          <div className="mb-1 text-right font-mono text-xs text-gray-500">
+            {formatPercent(component.score)}
+          </div>
+          <OptionalScoreBar score={component.score} />
+        </div>
+      </div>
+      {component.reason ? <p className="text-sm text-gray-300">{component.reason}</p> : null}
+    </div>
+  );
+
+  return (
+    <details
+      open={depth === 0}
+      className="rounded-lg border border-gray-800 bg-gray-900 p-3"
+      style={{ marginLeft: depth > 0 ? `${Math.min(depth, 4) * 1}rem` : undefined }}
+    >
+      <summary className="flex cursor-pointer list-none items-start gap-3">
+        <span className="mt-1 text-xs text-gray-500">{hasChildren ? 'v' : '-'}</span>
+        {summary}
+      </summary>
+      {component.namedScores || component.metadata ? (
+        <div className="mt-3 space-y-3">
+          <NamedScoresGrid scores={component.namedScores} />
+          <MetadataBlock metadata={component.metadata} />
+        </div>
+      ) : null}
+      {hasChildren ? (
+        <div className="mt-3 space-y-2">
+          {component.componentResults.map((child, childIndex) => (
+            <GradingComponentNode
+              key={`${child.reason ?? 'component'}-${childIndex}`}
+              component={child}
+              index={childIndex}
+              depth={depth + 1}
+            />
+          ))}
+        </div>
+      ) : null}
+    </details>
+  );
+}
+
+function ArtifactGradingTab({
   result,
   trial,
   runId,
@@ -728,12 +985,12 @@ function TrialChecksTab({
   onOpenFile,
 }: {
   result: EvalResult;
-  trial: EvalCaseTrial;
+  trial?: EvalCaseTrial;
   runId: string;
   projectId?: string;
   onOpenFile: (path: string) => void;
 }) {
-  const gradingPath = trial.grading_path;
+  const gradingPath = result.grading_path ?? trial?.grading_path;
   const resultDir = result.result_dir;
   const evalId = result.testId;
   const { data: gradingContent, isLoading } =
@@ -750,18 +1007,22 @@ function TrialChecksTab({
     <div className="space-y-6">
       <div className="rounded-lg border border-gray-800 bg-gray-900 p-4">
         <div className="flex items-center gap-4">
-          <span className="text-sm font-medium text-gray-400">Attempt score</span>
+          <span className="text-sm font-medium text-gray-400">
+            {trial ? 'Attempt score' : 'Overall score'}
+          </span>
           <div className="flex-1">
             <ScoreBar score={result.score} />
           </div>
         </div>
       </div>
 
-      <div className="grid gap-3 md:grid-cols-3">
-        <RunMetricRow label="Duration" value={formatDuration(trial.duration_ms)} />
-        <RunMetricRow label="Cost" value={formatCost(trial.cost_usd)} />
-        <RunMetricRow label="Tokens" value={formatTokens(caseTrialTokenTotal(trial))} />
-      </div>
+      {trial ? (
+        <div className="grid gap-3 md:grid-cols-3">
+          <RunMetricRow label="Duration" value={formatDuration(trial.duration_ms)} />
+          <RunMetricRow label="Cost" value={formatCost(trial.cost_usd)} />
+          <RunMetricRow label="Tokens" value={formatTokens(caseTrialTokenTotal(trial))} />
+        </div>
+      ) : null}
 
       <div className="rounded-lg border border-gray-800 bg-gray-900 p-4">
         <div className="flex flex-wrap items-center justify-between gap-3">
@@ -778,27 +1039,12 @@ function TrialChecksTab({
           <p className="mt-3 text-sm text-gray-500">Loading grading artifact...</p>
         ) : null}
         {parsed?.error ? <p className="mt-3 text-sm text-red-300">{parsed.error}</p> : null}
-        {parsed?.summary ? (
-          <div className="mt-3 grid gap-3 md:grid-cols-3">
-            <RunMetricRow
-              label="Assertion pass rate"
-              value={formatPercent(parsed.summary.pass_rate)}
-            />
-            <RunMetricRow label="Passed" value={String(parsed.summary.passed ?? 0)} />
-            <RunMetricRow label="Failed" value={String(parsed.summary.failed ?? 0)} />
-          </div>
+        {!isLoading && !parsed ? (
+          <p className="mt-3 text-sm text-gray-500">No grading artifact content available.</p>
         ) : null}
       </div>
 
-      {parsed && parsed.assertions.length > 0 ? (
-        <div className="space-y-2">
-          {parsed.assertions.map((assertion, index) => (
-            <AssertionCard key={`${assertion.text}-${index}`} assertion={assertion} />
-          ))}
-        </div>
-      ) : !isLoading ? (
-        <p className="text-sm text-gray-500">No assertion steps recorded in grading.json.</p>
-      ) : null}
+      {parsed?.result ? <GradingArtifactView result={parsed.result} /> : null}
     </div>
   );
 }

--- a/apps/dashboard/src/components/ResultTable.test.tsx
+++ b/apps/dashboard/src/components/ResultTable.test.tsx
@@ -19,6 +19,7 @@ function repeatResult(overrides: Partial<EvalResult> = {}): EvalResult {
       {
         attempt: 0,
         sample_index: 1,
+        sample_path: 'sample-1',
         attempt_path: 'sample-1',
         score: 1,
         verdict: 'pass',
@@ -29,6 +30,7 @@ function repeatResult(overrides: Partial<EvalResult> = {}): EvalResult {
       {
         attempt: 1,
         sample_index: 2,
+        sample_path: 'sample-2',
         attempt_path: 'sample-2',
         score: 0.51,
         verdict: 'fail',
@@ -39,6 +41,7 @@ function repeatResult(overrides: Partial<EvalResult> = {}): EvalResult {
       {
         attempt: 2,
         sample_index: 3,
+        sample_path: 'sample-3',
         attempt_path: 'sample-3',
         score: 0,
         verdict: 'fail',

--- a/apps/dashboard/src/components/ResultTable.tsx
+++ b/apps/dashboard/src/components/ResultTable.tsx
@@ -151,7 +151,7 @@ function caseTrialTokenTotal(trial: EvalCaseTrial): number | undefined {
 }
 
 function caseTrialPath(trial: EvalCaseTrial, index = 0): string {
-  return trial.attempt_path ?? trial.run_path ?? `attempt-${trial.attempt ?? index + 1}`;
+  return trial.sample_path ?? trial.attempt_path ?? trial.run_path ?? `sample-${index + 1}`;
 }
 
 function compactTokenBreakdown(result: EvalResult): string | undefined {

--- a/apps/dashboard/src/lib/result-table.test.ts
+++ b/apps/dashboard/src/lib/result-table.test.ts
@@ -191,6 +191,41 @@ describe('result-table model', () => {
     });
   });
 
+  it('uses finalized sample_path values when grouping repeat-run trials', () => {
+    const model = buildResultTableModel({
+      passThreshold: 0.8,
+      results: [
+        result({
+          testId: 'sample-path-case',
+          score: 1,
+          attempts: [
+            {
+              attempt: 0,
+              sample_index: 1,
+              sample_path: 'sample-1',
+              attempt_path: 'attempt-1',
+              score: 1,
+              verdict: 'pass',
+            },
+            {
+              attempt: 1,
+              sample_index: 2,
+              sample_path: 'sample-2',
+              attempt_path: 'attempt-2',
+              score: 1,
+              verdict: 'pass',
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(model.repeatGroups[0].trials.map((trial) => trial.sample_path)).toEqual([
+      'sample-1',
+      'sample-2',
+    ]);
+  });
+
   it('accepts legacy scorer URL state as a grader alias', () => {
     const model = buildResultTableModel({
       passThreshold: 0.8,

--- a/apps/dashboard/src/lib/result-table.ts
+++ b/apps/dashboard/src/lib/result-table.ts
@@ -296,7 +296,7 @@ function buildRow(result: EvalResult, index: number, passThreshold: number): Res
 
 function buildRepeatGroup(row: ResultTableRow, passThreshold: number): RepeatRunGroup | undefined {
   const trials = caseTrials(row.result).filter(
-    (trial) => trial.attempt_path || trial.run_path || trial.verdict,
+    (trial) => trial.sample_path || trial.attempt_path || trial.run_path || trial.verdict,
   );
   if (trials.length <= 1) return undefined;
 

--- a/apps/dashboard/src/lib/types.ts
+++ b/apps/dashboard/src/lib/types.ts
@@ -130,6 +130,7 @@ export interface EvalCaseTrial {
   attempt?: number;
   sample_index?: number;
   retry_index?: number;
+  sample_path?: string;
   attempt_path?: string;
   run_path?: string;
   score?: number;


### PR DESCRIPTION
## Summary
Dashboard grading details now read the finalized Promptfoo-style `grading.json` shape directly, so run detail pages show the aggregate pass/score/reason before the recursive `component_results` tree. Component rows are labeled from `assertion` metadata, include pass/score/reason, and show `named_scores` plus metadata without reviving the old public `assertion_results`, `evidence`, `graders`, or `checks` artifact fields.

This also keeps finalized `sample_path` / `sample-N` artifact paths visible in repeat/sample rows, while ordinary rows with a `grading_path` now open the same artifact-backed grading display instead of falling back to sparse index summary fields.

## Validation
- `bun test ./src/components/EvalDetail.test.ts`
- `bun --filter @agentv/dashboard test`
- `bun --filter @agentv/dashboard build`
- `bun run build`
- Browser UAT with `agent-browser` against a disposable `.agentv/results/.../sample-1/grading.json` bundle at desktop 1440x1000 and mobile 390x844.
- Manual diff review completed. `ce-code-review` multi-agent review was not run because this Codex harness exposes subagents only when the user explicitly requests delegation/parallel agents.

## Evidence
Private evidence branch: `EntityProcess/agentv-private:evidence/av-kfik-28-5-dashboard-component-results`
Evidence commit: `7dad319`

Artifacts:
- `dashboard-grading-desktop.png`
- `dashboard-grading-mobile.png`

## Post-Deploy Monitoring & Validation
No additional production monitoring required. This is a local Dashboard rendering change over static AgentV result artifacts; validation is through CI plus manual Dashboard UAT on the finalized artifact shape.

Healthy signals after merge:
- GitHub Actions pass for build, typecheck, lint, and tests.
- Opening a run with `sample-1/grading.json` shows aggregate grading and recursive components in the Grading tab.

Failure signals and mitigation:
- Dashboard detail shows sparse grading or JSON parse errors for finalized `component_results` artifacts.
- Revert this PR or restore the prior Dashboard bundle while investigating artifact parsing.

Validation window and owner: coordinator review before merge; no merge from this worker.

## Related
Related: av-kfik.28.5

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
