### PR TITLE
docs(agent): clarify matrix authoring boundaries

### DIFF
--- a/.agents/product-boundary.md
+++ b/.agents/product-boundary.md
@@ -37,6 +37,20 @@ Dashboard must not require the `px` CLI at runtime, must not query Phoenix datab
 
 AgentV transcript artifacts are not Phoenix-native conversation inputs. Model-call spans may contain cumulative input messages, so treating Phoenix span input as a linear transcript can duplicate or distort the conversation. Keep AgentV transcript/index/storage semantics in AgentV artifacts.
 
+## Promptfoo-Compatible Authoring Boundary
+
+AgentV should adopt Promptfoo-compatible eval matrix authoring where it strengthens repo-native evaluation, but Promptfoo is reference evidence rather than schema authority. The core mental model is `prompts x tests/vars x targets`, with repeat samples and retries applied as run policy after the authored matrix is resolved.
+
+Keep these AgentV-native boundaries explicit:
+
+- `targets` are systems under test. A target `id` is stable AgentV identity; `provider` inside the target names the backend or adapter kind.
+- Top-level Promptfoo `providers` is not the canonical AgentV authoring key.
+- Coding-agent testbeds use `environment` recipes for host/Docker substrate, setup, fixtures, services, and cwd. Do not make Promptfoo lifecycle `extensions` or public `workspace` authoring the canonical testbed contract.
+- Top-level `env` means provider/eval environment variables. `extensions` remain lifecycle hooks.
+- Reusable prompts, tests, defaults, and environments use field-local `file://` refs such as `prompts: file://...`, `tests: file://...`, and `environment: file://...`.
+- Grouping and Dashboard navigation use tags and run-bundle metadata, not experiment path buckets, Vercel path layout, or model-as-experiment grouping.
+- AgentV run bundles, traces, transcripts, datasets, indexes, and Git-backed artifacts stay AgentV-owned. Do not design an Opik export path or Phoenix projection path for those artifacts.
+
 ## Design Principles
 
 ### 1. Lightweight Core, Plugin Extensibility
@@ -72,7 +86,7 @@ Aim for the maximum feature surface with the minimum primitives.
 Before proposing a new feature, enumerate which existing primitives could achieve the same outcome when composed.
 
 - Oracle validation is a `cli` provider target that runs a reference solution through the same evaluators.
-- Snapshot MCP for benchmarks is frozen data in the workspace template plus `before_all` and `after_all` hooks.
+- Snapshot MCP for benchmarks is frozen data in the environment recipe plus `before_all` and `after_all` hooks.
 - Harness variant comparison is target hooks with different `before_each` setup scripts.
 - Skill evaluation is `tool-trajectory` plus `execution-metrics` plus `rubric` composed via `assert-set`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,48 @@ AgentV aims to be the repo-native, workspace-native evaluation framework for AI 
 - Adapter boundaries: integrate with Phoenix, Harbor, Opik, and provider-specific systems through narrow adapters instead of absorbing their concepts into core.
 - AI-native extensibility: keep the core small and composable so engineers and coding agents can extend it with plugins, wrappers, and harness-specific glue.
 
+Eval authoring mental model:
+
+- AgentV adopts Promptfoo-compatible matrix authoring where it helps: an eval expands `prompts x tests/vars x targets`, then applies repeat samples/retries as run policy. This is compatibility by composition, not a wholesale copy of Promptfoo's schema.
+- Author systems under test as `targets`. A target `id` is the stable AgentV identity; `provider` inside the target names the backend or adapter kind. Top-level Promptfoo `providers` is reference evidence, not the canonical AgentV authoring key.
+- Use `environment` recipes for coding-agent testbeds, including host/Docker setup, repo materialization, fixtures, services, and cwd. Do not use Promptfoo `extensions` or public `workspace` authoring as the canonical testbed contract.
+- Use top-level `env` for provider/eval environment variables. Use `extensions` for lifecycle hooks. Use field-local `file://` refs for reusable prompts, tests, defaults, and environments.
+- Use `tags` and run-bundle metadata for grouping and Dashboard navigation. Do not use experiment path buckets, Vercel path layout, or model-as-experiment grouping as canonical AgentV semantics.
+- AgentV run bundles, traces, transcripts, datasets, indexes, and Git-backed artifacts stay AgentV-owned. Do not design an Opik export path or Phoenix projection path for them; Phoenix correlation is link-out only when `external_trace` metadata already exists.
+
+Concrete matrix example:
+
+```yaml
+prompts:
+  - file://prompts/fix-bug.md
+  - file://prompts/add-test.md
+
+tests:
+  - vars:
+      issue: "Repair the failing parser case"
+      repo: "file://fixtures/parser"
+    assert:
+      - type: llm-rubric
+        value: "The answer identifies the parser bug and includes a test."
+  - vars:
+      issue: "Explain the flaky retry behavior"
+      repo: "file://fixtures/retry"
+
+targets:
+  - id: codex-host
+    provider: codex-cli
+    runtime: host
+  - id: claude-docker
+    provider: claude-cli
+    runtime: docker
+
+environment: file://.agentv/environments/local-repo.yaml
+tags:
+  experiment: prompt-compare
+```
+
+This produces eight authored target-case executions before repeat policy: 2 prompts x 2 `tests[].vars` cases x 2 targets.
+
 Phoenix boundary after the 2026-06-20 product decision:
 
 - AgentV-owned run bundles, traces, transcripts, datasets, experiments, indexes, and Git-backed artifacts are not exported or projected into Phoenix.

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -4,9 +4,9 @@ Shared domain vocabulary for this project — entities, named processes, and sta
 
 ## Providers and Targets
 
