### PR TITLE
fix(artifacts): flatten metrics sidecar

### DIFF
--- a/apps/cli/src/commands/results/manifest.ts
+++ b/apps/cli/src/commands/results/manifest.ts
@@ -4,11 +4,13 @@ import path from 'node:path';
 import {
   type EvaluationResult,
   type ExternalTraceMetadataWire,
+  type MetricsArtifactWire,
   type ResultArtifactPointersWire,
   type RunRuntimeSourceMetadata,
   type TraceSummary,
   buildTraceFromMessages,
   fromTraceEnvelopeWire,
+  normalizeMetricsArtifactWire,
   toCamelCaseDeep,
   traceEnvelopeToTraceSummary,
   traceEnvelopeToTranscriptMessages,
@@ -86,20 +88,6 @@ export interface ResultManifestRecord {
   readonly files_path?: string;
   readonly graders_path?: string;
   readonly metadata?: Record<string, unknown>;
-}
-
-interface MetricsUsageArtifact {
-  readonly duration?: {
-    readonly total_ms?: number;
-  };
-  readonly tokens?: {
-    readonly input?: number;
-    readonly output?: number;
-    readonly reasoning?: number;
-  };
-  readonly cost?: {
-    readonly usd?: number | null;
-  };
 }
 
 interface LegacyTimingArtifact {
@@ -390,7 +378,9 @@ function hydrateManifestRecord(
   options: ManifestHydrationOptions,
 ): EvaluationResult {
   const grading = readOptionalJson<GradingArtifact>(baseDir, record.grading_path);
-  const metrics = readOptionalJson<MetricsUsageArtifact>(baseDir, record.metrics_path);
+  const metrics = normalizeMetricsArtifactWire(
+    readOptionalJson<MetricsArtifactWire | Record<string, unknown>>(baseDir, record.metrics_path),
+  );
   const timing = metrics ?? readOptionalJson<LegacyTimingArtifact>(baseDir, record.timing_path);
   const testId = record.test_id ?? 'unknown';
   const gradingAssertions = grading

--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -62,6 +62,7 @@ import {
   loadConfig,
   loadProjectRegistry,
   normalizeCategoryPath,
+  normalizeMetricsArtifactWire,
   normalizeTraceArtifactToTraceSessionResponse,
   omitExternalTraceMetadataKeys,
   readGitResultArtifact,
@@ -1154,7 +1155,7 @@ function buildRepeatTrialReadModels(
     const answerPath = caseTrialArtifactPath(resultDir, runPath, 'outputs/answer.md');
     const resultPath = caseTrialArtifactPath(resultDir, runPath, 'result.json');
     const runResult = readArtifactJsonObject(baseDir, resultPath);
-    const metrics = readArtifactJsonObject(baseDir, metricsPath);
+    const metrics = normalizeMetricsArtifactWire(readArtifactJsonObject(baseDir, metricsPath));
     const timing = readArtifactJsonObject(baseDir, timingPath);
     const toolCalls = objectField(metrics, 'tool_calls');
     const tokenUsage = objectField(metrics, 'tokens') ?? objectField(timing, 'token_usage');

--- a/apps/cli/src/commands/results/validate.ts
+++ b/apps/cli/src/commands/results/validate.ts
@@ -18,6 +18,11 @@
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 
+import {
+  LEGACY_METRICS_SCHEMA_VERSION,
+  METRICS_SCHEMA_VERSION,
+  normalizeMetricsArtifactWire,
+} from '@agentv/core';
 import { command, positional, string } from 'cmd-ts';
 
 import { RESULT_INDEX_FILENAME, resolveExistingRunPrimaryPath } from '../eval/result-layout.js';
@@ -112,6 +117,50 @@ function validateNoLegacyGradingFields(value: unknown, pathLabel: string): strin
     errors.push(...validateNoLegacyGradingFields(entry, `${pathLabel}.${key}`));
   }
   return errors;
+}
+
+function validateMetricsArtifact(value: unknown): Diagnostic[] {
+  if (!isRecord(value)) {
+    return [{ severity: 'error', message: 'metrics.json must be an object' }];
+  }
+
+  const diagnostics: Diagnostic[] = [];
+  const schemaVersion = value.schema_version;
+  const isCurrentSchema = schemaVersion === METRICS_SCHEMA_VERSION;
+  const isLegacySchema = schemaVersion === LEGACY_METRICS_SCHEMA_VERSION;
+
+  if (isCurrentSchema && Object.hasOwn(value, 'trace')) {
+    diagnostics.push({
+      severity: 'error',
+      message: 'metrics.json must not include trace in agentv.metrics.v2',
+    });
+  } else if (isLegacySchema && Object.hasOwn(value, 'trace')) {
+    diagnostics.push({
+      severity: 'warning',
+      message: 'metrics.json uses legacy trace identity; readers ignore it',
+    });
+  }
+
+  if (isCurrentSchema && Object.hasOwn(value, 'metrics')) {
+    diagnostics.push({
+      severity: 'error',
+      message: 'metrics.json must not include nested metrics in agentv.metrics.v2',
+    });
+  } else if (isLegacySchema && Object.hasOwn(value, 'metrics')) {
+    diagnostics.push({
+      severity: 'warning',
+      message: 'metrics.json uses legacy nested metrics; readers flatten it',
+    });
+  }
+
+  if (!normalizeMetricsArtifactWire(value)) {
+    diagnostics.push({
+      severity: 'error',
+      message: 'metrics.json does not match a supported metrics artifact shape',
+    });
+  }
+
+  return diagnostics;
 }
 
 // ── Checks ───────────────────────────────────────────────────────────────
@@ -372,6 +421,21 @@ function checkArtifactFiles(runDir: string, entries: IndexEntry[]): Diagnostic[]
           severity: 'warning',
           message: `${testId}: metrics.json not found at '${entry.metrics_path}'`,
         });
+      } else {
+        try {
+          const metrics = JSON.parse(readFileSync(metricsPath, 'utf8'));
+          for (const diagnostic of validateMetricsArtifact(metrics)) {
+            diagnostics.push({
+              severity: diagnostic.severity,
+              message: `${testId}: ${diagnostic.message}`,
+            });
+          }
+        } catch {
+          diagnostics.push({
+            severity: 'error',
+            message: `${testId}: metrics.json is not valid JSON`,
+          });
+        }
       }
     }
   }

