### PR TITLE
fix(core): reject authored use_target targets

### DIFF
--- a/packages/core/src/evaluation/providers/targets.ts
+++ b/packages/core/src/evaluation/providers/targets.ts
@@ -908,7 +908,6 @@ export type ResolvedTarget =
  * here automatically makes it valid in targets.yaml without a separate update.
  */
 export const COMMON_TARGET_SETTINGS = [
-  'use_target',
   'runtime',
   'batch_requests',
   'subagent_mode_allowed',

--- a/packages/core/src/evaluation/validation/targets-validator.ts
+++ b/packages/core/src/evaluation/validation/targets-validator.ts
@@ -347,6 +347,7 @@ function validateUnknownSettings(
     'env',
     'grader_target',
     'judge_target',
+    'use_target',
     'workers',
     '$schema',
     'targets',
@@ -695,17 +696,23 @@ export async function validateTargetsFile(filePath: string): Promise<ValidationR
     const provider = effectiveTarget.provider;
     const rawTarget = rawTargets[i];
     const rawUseTarget = isObject(rawTarget) ? rawTarget.use_target : undefined;
-    const hasUseTarget =
-      isNonEmptyString(effectiveTarget.use_target) || isNonEmptyString(rawUseTarget);
+    if (effectiveTarget.use_target !== undefined || rawUseTarget !== undefined) {
+      errors.push({
+        severity: 'error',
+        filePath: absolutePath,
+        location: `${location}.use_target`,
+        message:
+          "The 'use_target' field has been removed from authored targets.yaml target definitions. Define a concrete target with 'provider' instead.",
+      });
+    }
     const providerValue = typeof provider === 'string' ? provider.trim().toLowerCase() : undefined;
     const isTemplated = isEnvTemplated(provider);
-    if (!hasUseTarget && (typeof provider !== 'string' || provider.trim().length === 0)) {
+    if (typeof provider !== 'string' || provider.trim().length === 0) {
       errors.push({
         severity: 'error',
         filePath: absolutePath,
         location: `${location}.provider`,
-        message:
-          "Missing or invalid 'provider' field (must be a non-empty string, or use use_target for delegation)",
+        message: "Missing or invalid 'provider' field (must be a non-empty string)",
       });
     } else if (!isTemplated && (providerValue === 'claude' || providerValue === 'copilot')) {
       errors.push({

--- a/packages/core/test/evaluation/validation/targets-validator.test.ts
+++ b/packages/core/test/evaluation/validation/targets-validator.test.ts
@@ -408,12 +408,13 @@ targets:
     ).toBe(true);
   });
 
-  it('accepts env-templated use_target values without resolving the env during validation', async () => {
+  it('rejects use_target on authored target definitions', async () => {
     const filePath = path.join(tempDir, 'templated-use-target.yaml');
     await writeFile(
       filePath,
       `targets:
   - id: default
+    provider: mock
     use_target: "{{ env.AGENT_TARGET }}"
   - id: grader
     use_target: "{{ env.GRADER_TARGET }}"
@@ -424,34 +425,23 @@ targets:
 `,
     );
 
-    const originalAgentTarget = process.env.AGENT_TARGET;
-    const originalGraderTarget = process.env.GRADER_TARGET;
-    Reflect.deleteProperty(process.env, 'AGENT_TARGET');
-    Reflect.deleteProperty(process.env, 'GRADER_TARGET');
+    const result = await validateTargetsFile(filePath);
 
-    try {
-      const result = await validateTargetsFile(filePath);
-
-      expect(result.valid).toBe(true);
-      expect(
-        result.errors.some(
-          (error) =>
-            error.severity === 'error' &&
-            error.message.includes("Missing or invalid 'provider' field"),
-        ),
-      ).toBe(false);
-    } finally {
-      if (originalAgentTarget === undefined) {
-        Reflect.deleteProperty(process.env, 'AGENT_TARGET');
-      } else {
-        process.env.AGENT_TARGET = originalAgentTarget;
-      }
-      if (originalGraderTarget === undefined) {
-        Reflect.deleteProperty(process.env, 'GRADER_TARGET');
-      } else {
-        process.env.GRADER_TARGET = originalGraderTarget;
-      }
-    }
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        severity: 'error',
+        location: 'targets[0].use_target',
+        message: expect.stringContaining("'use_target' field has been removed"),
+      }),
+    );
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        severity: 'error',
+        location: 'targets[1].use_target',
+        message: expect.stringContaining("'use_target' field has been removed"),
+      }),
+    );
   });
 
   it('rejects legacy env interpolation in target YAML', async () => {


### PR DESCRIPTION
## Summary

Authored `targets.yaml` entries now fail validation when they use `use_target`, including env-template forms such as `use_target: "{{ env.AGENT_TARGET }}"`. This turns the previous validate/pass then prepare/eval failure into an immediate removed-field validation error.

Generic unknown fields remain warning-only by default. That keeps AgentV aligned with Promptfoo's permissive validation behavior for unrecognized fields while still treating `use_target` as a targeted unsupported field in AgentV 5 authored targets.

## Validation

- `bun test packages/core/test/evaluation/validation/targets-validator.test.ts`
- `bun run build`
- `bun apps/cli/src/cli.ts validate /tmp/tmp.dii994QnHC/use/.agentv/targets.yaml` confirmed `use_target` exits non-zero.
- `bun apps/cli/src/cli.ts validate /tmp/tmp.dii994QnHC/warn/.agentv/targets.yaml` confirmed unknown provider settings remain warnings with exit 0.
- `bun apps/cli/src/cli.ts validate /tmp/tmp.dii994QnHC/project/.agentv/config.yaml` confirmed unexpected config fields remain warnings with exit 0.
- `bun apps/cli/src/cli.ts validate /tmp/tmp.dii994QnHC/warn/.agentv/targets.yaml --max-warnings 0` confirmed warnings can still be promoted to failure.
- `bunx biome check packages/core/src/evaluation/providers/targets.ts packages/core/src/evaluation/validation/targets-validator.ts packages/core/test/evaluation/validation/targets-validator.test.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