-**Provider** — an adapter plugin that connects AgentV's evaluation engine to a specific AI system (e.g., copilot CLI, copilot SDK, Claude API, pi). Each provider implements the request/response contract: given a test case, invoke the AI system and return its output. Providers are selected per-target in eval YAML and can be extended via the provider registry.
+**Provider** — an adapter plugin that connects AgentV's evaluation engine to a specific AI system (e.g., copilot CLI, copilot SDK, Claude API, pi). Each provider implements the request/response contract: given a test case, invoke the AI system and return its output. Providers are selected inside `targets[]` in eval YAML and can be extended via the provider registry. Top-level Promptfoo `providers` is useful reference evidence, but it is not the canonical AgentV authoring key.
 
-**Target** — The eval YAML or config declaration that activates a specific provider for an evaluation run. A target has a stable `id`, a `provider` backend kind, an optional `runtime`, and provider settings under `config`; field-level `file://` references can load prompts, defaults, or other config fragments at the boundary. A single eval file can declare multiple targets to compare AI systems side by side. Targets select agents/providers; they do not own the authored host/Docker testbed recipe.
+**Target** — The eval YAML or config declaration for a system under test. A target has a stable AgentV `id`, a `provider` backend or adapter kind, an optional `runtime`, and provider settings under `config`; field-level `file://` references can load prompts, defaults, or other config fragments at the boundary. A single eval file can declare multiple targets to compare AI systems side by side. Targets select agents/providers; they do not own the authored host/Docker testbed recipe.
 
 **Target runtime** — The placement/transport mode for invoking a target provider, such as host execution, sandbox/container placement, CLI subprocess, app-server protocol, RPC, or SDK child runner. Runtime describes how the selected agent is invoked. Advanced home/env/profile-style overlays are provider or runtime configuration details, not the authored testbed recipe. Runtime is separate from the environment that prepares files, services, and cwd.
 
@@ -14,13 +14,15 @@ Shared domain vocabulary for this project — entities, named processes, and sta
 
 ## Evaluation Model
 
-**Eval / Eval YAML** — The only composable and runnable AgentV authoring primitive. An eval YAML file can be a reusable task suite that owns task context, a wrapper eval that imports suites and binds top-level runtime policy, or a sidecar around raw JSONL cases. AgentV does not have a separate runnable `experiment.yaml` artifact.
+**Eval / Eval YAML** — The composable and runnable AgentV authoring primitive. An eval YAML file describes the prompts, tests, variables, targets, assertions, environments, tags, and run policy for an evaluation. AgentV does not have a separate runnable `experiment.yaml` artifact.
 
-**Task suite** — Eval YAML that owns what is being tested: prompts, datasets, input files, fixtures, `environment`, assertions, expected references, and judge criteria. It can run directly or be imported by another eval with `tests[].include` and `type: suite`.
+**Matrix authoring** — The Promptfoo-compatible shape AgentV adopts where useful: `prompts x tests/vars x targets`, with repeat samples and retries applied as run policy after the authored matrix is resolved. AgentV uses this matrix model without copying Promptfoo wholesale. AgentV-native boundaries remain: `targets` identify systems under test, `provider` names the backend/adapter kind inside a target, `environment` recipes prepare coding-agent testbeds, `env` carries provider/eval variables, `extensions` are lifecycle hooks, reusable content uses field-local `file://` refs, and grouping uses tags plus run-bundle metadata.
 