--- a/apps/cli/test/commands/eval/artifact-writer.test.ts
+++ b/apps/cli/test/commands/eval/artifact-writer.test.ts
@@ -2019,12 +2019,8 @@ describe('writeArtifactsFromResults', () => {
     );
 
     expect(summary.schema_version).toBe(METRICS_SCHEMA_VERSION);
-    expect(summary.trace).toMatchObject({
-      schema_version: 'agentv.trace.v1',
-      trace_id: expect.any(String),
-      root_span_id: expect.any(String),
-    });
-    expect(summary.trace).not.toHaveProperty('path');
+    expect(summary).not.toHaveProperty('trace');
+    expect(summary).not.toHaveProperty('metrics');
     expect(summary.source_artifacts).toMatchObject({
       transcript_path: 'transcript.json',
       grading_path: 'grading.json',
@@ -2034,29 +2030,29 @@ describe('writeArtifactsFromResults', () => {
     await expect(
       readFile(runArtifactPath(testDir, indexLine, 'sample-1', 'trace.json'), 'utf8'),
     ).rejects.toThrow();
-    expect(summary.metrics.total_turns).toBe(2);
-    expect(summary.metrics.total_tool_calls).toBe(4);
-    expect(summary.metrics.total_steps).toBe(2);
-    expect(summary.metrics.tool_calls).toMatchObject({
+    expect(summary.total_turns).toBe(2);
+    expect(summary.total_tool_calls).toBe(4);
+    expect(summary.total_steps).toBe(2);
+    expect(summary.tool_calls).toMatchObject({
       Read: 1,
       Bash: 1,
       WebFetch: 1,
       Edit: 1,
     });
-    expect(summary.metrics.tool_call_counts).toMatchObject({
+    expect(summary.tool_call_counts).toMatchObject({
       Read: 1,
       Bash: 1,
       WebFetch: 1,
       Edit: 1,
     });
-    expect(summary.metrics.tool_category_counts).toMatchObject({
+    expect(summary.tool_category_counts).toMatchObject({
       file_read: 1,
       shell: 1,
       web_fetch: 1,
       file_edit: 1,
     });
-    expect(summary.metrics.tool_call_events).toHaveLength(4);
-    expect(summary.metrics.shell_commands).toEqual([
+    expect(summary.tool_call_events).toHaveLength(4);
+    expect(summary.shell_commands).toEqual([
       {
         command: 'bun test apps/cli/test/commands/eval/artifact-writer.test.ts',
         tool_call_id: 'bash-1',
@@ -2065,25 +2061,25 @@ describe('writeArtifactsFromResults', () => {
         duration_ms: 1200,
       },
     ]);
-    expect(summary.metrics.files_read).toContainEqual({
+    expect(summary.files_read).toContainEqual({
       path: 'src/input.ts',
       tool_call_id: 'read-1',
       source: 'tool_input',
     });
-    expect(summary.metrics.files_modified).toContainEqual({
+    expect(summary.files_modified).toContainEqual({
       path: 'src/output.ts',
       operation: 'edit',
       tool_call_id: 'edit-1',
       source: 'tool_input',
     });
-    expect(summary.metrics.files_modified).toContainEqual({
+    expect(summary.files_modified).toContainEqual({
       path: 'src/output.ts',
       operation: 'workspace_diff',
       source: 'file_changes',
     });
-    expect(summary.metrics.files_created).toEqual(['src/new.ts']);
-    expect(summary.metrics.files_deleted).toEqual(['src/gone.ts']);
-    expect(summary.metrics.web_fetches).toEqual([
+    expect(summary.files_created).toEqual(['src/new.ts']);
+    expect(summary.files_deleted).toEqual(['src/gone.ts']);
+    expect(summary.web_fetches).toEqual([
       {
         url: 'https://example.com/spec',
         method: 'GET',
@@ -2092,17 +2088,14 @@ describe('writeArtifactsFromResults', () => {
         tool_call_id: 'web-1',
       },
     ]);
-    expect(summary.metrics.errors).toContainEqual({
+    expect(summary.errors).toContainEqual({
       message: 'quality gate failed',
     });
-    expect(summary.metrics.errors_encountered).toBe(1);
-    expect(summary.metrics.output_chars).toBe('Editing output.'.length);
-    expect(summary.metrics.transcript_chars).toBeGreaterThan(0);
-    expect(summary.metrics.thinking_blocks).toBe(2);
-    expect(summary.metrics.reasoning_blocks.map((block) => block.kind)).toEqual([
-      'reasoning',
-      'thinking',
-    ]);
+    expect(summary.errors_encountered).toBe(1);
+    expect(summary.output_chars).toBe('Editing output.'.length);
+    expect(summary.transcript_chars).toBeGreaterThan(0);
+    expect(summary.thinking_blocks).toBe(2);
+    expect(summary.reasoning_blocks.map((block) => block.kind)).toEqual(['reasoning', 'thinking']);
     expect(summary).not.toHaveProperty('usage_summary');
 
     expect(summary).toMatchObject({

--- a/apps/cli/test/commands/results/export-e2e-providers.test.ts
+++ b/apps/cli/test/commands/results/export-e2e-providers.test.ts
@@ -532,9 +532,11 @@ describe('export e2e — multi-provider metrics verification', () => {
           'utf8',
         ),
       );
-      expect(metrics.metrics.total_tool_calls).toBe(3);
-      expect(metrics.metrics.tool_call_counts.Read).toBe(2);
-      expect(metrics.metrics.tool_call_counts.Write).toBe(1);
+      expect(metrics).not.toHaveProperty('trace');
+      expect(metrics).not.toHaveProperty('metrics');
+      expect(metrics.total_tool_calls).toBe(3);
+      expect(metrics.tool_call_counts.Read).toBe(2);
+      expect(metrics.tool_call_counts.Write).toBe(1);
 
       expect(grading.component_results?.[0].component_results?.[0].assertion?.value).toBe(
         'Contains 42',
@@ -559,7 +561,9 @@ describe('export e2e — multi-provider metrics verification', () => {
       const metrics = JSON.parse(
         readFileSync(path.join(runArtifactDir(outputDir, COPILOT_RESULT), 'metrics.json'), 'utf8'),
       );
-      expect(metrics.metrics.total_tool_calls).toBe(0);
+      expect(metrics).not.toHaveProperty('trace');
+      expect(metrics).not.toHaveProperty('metrics');
+      expect(metrics.total_tool_calls).toBe(0);
     });
 
     it('should handle error result in grading', async () => {
@@ -577,7 +581,9 @@ describe('export e2e — multi-provider metrics verification', () => {
       const metrics = JSON.parse(
         readFileSync(path.join(runArtifactDir(outputDir, ERROR_RESULT), 'metrics.json'), 'utf8'),
       );
-      expect(metrics.metrics.errors_encountered).toBe(1);
+      expect(metrics).not.toHaveProperty('trace');
+      expect(metrics).not.toHaveProperty('metrics');
+      expect(metrics.errors_encountered).toBe(1);
     });
 
     it('should produce grading files for all test IDs in multi-target run', async () => {

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -2294,6 +2294,80 @@ describe('serve app', () => {
         `${JSON.stringify({ transcript_summary: secondSummary })}\n`,
       );
       writeFileSync(
+        path.join(runDir, resultDir, 'attempt-1', 'metrics.json'),
+        `${JSON.stringify({
+          schema_version: 'agentv.metrics.v2',
+          artifact_id: 'metrics-repeat-case-1',
+          generated_at: '2026-03-25T10:05:00.000Z',
+          test_id: 'repeat-case',
+          target: 'gpt-4o',
+          source_artifacts: {},
+          duration: { total_ms: 1000, total_seconds: 1, source: 'provider_reported' },
+          tokens: { total: 3, input: 1, output: 2, reasoning: 0, source: 'provider_reported' },
+          cost: { usd: 0.01, source: 'provider_reported' },
+          tool_calls: { Bash: 1 },
+          tool_call_counts: { Bash: 1 },
+          tool_category_counts: { shell: 1 },
+          total_tool_calls: 1,
+          total_steps: 1,
+          total_turns: 1,
+          tool_call_events: [],
+          shell_commands: [],
+          files_read: [],
+          files_modified: [],
+          files_created: [],
+          files_deleted: [],
+          web_fetches: [],
+          errors: [],
+          errors_encountered: 0,
+          output_chars: 0,
+          transcript_chars: 0,
+          reasoning_blocks: [],
+          thinking_blocks: 0,
+        })}\n`,
+      );
+      writeFileSync(
+        path.join(runDir, resultDir, 'attempt-2', 'metrics.json'),
+        `${JSON.stringify({
+          schema_version: 'agentv.metrics.v1',
+          artifact_id: 'metrics-repeat-case-2',
+          generated_at: '2026-03-25T10:05:01.000Z',
+          test_id: 'repeat-case',
+          target: 'gpt-4o',
+          trace: {
+            schema_version: 'agentv.trace.v1',
+            artifact_id: 'execution-trace-repeat-case-2',
+            trace_id: 'trace-repeat-case-2',
+            root_span_id: 'span-repeat-case-2',
+          },
+          source_artifacts: {},
+          duration: { total_ms: 2000, total_seconds: 2, source: 'provider_reported' },
+          tokens: { total: 7, input: 3, output: 4, reasoning: 0, source: 'provider_reported' },
+          cost: { usd: 0.02, source: 'provider_reported' },
+          metrics: {
+            tool_calls: { Read: 2 },
+            tool_call_counts: { Read: 2 },
+            tool_category_counts: { file_read: 2 },
+            total_tool_calls: 2,
+            total_steps: 1,
+            total_turns: 1,
+            tool_call_events: [],
+            shell_commands: [],
+            files_read: [],
+            files_modified: [],
+            files_created: [],
+            files_deleted: [],
+            web_fetches: [],
+            errors: [],
+            errors_encountered: 0,
+            output_chars: 0,
+            transcript_chars: 0,
+            reasoning_blocks: [],
+            thinking_blocks: 0,
+          },
+        })}\n`,
+      );
+      writeFileSync(
         path.join(runDir, 'index.jsonl'),
         toJsonl({
           ...RESULT_A,
@@ -2320,6 +2394,8 @@ describe('serve app', () => {
           attempts?: Array<{
             transcript_path?: string;
             transcript_summary?: Record<string, unknown>;
+            total_tool_calls?: number;
+            tool_calls?: Record<string, number>;
           }>;
         }>;
       };
@@ -2330,6 +2406,9 @@ describe('serve app', () => {
         `${resultDir}/attempt-1/transcript.json`,
         `${resultDir}/attempt-2/transcript.json`,
       ]);
+      expect(data.results[0]?.attempts?.map((trial) => trial.total_tool_calls)).toEqual([1, 2]);
+      expect(data.results[0]?.attempts?.[0]?.tool_calls).toEqual({ Bash: 1 });
+      expect(data.results[0]?.attempts?.[1]?.tool_calls).toEqual({ Read: 2 });
     });
 
     it('loads historical runs without test bundle metadata', async () => {

--- a/apps/cli/test/commands/results/shared.test.ts
+++ b/apps/cli/test/commands/results/shared.test.ts
@@ -73,6 +73,70 @@ describe('results shared source resolution', () => {
     expect(results[0].trace.toolCalls).toEqual({ rg: 1 });
   });
 
+  it('hydrates legacy nested metrics sidecars without requiring trace identity', () => {
+    const runDir = path.join(tempDir, '.agentv', 'results', '2026-03-25T10-00-00-000Z');
+    const caseDir = path.join(runDir, 'legacy-case', 'sample-1');
+    mkdirSync(caseDir, { recursive: true });
+    const indexPath = path.join(runDir, 'index.jsonl');
+    writeFileSync(
+      indexPath,
+      `${JSON.stringify({
+        timestamp: '2026-03-25T10:00:00.000Z',
+        test_id: 'legacy-case',
+        target: 'codex',
+        score: 1,
+        metrics_path: 'legacy-case/sample-1/metrics.json',
+      })}\n`,
+    );
+    writeFileSync(
+      path.join(caseDir, 'metrics.json'),
+      `${JSON.stringify({
+        schema_version: 'agentv.metrics.v1',
+        artifact_id: 'metrics-legacy-case',
+        generated_at: '2026-03-25T10:00:00.000Z',
+        test_id: 'legacy-case',
+        target: 'codex',
+        trace: {
+          schema_version: 'agentv.trace.v1',
+          artifact_id: 'execution-trace-legacy-case',
+          trace_id: 'trace-legacy',
+          root_span_id: 'span-legacy',
+        },
+        source_artifacts: {},
+        duration: { total_ms: 1234, total_seconds: 1.234, source: 'provider_reported' },
+        tokens: { total: 11, input: 7, output: 4, reasoning: 0, source: 'provider_reported' },
+        cost: { usd: 0.02, source: 'provider_reported' },
+        metrics: {
+          tool_calls: { Read: 2 },
+          tool_call_counts: { Read: 2 },
+          tool_category_counts: { file_read: 2 },
+          total_tool_calls: 2,
+          total_steps: 1,
+          total_turns: 1,
+          tool_call_events: [],
+          shell_commands: [],
+          files_read: [],
+          files_modified: [],
+          files_created: [],
+          files_deleted: [],
+          web_fetches: [],
+          errors: [],
+          errors_encountered: 0,
+          output_chars: 0,
+          transcript_chars: 0,
+          reasoning_blocks: [],
+          thinking_blocks: 0,
+        },
+      })}\n`,
+    );
+
+    const results = loadManifestResults(indexPath);
+
+    expect(results[0].durationMs).toBe(1234);
+    expect(results[0].tokenUsage).toEqual({ input: 7, output: 4, reasoning: 0 });
+    expect(results[0].costUsd).toBe(0.02);
+  });
+
   it('ignores legacy transcript artifact pointers when hydrating traces', () => {
     const runDir = path.join(tempDir, '.agentv', 'results', 'default', '2026-03-25T10-00-00-000Z');
     const transcriptRelativePath = 'pointer-case/transcript.jsonl';

--- a/apps/cli/test/commands/results/validate.test.ts
+++ b/apps/cli/test/commands/results/validate.test.ts
@@ -107,6 +107,134 @@ describe('results validate', () => {
     }
   });
 
+  it('rejects v2 metrics sidecars with trace or nested metrics fields', () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'agentv-validate-test-'));
+
+    try {
+      const runDir = path.join(tempDir, '.agentv', 'results', '2026-03-27T12-42-24-429Z');
+      const caseDir = path.join(runDir, 'test-greeting');
+      mkdirSync(caseDir, { recursive: true });
+      writeFileSync(
+        path.join(runDir, 'index.jsonl'),
+        `${JSON.stringify({
+          timestamp: '2026-03-27T12:42:24.429Z',
+          test_id: 'test-greeting',
+          score: 1,
+          target: 'gpt-4o',
+          scores: [{ name: 'quality', type: 'llm', score: 1, pass: true, reason: 'passed' }],
+          execution_status: 'ok',
+          summary_path: 'test-greeting/summary.json',
+          metrics_path: 'test-greeting/metrics.json',
+        })}\n`,
+      );
+      writeFileSync(path.join(caseDir, 'summary.json'), '{}\n');
+      writeFileSync(path.join(runDir, 'summary.json'), '{}\n');
+      writeFileSync(
+        path.join(caseDir, 'metrics.json'),
+        `${JSON.stringify({
+          schema_version: 'agentv.metrics.v2',
+          artifact_id: 'metrics-test-greeting',
+          generated_at: '2026-03-27T12:42:24.429Z',
+          test_id: 'test-greeting',
+          target: 'gpt-4o',
+          trace: { trace_id: 'trace-1' },
+          source_artifacts: {},
+          metrics: {},
+        })}\n`,
+      );
+
+      const { diagnostics } = validateRunDirectory(runDir);
+
+      expect(diagnostics).toContainEqual({
+        severity: 'error',
+        message: 'test-greeting: metrics.json must not include trace in agentv.metrics.v2',
+      });
+      expect(diagnostics).toContainEqual({
+        severity: 'error',
+        message: 'test-greeting: metrics.json must not include nested metrics in agentv.metrics.v2',
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('tolerates legacy nested metrics sidecars with warnings', () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'agentv-validate-test-'));
+
+    try {
+      const runDir = path.join(tempDir, '.agentv', 'results', '2026-03-27T12-42-24-429Z');
+      const caseDir = path.join(runDir, 'test-greeting');
+      mkdirSync(caseDir, { recursive: true });
+      writeFileSync(
+        path.join(runDir, 'index.jsonl'),
+        `${JSON.stringify({
+          timestamp: '2026-03-27T12:42:24.429Z',
+          test_id: 'test-greeting',
+          score: 1,
+          target: 'gpt-4o',
+          scores: [{ name: 'quality', type: 'llm', score: 1, pass: true, reason: 'passed' }],
+          execution_status: 'ok',
+          summary_path: 'test-greeting/summary.json',
+          metrics_path: 'test-greeting/metrics.json',
+        })}\n`,
+      );
+      writeFileSync(path.join(caseDir, 'summary.json'), '{}\n');
+      writeFileSync(path.join(runDir, 'summary.json'), '{}\n');
+      writeFileSync(
+        path.join(caseDir, 'metrics.json'),
+        `${JSON.stringify({
+          schema_version: 'agentv.metrics.v1',
+          artifact_id: 'metrics-test-greeting',
+          generated_at: '2026-03-27T12:42:24.429Z',
+          test_id: 'test-greeting',
+          target: 'gpt-4o',
+          trace: {
+            schema_version: 'agentv.trace.v1',
+            artifact_id: 'execution-trace-test-greeting',
+            trace_id: 'trace-1',
+            root_span_id: 'span-1',
+          },
+          source_artifacts: {},
+          metrics: {
+            tool_calls: {},
+            tool_call_counts: {},
+            tool_category_counts: {},
+            total_tool_calls: 0,
+            total_steps: 0,
+            total_turns: 0,
+            tool_call_events: [],
+            shell_commands: [],
+            files_read: [],
+            files_modified: [],
+            files_created: [],
+            files_deleted: [],
+            web_fetches: [],
+            errors: [],
+            errors_encountered: 0,
+            output_chars: 0,
+            transcript_chars: 0,
+            reasoning_blocks: [],
+            thinking_blocks: 0,
+          },
+        })}\n`,
+      );
+
+      const { diagnostics } = validateRunDirectory(runDir);
+
+      expect(diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+      expect(diagnostics).toContainEqual({
+        severity: 'warning',
+        message: 'test-greeting: metrics.json uses legacy trace identity; readers ignore it',
+      });
+      expect(diagnostics).toContainEqual({
+        severity: 'warning',
+        message: 'test-greeting: metrics.json uses legacy nested metrics; readers flatten it',
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('rejects legacy public grading fields', () => {
     const tempDir = mkdtempSync(path.join(tmpdir(), 'agentv-validate-test-'));
 

--- a/apps/web/src/content/docs/docs/next/tools/results.mdx
+++ b/apps/web/src/content/docs/docs/next/tools/results.mdx
@@ -122,10 +122,15 @@ Duplicate policy is explicit:
 ### Metrics sidecar
 
 Each attempt directory includes `metrics.json`
-(`schema_version: "agentv.metrics.v1"`). This is an AgentV-owned derived
+(`schema_version: "agentv.metrics.v2"`). This is an AgentV-owned derived
 projection over the attempt trace/transcript, result row, and `grading.json`.
 It is the compact executor behavior summary for dashboards, comparison exports,
 and metric-style graders; it is not canonical trace storage.
+Executor counters such as `tool_calls`, `total_tool_calls`,
+`tool_category_counts`, `errors_encountered`, and file/web/shell summaries live
+at the top level next to `duration`, `tokens`, `cost`, `execution`, and
+`trajectory`; trace identity belongs in the run index, result/transcript
+artifacts, and safe `external_trace` correlation metadata.
 
 Every case uses aggregate `summary.json`, then stores execution artifact details
 under `sample-N/`. Each `sample-N/` contains a compact per-attempt manifest

--- a/packages/core/src/evaluation/metrics.ts
+++ b/packages/core/src/evaluation/metrics.ts
@@ -12,7 +12,7 @@
 import { z } from 'zod';
 import type { Message, ToolCall } from './providers/types.js';
 import { METRICS_SCHEMA_VERSION } from './result-artifact-contract.js';
-import { EXECUTION_TRACE_SCHEMA_VERSION, type TraceEnvelope } from './trace-envelope.js';
+import type { TraceEnvelope } from './trace-envelope.js';
 import type { TraceEvent } from './trace.js';
 import type { EvaluationResult } from './types.js';
 
@@ -179,7 +179,7 @@ export const MetricsWireSchema = z
   })
   .strict();
 
-export const MetricsArtifactWireSchema = z
+const MetricsArtifactBaseWireSchema = z
   .object({
     schema_version: z.literal(METRICS_SCHEMA_VERSION),
     artifact_id: z.string(),
@@ -188,14 +188,6 @@ export const MetricsArtifactWireSchema = z
     target: z.string(),
     suite: z.string().optional(),
     category: z.string().optional(),
-    trace: z
-      .object({
-        schema_version: z.literal(EXECUTION_TRACE_SCHEMA_VERSION),
-        artifact_id: z.string(),
-        trace_id: z.string(),
-        root_span_id: z.string(),
-      })
-      .strict(),
     source_artifacts: z
       .object({
         transcript_path: z.string().optional(),
@@ -208,9 +200,10 @@ export const MetricsArtifactWireSchema = z
     cost: MetricsCostWireSchema.optional(),
     execution: z.record(z.string(), z.unknown()).optional(),
     trajectory: z.record(z.string(), z.unknown()).optional(),
-    metrics: MetricsWireSchema,
   })
   .strict();
+
+export const MetricsArtifactWireSchema = MetricsArtifactBaseWireSchema.merge(MetricsWireSchema);
 
 export type MetricsArtifactWire = z.infer<typeof MetricsArtifactWireSchema>;
 
@@ -229,6 +222,23 @@ function dropUndefined<T extends Record<string, unknown>>(value: T): T {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function normalizeMetricsArtifactWire(value: unknown): MetricsArtifactWire | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const nestedMetrics = isRecord(value.metrics) ? value.metrics : {};
+  const normalized = Object.fromEntries(
+    Object.entries({
+      ...value,
+      ...nestedMetrics,
+      schema_version: METRICS_SCHEMA_VERSION,
+    }).filter(([key]) => key !== 'trace' && key !== 'metrics'),
+  );
+
+  const parsed = MetricsArtifactWireSchema.safeParse(normalized);
+  return parsed.success ? parsed.data : undefined;
 }
 
 function normalizedKey(key: string): string {
@@ -911,18 +921,12 @@ export function buildMetricsArtifact(
       target: result.target ?? 'unknown',
       suite: result.suite,
       category: result.category,
-      trace: {
-        schema_version: EXECUTION_TRACE_SCHEMA_VERSION,
-        artifact_id: envelope.artifactId,
-        trace_id: envelope.trace.traceId,
-        root_span_id: envelope.trace.rootSpanId,
-      },
       source_artifacts: dropUndefined({
         transcript_path: options.transcriptPath,
         grading_path: options.gradingPath,
         file_changes_path: options.fileChangesPath,
       }),
-      metrics: buildMetrics(result),
+      ...buildMetrics(result),
     }),
   );
 }

--- a/packages/core/src/evaluation/result-artifact-contract.ts
+++ b/packages/core/src/evaluation/result-artifact-contract.ts
@@ -31,10 +31,11 @@ export const CANONICAL_METRICS_ARTIFACT_PATH = 'metrics.json' as const;
 export const CANONICAL_FILE_CHANGES_ARTIFACT_PATH = 'outputs/file_changes.diff' as const;
 
 export const TRANSCRIPT_SCHEMA_VERSION = 'agentv.normalized_transcript.v1' as const;
-export const METRICS_SCHEMA_VERSION = 'agentv.metrics.v1' as const;
+export const LEGACY_METRICS_SCHEMA_VERSION = 'agentv.metrics.v1' as const;
+export const METRICS_SCHEMA_VERSION = 'agentv.metrics.v2' as const;
 export const TRANSCRIPT_JSON_MEDIA_TYPE =
   'application/vnd.agentv.normalized-transcript.v1+json' as const;
-export const METRICS_JSON_MEDIA_TYPE = 'application/vnd.agentv.metrics.v1+json' as const;
+export const METRICS_JSON_MEDIA_TYPE = 'application/vnd.agentv.metrics.v2+json' as const;
 
 export type AgentVResultsRefName = (typeof AGENTV_RESULTS_REFS)[keyof typeof AGENTV_RESULTS_REFS];
 

--- a/packages/core/src/evaluation/run-artifacts.ts
+++ b/packages/core/src/evaluation/run-artifacts.ts
@@ -1338,7 +1338,7 @@ function buildAgentVRunResultArtifact(params: {
   readonly environmentPath?: string;
   readonly environment?: EnvironmentSummaryWire;
 }): AgentVRunResultArtifact {
-  const metrics = params.metricsArtifact.metrics;
+  const metrics = params.metricsArtifact;
   const fileChangesPath = params.hasFileChanges
     ? `./${CANONICAL_FILE_CHANGES_ARTIFACT_PATH}`
     : undefined;


### PR DESCRIPTION
## Summary

`metrics.json` now has a clean v2 sidecar contract: executor counters are top-level fields next to `duration`, `tokens`, `cost`, `execution`, and `trajectory`, and new artifacts no longer duplicate trace identity. Old run bundles remain readable because CLI and Dashboard read paths normalize legacy `metrics.metrics` and ignore legacy `metrics.trace`.

`results validate` now flags v2 sidecars that reintroduce `trace` or nested `metrics`, while tolerating v1 sidecars with compatibility warnings. The public results docs now describe the supported v2 shape directly.

Related: av-kfik.46.1

## Validation

- `bun test apps/cli/test/commands/eval/artifact-writer.test.ts apps/cli/test/commands/results/shared.test.ts apps/cli/test/commands/results/serve.test.ts apps/cli/test/commands/results/validate.test.ts apps/cli/test/commands/results/export-e2e-providers.test.ts` - 226 pass
- `bun run typecheck`
- `bun run lint`
- `bun run validate:examples` - 108 valid, 0 invalid
- `git diff --check`
- Live dogfood: `examples/features/readme-quickstart/evals/my-eval.eval.yaml` with live `codex-sdk-openai` target plus live `local-openai-grader`, canonical output `.agentv/results/2026-07-06T01-06-18-244Z`, result 1/1 pass, mean score 100%
- `bun apps/cli/src/cli.ts results validate .agentv/results/2026-07-06T01-06-18-244Z` - valid run directory, no issues
- Contract check on live `metrics.json`: `schema_version: agentv.metrics.v2`, `trace` absent, nested `metrics` absent, top-level counters present

## Evidence

Private evidence branch: `EntityProcess/agentv-private:evidence/av-kfik-46-1-artifact-metrics-flatten` at `9755da2`.

It includes the successful live run bundle, the temporary target config with env refs, `dogfood/checks/metrics-contract-check.json`, `dogfood/checks/artifact-tree.txt`, and `dogfood/checks/results-validate.txt`.

## Review Notes

`ce-code-review` multi-agent dispatch was unavailable in this Codex session, so I performed the fallback manual diff scan after the full local validation and dogfood pass. No actionable findings were found.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This changes the portable result artifact schema and local/CI readers; CI plus the live dogfood run are the relevant validation gates. After merge, a spot check of the next CI or dogfood run should confirm newly written `metrics.json` files continue to validate as `agentv.metrics.v2` without `trace` or nested `metrics`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
