### PR TITLE
feat(assertions): add promptfoo-compatible skill-used

### DIFF
--- a/packages/core/src/evaluation/graders/index.ts
+++ b/packages/core/src/evaluation/graders/index.ts
@@ -55,6 +55,7 @@ export type { LlmGraderOptions } from './llm-grader.js';
 export { formatToolCalls } from './format-tool-calls.js';
 
 export { SkillTriggerGrader } from './skill-trigger.js';
+export { SkillUsedGrader } from './skill-used.js';
 
 export { assembleLlmGraderPrompt } from './llm-grader-prompt.js';
 export type { LlmGraderPromptAssembly } from './llm-grader-prompt.js';

--- a/packages/core/src/evaluation/graders/skill-used.ts
+++ b/packages/core/src/evaluation/graders/skill-used.ts
@@ -1,0 +1,249 @@
+import type { SkillUsedGraderConfig } from '../types.js';
+import type { EvaluationContext, EvaluationScore, Grader } from './types.js';
+
+interface SkillCountValue {
+  readonly max?: number;
+  readonly min?: number;
+  readonly name?: string;
+  readonly pattern?: string;
+}
+
+interface SkillCallEntry {
+  readonly name: string;
+  readonly input?: unknown;
+  readonly path?: string;
+  readonly source?: string;
+  readonly isError?: boolean;
+  readonly is_error?: boolean;
+}
+
+type ResolvedSkillMatchers =
+  | { readonly kind: 'list'; readonly matchers: readonly { readonly name: string }[] }
+  | { readonly kind: 'count'; readonly matcher: SkillCountValue };
+
+export class SkillUsedGrader implements Grader {
+  readonly kind: 'skill-used' | 'not-skill-used';
+
+  constructor(private readonly config: SkillUsedGraderConfig) {
+    this.kind = config.type;
+  }
+
+  evaluate(context: EvaluationContext): EvaluationScore {
+    const inverse = this.config.type === 'not-skill-used' || this.config.negate === true;
+    const skillCalls = getSkillCalls(context);
+    const actualSkills = skillCalls.map(formatSkillCall);
+    const expected = resolveSkillMatchers(this.config.value);
+
+    if (expected.kind === 'list') {
+      return handleListSkillAssertion({
+        config: this.config,
+        inverse,
+        skillCalls,
+        actualSkills,
+        expected,
+      });
+    }
+
+    return handleCountSkillAssertion({
+      config: this.config,
+      inverse,
+      skillCalls,
+      actualSkills,
+      matcher: expected.matcher,
+    });
+  }
+}
+
+function getSkillCalls(context: EvaluationContext): SkillCallEntry[] {
+  const responseMetadata = context.responseMetadata ?? {};
+  const metadata = responseMetadata.metadata;
+  const rawSkillCalls =
+    responseMetadata.skill_calls ??
+    responseMetadata.skillCalls ??
+    (isRecord(metadata) ? (metadata.skillCalls ?? metadata.skill_calls) : undefined);
+
+  if (!Array.isArray(rawSkillCalls)) {
+    return [];
+  }
+
+  return rawSkillCalls.filter(
+    (entry): entry is SkillCallEntry =>
+      isRecord(entry) &&
+      typeof entry.name === 'string' &&
+      entry.name.trim().length > 0 &&
+      entry.isError !== true &&
+      entry.is_error !== true,
+  );
+}
+
+function matchesSkill(skillCall: SkillCallEntry, matcher: { name?: string; pattern?: string }) {
+  if (matcher.name && skillCall.name !== matcher.name) {
+    return false;
+  }
+
+  if (matcher.pattern && !matchesPattern(skillCall.name, matcher.pattern)) {
+    return false;
+  }
+
+  return true;
+}
+
+function formatSkillCall(skillCall: SkillCallEntry): string {
+  const details = [skillCall.source, skillCall.path].filter(Boolean).join(', ');
+  return details ? `${skillCall.name} (${details})` : skillCall.name;
+}
+
+function resolveSkillMatchers(value: unknown): ResolvedSkillMatchers {
+  const normalizeText = (text: unknown) => (typeof text === 'string' ? text.trim() : undefined);
+  const validateCount = (field: 'max' | 'min', count: unknown) => {
+    if (!Number.isFinite(count) || !Number.isInteger(count) || (count as number) < 0) {
+      throw new Error(`skill-used assertion object ${field} must be a finite non-negative integer`);
+    }
+  };
+
+  if (typeof value === 'string' && value.trim()) {
+    const name = value.trim();
+    return {
+      kind: 'list',
+      matchers: [{ name }],
+    };
+  }
+
+  if (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((item) => typeof item === 'string' && item.trim())
+  ) {
+    return {
+      kind: 'list',
+      matchers: value.map((item) => ({ name: item.trim() })),
+    };
+  }
+
+  if (isRecord(value)) {
+    const name = normalizeText(value.name);
+    const pattern = normalizeText(value.pattern);
+    if (!name && !pattern) {
+      throw new Error('skill-used assertion object must include a name or pattern property');
+    }
+    if ('min' in value) {
+      validateCount('min', value.min);
+    }
+    if ('max' in value) {
+      validateCount('max', value.max);
+    }
+    if (typeof value.min === 'number' && typeof value.max === 'number' && value.max < value.min) {
+      throw new Error('skill-used assertion object max must be greater than or equal to min');
+    }
+
+    return {
+      kind: 'count',
+      matcher: {
+        max: typeof value.max === 'number' ? value.max : undefined,
+        min: typeof value.min === 'number' ? value.min : undefined,
+        name,
+        pattern,
+      },
+    };
+  }
+
+  throw new Error('skill-used assertion must have a string, string array, or object value');
+}
+
+function handleListSkillAssertion(params: {
+  readonly config: SkillUsedGraderConfig;
+  readonly inverse: boolean;
+  readonly skillCalls: readonly SkillCallEntry[];
+  readonly actualSkills: readonly string[];
+  readonly expected: Extract<ResolvedSkillMatchers, { kind: 'list' }>;
+}): EvaluationScore {
+  const { config, inverse, skillCalls, actualSkills, expected } = params;
+  const missing = expected.matchers.filter(
+    (matcher) => !skillCalls.some((skillCall) => matchesSkill(skillCall, matcher)),
+  );
+  const matched = expected.matchers.filter((matcher) =>
+    skillCalls.some((skillCall) => matchesSkill(skillCall, matcher)),
+  );
+  const pass = inverse ? matched.length === 0 : missing.length === 0;
+  const expectedSkills = expected.matchers.map((matcher) => matcher.name);
+  const actualSummary = actualSkills.length > 0 ? actualSkills.join(', ') : '(none)';
+
+  let reason: string;
+  if (inverse) {
+    reason = pass
+      ? `Forbidden skill(s) were not used: ${expectedSkills.join(', ')}`
+      : `Forbidden skill(s) were used: ${matched.map((matcher) => matcher.name).join(', ')}. Actual skills: ${actualSummary}`;
+  } else if (pass) {
+    reason = `Observed required skill(s): ${expectedSkills.join(', ')}. Actual skills: ${actualSummary}`;
+  } else {
+    reason = `Missing required skill(s): ${missing.map((matcher) => matcher.name).join(', ')}. Actual skills: ${actualSummary}`;
+  }
+
+  return skillScore(config, pass, reason);
+}
+
+function handleCountSkillAssertion(params: {
+  readonly config: SkillUsedGraderConfig;
+  readonly inverse: boolean;
+  readonly skillCalls: readonly SkillCallEntry[];
+  readonly actualSkills: readonly string[];
+  readonly matcher: SkillCountValue;
+}): EvaluationScore {
+  const { config, inverse, skillCalls, actualSkills, matcher } = params;
+  const hasExplicitMin = matcher.min !== undefined;
+  const hasExplicitMax = matcher.max !== undefined;
+  const min = matcher.min ?? (hasExplicitMax ? 0 : 1);
+  const max = matcher.max;
+  const matchingSkillCalls = skillCalls.filter((skillCall) => matchesSkill(skillCall, matcher));
+  const count = matchingSkillCalls.length;
+  const matcherLabel = matcher.pattern || matcher.name || '*';
+
+  if (inverse) {
+    if (hasExplicitMin || (hasExplicitMax && max !== 0)) {
+      throw new Error(
+        'not-skill-used object assertions only support name/pattern with no count bounds, or max: 0',
+      );
+    }
+
+    const pass = count === 0;
+    const actualSummary = actualSkills.length > 0 ? actualSkills.join(', ') : '(none)';
+    const reason = pass
+      ? `Forbidden skill "${matcherLabel}" was not used. Actual skills: ${actualSummary}`
+      : `Forbidden skill "${matcherLabel}" was used ${count} time(s). Matches: ${matchingSkillCalls.map(formatSkillCall).join(', ')}`;
+    return skillScore(config, pass, reason);
+  }
+
+  const pass = count >= min && (max === undefined || count <= max);
+  let reason = `Matched skill "${matcherLabel}" ${count} time(s)`;
+  reason += max === undefined ? ` (expected at least ${min})` : ` (expected ${min}-${max})`;
+  if (matchingSkillCalls.length > 0) {
+    reason += `. Matches: ${matchingSkillCalls.map(formatSkillCall).join(', ')}`;
+  }
+
+  return skillScore(config, pass, reason);
+}
+
+function skillScore(config: SkillUsedGraderConfig, pass: boolean, reason: string): EvaluationScore {
+  return {
+    score: pass ? 1 : 0,
+    verdict: pass ? 'pass' : 'fail',
+    reason,
+    assertions: [{ text: reason, passed: pass }],
+    expectedAspectCount: 1,
+    details: {
+      assertion_type: config.type,
+    },
+  };
+}
+
+function matchesPattern(skillName: string, pattern: string): boolean {
+  const regexPattern = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.');
+  return new RegExp(`^${regexPattern}$`, 'i').test(skillName);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/core/src/evaluation/loaders/grader-parser.ts
+++ b/packages/core/src/evaluation/loaders/grader-parser.ts
@@ -106,7 +106,6 @@ const UNSUPPORTED_PROMPTFOO_ASSERTION_TYPES = new Set([
   'human',
   'max-score',
   'tool-call-f1',
-  'skill-used',
   'trajectory:goal-success',
   'trajectory:tool-args-match',
   'trajectory:step-count',
@@ -954,6 +953,27 @@ async function parseGraderList(
       };
 
       pushEvaluator(config);
+      continue;
+    }
+
+    if (typeValue === 'skill-used' || typeValue === 'not-skill-used') {
+      const weight = validateWeight(rawEvaluator.weight, name, evalId);
+      const { required, min_score } = parseRequiredAndMinScore(
+        rawEvaluator.required,
+        (rawEvaluator as Record<string, unknown>).min_score as JsonValue | undefined,
+        name,
+        evalId,
+      );
+
+      pushEvaluator({
+        name,
+        type: typeValue,
+        value: rawEvaluator.value as import('../types.js').SkillUsedGraderConfig['value'],
+        ...(weight !== undefined ? { weight } : {}),
+        ...(required !== undefined ? { required } : {}),
+        ...(min_score !== undefined ? { min_score } : {}),
+        ...(negate !== undefined ? { negate } : {}),
+      });
       continue;
     }
 
@@ -1915,6 +1935,17 @@ function generateAssertionName(typeValue: string, rawEvaluator: JsonObject): str
   const arrayValue = Array.isArray(rawEvaluator.value) ? rawEvaluator.value : undefined;
 
   switch (typeValue) {
+    case 'skill-used':
+    case 'not-skill-used': {
+      const rawValue = rawEvaluator.value;
+      if (typeof rawValue === 'string' && rawValue.trim()) {
+        return `${typeValue}-${rawValue.trim()}`;
+      }
+      if (Array.isArray(rawValue)) {
+        return `${typeValue}-${rawValue.length}`;
+      }
+      return typeValue;
+    }
     case 'skill-trigger': {
       const skillValue = asString(rawEvaluator.skill);
       return skillValue ? `skill-trigger-${skillValue}` : 'skill-trigger';

--- a/packages/core/src/evaluation/orchestrator.ts
+++ b/packages/core/src/evaluation/orchestrator.ts
@@ -2657,6 +2657,9 @@ function buildProviderResponseTransformMetadata(
 ): JsonObject | undefined {
   const metadata: Record<string, JsonValue> = {};
   const fields: Array<readonly [string, unknown]> = [
+    ['metadata', response.metadata],
+    ['skill_calls', response.metadata?.skillCalls],
+    ['attempted_skill_calls', response.metadata?.attemptedSkillCalls],
     ['raw', response.raw],
     ['usage', response.usage],
     ['token_usage', response.tokenUsage],

--- a/packages/core/src/evaluation/providers/claude-cli.ts
+++ b/packages/core/src/evaluation/providers/claude-cli.ts
@@ -11,6 +11,7 @@ import { recordClaudeLogEntry } from './claude-log-tracker.js';
 import { resolveDefaultProviderLogDir } from './log-directory.js';
 import { normalizeToolCall } from './normalize-tool-call.js';
 import { buildPromptDocument, normalizeInputFiles } from './preread.js';
+import { deriveSkillCallsFromToolCalls, skillCallMetadata } from './skill-calls.js';
 import { buildTargetExecutionEnvelope } from './target-execution.js';
 import type { ClaudeResolvedConfig } from './targets.js';
 import type {
@@ -187,6 +188,7 @@ export class ClaudeCliProvider implements Provider {
           args,
           exitCode: result.exitCode,
         },
+        metadata: skillCallMetadata(deriveSkillCallsFromToolCalls(completedToolCalls)),
         output,
         tokenUsage,
         costUsd,

--- a/packages/core/src/evaluation/providers/claude-sdk.ts
+++ b/packages/core/src/evaluation/providers/claude-sdk.ts
@@ -9,6 +9,7 @@ import { recordClaudeLogEntry } from './claude-log-tracker.js';
 import { resolveDefaultProviderLogDir } from './log-directory.js';
 import { normalizeToolCall } from './normalize-tool-call.js';
 import { buildPromptDocument, normalizeInputFiles } from './preread.js';
+import { deriveSkillCallsFromToolCalls, skillCallMetadata } from './skill-calls.js';
 import type { ClaudeResolvedConfig } from './targets.js';
 import type {
   Message,
@@ -213,6 +214,7 @@ export class ClaudeSdkProvider implements Provider {
           model: this.config.model,
           logFile: logger?.filePath,
         },
+        metadata: skillCallMetadata(deriveSkillCallsFromToolCalls(completedToolCalls)),
         output,
         tokenUsage,
         costUsd,

--- a/packages/core/src/evaluation/providers/claude.ts
+++ b/packages/core/src/evaluation/providers/claude.ts
@@ -8,6 +8,7 @@ import { extractTextContent, toContentArray } from './claude-content.js';
 import { recordClaudeLogEntry } from './claude-log-tracker.js';
 import { resolveDefaultProviderLogDir } from './log-directory.js';
 import { buildPromptDocument, normalizeInputFiles } from './preread.js';
+import { deriveSkillCallsFromToolCalls, skillCallMetadata } from './skill-calls.js';
 import type { ClaudeResolvedConfig } from './targets.js';
 import type {
   Message,
@@ -210,6 +211,7 @@ export class ClaudeProvider implements Provider {
           model: this.config.model,
           logFile: logger?.filePath,
         },
+        metadata: skillCallMetadata(deriveSkillCallsFromToolCalls(completedToolCalls)),
         output,
         tokenUsage,
         costUsd,

--- a/packages/core/src/evaluation/providers/codex-cli.ts
+++ b/packages/core/src/evaluation/providers/codex-cli.ts
@@ -12,6 +12,7 @@ import { trackChild } from '../../runtime/child-tracker.js';
 import { recordCodexLogEntry } from './codex-log-tracker.js';
 import { resolveDefaultProviderLogDir } from './log-directory.js';
 import { buildPromptDocument, normalizeInputFiles } from './preread.js';
+import { deriveSkillCallsFromMessages, skillCallMetadata } from './skill-calls.js';
 import type { CodexResolvedConfig } from './targets.js';
 import type {
   Message,
@@ -232,6 +233,7 @@ export class CodexCliProvider implements Provider {
           inputFiles,
           logFile: logger?.filePath,
         },
+        metadata: skillCallMetadata(deriveSkillCallsFromMessages(messages)),
         output: messages,
         durationMs,
         targetExecution: {

--- a/packages/core/src/evaluation/providers/codex.ts
+++ b/packages/core/src/evaluation/providers/codex.ts
@@ -8,6 +8,7 @@ import { recordCodexLogEntry } from './codex-log-tracker.js';
 import { resolveDefaultProviderLogDir } from './log-directory.js';
 import { normalizeToolCall } from './normalize-tool-call.js';
 import { buildPromptDocument, normalizeInputFiles } from './preread.js';
+import { deriveSkillCallsFromToolCalls, skillCallMetadata } from './skill-calls.js';
 import type { CodexResolvedConfig } from './targets.js';
 import type {
   Message,
@@ -176,6 +177,7 @@ export class CodexProvider implements Provider {
           model: this.config.model,
           logFile: logger?.filePath,
         },
+        metadata: skillCallMetadata(deriveSkillCallsFromToolCalls(completedToolCalls)),
         output,
         tokenUsage,
         durationMs,

--- a/packages/core/src/evaluation/providers/sdk-child-protocol.ts
+++ b/packages/core/src/evaluation/providers/sdk-child-protocol.ts
@@ -72,6 +72,7 @@ export interface SdkChildErrorWire {
 export interface SdkChildProviderResponseWire {
   readonly raw?: unknown;
   readonly usage?: JsonObject;
+  readonly metadata?: ProviderResponse['metadata'];
   readonly output?: readonly Message[];
   readonly token_usage?: ProviderTokenUsage;
   readonly cost_usd?: number;
@@ -142,6 +143,7 @@ export function providerResponseToWire(response: ProviderResponse): SdkChildProv
   return {
     raw: response.raw,
     usage: response.usage,
+    metadata: response.metadata,
     output: response.output,
     token_usage: response.tokenUsage,
     cost_usd: response.costUsd,
@@ -157,6 +159,7 @@ export function providerResponseFromWire(response: SdkChildProviderResponseWire)
   return {
     raw: response.raw,
     usage: response.usage,
+    metadata: response.metadata,
     output: response.output,
     tokenUsage: response.token_usage,
     costUsd: response.cost_usd,

--- a/packages/core/src/evaluation/providers/skill-calls.ts
+++ b/packages/core/src/evaluation/providers/skill-calls.ts
@@ -1,0 +1,170 @@
+import type { Message, SkillCall, ToolCall } from './types.js';
+
+const SKILL_PATH_PATTERN =
+  /(?:^|[/"'\s])(?:\.agents\/)?skills\/([^/"'\s]+)\/SKILL\.md(?:$|[)"'\s,;:])/g;
+
+export function deriveSkillCallsFromMessages(
+  messages: readonly Message[] | undefined,
+): readonly SkillCall[] {
+  if (!messages) {
+    return [];
+  }
+  return deriveSkillCallsFromToolCalls(messages.flatMap((message) => message.toolCalls ?? []));
+}
+
+export function deriveSkillCallsFromToolCalls(
+  toolCalls: readonly ToolCall[] | undefined,
+): readonly SkillCall[] {
+  if (!toolCalls) {
+    return [];
+  }
+
+  const skillCalls: SkillCall[] = [];
+  const heuristicKeys = new Set<string>();
+
+  const pushHeuristic = (entry: SkillCall) => {
+    const key = `${entry.name}\0${entry.path ?? ''}\0${entry.source ?? ''}`;
+    if (heuristicKeys.has(key)) {
+      return;
+    }
+    heuristicKeys.add(key);
+    skillCalls.push(entry);
+  };
+
+  for (const toolCall of toolCalls) {
+    const toolName = toolCall.tool.toLowerCase();
+    const input = asRecord(toolCall.input);
+    const isError = isErroredToolCall(toolCall);
+
+    if (toolName === 'skill') {
+      const skillName = normalizeSkillName(input?.skill ?? input?.name);
+      if (skillName) {
+        skillCalls.push(
+          dropUndefined({ name: skillName, input: toolCall.input, source: 'tool', isError }),
+        );
+      }
+      continue;
+    }
+
+    if (toolName === 'read') {
+      const path = normalizeText(input?.file_path ?? input?.path ?? input?.filePath);
+      const skillName = path ? skillNameFromPath(path) : undefined;
+      if (skillName) {
+        pushHeuristic(
+          dropUndefined({
+            name: skillName,
+            input: toolCall.input,
+            path,
+            source: 'heuristic',
+            isError,
+          }),
+        );
+      }
+      continue;
+    }
+
+    if (toolName === 'bash') {
+      const command = normalizeText(input?.command);
+      if (command) {
+        for (const candidate of skillPathCandidates(command)) {
+          pushHeuristic(
+            dropUndefined({
+              name: candidate.name,
+              input: toolCall.input,
+              path: candidate.path,
+              source: 'heuristic',
+              isError,
+            }),
+          );
+        }
+      }
+    }
+
+    if (toolCall.output !== undefined) {
+      const outputText =
+        typeof toolCall.output === 'string' ? toolCall.output : JSON.stringify(toolCall.output);
+      for (const candidate of skillPathCandidates(outputText)) {
+        pushHeuristic(
+          dropUndefined({
+            name: candidate.name,
+            path: candidate.path,
+            source: 'heuristic',
+            isError,
+          }),
+        );
+      }
+    }
+  }
+
+  return skillCalls;
+}
+
+export function skillCallMetadata(
+  skillCalls: readonly SkillCall[],
+): ProviderResponseSkillMetadata | undefined {
+  if (skillCalls.length === 0) {
+    return undefined;
+  }
+  return { skillCalls };
+}
+
+type ProviderResponseSkillMetadata = {
+  readonly skillCalls: readonly SkillCall[];
+};
+
+function skillPathCandidates(text: string): Array<{ name: string; path: string }> {
+  const candidates = new Map<string, { name: string; path: string }>();
+  for (const rawToken of text.split(/\s+/)) {
+    const token = rawToken.replace(/^[`"'([{<]+|[`"',;:)\]}>]+$/g, '').replace(/\\/g, '/');
+    const match = token.match(/(?:^|\/)(?:\.agents\/)?skills\/([^/\s]+)\/SKILL\.md$/);
+    if (match && isValidSkillName(match[1])) {
+      candidates.set(token, { name: match[1], path: token });
+    }
+  }
+
+  for (const match of text.replace(/\\/g, '/').matchAll(SKILL_PATH_PATTERN)) {
+    const pathMatch = match[0].match(/(?:\.agents\/)?skills\/([^/"'\s]+)\/SKILL\.md/);
+    const name = pathMatch?.[1];
+    if (name && isValidSkillName(name)) {
+      candidates.set(pathMatch[0], { name, path: pathMatch[0] });
+    }
+  }
+
+  return Array.from(candidates.values());
+}
+
+function skillNameFromPath(path: string): string | undefined {
+  const normalized = path.replace(/\\/g, '/');
+  const match = normalized.match(/(?:^|\/)(?:\.agents\/)?skills\/([^/\s]+)\/SKILL\.md$/);
+  const name = match?.[1];
+  return name && isValidSkillName(name) ? name : undefined;
+}
+
+function isErroredToolCall(toolCall: ToolCall): boolean | undefined {
+  if (toolCall.status === undefined || toolCall.status === 'ok' || toolCall.status === 'unknown') {
+    return undefined;
+  }
+  return true;
+}
+
+function normalizeSkillName(value: unknown): string | undefined {
+  return normalizeText(value);
+}
+
+function normalizeText(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function isValidSkillName(name: string): boolean {
+  return /^[A-Za-z0-9._:-]+$/.test(name);
+}
+
+function dropUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined)) as T;
+}

--- a/packages/core/src/evaluation/providers/types.ts
+++ b/packages/core/src/evaluation/providers/types.ts
@@ -215,6 +215,28 @@ export interface ToolCall {
 }
 
 /**
+ * Normalized provider skill-call metadata.
+ *
+ * This mirrors Promptfoo's `providerResponse.metadata.skillCalls` semantics:
+ * provider/import adapters populate entries from explicit provider events where
+ * possible, or from normalized tool-call evidence when the provider lacks a
+ * first-class skill event. Assertions consume this read model instead of
+ * scanning transcripts.
+ */
+export interface SkillCall {
+  /** Stable skill name. */
+  readonly name: string;
+  /** Original provider/tool input when available. */
+  readonly input?: unknown;
+  /** Skill file path or resolved descriptor path when available. */
+  readonly path?: string;
+  /** Evidence source such as `tool` or `heuristic`. */
+  readonly source?: string;
+  /** Whether the provider reported the skill attempt as errored. */
+  readonly isError?: boolean;
+}
+
+/**
  * An output message from agent execution.
  * Represents a single message in the conversation with optional tool calls.
  */
@@ -342,6 +364,10 @@ export interface ProviderStepInfo {
 export interface ProviderResponse {
   readonly raw?: unknown;
   readonly usage?: JsonObject;
+  readonly metadata?: Record<string, unknown> & {
+    readonly skillCalls?: readonly SkillCall[];
+    readonly attemptedSkillCalls?: readonly SkillCall[];
+  };
   readonly targetExecution?: TargetExecutionEnvelope;
   /** Output messages from agent execution (primary source for tool trajectory) */
   readonly output?: readonly Message[];

--- a/packages/core/src/evaluation/registry/builtin-graders.ts
+++ b/packages/core/src/evaluation/registry/builtin-graders.ts
@@ -15,6 +15,7 @@ import {
   LlmGrader,
   ScriptGrader,
   SkillTriggerGrader,
+  SkillUsedGrader,
   TokenUsageGrader,
   ToolTrajectoryGrader,
   runContainsAllAssertion,
@@ -64,6 +65,7 @@ import type {
   ScriptGraderConfig,
   SimilarGraderConfig,
   SkillTriggerGraderConfig,
+  SkillUsedGraderConfig,
   StartsWithGraderConfig,
   TokenUsageGraderConfig,
 } from '../types.js';
@@ -255,6 +257,11 @@ export const skillTriggerFactory: GraderFactoryFn = (config) => {
   return new SkillTriggerGrader(config as SkillTriggerGraderConfig);
 };
 
+/** Factory for Promptfoo-compatible `skill-used` and `not-skill-used` evaluators. */
+export const skillUsedFactory: GraderFactoryFn = (config) => {
+  return new SkillUsedGrader(config as SkillUsedGraderConfig);
+};
+
 /** Factory for `contains` deterministic assertion. */
 export const containsFactory: GraderFactoryFn = (config) => {
   const c = config as ContainsGraderConfig;
@@ -424,6 +431,8 @@ export function createBuiltinRegistry(): GraderRegistry {
     .register('cost', costFactory)
     .register('token-usage', tokenUsageFactory)
     .register('execution-metrics', executionMetricsFactory)
+    .register('skill-used', skillUsedFactory)
+    .register('not-skill-used', skillUsedFactory)
     .register('skill-trigger', skillTriggerFactory)
     .register('assert-set', assertSetFactory)
     .register('contains', containsFactory)

--- a/packages/core/src/evaluation/replay-fixtures.ts
+++ b/packages/core/src/evaluation/replay-fixtures.ts
@@ -16,6 +16,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { z } from 'zod';
 
+import { deriveSkillCallsFromMessages, skillCallMetadata } from './providers/skill-calls.js';
 import type { ResolvedTarget } from './providers/targets.js';
 import type { Message, ProviderResponse, ProviderTokenUsage, ToolCall } from './providers/types.js';
 import type { EvalTest } from './types.js';
@@ -403,6 +404,7 @@ export function replayFixtureRecordToProviderResponse(
 ): ProviderResponse {
   return {
     output: record.output,
+    metadata: skillCallMetadata(deriveSkillCallsFromMessages(record.output)),
     tokenUsage: record.tokenUsage,
     costUsd: record.costUsd,
     durationMs: record.durationMs,

--- a/packages/core/src/evaluation/replay-trace-envelopes.ts
+++ b/packages/core/src/evaluation/replay-trace-envelopes.ts
@@ -10,6 +10,7 @@
  */
 
 import { readFile } from 'node:fs/promises';
+import { deriveSkillCallsFromMessages, skillCallMetadata } from './providers/skill-calls.js';
 import type { ProviderResponse } from './providers/types.js';
 import {
   type ReplayFixtureLookup,
@@ -83,6 +84,7 @@ export function traceEnvelopeReplayRecordToProviderResponse(
 
   return {
     output,
+    metadata: skillCallMetadata(deriveSkillCallsFromMessages(output)),
     tokenUsage: summary.tokenUsage,
     costUsd: summary.costUsd,
     durationMs: summary.durationMs,

--- a/packages/core/src/evaluation/replay-transcripts.ts
+++ b/packages/core/src/evaluation/replay-transcripts.ts
@@ -12,6 +12,7 @@ import {
   groupTranscriptJsonLines,
   readTranscriptJsonl,
 } from '../import/types.js';
+import { deriveSkillCallsFromMessages, skillCallMetadata } from './providers/skill-calls.js';
 import type { ProviderResponse } from './providers/types.js';
 import type { ReplayFixtureLookup } from './replay-fixtures.js';
 
@@ -49,6 +50,7 @@ export function transcriptReplayRecordToProviderResponse(
   const entry = record.entry;
   return {
     output: entry.messages,
+    metadata: skillCallMetadata(deriveSkillCallsFromMessages(entry.messages)),
     tokenUsage: entry.tokenUsage,
     durationMs: entry.durationMs,
     costUsd: entry.costUsd ?? undefined,

--- a/packages/core/src/evaluation/types.ts
+++ b/packages/core/src/evaluation/types.ts
@@ -180,6 +180,8 @@ const GRADER_KIND_VALUES = [
   'script',
   'llm-grader',
   'tool-trajectory',
+  'skill-used',
+  'not-skill-used',
   'field-accuracy',
   'latency',
   'cost',
@@ -906,6 +908,27 @@ export type SkillTriggerGraderConfig = {
   readonly negate?: boolean;
 };
 
+export type SkillUsedValue =
+  | string
+  | readonly string[]
+  | {
+      readonly name?: string;
+      readonly pattern?: string;
+      readonly min?: number;
+      readonly max?: number;
+    };
+
+export type SkillUsedGraderConfig = {
+  readonly name: string;
+  readonly type: 'skill-used' | 'not-skill-used';
+  readonly value: SkillUsedValue;
+  readonly weight?: number;
+  readonly required?: boolean;
+  /** Minimum score (0-1) for this evaluator to pass. Independent of `required` gate. */
+  readonly min_score?: number;
+  readonly negate?: boolean;
+};
+
 /**
  * Configuration for the inline-assert evaluator.
  * Wraps an AssertFn for in-process evaluation via the evaluate() API.
@@ -926,6 +949,7 @@ export type GraderConfig = (
   | LlmGraderConfig
   | LlmRubricGraderConfig
   | ToolTrajectoryGraderConfig
+  | SkillUsedGraderConfig
   | FieldAccuracyGraderConfig
   | LatencyGraderConfig
   | CostGraderConfig

--- a/packages/core/src/evaluation/validation/eval-file.schema.ts
+++ b/packages/core/src/evaluation/validation/eval-file.schema.ts
@@ -16,7 +16,6 @@ const JsonObjectSchema = z.object({}).catchall(z.unknown());
 const JsonRecordSchema = z.record(z.unknown());
 const UnsupportedPromptfooAssertionTypes = new Set([
   'tool-call-f1',
-  'skill-used',
   'trajectory:goal-success',
   'trajectory:tool-args-match',
   'trajectory:step-count',
@@ -230,6 +229,8 @@ const PromptfooAssertionSchema = EvaluatorCommonSchema.extend({
     'python',
     'webhook',
     'similar',
+    'skill-used',
+    'not-skill-used',
     'contains',
     'contains-any',
     'contains-all',

--- a/packages/core/src/evaluation/validation/eval-validator.ts
+++ b/packages/core/src/evaluation/validation/eval-validator.ts
@@ -105,7 +105,6 @@ const UNSUPPORTED_PROMPTFOO_ASSERTION_TYPES = new Set([
   'human',
   'max-score',
   'tool-call-f1',
-  'skill-used',
   'trajectory:goal-success',
   'trajectory:tool-args-match',
   'trajectory:step-count',

--- a/packages/core/test/evaluation/graders/skill-used.test.ts
+++ b/packages/core/test/evaluation/graders/skill-used.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'bun:test';
+
+import { SkillUsedGrader } from '../../../src/evaluation/graders/skill-used.js';
+import type { EvaluationContext } from '../../../src/evaluation/graders/types.js';
+import type { SkillUsedGraderConfig } from '../../../src/evaluation/types.js';
+
+const baseContext: EvaluationContext = {
+  evalCase: {
+    id: 'case-1',
+    question: 'Use a skill',
+    input: [{ role: 'user', content: 'Use a skill' }],
+    expected_output: [],
+    reference_answer: '',
+    file_paths: [],
+    criteria: '',
+  },
+  candidate: 'done',
+  target: { name: 'mock', kind: 'mock', config: {} },
+  provider: {
+    id: 'mock',
+    kind: 'mock',
+    targetName: 'mock',
+    async invoke() {
+      return { output: [{ role: 'assistant', content: 'ok' }] };
+    },
+  },
+  attempt: 0,
+  promptInputs: { question: 'Use a skill' },
+  now: new Date('2026-07-06T00:00:00Z'),
+  responseMetadata: {
+    skill_calls: [
+      { name: 'csv-analyzer', source: 'tool', path: '.agents/skills/csv-analyzer/SKILL.md' },
+      { name: 'web-search', source: 'tool' },
+      { name: 'broken-skill', source: 'tool', isError: true },
+      { name: 'legacy-error', source: 'tool', is_error: true },
+    ],
+  },
+};
+
+function run(overrides: Partial<SkillUsedGraderConfig>) {
+  const config: SkillUsedGraderConfig = {
+    name: 'skill',
+    type: 'skill-used',
+    value: 'csv-analyzer',
+    ...overrides,
+  };
+  return new SkillUsedGrader(config).evaluate(baseContext);
+}
+
+describe('SkillUsedGrader', () => {
+  it('passes for a required skill string from normalized metadata', () => {
+    const result = run({ value: 'csv-analyzer' });
+
+    expect(result.verdict).toBe('pass');
+    expect(result.score).toBe(1);
+  });
+
+  it('requires all skills in a string array', () => {
+    expect(run({ value: ['csv-analyzer', 'web-search'] }).verdict).toBe('pass');
+    expect(run({ value: ['csv-analyzer', 'missing-skill'] }).verdict).toBe('fail');
+  });
+
+  it('supports object name counts and glob pattern counts', () => {
+    expect(run({ value: { name: 'csv-analyzer', min: 1, max: 1 } }).verdict).toBe('pass');
+    expect(run({ value: { pattern: '*SEARCH', min: 1 } }).verdict).toBe('pass');
+    expect(run({ value: { pattern: '*search', min: 2 } }).verdict).toBe('fail');
+  });
+
+  it('ignores errored skill calls', () => {
+    expect(run({ value: 'broken-skill' }).verdict).toBe('fail');
+    expect(run({ value: { pattern: '*error', min: 1 } }).verdict).toBe('fail');
+  });
+
+  it('supports not-skill-used inverse behavior', () => {
+    expect(run({ type: 'not-skill-used', value: 'missing-skill' }).verdict).toBe('pass');
+    expect(run({ type: 'not-skill-used', value: 'csv-analyzer' }).verdict).toBe('fail');
+    expect(run({ type: 'not-skill-used', value: { pattern: 'missing-*', max: 0 } }).verdict).toBe(
+      'pass',
+    );
+  });
+
+  it('rejects not-skill-used object count bounds other than max zero', () => {
+    expect(() => run({ type: 'not-skill-used', value: { name: 'csv-analyzer', min: 1 } })).toThrow(
+      /not-skill-used object assertions only support/,
+    );
+  });
+
+  it('does not scan output tool calls when normalized skill metadata is absent', () => {
+    const config: SkillUsedGraderConfig = {
+      name: 'skill',
+      type: 'skill-used',
+      value: 'csv-analyzer',
+    };
+    const result = new SkillUsedGrader(config).evaluate({
+      ...baseContext,
+      responseMetadata: undefined,
+      output: [
+        {
+          role: 'assistant',
+          toolCalls: [{ tool: 'Skill', input: { skill: 'csv-analyzer' } }],
+        },
+      ],
+    });
+
+    expect(result.verdict).toBe('fail');
+    expect(result.assertions[0].text).toContain('Actual skills: (none)');
+  });
+});

--- a/packages/core/test/evaluation/loaders/grader-parser.test.ts
+++ b/packages/core/test/evaluation/loaders/grader-parser.test.ts
@@ -15,6 +15,7 @@ import type {
   LlmRubricGraderConfig,
   RegexGraderConfig,
   ScriptGraderConfig,
+  SkillUsedGraderConfig,
 } from '../../../src/evaluation/types.js';
 
 describe('parseGraders - deterministic assertion types', () => {
@@ -454,6 +455,32 @@ describe('parseGraders - deterministic assertion types', () => {
         'test-1',
       ),
     ).rejects.toThrow("Unsupported promptfoo assertion type 'tool-call-f1'");
+  });
+
+  it('parses promptfoo-compatible skill-used assertions', async () => {
+    const evaluators = await parseGraders(
+      {
+        assert: [
+          { type: 'skill-used', value: 'csv-analyzer' },
+          { type: 'not-skill-used', value: { pattern: 'web-*', max: 0 } },
+        ],
+      },
+      undefined,
+      [tempDir],
+      'test-1',
+    );
+
+    expect(evaluators).toHaveLength(2);
+    expect(evaluators?.[0]).toMatchObject({
+      name: 'skill-used-csv-analyzer',
+      type: 'skill-used',
+      value: 'csv-analyzer',
+    } satisfies Partial<SkillUsedGraderConfig>);
+    expect(evaluators?.[1]).toMatchObject({
+      name: 'not-skill-used',
+      type: 'not-skill-used',
+      value: { pattern: 'web-*', max: 0 },
+    } satisfies Partial<SkillUsedGraderConfig>);
   });
 });
 

--- a/packages/core/test/evaluation/providers/claude.test.ts
+++ b/packages/core/test/evaluation/providers/claude.test.ts
@@ -234,6 +234,52 @@ describe('ClaudeProvider', () => {
     expect(firstMsg?.toolCalls?.[0]?.id).toBe('tc-1');
   });
 
+  it('normalizes Claude Skill tool calls into provider skill metadata', async () => {
+    const queryMock = mock(() =>
+      createMockQuery({
+        messages: [
+          {
+            type: 'assistant',
+            message: {
+              content: [
+                {
+                  type: 'tool_use',
+                  name: 'Skill',
+                  input: { skill: 'csv-analyzer' },
+                  id: 'skill-1',
+                },
+              ],
+            },
+          },
+          {
+            type: 'result',
+            subtype: 'success',
+            total_cost_usd: 0.01,
+            duration_ms: 500,
+            usage: {},
+          },
+        ],
+      }),
+    );
+
+    mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+      query: queryMock,
+    }));
+
+    const { ClaudeProvider } = await import('../../../src/evaluation/providers/claude.js');
+
+    const provider = new ClaudeProvider('test-target', {});
+    const response = await provider.invoke({ question: 'Use csv analyzer' });
+
+    expect(response.metadata?.skillCalls).toEqual([
+      {
+        name: 'csv-analyzer',
+        input: { skill: 'csv-analyzer' },
+        source: 'tool',
+      },
+    ]);
+  });
+
   it('sets bypassPermissions in query options', async () => {
     const queryMock = mock((_params: unknown) =>
       createMockQuery({

--- a/packages/core/test/evaluation/providers/codex-sdk.test.ts
+++ b/packages/core/test/evaluation/providers/codex-sdk.test.ts
@@ -416,6 +416,44 @@ describe('CodexProvider (SDK)', () => {
     expect(msg?.toolCalls?.[0]?.id).toBe('cmd-1');
   });
 
+  it('normalizes Codex SKILL.md command reads into provider skill metadata', async () => {
+    const thread = createMockThread({
+      events: [
+        {
+          type: 'item.completed',
+          item: {
+            id: 'cmd-1',
+            type: 'command_execution',
+            command: 'sed -n 1,80p .agents/skills/csv-analyzer/SKILL.md',
+            aggregated_output: 'skill instructions',
+            status: 'completed',
+          },
+        },
+        {
+          type: 'item.completed',
+          item: { id: 'msg-1', type: 'agent_message', text: 'Used the skill' },
+        },
+      ],
+    });
+    const codexInstance = createMockCodex(thread);
+    const sdkMock = mockCodexSdk(codexInstance);
+
+    mock.module('@openai/codex-sdk', () => sdkMock);
+    const { CodexProvider } = await import('../../../src/evaluation/providers/codex.js');
+
+    const provider = new CodexProvider('test-target', { command: ['codex'] });
+    const response = await provider.invoke({ question: 'Use csv analyzer' });
+
+    expect(response.metadata?.skillCalls).toEqual([
+      {
+        name: 'csv-analyzer',
+        input: { command: 'sed -n 1,80p .agents/skills/csv-analyzer/SKILL.md' },
+        path: '.agents/skills/csv-analyzer/SKILL.md',
+        source: 'heuristic',
+      },
+    ]);
+  });
+
   it('extracts file change tool calls from events', async () => {
     const thread = createMockThread({
       events: [

--- a/packages/core/test/evaluation/providers/replay-transcripts.test.ts
+++ b/packages/core/test/evaluation/providers/replay-transcripts.test.ts
@@ -23,7 +23,13 @@ describe('ReplayProvider transcript source', () => {
         {
           role: 'assistant',
           content: 'I inspected it.',
-          toolCalls: [{ tool: 'Read', input: { path: 'package.json' }, output: '{}' }],
+          toolCalls: [
+            {
+              tool: 'Read',
+              input: { path: '.agents/skills/csv-analyzer/SKILL.md' },
+              output: 'skill instructions',
+            },
+          ],
         },
       ],
       source: {
@@ -53,6 +59,14 @@ describe('ReplayProvider transcript source', () => {
     expect(response.output).toEqual(transcript.messages);
     expect(response.tokenUsage).toEqual({ input: 10, output: 5 });
     expect(response.durationMs).toBe(1234);
+    expect(response.metadata?.skillCalls).toEqual([
+      {
+        name: 'csv-analyzer',
+        input: { path: '.agents/skills/csv-analyzer/SKILL.md' },
+        path: '.agents/skills/csv-analyzer/SKILL.md',
+        source: 'heuristic',
+      },
+    ]);
     expect(response.raw?.replay_transcript).toMatchObject({
       test_id: 'copilot-case',
       target: 'copilot-cli',

--- a/packages/core/test/evaluation/providers/sdk-child-provider.test.ts
+++ b/packages/core/test/evaluation/providers/sdk-child-provider.test.ts
@@ -29,6 +29,13 @@ describe('SdkChildProvider', () => {
     const response = await provider.invoke({ question: 'hello' });
 
     expect(extractLastAssistantContent(response.output)).toBe('child ok');
+    expect(response.metadata?.skillCalls).toEqual([
+      {
+        name: 'codex/list_mcp_resources',
+        input: { skill: 'codex/list_mcp_resources' },
+        source: 'tool',
+      },
+    ]);
     const raw = response.raw as {
       child_runner?: { events?: readonly { message?: string }[]; stderr?: string };
     };
@@ -148,6 +155,15 @@ if (mode === 'success') {
   write({
     type: 'result',
     response: {
+      metadata: {
+        skillCalls: [
+          {
+            name: 'codex/list_mcp_resources',
+            input: { skill: 'codex/list_mcp_resources' },
+            source: 'tool',
+          },
+        ],
+      },
       output: [{ role: 'assistant', content: 'child ok' }],
       token_usage: { input: 1, output: 2 },
       duration_ms: 3,

--- a/packages/core/test/evaluation/providers/skill-calls.test.ts
+++ b/packages/core/test/evaluation/providers/skill-calls.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'bun:test';
+
+import { deriveSkillCallsFromToolCalls } from '../../../src/evaluation/providers/skill-calls.js';
+
+describe('deriveSkillCallsFromToolCalls', () => {
+  it('preserves explicit provider skill names without path-name validation', () => {
+    const skillCalls = deriveSkillCallsFromToolCalls([
+      { tool: 'Skill', input: { skill: 'codex/list_mcp_resources' } },
+    ]);
+
+    expect(skillCalls).toEqual([
+      {
+        name: 'codex/list_mcp_resources',
+        input: { skill: 'codex/list_mcp_resources' },
+        source: 'tool',
+      },
+    ]);
+  });
+});

--- a/packages/core/test/evaluation/validation/eval-validator.test.ts
+++ b/packages/core/test/evaluation/validation/eval-validator.test.ts
@@ -1681,6 +1681,32 @@ tests:
       ).toBe(true);
     });
 
+    it('accepts promptfoo-compatible skill-used assertions', async () => {
+      const filePath = path.join(tempDir, 'assert-skill-used.yaml');
+      await writeFile(
+        filePath,
+        `prompts:
+  - "{{ prompt }}"
+tests:
+  - id: test-1
+    vars:
+      prompt: "Use csv tools"
+    assert:
+      - type: skill-used
+        value:
+          pattern: "csv-*"
+          min: 1
+      - type: not-skill-used
+        value: web-search
+`,
+      );
+
+      const result = await validateEvalFile(filePath);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
     it('validates required field accepts boolean', async () => {
       const filePath = path.join(tempDir, 'assert-required-bool.yaml');
       await writeFile(

--- a/packages/sdk/src/assertion.ts
+++ b/packages/sdk/src/assertion.ts
@@ -42,6 +42,8 @@ export type AssertionType =
   | 'script'
   | 'assert-set'
   | 'tool-trajectory'
+  | 'skill-used'
+  | 'not-skill-used'
   | 'field-accuracy'
   | 'latency'
   | 'cost'


### PR DESCRIPTION
## Summary

AgentV can now author and run Promptfoo-compatible `skill-used` and `not-skill-used` assertions against normalized provider skill-call metadata. The assertion no longer has to infer from raw transcripts: Claude, Codex, SDK child providers, and replay/import paths populate `metadata.skillCalls`, and orchestration exposes it to graders as `skill_calls`.

This covers Promptfoo's string, string-array, object `name` / `pattern` / `min` / `max`, inverse/not, and errored-call behavior for this slice. The old `skill-trigger` authored migration is intentionally left for the dependent schema/docs Beads (`av-kfik.45.1`, `av-kfik.45.4`) rather than broadened here.

## Validation

- `bun test packages/core/test/evaluation/graders/skill-used.test.ts packages/core/test/evaluation/providers/skill-calls.test.ts packages/core/test/evaluation/providers/sdk-child-provider.test.ts packages/core/test/evaluation/loaders/grader-parser.test.ts packages/core/test/evaluation/validation/eval-validator.test.ts packages/core/test/evaluation/providers/claude.test.ts packages/core/test/evaluation/providers/codex-sdk.test.ts packages/core/test/evaluation/providers/replay-transcripts.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run validate:examples`
- `git diff --check`
- Live dogfood: `codex-sdk` target plus live OpenAI-compatible grader, 1/1 pass, run `skill-used-dogfood-20260706021524`

## Evidence

Private evidence branch: `EntityProcess/agentv-private:evidence/av-kfik.45.3-skill-used`

The evidence branch contains the passing run bundle, source eval/targets, artifact tree, and README. Note: the copied `.env` pointed at `126.0.0.1:10531`, while the local proxy was listening on `127.0.0.1:10531`; the dogfood command used a temporary endpoint override to hit the live proxy without changing repo files.

## Code Review

Dedicated CE subagent review was unavailable in this harness because the Codex subagent tool policy only permits spawning when the user explicitly asks for subagents or parallel agent work. I performed a manual diff review focused on assertion semantics, provider metadata boundaries, SDK child metadata propagation, and test coverage; it found and fixed the SDK child metadata drop before PR creation.

## Post-Deploy Monitoring & Validation

No additional production monitoring required; this is local/CI eval assertion behavior and provider metadata plumbing, not a deployed service. After merge, watch GitHub Actions for the package build/test matrix and inspect any downstream eval failures containing `skill-used`, `not-skill-used`, `skill_calls`, or `metadata.skillCalls`. A healthy signal is authored YAML validating and run rows showing `skill-used` scores based on `Actual skills: ...`; rollback trigger is deterministic assertion failure where provider transcripts include a skill call but `skill_calls` is empty.

## Related

Related: av-kfik.45.3

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