-**Raw case file** — YAML, JSONL, or directory case data imported with `tests: ./cases.yaml`, string shorthand, or `type: tests`. Raw cases are reusable data inputs; they do not carry imported suite context such as shared `environment`, shared `input`, or shared `assertions`.
+**Task suite** — Eval YAML that owns what is being tested: prompts, datasets, input files, fixtures, `environment`, assertions, expected references, and judge criteria. It can run directly or share reusable parts through field-local `file://` refs such as `prompts: file://...`, `tests: file://...`, `defaults: file://...`, and `environment: file://...`.
 
-**Wrapper eval** — Eval YAML whose main job is to import task suites and bind top-level runtime policy such as target selection, repeat count, timeout, budget, and thresholds. Wrapper evals may live under an `experiments/` directory, but that path is an optional user-owned convention and AgentV does not infer behavior from it. A wrapper that imports suites with `type: suite` does not define parent `environment`; imported suites own task environment unless a future scoped feature explicitly defines environment override semantics.
+**Raw case file** — YAML, JSONL, or directory case data loaded with `tests: file://./cases.yaml`, string shorthand, or another supported field-local tests reference. Raw cases are reusable data inputs; they do not carry imported suite context such as shared `environment`, shared `input`, or shared `assertions`.
+
+**Policy eval** — Eval YAML whose main job is to bind top-level runtime policy such as target selection, repeat count, timeout, budget, thresholds, and tags around explicit prompts/tests/targets refs. Policy evals may live under an `experiments/` directory, but that path is an optional user-owned convention and AgentV does not infer behavior from it. Use tags and run-bundle metadata for grouping rather than experiment path buckets, Vercel path layout, or model-as-experiment grouping.
 
 **Experiment** — A string metadata/run-grouping label such as `baseline`, `candidate`, `with_skills`, or `without_skills`. It is not a runtime-policy object and not a result path namespace. Experiment is expressed as the reserved `tags.experiment` key (see **Tags**); there is no top-level `experiment` field. Runtime policy belongs in top-level eval fields or target objects; the experiment label is recorded in `summary.json` and `.internal/index.jsonl` for Dashboard grouping and comparison. Lifecycle setup belongs in `extensions` or target hooks, not in a separate experiment artifact.
 
@@ -72,7 +74,7 @@ env:
   OPENAI_API_KEY: "{{ env.OPENAI_API_KEY }}"
 ```
 
-**Run bundle** — A committed local result directory at `.agentv/results/<run_id>/`. `summary.json` records run metadata such as `run_id` and `experiment`; `.internal/index.jsonl` records per-case rows.
+**Run bundle** — A committed local result directory at `.agentv/results/<run_id>/`. `summary.json` records run metadata such as `run_id` and `experiment`; `.internal/index.jsonl` records per-case rows. Run bundles, traces, transcripts, datasets, indexes, and Git-backed artifacts stay AgentV-owned. They are not discovered through an Opik export path or a Phoenix projection path; optional Phoenix integration is link-out correlation only through safe `external_trace` metadata.
 
 **Run manifest** — The root `summary.json` file in a run bundle. It owns aggregate run metadata and rollups such as `run_id`, `experiment`, timestamps, planned/completed counts, pass rate, score summaries, duration, tokens, and cost.
 


### PR DESCRIPTION
## Summary
Future AgentV workers now have a canonical agent-facing mental model for Promptfoo-compatible matrix authoring without needing Beads or chat context. The docs distinguish the compatible matrix shape from AgentV-native boundaries: targets own stable system-under-test identity, providers stay backend adapters inside targets, environments own coding-agent testbeds, and tags/run-bundle metadata own grouping.

The guidance also makes the artifact boundary explicit: AgentV-owned run bundles, traces, transcripts, datasets, indexes, and Git-backed artifacts stay AgentV-owned, with no Opik export path or Phoenix projection path.

## Related
Related: av-kfik.44

## Verification
- `git diff --check`
- `bunx biome check AGENTS.md CONCEPTS.md .agents/product-boundary.md`

No repo `check-links` or docs-link script is exposed in `package.json`; broader local `bun run verify` was skipped because this is docs-only and GitHub Actions are the merge gate.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
