### PR TITLE
feat(runtime): execute docker environment recipes

### DIFF
--- a/packages/core/src/evaluation/environment/docker.ts
+++ b/packages/core/src/evaluation/environment/docker.ts
@@ -1,0 +1,192 @@
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import type {
+  DockerEnvironmentRecipe,
+  EnvironmentSetupConfig,
+} from '../loaders/environment-recipe.js';
+import type { TargetRuntimeConfig } from '../providers/sandbox-runner.js';
+import type { JsonObject } from '../types.js';
+import {
+  type CommandExecutor,
+  DefaultCommandExecutor,
+  DockerWorkspaceProvider,
+} from '../workspace/docker-workspace.js';
+
+export type DockerEnvironmentSetupStatus = 'skipped' | 'success' | 'failed';
+
+export interface DockerEnvironmentSetupResult {
+  readonly type: 'docker';
+  readonly image: string;
+  readonly workdir: string;
+  readonly status: DockerEnvironmentSetupStatus;
+  readonly command?: readonly string[] | string;
+  readonly cwd?: string;
+  readonly args?: JsonObject;
+  readonly stdout?: string;
+  readonly stderr?: string;
+  readonly exitCode?: number;
+  readonly targetRuntime: TargetRuntimeConfig;
+}
+
+export class DockerEnvironmentSetupError extends Error {
+  readonly result: DockerEnvironmentSetupResult;
+
+  constructor(message: string, result: DockerEnvironmentSetupResult) {
+    super(message);
+    this.name = 'DockerEnvironmentSetupError';
+    this.result = result;
+  }
+}
+
+function dockerImageTag(recipe: DockerEnvironmentRecipe): string {
+  const hash = createHash('sha256')
+    .update(recipe.context ?? '')
+    .update('\0')
+    .update(recipe.dockerfile ?? '')
+    .digest('hex')
+    .slice(0, 16);
+  return `agentv-environment:${hash}`;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function setupPayload(recipe: DockerEnvironmentRecipe): JsonObject {
+  return {
+    args: recipe.setup?.args ?? {},
+    environment: {
+      type: 'docker',
+      workdir: recipe.workdir,
+      ...(recipe.image ? { image: recipe.image } : {}),
+      ...(recipe.context ? { context: recipe.context } : {}),
+      ...(recipe.dockerfile ? { dockerfile: recipe.dockerfile } : {}),
+    },
+    ...(recipe.setup?.env ? { env: recipe.setup.env } : {}),
+  };
+}
+
+function setupCommandLine(setup: EnvironmentSetupConfig, payload: string): string {
+  const envPrefix = Object.entries(setup.env ?? {})
+    .map(([key, value]) => `${key}=${shellQuote(value)}`)
+    .join(' ');
+  const command =
+    typeof setup.command === 'string'
+      ? setup.command
+      : setup.command.map((entry) => shellQuote(entry)).join(' ');
+  const setupCommand = envPrefix ? `${envPrefix} ${command}` : command;
+  return `printf %s ${shellQuote(payload)} | (${setupCommand})`;
+}
+
+function setupTimeoutSeconds(setup: EnvironmentSetupConfig | undefined): number | undefined {
+  return setup?.timeout_seconds;
+}
+
+function dockerRuntimeForRecipe(
+  recipe: DockerEnvironmentRecipe,
+  image: string,
+): TargetRuntimeConfig {
+  const setup = recipe.setup;
+  const payload = JSON.stringify(setupPayload({ ...recipe, image }), null, 2);
+  const tempDir = path.resolve(tmpdir());
+  const recipeMounts = (recipe.mounts ?? []).map((mount) => ({
+    source: mount.source,
+    target: mount.target,
+    access: mount.read_only === true ? 'ro' : (mount.access ?? 'rw'),
+  }));
+  const mounts = recipeMounts.some((mount) => mount.target === tempDir)
+    ? recipeMounts
+    : [...recipeMounts, { source: tempDir, target: tempDir, access: 'rw' }];
+  return {
+    mode: 'sandbox',
+    engine: 'docker',
+    image,
+    workdir: recipe.workdir,
+    host_cwd: recipe.sourceDir,
+    env: {
+      ...(recipe.env ?? {}),
+      AGENTV_ENVIRONMENT_WORKDIR: recipe.workdir,
+    },
+    ...(recipe.secrets !== undefined ? { secrets: recipe.secrets } : {}),
+    mounts,
+    ...(recipe.resources?.memory !== undefined ? { memory: recipe.resources.memory } : {}),
+    ...(recipe.resources?.cpus !== undefined ? { cpus: recipe.resources.cpus } : {}),
+    ...(setup !== undefined ? { setup: [setupCommandLine(setup, payload)] } : {}),
+    ...(setupTimeoutSeconds(setup) !== undefined
+      ? { setup_timeout: setupTimeoutSeconds(setup) }
+      : {}),
+  };
+}
+
+function formatDockerFailure(
+  action: string,
+  result: { stderr: string; stdout: string; exitCode: number },
+) {
+  const details = result.stderr.trim() || result.stdout.trim();
+  return details
+    ? `docker ${action} failed (exit ${result.exitCode}): ${details}`
+    : `docker ${action} failed (exit ${result.exitCode})`;
+}
+
+export async function prepareDockerEnvironment(
+  recipe: DockerEnvironmentRecipe,
+  executor: CommandExecutor = new DefaultCommandExecutor(),
+): Promise<DockerEnvironmentSetupResult> {
+  const image = recipe.context ? (recipe.image ?? dockerImageTag(recipe)) : recipe.image;
+  if (!image) {
+    throw new Error('Docker environment requires image when context is not set.');
+  }
+
+  const docker = new DockerWorkspaceProvider(
+    {
+      image,
+      ...(recipe.resources?.memory !== undefined ? { memory: recipe.resources.memory } : {}),
+      ...(recipe.resources?.cpus !== undefined ? { cpus: recipe.resources.cpus } : {}),
+    },
+    executor,
+  );
+
+  if (!(await docker.isDockerAvailable())) {
+    throw new Error(
+      'Docker environment configured but Docker CLI is not available. Install Docker and ensure it is running.',
+    );
+  }
+
+  if (recipe.context) {
+    const argv = ['docker', 'build', '-t', image];
+    if (recipe.dockerfile) {
+      argv.push('-f', recipe.dockerfile);
+    }
+    argv.push(recipe.context);
+    const result = await executor.exec(argv, { timeoutMs: 30 * 60 * 1000 });
+    if (result.exitCode !== 0) {
+      const failure: DockerEnvironmentSetupResult = {
+        type: 'docker',
+        image,
+        workdir: recipe.workdir,
+        status: 'failed',
+        stderr: result.stderr,
+        stdout: result.stdout,
+        exitCode: result.exitCode,
+        targetRuntime: dockerRuntimeForRecipe(recipe, image),
+      };
+      throw new DockerEnvironmentSetupError(formatDockerFailure('build', result), failure);
+    }
+  } else {
+    await docker.pullImage();
+  }
+
+  const runtime = dockerRuntimeForRecipe(recipe, image);
+  return {
+    type: 'docker',
+    image,
+    workdir: recipe.workdir,
+    status: recipe.setup ? 'success' : 'skipped',
+    ...(recipe.setup?.command !== undefined ? { command: recipe.setup.command } : {}),
+    cwd: recipe.sourceDir,
+    ...(recipe.setup?.args !== undefined ? { args: recipe.setup.args } : {}),
+    targetRuntime: runtime,
+  };
+}

--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -419,6 +419,7 @@ export interface EvaluationCache {
 export interface RunEvalCaseOptions {
   readonly evalCase: EvalTest;
   readonly provider: Provider;
+  readonly providerFactory?: (target: ResolvedTarget) => Provider;
   readonly target: ResolvedTarget;
   readonly evaluators: Partial<Record<string, Grader>> & { readonly 'llm-grader': Grader };
   readonly now?: () => Date;
@@ -1257,6 +1258,7 @@ export async function runEvaluation(
         const runCaseOptions: RunEvalCaseOptions = {
           evalCase: evalCase,
           provider: primaryProvider,
+          providerFactory,
           target,
           evaluators: evaluatorRegistry,
           maxRetries,
@@ -1874,12 +1876,6 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
   const promptInputs = await buildPromptInputs(evalCase, formattingMode);
   const typeRegistry = providedTypeRegistry ?? createBuiltinRegistry();
 
-  const cacheKey = useCache ? createCacheKey(provider, target, evalCase, promptInputs) : undefined;
-  let cachedResponse: ProviderResponse | undefined;
-  if (cacheKey && cache) {
-    cachedResponse = await cache.get(cacheKey);
-  }
-
   const nowFn = now ?? (() => new Date());
 
   let afterEachOutput: string | undefined;
@@ -1921,10 +1917,24 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
     beforeAllOutput,
     beforeEachOutput,
     baselineCommit,
+    targetCwd,
+    targetRuntime,
     isSharedWorkspace,
     caseWorkspaceFile,
     extensionState,
   } = workspaceSetup;
+  const effectiveTarget = targetRuntime ? { ...target, runtime: targetRuntime } : target;
+  const effectiveProvider =
+    targetRuntime !== undefined
+      ? (options.providerFactory ?? createProvider)(effectiveTarget)
+      : provider;
+  const cacheKey = useCache
+    ? createCacheKey(effectiveProvider, effectiveTarget, evalCase, promptInputs)
+    : undefined;
+  let cachedResponse: ProviderResponse | undefined;
+  if (cacheKey && cache) {
+    cachedResponse = await cache.get(cacheKey);
+  }
   const extensionMetadata = extensionState?.metadata;
   const providerMetadata = mergeMetadata(evalCase.metadata, extensionState?.providerContext);
   const resultMetadata = mergeMetadata(evalCase.metadata, extensionMetadata);
@@ -2032,15 +2042,15 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
   if (evalCase.mode === 'conversation' && evalCase.turns?.length) {
     let conversationResult = await runConversationMode({
       evalCase,
-      provider,
-      target,
+      provider: effectiveProvider,
+      target: effectiveTarget,
       evaluators,
       typeRegistry,
       graderProvider,
       promptInputs,
       nowFn,
       signal,
-      workspacePath,
+      workspacePath: targetCwd ?? workspacePath,
       caseWorkspaceFile,
       agentTimeoutMs,
       streamCallbacks: options.streamCallbacks,
@@ -2085,15 +2095,15 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
 
   while (!providerResponse && attempt < attemptBudget) {
     try {
-      providerResponse = await invokeProvider(provider, {
+      providerResponse = await invokeProvider(effectiveProvider, {
         evalCase: evalCase,
-        target,
+        target: effectiveTarget,
         promptInputs,
         attempt,
         evalFilePath,
         agentTimeoutMs,
         signal,
-        cwd: workspacePath,
+        cwd: targetCwd ?? workspacePath,
         workspaceFile: caseWorkspaceFile,
         captureFileChanges: !!baselineCommit,
         streamCallbacks: options.streamCallbacks,
@@ -2112,8 +2122,8 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
   }
 
   // Try fallback targets in order after exhausting retries on the primary
-  if (!providerResponse && target.fallbackTargets?.length && targetResolver) {
-    for (const fallbackName of target.fallbackTargets) {
+  if (!providerResponse && effectiveTarget.fallbackTargets?.length && targetResolver) {
+    for (const fallbackName of effectiveTarget.fallbackTargets) {
       const fallbackProvider = targetResolver(fallbackName);
       if (!fallbackProvider) {
         continue;
@@ -2121,13 +2131,13 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
       try {
         providerResponse = await invokeProvider(fallbackProvider, {
           evalCase: evalCase,
-          target,
+          target: effectiveTarget,
           promptInputs,
           attempt: 0,
           evalFilePath,
           agentTimeoutMs,
           signal,
-          cwd: workspacePath,
+          cwd: targetCwd ?? workspacePath,
           workspaceFile: caseWorkspaceFile,
           captureFileChanges: !!baselineCommit,
           streamCallbacks: options.streamCallbacks,
@@ -2145,11 +2155,11 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
   if (!providerResponse) {
     const errorResult = buildErrorResult(
       evalCase,
-      target.name,
+      effectiveTarget.name,
       nowFn(),
       lastError ?? new Error('Provider did not return a response'),
       promptInputs,
-      provider,
+      effectiveProvider,
       'agent',
       'provider_error',
       verbose,
@@ -2172,7 +2182,7 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
       evalCase,
       evalFilePath,
       repoRoot,
-      target: targetUsed ? { ...target, name: targetUsed } : target,
+      target: targetUsed ? { ...effectiveTarget, name: targetUsed } : effectiveTarget,
       attempt,
       response: providerResponse,
       nowFn,
@@ -2247,8 +2257,8 @@ export async function runEvalCase(options: RunEvalCaseOptions): Promise<Evaluati
     const result = await evaluateCandidate({
       evalCase,
       candidate,
-      target,
-      provider,
+      target: effectiveTarget,
+      provider: effectiveProvider,
       evaluators,
       typeRegistry,
       promptInputs,

--- a/packages/core/src/evaluation/providers/sandbox-runner.ts
+++ b/packages/core/src/evaluation/providers/sandbox-runner.ts
@@ -107,6 +107,10 @@ function dockerWorkdir(runtime: TargetRuntimeConfig): string | undefined {
   return asString(runtime.workdir) ?? asString(runtime.workspace);
 }
 
+function dockerHostCwd(runtime: TargetRuntimeConfig): string | undefined {
+  return asString(runtime.host_cwd);
+}
+
 function dockerNetwork(runtime: TargetRuntimeConfig): string {
   const network = asString(runtime.network);
   return network ?? 'none';
@@ -114,6 +118,14 @@ function dockerNetwork(runtime: TargetRuntimeConfig): string {
 
 function dockerSetupCommands(runtime: TargetRuntimeConfig): readonly string[] {
   return asStringArray(runtime.setup);
+}
+
+function dockerMemory(runtime: TargetRuntimeConfig): string | undefined {
+  return asString(runtime.memory);
+}
+
+function dockerCpus(runtime: TargetRuntimeConfig): number | undefined {
+  return typeof runtime.cpus === 'number' && runtime.cpus > 0 ? runtime.cpus : undefined;
 }
 
 export async function runDockerSandboxCommand(
@@ -159,6 +171,16 @@ export async function runDockerSandboxCommand(
     argv.push('--workdir', workdir);
   }
 
+  const memory = dockerMemory(options.runtime);
+  if (memory) {
+    argv.push('--memory', memory);
+  }
+
+  const cpus = dockerCpus(options.runtime);
+  if (cpus !== undefined) {
+    argv.push('--cpus', String(cpus));
+  }
+
   for (const [key, value] of Object.entries(dockerEnv(options.runtime))) {
     argv.push('--env', `${key}=${value}`);
   }
@@ -172,7 +194,7 @@ export async function runDockerSandboxCommand(
 
   return new Promise((resolve) => {
     const child = spawn('docker', argv, {
-      cwd: options.cwd,
+      cwd: dockerHostCwd(options.runtime) ?? options.cwd,
       env: process.env,
       windowsHide: true,
     });

--- a/packages/core/src/evaluation/workspace/setup.ts
+++ b/packages/core/src/evaluation/workspace/setup.ts
@@ -18,12 +18,21 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 
 import {
+  DockerEnvironmentSetupError,
+  type DockerEnvironmentSetupResult,
+  prepareDockerEnvironment,
+} from '../environment/docker.js';
+import {
   HostEnvironmentSetupError,
   type HostEnvironmentSetupResult,
   prepareHostEnvironment,
 } from '../environment/host.js';
 import { type ExtensionRuntimeState, runExtensionsForHook } from '../extensions/runner.js';
-import type { HostEnvironmentRecipe } from '../loaders/environment-recipe.js';
+import type {
+  DockerEnvironmentRecipe,
+  HostEnvironmentRecipe,
+} from '../loaders/environment-recipe.js';
+import type { TargetRuntimeConfig } from '../providers/sandbox-runner.js';
 import type {
   AgentVExtensionConfig,
   EvalTest,
@@ -73,9 +82,11 @@ export interface WorkspaceSetupHookExecution {
 export interface EnvironmentSetupExecution {
   readonly scope: 'environment';
   readonly name: 'setup';
-  readonly status: HostEnvironmentSetupResult['status'];
+  readonly status: HostEnvironmentSetupResult['status'] | DockerEnvironmentSetupResult['status'];
   readonly testId: string;
   readonly workdir: string;
+  readonly type?: 'host' | 'docker';
+  readonly image?: string;
   readonly command?: readonly string[] | string;
   readonly cwd?: string;
   readonly output?: string;
@@ -160,6 +171,8 @@ export interface EvalCaseWorkspaceSetup {
   readonly beforeAllOutput?: string;
   readonly beforeEachOutput?: string;
   readonly baselineCommit?: string;
+  readonly targetCwd?: string;
+  readonly targetRuntime?: TargetRuntimeConfig;
   readonly isSharedWorkspace: boolean;
   readonly hookExecutions: readonly WorkspaceSetupHookExecution[];
   readonly environmentSetupExecutions: readonly EnvironmentSetupExecution[];
@@ -255,8 +268,9 @@ function hostEnvironment(evalCase: EvalTest): HostEnvironmentRecipe | undefined 
   return environment?.type === 'host' ? environment : undefined;
 }
 
-function unsupportedDockerEnvironment(evalCase: EvalTest): boolean {
-  return evalCase.environment?.type === 'docker';
+function dockerEnvironment(evalCase: EvalTest): DockerEnvironmentRecipe | undefined {
+  const environment = evalCase.environment;
+  return environment?.type === 'docker' ? environment : undefined;
 }
 
 function stableWorkspaceValue(value: unknown): string {
@@ -372,15 +386,6 @@ function selectSuiteHostEnvironment(
   >();
 
   for (const evalCase of evalCases) {
-    if (unsupportedDockerEnvironment(evalCase)) {
-      throw new WorkspaceSetupError(
-        `Docker environment recipes are not implemented for runtime execution yet: test '${evalCase.id}'.`,
-        {
-          failureStage: 'setup',
-          failureReasonCode: 'unsupported_environment',
-        },
-      );
-    }
     const environment = hostEnvironment(evalCase);
     if (!environment || isAttemptScopedWorkspace(effectiveRuntimeWorkspace(evalCase))) {
       continue;
@@ -528,6 +533,30 @@ function environmentSetupExecution(options: {
     status: options.error ? 'failed' : options.result.status,
     testId: options.testId,
     workdir: options.result.workdir,
+    type: options.result.type,
+    ...(options.result.command !== undefined && { command: options.result.command }),
+    ...(options.result.cwd !== undefined && { cwd: options.result.cwd }),
+    ...(options.result.stdout !== undefined && { output: options.result.stdout }),
+    ...((options.error ?? options.result.stderr)
+      ? { error: options.error ?? options.result.stderr }
+      : {}),
+    ...(options.result.exitCode !== undefined && { exitCode: options.result.exitCode }),
+  };
+}
+
+function dockerEnvironmentSetupExecution(options: {
+  readonly result: DockerEnvironmentSetupResult;
+  readonly testId: string;
+  readonly error?: string;
+}): EnvironmentSetupExecution {
+  return {
+    scope: 'environment',
+    name: 'setup',
+    status: options.error ? 'failed' : options.result.status,
+    testId: options.testId,
+    workdir: options.result.workdir,
+    type: options.result.type,
+    image: options.result.image,
     ...(options.result.command !== undefined && { command: options.result.command }),
     ...(options.result.cwd !== undefined && { cwd: options.result.cwd }),
     ...(options.result.stdout !== undefined && { output: options.result.stdout }),
@@ -554,6 +583,39 @@ async function prepareHostEnvironmentForSetup(
   } catch (error) {
     if (error instanceof HostEnvironmentSetupError) {
       const execution = environmentSetupExecution({
+        result: error.result,
+        testId,
+        error: error.message,
+      });
+      throw new WorkspaceSetupError(error.message, {
+        failureStage: 'setup',
+        failureReasonCode: 'environment_setup_error',
+        environmentSetupExecutions: [execution],
+        cause: error,
+      });
+    }
+    throw error;
+  }
+}
+
+async function prepareDockerEnvironmentForSetup(
+  environment: DockerEnvironmentRecipe,
+  testId: string,
+): Promise<{
+  readonly targetCwd: string;
+  readonly targetRuntime: TargetRuntimeConfig;
+  readonly execution: EnvironmentSetupExecution;
+}> {
+  try {
+    const result = await prepareDockerEnvironment(environment);
+    return {
+      targetCwd: result.workdir,
+      targetRuntime: result.targetRuntime,
+      execution: dockerEnvironmentSetupExecution({ result, testId }),
+    };
+  } catch (error) {
+    if (error instanceof DockerEnvironmentSetupError) {
+      const execution = dockerEnvironmentSetupExecution({
         result: error.result,
         testId,
         error: error.message,
@@ -941,19 +1003,13 @@ export async function prepareEvalCaseWorkspace(
   } = options;
 
   const runtimeWorkspace = effectiveRuntimeWorkspace(evalCase);
-  if (unsupportedDockerEnvironment(evalCase)) {
-    throw new WorkspaceSetupError(
-      `Docker environment recipes are not implemented for runtime execution yet: test '${evalCase.id}'.`,
-      {
-        failureStage: 'setup',
-        failureReasonCode: 'unsupported_environment',
-      },
-    );
-  }
   const runtimeEnvironment = hostEnvironment(evalCase);
+  const runtimeDockerEnvironment = dockerEnvironment(evalCase);
   let workspacePath: string | undefined = isAttemptScopedWorkspace(runtimeWorkspace)
     ? undefined
     : sharedWorkspacePath;
+  let targetCwd: string | undefined;
+  let targetRuntime: TargetRuntimeConfig | undefined;
   const inheritedSuiteWorkspaceFile = workspacePath ? suiteWorkspaceFile : undefined;
   let beforeAllOutput: string | undefined;
   let beforeEachOutput: string | undefined;
@@ -977,6 +1033,29 @@ export async function prepareEvalCaseWorkspace(
         }
         const message = error instanceof Error ? error.message : String(error);
         throw new WorkspaceSetupError(`Failed to prepare host environment: ${message}`, {
+          failureStage: 'setup',
+          failureReasonCode: 'environment_setup_error',
+          hookExecutions,
+          cause: error,
+        });
+      }
+    }
+
+    if (runtimeDockerEnvironment) {
+      try {
+        const prepared = await prepareDockerEnvironmentForSetup(
+          runtimeDockerEnvironment,
+          evalCase.id,
+        );
+        targetCwd = prepared.targetCwd;
+        targetRuntime = prepared.targetRuntime;
+        environmentSetupExecutions.push(prepared.execution);
+      } catch (error) {
+        if (error instanceof WorkspaceSetupError) {
+          throw error;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        throw new WorkspaceSetupError(`Failed to prepare Docker environment: ${message}`, {
           failureStage: 'setup',
           failureReasonCode: 'environment_setup_error',
           hookExecutions,
@@ -1397,6 +1476,8 @@ export async function prepareEvalCaseWorkspace(
     ...(beforeAllOutput !== undefined && { beforeAllOutput }),
     ...(beforeEachOutput !== undefined && { beforeEachOutput }),
     ...(baselineCommit !== undefined && { baselineCommit }),
+    ...(targetCwd !== undefined && { targetCwd }),
+    ...(targetRuntime !== undefined && { targetRuntime }),
     isSharedWorkspace,
     hookExecutions,
     environmentSetupExecutions,

--- a/packages/core/test/evaluation/environment/docker.test.ts
+++ b/packages/core/test/evaluation/environment/docker.test.ts
@@ -1,0 +1,138 @@
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { prepareDockerEnvironment } from '../../../src/evaluation/environment/docker.js';
+import type {
+  CommandExecutor,
+  ExecResult,
+} from '../../../src/evaluation/workspace/docker-workspace.js';
+
+class MockExecutor implements CommandExecutor {
+  readonly calls: Array<{
+    argv: readonly string[];
+    options?: { timeoutMs?: number; stdin?: string };
+  }> = [];
+  private responses: ExecResult[] = [];
+
+  pushResponse(response: Partial<ExecResult>): void {
+    this.responses.push({ stdout: '', stderr: '', exitCode: 0, ...response });
+  }
+
+  async exec(
+    argv: readonly string[],
+    options?: { timeoutMs?: number; stdin?: string },
+  ): Promise<ExecResult> {
+    this.calls.push({ argv, options });
+    return this.responses.shift() ?? { stdout: '', stderr: '', exitCode: 0 };
+  }
+}
+
+describe('prepareDockerEnvironment', () => {
+  it('pulls image recipes and exposes a sandbox target runtime', async () => {
+    const executor = new MockExecutor();
+    executor.pushResponse({ stdout: '24.0.0' });
+    executor.pushResponse({ exitCode: 1 });
+    executor.pushResponse({ stdout: 'pulled' });
+
+    const result = await prepareDockerEnvironment(
+      {
+        type: 'docker',
+        image: 'node:22-alpine',
+        workdir: '/app',
+        sourceDir: '/evals',
+        env: { CASE_ENV: '1' },
+        resources: { cpus: 1.5, memory: '1g' },
+        mounts: [{ source: '/host/repo', target: '/repo', read_only: true }],
+      },
+      executor,
+    );
+
+    expect(executor.calls.map((call) => call.argv)).toEqual([
+      ['docker', 'version', '--format', '{{.Server.Version}}'],
+      ['docker', 'image', 'inspect', 'node:22-alpine'],
+      ['docker', 'pull', 'node:22-alpine'],
+    ]);
+    expect(result.status).toBe('skipped');
+    const tempDir = path.resolve(tmpdir());
+    expect(result.targetRuntime).toMatchObject({
+      mode: 'sandbox',
+      engine: 'docker',
+      image: 'node:22-alpine',
+      workdir: '/app',
+      host_cwd: '/evals',
+      env: { CASE_ENV: '1', AGENTV_ENVIRONMENT_WORKDIR: '/app' },
+      cpus: 1.5,
+      memory: '1g',
+    });
+    expect(result.targetRuntime.mounts).toEqual([
+      { source: '/host/repo', target: '/repo', access: 'ro' },
+      { source: tempDir, target: tempDir, access: 'rw' },
+    ]);
+  });
+
+  it('builds context recipes with dockerfile and schedules setup before target commands', async () => {
+    const executor = new MockExecutor();
+    executor.pushResponse({ stdout: '24.0.0' });
+    executor.pushResponse({ stdout: 'built' });
+
+    const result = await prepareDockerEnvironment(
+      {
+        type: 'docker',
+        image: 'agentv/example:local',
+        context: '/tmp/context',
+        dockerfile: '/tmp/context/Dockerfile.agentv',
+        workdir: '/workspace',
+        sourceDir: '/evals',
+        setup: {
+          command: ['node', 'setup.mjs'],
+          args: { repo: 'fixture' },
+          env: { SETUP_TOKEN: 'secret-value' },
+          timeout_seconds: 3,
+        },
+      },
+      executor,
+    );
+
+    expect(executor.calls.map((call) => call.argv)).toEqual([
+      ['docker', 'version', '--format', '{{.Server.Version}}'],
+      [
+        'docker',
+        'build',
+        '-t',
+        'agentv/example:local',
+        '-f',
+        '/tmp/context/Dockerfile.agentv',
+        '/tmp/context',
+      ],
+    ]);
+    expect(result.status).toBe('success');
+    expect(result.targetRuntime.setup).toEqual([expect.stringContaining("printf %s '{")]);
+    expect(result.targetRuntime.setup?.[0]).toContain("SETUP_TOKEN='secret-value'");
+    expect(result.targetRuntime.setup?.[0]).toContain("'node' 'setup.mjs'");
+    expect(result.targetRuntime.setup?.[0]).toContain('"repo": "fixture"');
+    expect(result.targetRuntime.setup?.[0]).toContain('"SETUP_TOKEN": "secret-value"');
+  });
+
+  it('does not add a duplicate temp mount when the recipe already mounts that target', async () => {
+    const executor = new MockExecutor();
+    executor.pushResponse({ stdout: '24.0.0' });
+    executor.pushResponse({ exitCode: 0 });
+    const tempDir = path.resolve(tmpdir());
+
+    const result = await prepareDockerEnvironment(
+      {
+        type: 'docker',
+        image: 'alpine:3.20',
+        workdir: '/app',
+        sourceDir: '/evals',
+        mounts: [{ source: tempDir, target: tempDir, access: 'rw' }],
+      },
+      executor,
+    );
+
+    expect(result.targetRuntime.mounts).toEqual([
+      { source: tempDir, target: tempDir, access: 'rw' },
+    ]);
+  });
+});

--- a/packages/core/test/evaluation/orchestrator.test.ts
+++ b/packages/core/test/evaluation/orchestrator.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import { execSync } from 'node:child_process';
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -1028,6 +1029,170 @@ console.log('spreadsheet: revenue,total\\nQ1,42');`,
       expect(provider.invokeRequests[0]?.cwd).toBe(workdir);
       expect(existsSync(path.join(workdir, 'ready.txt'))).toBe(true);
     } finally {
+      const { rm } = await import('node:fs/promises');
+      await rm(sourceDir, { recursive: true, force: true });
+    }
+  });
+
+  it('dispatches docker environment recipes as sandbox runtime for CLI targets', async () => {
+    const sourceDir = mkdtempSync(path.join(tmpdir(), 'agentv-docker-environment-source-'));
+    const binDir = path.join(sourceDir, 'bin');
+    const dockerLog = path.join(sourceDir, 'docker.log');
+    mkdirSync(binDir, { recursive: true });
+    const dockerShim = path.join(binDir, 'docker');
+    writeFileSync(
+      dockerShim,
+      [
+        '#!/usr/bin/env sh',
+        `printf '%s\\n' "$*" >> ${JSON.stringify(dockerLog)}`,
+        'case "$1 $2" in',
+        '  "version --format") echo "24.0.0"; exit 0 ;;',
+        '  "image inspect") exit 0 ;;',
+        '  *) exit 0 ;;',
+        'esac',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    chmodSync(dockerShim, 0o755);
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${binDir}${path.delimiter}${previousPath ?? ''}`;
+
+    const resolvedTargets: ResolvedTarget[] = [];
+    const provider = new CapturingCliProvider('docker-cli', {
+      output: [{ role: 'assistant', content: 'OK' }],
+    });
+
+    try {
+      const results = await runEvaluation({
+        testFilePath: 'in-memory.yaml',
+        repoRoot: 'in-memory',
+        target: {
+          kind: 'cli',
+          name: 'docker-cli',
+          config: { command: 'agent --out {OUTPUT_FILE}' },
+        },
+        providerFactory: (resolved) => {
+          resolvedTargets.push(resolved);
+          return provider;
+        },
+        evaluators: evaluatorRegistry,
+        evalCases: [
+          {
+            ...baseTestCase,
+            environment: {
+              type: 'docker',
+              image: 'alpine:3.20',
+              workdir: '/app',
+              sourceDir,
+              env: { CASE_ENV: '1' },
+              mounts: [{ source: sourceDir, target: '/mnt/source', access: 'ro' }],
+              resources: { cpus: 2, memory: '512m' },
+              setup: {
+                command: ['sh', '-c', 'test "$AGENTV_ENVIRONMENT_WORKDIR" = /app'],
+                args: { fixture: 'ready' },
+              },
+            },
+          },
+        ],
+      });
+
+      expect(results).toHaveLength(1);
+      expect(provider.lastRequest?.cwd).toBe('/app');
+      const sandboxTarget = resolvedTargets.find(
+        (resolved) => resolved.runtime?.mode === 'sandbox',
+      );
+      expect(sandboxTarget?.runtime).toMatchObject({
+        mode: 'sandbox',
+        engine: 'docker',
+        image: 'alpine:3.20',
+        workdir: '/app',
+        host_cwd: sourceDir,
+        env: { CASE_ENV: '1', AGENTV_ENVIRONMENT_WORKDIR: '/app' },
+        memory: '512m',
+        cpus: 2,
+      });
+      expect(sandboxTarget?.runtime?.mounts).toContainEqual({
+        source: sourceDir,
+        target: '/mnt/source',
+        access: 'ro',
+      });
+      expect(sandboxTarget?.runtime?.mounts).toContainEqual({
+        source: path.resolve(tmpdir()),
+        target: path.resolve(tmpdir()),
+        access: 'rw',
+      });
+      expect(sandboxTarget?.runtime?.setup).toHaveLength(1);
+      expect(readFileSync(dockerLog, 'utf8')).toContain('image inspect alpine:3.20');
+    } finally {
+      process.env.PATH = previousPath;
+      const { rm } = await import('node:fs/promises');
+      await rm(sourceDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns structured unsupported results for docker environments with unsupported providers', async () => {
+    const sourceDir = mkdtempSync(path.join(tmpdir(), 'agentv-docker-unsupported-source-'));
+    const binDir = path.join(sourceDir, 'bin');
+    mkdirSync(binDir, { recursive: true });
+    const dockerShim = path.join(binDir, 'docker');
+    writeFileSync(
+      dockerShim,
+      [
+        '#!/usr/bin/env sh',
+        'case "$1 $2" in',
+        '  "version --format") echo "24.0.0"; exit 0 ;;',
+        '  "image inspect") exit 0 ;;',
+        '  *) exit 0 ;;',
+        'esac',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    chmodSync(dockerShim, 0o755);
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${binDir}${path.delimiter}${previousPath ?? ''}`;
+
+    try {
+      const results = await runEvaluation({
+        testFilePath: 'in-memory.yaml',
+        repoRoot: 'in-memory',
+        target: {
+          kind: 'codex-cli',
+          name: 'codex-docker',
+          graderTarget: 'grader',
+          config: { executable: 'codex' },
+        },
+        targets: [{ name: 'grader', provider: 'mock', response: '{}' }],
+        evaluators: evaluatorRegistry,
+        evalCases: [
+          {
+            ...baseTestCase,
+            environment: {
+              type: 'docker',
+              image: 'alpine:3.20',
+              workdir: '/app',
+              sourceDir,
+            },
+          },
+        ],
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.executionStatus).toBe('execution_error');
+      expect(results[0]?.failureStage).toBe('agent');
+      expect(results[0]?.failureReasonCode).toBe('target_sandbox_infra_failure');
+      expect(results[0]?.targetExecution).toMatchObject({
+        status: 'error',
+        runtimeMode: 'sandbox',
+        providerKind: 'codex-cli',
+        details: {
+          unsupported_provider: 'codex-cli',
+          supported_sandbox_provider: 'cli',
+        },
+      });
+    } finally {
+      process.env.PATH = previousPath;
       const { rm } = await import('node:fs/promises');
       await rm(sourceDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
Docker environment recipes now prepare a local Docker image/context and run generic CLI targets inside that environment with `environment.workdir` as the command cwd. The environment recipe remains separate from target/provider selection: Docker setup builds or pulls the image, produces a sandbox runtime for compatible CLI targets, and unsupported provider combinations return structured sandbox-infra results instead of falling back to host execution.

## Implementation Notes
- Supports `type: docker` recipes with `image`, `context`, `dockerfile`, `workdir`, `env`, `secrets`, `mounts`, `resources.cpus`, `resources.memory`, and `setup.command/setup.args/setup.env`.
- Uses the existing Docker workspace/provider plumbing for image availability and the existing sandbox runner for execution, with resource limits and the Docker host cwd threaded through.
- Adds a temp-dir mount so CLI `{PROMPT_FILE}` and `{OUTPUT_FILE}` paths remain available across the host/managed Docker boundary.
- Keeps host environment behavior unchanged and delays provider creation until after environment setup so Docker-derived runtime config is applied only when needed.

## Validation
- `bunx biome check packages/core/src/evaluation/environment/docker.ts packages/core/src/evaluation/workspace/setup.ts packages/core/src/evaluation/providers/sandbox-runner.ts packages/core/src/evaluation/orchestrator.ts packages/core/test/evaluation/environment/docker.test.ts packages/core/test/evaluation/orchestrator.test.ts`
- `bun test packages/core/test/evaluation/environment/docker.test.ts packages/core/test/evaluation/orchestrator.test.ts packages/core/test/evaluation/providers/cli.test.ts packages/core/test/evaluation/providers/sandbox-runtime.test.ts`
- `bun run typecheck`
- `git diff --check`

## Dogfood Evidence
Controlled Docker CLI target:
- Command: `bun apps/cli/src/cli.ts eval /tmp/agentv-docker-env-dogfood/docker-env.eval.yaml --targets /tmp/agentv-docker-env-dogfood/targets.yaml --target docker-cli --workers 1`
- Run ID: `2026-07-05T10-52-06-267Z`
- Result path: `.agentv/results/2026-07-05T10-52-06-267Z`
- Result: PASS 1/1, target provider `cli`, runtime `sandbox`, command cwd `/app`.

Live LLM grader with Docker CLI target:
- Command: `bun apps/cli/src/cli.ts eval /tmp/agentv-docker-env-dogfood/docker-env-live-grader.eval.yaml --targets /tmp/agentv-docker-env-dogfood/targets-live-grader.yaml --target docker-cli-live-graded --workers 1`
- Run ID: `2026-07-05T10-53-51-519Z`
- Result path: `.agentv/results/2026-07-05T10-53-51-519Z`
- Provider/target: target provider `cli`; grader target OpenAI-compatible provider via GitHub Models.
- Result: PASS 1/1, score 1.0, runtime `sandbox`, command cwd `/app`, exit code 0.

Private evidence was published to `agentv-private:evidence/av-noh3-2-4-docker-environment-runtime` at commit `bd0f659`.

## Post-Deploy Monitoring & Validation
After merge, validate the first environment docs/example PR against this behavior with one Docker recipe that uses an image and one that builds from context/dockerfile. Watch CI failures around sandbox runtime tests and CLI output-file handling, because those paths depend on the host temp-dir mount being available inside Docker.

## Related
Bead: av-noh3.2.4

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
