### PR TITLE
docs(eval): finish promptfoo authoring guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,18 @@ targets:
     runtime: host
     config:
       api_format: chat
-      base_url: ${{ LOCAL_OPENAI_PROXY_BASE_URL }}
-      api_key: ${{ LOCAL_OPENAI_PROXY_API_KEY }}
-      model: ${{ LOCAL_OPENAI_PROXY_MODEL }}
+      base_url: "{{ env.LOCAL_OPENAI_PROXY_BASE_URL }}"
+      api_key: "{{ env.LOCAL_OPENAI_PROXY_API_KEY }}"
+      model: "{{ env.LOCAL_OPENAI_PROXY_MODEL }}"
 
 graders:
   - id: local-openai-grader
     provider: openai
     config:
       api_format: chat
-      base_url: ${{ LOCAL_OPENAI_PROXY_BASE_URL }}
-      api_key: ${{ LOCAL_OPENAI_PROXY_API_KEY }}
-      model: ${{ LOCAL_OPENAI_PROXY_MODEL }}
+      base_url: "{{ env.LOCAL_OPENAI_PROXY_BASE_URL }}"
+      api_key: "{{ env.LOCAL_OPENAI_PROXY_API_KEY }}"
+      model: "{{ env.LOCAL_OPENAI_PROXY_MODEL }}"
 
 defaults:
   target: local-openai
@@ -128,8 +128,8 @@ target:
   runtime: host
   config:
     api_format: chat
-    base_url: ${{ LOCAL_OPENAI_PROXY_BASE_URL }}
-    api_key: ${{ LOCAL_OPENAI_PROXY_API_KEY }}
+    base_url: "{{ env.LOCAL_OPENAI_PROXY_BASE_URL }}"
+    api_key: "{{ env.LOCAL_OPENAI_PROXY_API_KEY }}"
     model: gpt-5.4-mini
 evaluate_options:
   repeat:

--- a/apps/web/src/content/docs/docs/next/evaluation/batch-cli.mdx
+++ b/apps/web/src/content/docs/docs/next/evaluation/batch-cli.mdx
@@ -30,28 +30,30 @@ Use batch CLI evaluation when:
 description: Batch CLI demo using structured input
 target: batch_cli
 
+prompts:
+  - "{{ input }}"
+
 tests:
   - id: case-001
     criteria: |-
       Batch runner returns JSON with decision=CLEAR.
     vars:
+      input:
+        - role: system
+          content: You are a batch processor.
+        - role: user
+          content:
+            request:
+              type: screening_check
+              jurisdiction: AU
+            row:
+              id: case-001
+              name: Example A
+              amount: 5000
       expected_output:
         - role: assistant
           content:
             decision: CLEAR
-
-    input:
-      - role: system
-        content: You are a batch processor.
-      - role: user
-        content:
-          request:
-            type: screening_check
-            jurisdiction: AU
-          row:
-            id: case-001
-            name: Example A
-            amount: 5000
 
     assert:
       - name: decision-check
@@ -63,23 +65,22 @@ tests:
     criteria: |-
       Batch runner returns JSON with decision=REVIEW.
     vars:
+      input:
+        - role: system
+          content: You are a batch processor.
+        - role: user
+          content:
+            request:
+              type: screening_check
+              jurisdiction: AU
+            row:
+              id: case-002
+              name: Example B
+              amount: 25000
       expected_output:
         - role: assistant
           content:
             decision: REVIEW
-
-    input:
-      - role: system
-        content: You are a batch processor.
-      - role: user
-        content:
-          request:
-            type: screening_check
-            jurisdiction: AU
-          row:
-            id: case-002
-            name: Example B
-            amount: 25000
 
     assert:
       - name: decision-check

--- a/apps/web/src/content/docs/docs/next/evaluation/eval-cases.mdx
+++ b/apps/web/src/content/docs/docs/next/evaluation/eval-cases.mdx
@@ -39,37 +39,60 @@ tests:
 | `environment` | No | Per-case environment recipe (overrides suite-level) |
 | `metadata` | No | Arbitrary key-value pairs passed to graders, setup commands, and lifecycle extensions |
 
-## Input
+## Prompt Data
 
-The simplest form is a string, which expands to a single user message:
-
-```yaml
-input: What is 15 + 27?
-```
-
-Structured object input also expands to a single user message while preserving the object for script graders and batch runners:
+In normal authored eval YAML, put prompt text in top-level `prompts` and
+per-case data in `tests[].vars`. The simplest form uses one prompt template and
+one string var:
 
 ```yaml
-input:
-  request:
-    type: classify_ticket
-  ticket:
-    title: Login button is broken
+prompts:
+  - "{{ question }}"
+
+tests:
+  - id: addition
+    vars:
+      question: What is 15 + 27?
 ```
 
-Top-level `role` is reserved for message objects. If your structured payload needs its own role field, nest it under another key.
-
-For multi-turn or system messages, use a message array:
+Structured object data can stay in vars for script graders and batch runners:
 
 ```yaml
-input:
-  - role: system
-    content: You are a helpful math tutor.
-  - role: user
-    content: What is 15 + 27?
+prompts:
+  - "{{ input }}"
+
+tests:
+  - id: classify-ticket
+    vars:
+      input:
+        request:
+          type: classify_ticket
+        ticket:
+          title: Login button is broken
 ```
 
-When suite-level `input` is defined in the eval file, those messages are prepended to the test's input. See [Suite-level Input](/docs/evaluation/eval-files/#suite-level-input).
+Top-level `role` is reserved for message objects. If your structured payload
+needs its own role field, nest it under another key.
+
+For multi-turn or system messages, put the message array in `prompts`:
+
+```yaml
+prompts:
+  - - role: system
+      content: You are a helpful math tutor.
+    - role: user
+      content: "What is {{ a }} + {{ b }}?"
+
+tests:
+  - id: addition
+    vars:
+      a: 15
+      b: 27
+```
+
+Do not author `tests[].input` or top-level `input` in normal eval YAML. Those
+legacy direct-input fields are rejected; external raw-case imports are the only
+compatibility path for old input rows.
 
 ## Criteria
 
@@ -128,7 +151,8 @@ eval suites, or tags/filters for target-specific cases.
 ```yaml
 tests:
   - id: complex-case
-    input: Explain quicksort algorithm
+    vars:
+      input: Explain quicksort algorithm
 
     assert:
       - Provides a detailed explanation
@@ -147,13 +171,15 @@ assert:
 
 tests:
   - id: normal-case
-    input: What is 2+2?
+    vars:
+      input: What is 2+2?
     assert:
       - Returns the correct answer
     # Gets latency_check from root-level assertions
 
   - id: special-case
-    input: Handle this edge case
+    vars:
+      input: Handle this edge case
     execution:
       skip_defaults: true
     assert:
@@ -178,7 +204,8 @@ environment:
 
 tests:
   - id: case-1
-    input: Do something
+    vars:
+      input: Do something
     assert:
       - Completes the requested task
     environment:
@@ -189,7 +216,8 @@ tests:
         cwd: "."
 
   - id: case-2
-    input: Do something else
+    vars:
+      input: Do something else
     assert:
       - Completes the requested task
     # Inherits suite-level environment
@@ -205,7 +233,8 @@ Pass arbitrary key-value pairs to lifecycle commands via the `metadata` field. T
 ```yaml
 tests:
   - id: sympy-20590
-    input: Fix the diophantine equation bug in repo/.
+    vars:
+      input: Fix the diophantine equation bug in repo/.
     metadata:
       source_repo: sympy/sympy
       source_commit: "abc123def"
@@ -263,7 +292,8 @@ AgentV groups the strings into a rubric grader automatically:
 ```yaml
 tests:
   - id: bug-fix-review
-    input: Review this failing parser implementation.
+    vars:
+      input: Review this failing parser implementation.
     assert:
       - Identifies the root cause of the parser failure
       - Proposes a concrete code change
@@ -300,7 +330,8 @@ Multi-word assertion types use kebab-case (`contains-all`, `is-json`, etc.).
 ```yaml
 tests:
   - id: json-api
-    input: Return the system status as JSON
+    vars:
+      input: Return the system status as JSON
     assert:
       - type: is-json
       - type: contains
@@ -314,13 +345,15 @@ Use `contains-all` or `contains-any` to check multiple values in a single assert
 ```yaml
 tests:
   - id: required-fields
-    input: "Confirm details: name is Alice, email is alice@example.com"
+    vars:
+      input: "Confirm details: name is Alice, email is alice@example.com"
     assert:
       - type: contains-all
         value: ["Alice", "alice@example.com"]
 
   - id: greeting-variant
-    input: "Greet the user warmly."
+    vars:
+      input: "Greet the user warmly."
     assert:
       - type: contains-any
         value: ["Hello", "Hi", "Hey", "Welcome", "Greetings"]
@@ -341,7 +374,8 @@ All deterministic assertions support these optional fields:
 ```yaml
 tests:
   - id: no-competitors
-    input: "Describe our product advantages."
+    vars:
+      input: "Describe our product advantages."
     assert:
       - Response must not mention any competitor
       - type: contains-any
@@ -349,7 +383,8 @@ tests:
         negate: true
 
   - id: required-inputs
-    input: "Process customs entry for country BE."
+    vars:
+      input: "Process customs entry for country BE."
     assert:
       - Agent asks for missing rule codes
       - name: asks-for-rule-codes
@@ -435,7 +470,8 @@ Plain assertion strings are the default shape for semantic checks:
 ```yaml
 tests:
   - id: simple-eval
-    input: "Debug this function..."
+    vars:
+      input: "Debug this function..."
     assert:
       - Assistant correctly explains the bug and proposes a fix
 ```
@@ -498,7 +534,8 @@ To combine deterministic checks with semantic checks, add both explicitly:
 ```yaml
 tests:
   - id: mixed-eval
-    input: "Debug this function..."
+    vars:
+      input: "Debug this function..."
     assert:
       - Explains why the bug happens
       - type: contains
@@ -536,7 +573,8 @@ tests:
     metadata:
       language: python
       difficulty: medium
-    input: Write a function to sort a list
+    vars:
+      input: Write a function to sort a list
     assert:
       - Generates valid Python
 ```

--- a/apps/web/src/content/docs/docs/next/evaluation/eval-files.mdx
+++ b/apps/web/src/content/docs/docs/next/evaluation/eval-files.mdx
@@ -345,7 +345,8 @@ requires:
 tests:
   - id: denied-party
     criteria: Identifies denied parties correctly
-    input: Screen "Acme Corp" against denied parties list
+    vars:
+      input: Screen "Acme Corp" against denied parties list
 ```
 
 When `category` is omitted, AgentV derives it from the eval file path. Generic
@@ -368,6 +369,8 @@ separate grader panel.
 
 ```yaml
 description: API response validation
+prompts:
+  - "{{ input }}"
 assert:
   - type: is-json
     required: true
@@ -378,7 +381,8 @@ assert:
 
 tests:
   - id: health-check
-    input: Check API health
+    vars:
+      input: Check API health
 ```
 
 `assert` supports rubric shorthand strings, deterministic assertion types
@@ -535,7 +539,7 @@ validation instead of being skipped at runtime.
 `__metric` names the generated assertions, `__threshold` sets the test threshold,
 `__metadata:<key>` adds metadata, and `__config:__expectedN:threshold` sets an
 assertion `min_score`. Ordinary columns become `vars`, so CSV rows can rely on
-suite-level `input` that interpolates those variables.
+suite-level `prompts` that interpolate those variables.
 
 String shorthand is raw-case-only. Use a direct raw-case path or file ref when
 you want case data to run in the parent suite context:
@@ -544,7 +548,8 @@ you want case data to run in the parent suite context:
 tests:
   - file://./cases/regression.jsonl
   - id: local-edge-case
-    input: ...
+    vars:
+      input: ...
 ```
 
 Run multiple eval files directly from the CLI, and use tags to group suites that

--- a/apps/web/src/content/docs/docs/next/evaluation/examples.mdx
+++ b/apps/web/src/content/docs/docs/next/evaluation/examples.mdx
@@ -138,11 +138,15 @@ Validate that an agent uses specific tools during execution:
 description: Tool usage validation
 target: mock_agent
 
+prompts:
+  - "{{ input }}"
+
 tests:
   # Validate minimum tool usage (order doesn't matter)
   - id: research-depth
     criteria: Agent researches thoroughly
-    input: Research REST vs GraphQL
+    vars:
+      input: Research REST vs GraphQL
     assert:
       - name: research-check
         type: trajectory:tool-used
@@ -157,7 +161,8 @@ tests:
   # Validate exact tool sequence
   - id: auth-flow
     criteria: Agent follows auth sequence
-    input: Authenticate user
+    vars:
+      input: Authenticate user
     assert:
       - name: auth-sequence
         type: trajectory:tool-sequence
@@ -208,10 +213,14 @@ Evaluate pre-existing trace files without running an agent:
 description: Static trace evaluation
 target: static_trace
 
+prompts:
+  - "{{ input }}"
+
 tests:
   - id: validate-trace-file
     criteria: Trace contains required steps
-    input: Analyze trace
+    vars:
+      input: Analyze trace
     assert:
       - name: trace-check
         type: trajectory:tool-sequence
@@ -230,38 +239,40 @@ Test multi-turn interactions where intermediate messages set context:
 description: Multi-turn debugging session with clarifying questions
 target: default
 
+prompts:
+  - "{{ input }}"
+
 tests:
   - id: debug-with-clarification
     criteria: |-
       Assistant conducts a multi-turn debugging session, asking clarification
       questions when needed, correctly diagnosing the bug, and proposing a clear
       fix with rationale.
-
-    input:
-      - role: system
-        content: You are an expert debugging assistant who reasons step by step, asks clarifying questions, and explains fixes clearly.
-      - role: user
-        content: |-
-          I'm getting an off-by-one error in this function, but I can't see why:
-
-          ```python
-          def get_items(items):
-              result = []
-              for i in range(len(items) - 1):
-                  result.append(items[i])
-              return result
-          ```
-
-          Sometimes the last element is missing. Can you help debug this?
-      - role: assistant
-        content: |-
-          I can help debug this. Before I propose a fix, could you tell me:
-          - What output you expect for an example input list
-          - What output you actually get
-      - role: user
-        content: |-
-          For `[1, 2, 3, 4]` I expect `[1, 2, 3, 4]`, but I get `[1, 2, 3]`.
     vars:
+      input:
+        - role: system
+          content: You are an expert debugging assistant who reasons step by step, asks clarifying questions, and explains fixes clearly.
+        - role: user
+          content: |-
+            I'm getting an off-by-one error in this function, but I can't see why:
+
+            ```python
+            def get_items(items):
+                result = []
+                for i in range(len(items) - 1):
+                    result.append(items[i])
+                return result
+            ```
+
+            Sometimes the last element is missing. Can you help debug this?
+        - role: assistant
+          content: |-
+            I can help debug this. Before I propose a fix, could you tell me:
+            - What output you expect for an example input list
+            - What output you actually get
+        - role: user
+          content: |-
+            For `[1, 2, 3, 4]` I expect `[1, 2, 3, 4]`, but I get `[1, 2, 3]`.
       expected_output: |-
         You have an off-by-one error in your loop bounds.
         You're iterating with `range(len(items) - 1)`, which stops before the last index.
@@ -291,33 +302,35 @@ Evaluate external batch runners that process all tests in one invocation:
 description: Batch CLI demo (AML screening)
 target: batch_cli
 
+prompts:
+  - "{{ input }}"
+
 tests:
   - id: aml-001
     criteria: |-
       Batch runner returns JSON with decision=CLEAR.
     vars:
+      input:
+        - role: system
+          content: You are a deterministic AML screening batch checker.
+        - role: user
+          content:
+            request:
+              type: aml_screening_check
+              jurisdiction: AU
+              effective_date: 2025-01-01
+            row:
+              id: aml-001
+              customer_name: Example Customer A
+              origin_country: NZ
+              destination_country: AU
+              transaction_type: INTERNATIONAL_TRANSFER
+              amount: 5000
+              currency: USD
       expected_output:
         - role: assistant
           content:
             decision: CLEAR
-
-    input:
-      - role: system
-        content: You are a deterministic AML screening batch checker.
-      - role: user
-        content:
-          request:
-            type: aml_screening_check
-            jurisdiction: AU
-            effective_date: 2025-01-01
-          row:
-            id: aml-001
-            customer_name: Example Customer A
-            origin_country: NZ
-            destination_country: AU
-            transaction_type: INTERNATIONAL_TRANSFER
-            amount: 5000
-            currency: USD
 
     assert:
       - name: decision-check
@@ -329,28 +342,27 @@ tests:
     criteria: |-
       Batch runner returns JSON with decision=REVIEW.
     vars:
+      input:
+        - role: system
+          content: You are a deterministic AML screening batch checker.
+        - role: user
+          content:
+            request:
+              type: aml_screening_check
+              jurisdiction: AU
+              effective_date: 2025-01-01
+            row:
+              id: aml-002
+              customer_name: Example Customer B
+              origin_country: IR
+              destination_country: AU
+              transaction_type: INTERNATIONAL_TRANSFER
+              amount: 2000
+              currency: USD
       expected_output:
         - role: assistant
           content:
             decision: REVIEW
-
-    input:
-      - role: system
-        content: You are a deterministic AML screening batch checker.
-      - role: user
-        content:
-          request:
-            type: aml_screening_check
-            jurisdiction: AU
-            effective_date: 2025-01-01
-          row:
-            id: aml-002
-            customer_name: Example Customer B
-            origin_country: IR
-            destination_country: AU
-            transaction_type: INTERNATIONAL_TRANSFER
-            amount: 2000
-            currency: USD
 
     assert:
       - name: decision-check
@@ -364,40 +376,45 @@ tests:
 - `target: batch_cli` -- configure the CLI provider with `batch_requests: true`
 - The batch runner reads the eval YAML via `--eval` flag and outputs JSONL keyed by `id`
 - Put structured data in `user.content` as objects for the runner to extract
-- Use `expected_output` with object fields for structured expected output
+- Use `vars.expected_output` with object fields for structured expected output
 - Each test has its own grader to validate its portion of the output
 
-## Suite-level Input
+## Shared Prompt Context
 
-Share a common prompt or system instruction across all tests. Suite-level `input` messages are prepended to each test's input, like suite-level `assert` for graders:
+Share a common prompt or system instruction across all tests with top-level
+`prompts`, then keep per-case data in `tests[].vars`:
 
 ```yaml
 description: Travel assistant evaluation
-input: |
-  You are a knowledgeable travel assistant.
-  Always include a practical safety tip.
+prompts:
+  - - role: system
+      content: |
+        You are a knowledgeable travel assistant.
+        Always include a practical safety tip.
+    - role: user
+      content: "{{ question }}"
 
 tests: ./cases.yaml
 ```
 
-```yaml
-# cases.yaml — tests only need their own queries
+```yaml title="cases.yaml"
 - id: japan-spring
   criteria: Recommends spring for cherry blossoms and mentions visa requirements
-  input: When is the best time to visit Japan?
+  vars:
+    question: When is the best time to visit Japan?
 
 - id: iceland-lights
   criteria: Recommends winter for Northern Lights
-  input: I want to see the Northern Lights in Iceland. When should I go?
+  vars:
+    question: I want to see the Northern Lights in Iceland. When should I go?
 
 - id: currency-only
   criteria: Provides direct answer about currency
-  input: What currency does Thailand use?
-  execution:
-    skip_defaults: true   # no suite-level input
+  vars:
+    question: What currency does Thailand use?
 ```
 
-See the [suite-level-input example](https://github.com/EntityProcess/agentv/tree/main/examples/features/suite-level-input) for a complete working version.
+See the [suite-level input migration example](https://github.com/EntityProcess/agentv/tree/main/examples/features/suite-level-input) for a complete working version.
 
 ## File Path Conventions
 

--- a/apps/web/src/content/docs/docs/next/evaluation/experiments.mdx
+++ b/apps/web/src/content/docs/docs/next/evaluation/experiments.mdx
@@ -36,10 +36,13 @@ environment:
   setup:
     command: ["bash", "-lc", "bun install && bun run build"]
     cwd: "."
+prompts:
+  - "{{ input }}"
 
 tests:
   - id: refund-eligibility
-    input: Can this customer get a refund?
+    vars:
+      input: Can this customer get a refund?
     criteria: Applies the refund policy correctly
 ```
 
@@ -66,11 +69,14 @@ controls:
 # experiments/refunds-codex.eval.yaml
 name: refunds-codex
 target: codex-gpt5
+prompts:
+  - "{{ input }}"
 
 tests:
   - file://../evals/cases/refund-smoke.cases.yaml
   - id: local-edge-case
-    input: Check a damaged final-sale refund.
+    vars:
+      input: Check a damaged final-sale refund.
 ```
 
 The `experiments/` folder is optional and user-owned. AgentV does not scan it
@@ -115,10 +121,13 @@ evaluate_options:
 timeout_seconds: 300
 tags:
   area: agentic
+prompts:
+  - "{{ input }}"
 
 tests:
   - id: critical-case
-    input: "..."
+    vars:
+      input: "..."
     criteria: Must pass exactly
     run:
       threshold: 1.0

--- a/apps/web/src/content/docs/docs/next/evaluation/rubrics.mdx
+++ b/apps/web/src/content/docs/docs/next/evaluation/rubrics.mdx
@@ -13,10 +13,14 @@ Rubrics are defined with `assert` entries and support binary checklist grading a
 The simplest form: list plain strings in `assert` and each one becomes a required criterion:
 
 ```yaml
+prompts:
+  - "{{ input }}"
+
 tests:
   - id: quicksort-explain
     criteria: Explain how quicksort works
-    input: Explain quicksort algorithm
+    vars:
+      input: Explain quicksort algorithm
     assert:
       - Mentions divide-and-conquer approach
       - Explains partition step
@@ -30,10 +34,14 @@ All strings are collected into a single llm-rubric grader automatically.
 Use `type: llm-rubric` explicitly when you need weights, required flags, or score ranges. Put structured rubric items in `value`:
 
 ```yaml
+prompts:
+  - "{{ input }}"
+
 tests:
   - id: quicksort-explain
     criteria: Explain how quicksort works
-    input: Explain quicksort algorithm
+    vars:
+      input: Explain quicksort algorithm
     assert:
       - type: llm-rubric
         value:
@@ -206,10 +214,14 @@ Use this for qualitative tool-use checks. Use `skill-used`, `not-skill-used`, or
 Rubrics work alongside script and LLM graders:
 
 ```yaml
+prompts:
+  - "{{ input }}"
+
 tests:
   - id: code-quality
     criteria: Generates correct, clean Python code
-    input: Write a fibonacci function
+    vars:
+      input: Write a fibonacci function
     assert:
       - type: llm-rubric
         value:

--- a/apps/web/src/content/docs/docs/next/evaluation/running-evals.mdx
+++ b/apps/web/src/content/docs/docs/next/evaluation/running-evals.mdx
@@ -492,9 +492,13 @@ graders:
     config:
       model: gpt-5-mini
 
+prompts:
+  - "{{ input }}"
+
 tests:
   - id: smoke
-    input: Fix the failing test
+    vars:
+      input: Fix the failing test
 
 defaults:
   target: codex-local

--- a/apps/web/src/content/docs/docs/next/graders/custom-graders.mdx
+++ b/apps/web/src/content/docs/docs/next/graders/custom-graders.mdx
@@ -37,9 +37,13 @@ tests:
 ### Per-Case Override
 
 ```yaml
+prompts:
+  - "{{ input }}"
+
 tests:
   - id: test-1
-    input: Generate a JSON config
+    vars:
+      input: Generate a JSON config
     assert:
       - Returns valid JSON
       - name: json_check
@@ -52,9 +56,13 @@ tests:
 Use multiple graders on the same case for comprehensive scoring:
 
 ```yaml
+prompts:
+  - "{{ input }}"
+
 tests:
   - id: code-generation
-    input: Write a sorting function
+    vars:
+      input: Write a sorting function
     assert:
       - Code is syntactically valid
       - Handles edge cases such as empty lists and single-element lists

--- a/apps/web/src/content/docs/docs/next/graders/execution-metrics.mdx
+++ b/apps/web/src/content/docs/docs/next/graders/execution-metrics.mdx
@@ -47,10 +47,14 @@ assert:
 ### Example: Comprehensive Efficiency Check
 
 ```yaml
+prompts:
+  - "{{ input }}"
+
 tests:
   - id: efficient-research
     criteria: Agent researches and summarizes efficiently
-    input: Research the topic and provide a summary
+    vars:
+      input: Research the topic and provide a summary
     assert:
       - name: efficiency
         type: execution-metrics
@@ -120,10 +124,14 @@ Fails if total token usage exceeds the threshold.
 Execution metrics work well alongside semantic graders:
 
 ```yaml
+prompts:
+  - "{{ input }}"
+
 tests:
   - id: code-generation
     criteria: Generates correct, efficient code
-    input: Write a sorting algorithm
+    vars:
+      input: Write a sorting algorithm
     assert:
       # Semantic quality
       - name: quality

--- a/apps/web/src/content/docs/docs/next/graders/script-graders.mdx
+++ b/apps/web/src/content/docs/docs/next/graders/script-graders.mdx
@@ -454,10 +454,13 @@ environment:
   workdir: ./workspace-template
 
 target: my_agent
+prompts:
+  - "{{ input }}"
 
 tests:
   - id: implement-feature
-    input: "Implement the TODO functions in src/index.ts"
+    vars:
+      input: "Implement the TODO functions in src/index.ts"
     assert:
       - Agent implements the feature correctly
       - name: functional-check

--- a/apps/web/src/content/docs/docs/next/guides/eval-authoring.mdx
+++ b/apps/web/src/content/docs/docs/next/guides/eval-authoring.mdx
@@ -77,7 +77,8 @@ Test **decision-making discipline**, not git infrastructure operations:
 ```yaml
 # BAD — requires GitHub remote
 - id: merge-check
-  input: "Merge PR #42 if it looks safe"
+  vars:
+    input: "Merge PR #42 if it looks safe"
 ```
 
 **Do** frame prompts as hypothetical with inline context:
@@ -85,16 +86,17 @@ Test **decision-making discipline**, not git infrastructure operations:
 ```yaml
 # GOOD — self-contained, no remote needed
 - id: merge-check
-  input: |
-    Here is what PR #42 changes:
+  vars:
+    input: |
+      Here is what PR #42 changes:
 
-    ```diff
-    -  timeout: 30_000
-    +  timeout: 5_000
-    ```
+      ```diff
+      -  timeout: 30_000
+      +  timeout: 5_000
+      ```
 
-    The PR description says: "Reduce timeout for faster feedback."
-    Should this be shipped? What risks do you see?
+      The PR description says: "Reduce timeout for faster feedback."
+      Should this be shipped? What risks do you see?
 ```
 
 ## Workspace State Consistency: Git Diff Verification
@@ -137,16 +139,17 @@ When you don't want to maintain actual diffs, describe the changes inline:
 
 ```yaml
 - id: ship-decision
-  input: |
-    You are reviewing a proposed change. Here is the diff:
+  vars:
+    input: |
+      You are reviewing a proposed change. Here is the diff:
 
-    ```diff
-    --- a/src/config.ts
-    +++ b/src/config.ts
-    @@ -10,3 +10,3 @@
-    -  retries: 3,
-    +  retries: 0,
-    ```
+      ```diff
+      --- a/src/config.ts
+      +++ b/src/config.ts
+      @@ -10,3 +10,3 @@
+      -  retries: 3,
+      +  retries: 0,
+      ```
 
     The author says: "Disable retries to reduce latency."
     Should this be shipped?

--- a/apps/web/src/content/docs/docs/next/guides/skill-improvement-workflow.mdx
+++ b/apps/web/src/content/docs/docs/next/guides/skill-improvement-workflow.mdx
@@ -234,11 +234,14 @@ tags:
   skill: "code-reviewer"
 metadata:
   source_adapter: "agent-skills-evals-json"
+prompts:
+  - "{{ input }}"
 tests:
   - id: "1"
     criteria: |-
       The function should handle division by zero.
-    input: "Review this Python function for bugs:..."
+    vars:
+      input: "Review this Python function for bugs:..."
     assert:
       - metric: agent-skills-criteria
         type: llm-rubric

--- a/apps/web/src/content/docs/docs/next/integrations/agent-skills-evals.mdx
+++ b/apps/web/src/content/docs/docs/next/integrations/agent-skills-evals.mdx
@@ -102,14 +102,21 @@ The generated `llm-rubric` assertion emits per-criterion grading rows in AgentV 
 
 ## Files
 
-`evals.json` file paths map to AgentV `input_files`:
+`evals.json` file paths map to file-backed prompt content:
 
 ```yaml
+prompts:
+  - - role: user
+      content:
+        - type: text
+          value: "{{ input }}"
+        - type: file
+          value: evals/files/sales.csv
+
 tests:
   - id: "1"
-    input_files:
-      - evals/files/sales.csv
-    input: "Analyze the sales data."
+    vars:
+      input: "Analyze the sales data."
 ```
 
 Use `environment.setup.command` when the eval should materialize a repository
@@ -149,13 +156,20 @@ tags:
 metadata:
   source_adapter: "agent-skills-evals-json"
 
+prompts:
+  - - role: user
+      content:
+        - type: text
+          value: "{{ input }}"
+        - type: file
+          value: evals/files/sales.csv
+
 tests:
   - id: "1"
     criteria: |-
       The top 3 months by revenue are November, September, and December.
-    input: "Find the top 3 months by revenue."
-    input_files:
-      - "evals/files/sales.csv"
+    vars:
+      input: "Find the top 3 months by revenue."
     # Promoted from evals.json expected_output, assertions[], and expectations[]
     # Replace with type: is-json, contains, or regex for deterministic checks
     assert:
@@ -207,10 +221,14 @@ Use AgentV YAML directly when AgentV owns the eval lifecycle.
 ### EVAL.yaml
 
 ```yaml
+prompts:
+  - "{{ input }}"
+
 tests:
   - id: "1"
-    input: |
-      A customer says their order #12345 hasn't arrived after 2 weeks. Help them.
+    vars:
+      input: |
+        A customer says their order #12345 hasn't arrived after 2 weeks. Help them.
     criteria: |
       An empathetic response that offers to track the order and provides next steps.
     assert:

--- a/apps/web/src/content/docs/docs/next/targets/coding-agents.mdx
+++ b/apps/web/src/content/docs/docs/next/targets/coding-agents.mdx
@@ -333,13 +333,13 @@ prompt includes a preread block with `file://` URIs pointing to absolute paths
 on disk, then the user query references each file:
 
 ```yaml
-input:
-  - role: user
-    content:
-      - type: file
-        value: ./src/example.ts
-      - type: text
-        value: Review this code
+prompts:
+  - - role: user
+      content:
+        - type: file
+          value: ./src/example.ts
+        - type: text
+          value: Review this code
 ```
 
 The agent receives a prompt like:

--- a/apps/web/src/content/docs/docs/next/targets/configuration.mdx
+++ b/apps/web/src/content/docs/docs/next/targets/configuration.mdx
@@ -134,9 +134,13 @@ graders:
     config:
       model: gpt-5-mini
 
+prompts:
+  - "{{ input }}"
+
 tests:
   - id: smoke
-    input: Fix the failing test.
+    vars:
+      input: Fix the failing test.
 
 defaults:
   target: codex-local

--- a/skills-data/agentv-bench/SKILL.md
+++ b/skills-data/agentv-bench/SKILL.md
@@ -49,7 +49,7 @@ Before running or optimizing, understand what you're working with.
 
 2. **Identify success criteria** — what does "good" look like for this agent? What are the edge cases? What would a failure look like? Talk to the user if this isn't clear from the artifacts alone.
 
-3. **Understand the target harness** — which provider runs the agent (Claude, GPT, Copilot CLI, Gemini, custom CLI)? This affects what grader types are available and how to run tests. Targets are configured in `.agentv/targets.yaml` (canonical location, searched from the eval file directory upward). Sensitive values like `api_key` must use `${{ ENV_VAR }}` syntax — literal secrets are rejected as a security guardrail.
+3. **Understand the target harness** — which provider runs the agent (Claude, GPT, Copilot CLI, Gemini, custom CLI)? This affects what grader types are available and how to run tests. Targets are configured in `.agentv/targets.yaml` (canonical location, searched from the eval file directory upward). Sensitive values like `api_key` must use `{{ env.ENV_VAR }}` references — literal secrets are rejected as a security guardrail.
 
 4. **Challenge assumptions** — if evals already exist, review their quality before running:
    - Are the test cases testing the right things?
@@ -65,7 +65,7 @@ Before running or optimizing, understand what you're working with.
 
 AgentV supports two evaluation formats:
 
-**EVAL.yaml** (native, full features) — supports environment recipes, script graders, multi-turn conversations, tool trajectory scoring, workspace file tracking, and multi-provider targets. Use this for agent evaluation.
+**EVAL.yaml** (native, full features) — supports prompt matrices, environment recipes, script graders, multi-turn conversations, tool trajectory scoring, workspace file tracking, and multi-provider targets. Use this for agent evaluation.
 
 ```yaml
 # example.eval.yaml
@@ -89,7 +89,7 @@ tests:
       - Review identifies the null pointer bug and suggests a concrete fix
 ```
 
-Multi-skill evaluation is handled naturally via input messages — describe the task in the test input, and the agent uses whatever skills it needs.
+Multi-skill evaluation is handled naturally via prompt messages — describe the task in `prompts`, put row-specific data in `tests[].vars`, and the agent uses whatever skills it needs.
 
 **evals.json** (skill-creator compatible) — auto-promoted to EVAL-equivalent format:
 - `prompt` → input messages
@@ -127,7 +127,7 @@ Prefer deterministic graders over LLM graders whenever possible. If an assertion
 
 This section is one continuous sequence — don't stop partway through.
 
-Each run produces a new `.agentv/results/default/<timestamp>/` directory automatically. Use timestamps to identify iterations when comparing runs.
+Each run produces a new canonical `.agentv/results/<run_id>/` directory automatically. Use the printed run id and `.internal/index.jsonl` when comparing runs.
 
 ### Choosing a run mode
 
@@ -228,11 +228,11 @@ Each grader subagent (operating under `agents/grader.md` instructions):
 2. Reads `<test-id>/response.md` for the candidate output
 3. Grades the response against the prompt criteria
 4. **Writes its result to disk**: `<run-dir>/<evalset>/<test-id>/llm_grader_results/<name>.json`
-5. Returns score (0.0–1.0) and per-assertion evidence to the orchestrator
+5. Returns score (0.0–1.0) and per-assertion notes to the orchestrator
 
-**Writing to disk is critical.** Assertion arrays are lost if accumulated only in the orchestrator's context across multiple batches (context summarization drops detail). Writing per-test results to `llm_grader_results/<name>.json` makes grading resumable and assertion evidence durable.
+**Writing to disk is critical.** Intermediate assertion arrays are lost if accumulated only in the orchestrator's context across multiple batches (context summarization drops detail). Writing per-test results to `llm_grader_results/<name>.json` makes grading resumable. Public `grading.json` artifacts normalize these details into recursive `component_results`.
 
-The result file format is:
+The intermediate subagent result file format is:
 ```json
 { "score": 0.85, "assertions": [{"text": "...", "passed": true, "evidence": "..."}] }
 ```
@@ -246,18 +246,19 @@ agentv pipeline bench <run-dir>
 agentv results validate <run-dir>
 ```
 
-`pipeline bench` reads LLM grader results from `llm_grader_results/<name>.json` per test automatically, merges with script-grader scores, computes weighted pass_rate, and writes `grading.json` + `index.jsonl` + `summary.json`.
+`pipeline bench` reads LLM grader results from `llm_grader_results/<name>.json` per test automatically, merges with script-grader scores, computes aggregate scores, and writes the canonical run bundle with `.internal/index.jsonl`, `summary.json`, and per-attempt `grading.json`.
 
 > **Diagnosing `pass_rate=0`:** If `pipeline bench` reports `pass_rate=0` across the board, do **not** assume the tests genuinely failed. First verify the grading pipeline ran correctly: check that `<test-id>/llm_grader_results/<name>.json` exists and is non-empty for each test. If these files are absent or empty, the grader subagents failed to produce output (most common cause: `agents/grader.md` was not embedded in the subagent prompts — see Phase 2). Treat `pass_rate=0` as a real signal only after confirming grader results exist.
 
 ### Artifacts
 
 All artifacts use established schemas — see `references/schemas.md` for the full definitions. Do not modify the structure. Key artifacts per run:
-- **grading.json**: per-test assertions with `{text, passed, evidence}`, plus summary
-- **timing.json**: `{total_tokens, duration_ms, total_duration_seconds}`
-- **summary.json**: per-target aggregate `{pass_rate, time_seconds, tokens}`
+- **.internal/index.jsonl**: canonical row index for compare, Dashboard, rerun, and artifact discovery
+- **grading.json**: aggregate `pass`, `score`, `reason`, recursive `component_results`, and optional `assertion`, `named_scores`, and `metadata`
+- **metrics.json**: token, cost, timing, tool, and transcript metrics for the attempt
+- **summary.json**: run-level aggregate metadata and pass/score rollups
 
-Write artifacts to `.agentv/artifacts/` or the iteration directory.
+Write artifacts to `.agentv/results/<run_id>/` through the CLI unless a task explicitly needs a fixed output path.
 
 ### Environment features (EVAL.yaml only)
 
@@ -350,7 +351,7 @@ If a prompt file is referenced in both task input and grader configs, optimize f
 After improving:
 
 1. Apply your changes to the agent's prompts/skills/config
-2. Re-run all test cases (agentv creates a new `.agentv/results/default/<timestamp>/` directory automatically)
+2. Re-run all test cases (agentv creates a new `.agentv/results/<run_id>/` directory automatically)
 3. Compare against the previous iteration (Step 4). If running in automated mode, use the **automated keep/discard** logic below instead of manual judgment — it will decide whether to keep or revert the change for you.
 4. Present results to the user (or log the decision if running automated keep/discard)
 5. Stop when ANY of:

--- a/skills-data/agentv-bench/agents/executor.md
+++ b/skills-data/agentv-bench/agents/executor.md
@@ -14,7 +14,7 @@ You are the executor for an AgentV evaluation test case. Your job is to **perfor
 You are the target agent being evaluated. Do the task to the best of your ability — your output will be graded by a separate grader agent.
 
 **You will receive these parameters:**
-- `test-dir`: Path to the test case directory (e.g., `.agentv/results/default/<timestamp>/<test-id>/`)
+- `test-dir`: Path to the prepared test case directory inside the run bundle (for example `.agentv/results/<run_id>/<result-dir>/`)
 
 ## Process
 

--- a/skills-data/agentv-bench/references/autoresearch.md
+++ b/skills-data/agentv-bench/references/autoresearch.md
@@ -56,14 +56,14 @@ Before proceeding to the next iteration, log the decision and rationale so the u
 Iteration 2: KEEP
   wins=3, losses=1, ties=6, meanDelta=+0.05
   Rationale: candidate wins outweigh losses (3 > 1)
-  Baseline promoted: .agentv/results/default/20250101-120000/index.jsonl
+  Baseline promoted: .agentv/results/2025-01-01T12-00-00-000Z/.internal/index.jsonl
 ```
 
 ```
 Iteration 3: DISCARD
   wins=1, losses=2, ties=7, meanDelta=-0.03
   Rationale: candidate losses outweigh wins (2 > 1)
-  Reverted to baseline: .agentv/results/default/20250101-110000/index.jsonl
+  Reverted to baseline: .agentv/results/2025-01-01T11-00-00-000Z/.internal/index.jsonl
   Next: try a different mutation
 ```
 
@@ -210,20 +210,20 @@ agentv eval <eval-path> --experiment autoresearch-<name>
 
 **b. Extract scores (bash only — do NOT read result files into your context)**
 
-Find the latest timestamped directory in the experiment folder. Use bash/jq to extract small structured values:
+Find the latest run directory. Use bash/jq to extract small structured values:
 
 ```bash
 # Find latest run dir
-RUN_DIR=$(ls -td <experiment-dir>/20*/ | head -1)
+RUN_DIR=$(ls -td .agentv/results/20*/ | head -1)
 
 # Overall score (mean of all scores in index.jsonl)
-SCORE=$(jq -sr '[.[].scores[].score] | add / length' "$RUN_DIR/index.jsonl")
+SCORE=$(jq -sr '[.[].score] | add / length' "$RUN_DIR/.internal/index.jsonl")
 
-# Per-assertion pass rates as JSON object
-PASS_RATES=$(jq -sr '[.[].scores[]] | group_by(.type) | map({key: .[0].type, value: (map(.score) | add / length)}) | from_entries' "$RUN_DIR/index.jsonl")
+# Per-target mean scores as JSON object
+TARGET_SCORES=$(jq -sr 'group_by(.target) | map({key: .[0].target, value: (map(.score) | add / length)}) | from_entries' "$RUN_DIR/.internal/index.jsonl")
 
-# Cost (if timing.json exists)
-COST=$(jq -r '.cost_usd // 0' "$RUN_DIR/timing.json" 2>/dev/null || echo 0)
+# Cost (if present in summary.json)
+COST=$(jq -r '.cost_usd // .total_cost_usd // 0' "$RUN_DIR/summary.json" 2>/dev/null || echo 0)
 ```
 
 Capture only these small outputs (`SCORE`, `PASS_RATES`, `COST`) — never read the full JSONL into context.

--- a/skills-data/agentv-bench/references/environment-adaptation.md
+++ b/skills-data/agentv-bench/references/environment-adaptation.md
@@ -21,7 +21,7 @@ for each test case, show the prompt and output. Ask for feedback inline. Skip be
 - **Codex**: Supports skills via `.agents/` or `.codex/` folders. Emits `command_execution`
   and `file_change` tool calls.
 - **Custom CLI**: Needs `command` and output file pattern in target config
-- **Target config**: Uses `${{ ENV_VAR }}` syntax (not `${ENV_VAR}`) for API keys
+- **Target config**: Uses `{{ env.ENV_VAR }}` references for API keys
 
 **Note**: "Description Optimization" (see `references/description-optimization.md`) applies
 to any platform with skill-discovery mechanisms. All listed providers support skills.

--- a/skills-data/agentv-bench/references/eval-yaml-spec.md
+++ b/skills-data/agentv-bench/references/eval-yaml-spec.md
@@ -20,7 +20,7 @@ The grader agent uses this to evaluate assertions without the CLI.
 
 - `id` (string, required) — unique test identifier
 - `vars` (object, required when prompts need row data) — prompt-template variables for this row
-- `expected_output` (string | Message[], optional) — passive reference answer. String shorthand expands to `[{role: assistant, content: "..."}]`. It is available to declared graders, but does not add an implicit grader when `assertions` is present.
+- `vars.expected_output` (string | Message[], optional) — passive reference answer data. It is available to declared graders, but does not add an implicit grader when `assert` is present.
 - `criteria` (string, optional) — human-readable success criteria
 - `assert` (array, optional) — grader assertions
 - `environment` (object | `file://...`, optional) — per-case testbed override
@@ -31,8 +31,8 @@ If `assert` already states the grading contract, omit `criteria` instead of
 duplicating the same rubric. Prefer plain assertion strings for semantic checks
 when the default LLM rubric grader can judge them; use multiple named
 `type: llm-rubric` blocks only for custom prompts, custom grader targets, or
-intentional grader panels. Write `expected_output` as a golden/reference answer,
-not as criteria or scoring instructions.
+intentional grader panels. Write `vars.expected_output` as a golden/reference
+answer, not as criteria or scoring instructions.
 
 For historical or repo-state evals, materialize the repository through
 `environment.setup.command` and pass the repo/ref as argv inputs. A SHA in
@@ -45,11 +45,12 @@ checkout. `setup.command` is a non-empty string array. Put the executable at
 
 ### Default grader contract
 
-When a test has no `assertions`, AgentV uses the default `llm-rubric` with the case context,
-including `criteria` and `expected_output` when present.
+When a test has no `assert`, AgentV can use configured suite/default graders
+with the case context, including `criteria` and `vars.expected_output` when
+present.
 
-When `assertions` is present, the list is explicit: run only the declared
-assertions/graders. `expected_output` remains reference data for graders that consume it,
+When `assert` is present, the list is explicit: run only the declared
+assertions/graders. `vars.expected_output` remains reference data for graders that consume it,
 such as `llm-rubric`, `script`, or `field-accuracy`; it does not trigger an additional
 default `llm-rubric`.
 When the declared assertion strings fully express the semantic contract, do not
@@ -211,18 +212,20 @@ Same as contains variants but explicitly case-insensitive.
 
 ### Script-based assertions
 
-#### `script-grader`
+#### `script`
 
-- **Fields:** `path` (string, required — path to script), `command` (string[], optional — custom command)
+- **Fields:** `command` (string[], required — command to execute), optional `cwd`, `config`, and `target`
 - **Script SDK:** Use `defineScriptGrader` from `@agentv/sdk`:
   ```typescript
   import { defineScriptGrader } from '@agentv/sdk';
   export default defineScriptGrader(({ output, trace }) => ({
+    pass: (output ?? '').includes('expected'),
     score: (output ?? '').includes('expected') ? 1 : 0,
-    assert: [{ text: 'Contains expected', passed: (output ?? '').includes('expected') }],
+    reason: 'Checks for the expected token',
+    checks: [{ text: 'Contains expected', pass: (output ?? '').includes('expected'), reason: 'Substring check' }],
   }));
   ```
-- **Recipe:** The CLI runs the script, passing canonical JSON on stdin (`{output, input, expected_output, ...}`). Script returns `{"score": N, "assertions": [...]}`
+- **Recipe:** The CLI runs the script, passing canonical JSON on stdin (`{output, input, expected_output, ...}`). Script returns `{pass, score, reason, checks?}`; public artifacts normalize `checks` into recursive `component_results`.
 - **PASS:** score >= 0.5 (or as configured).
 
 ### Assertion groups
@@ -252,42 +255,22 @@ All assertion types support:
 - `negate` (boolean, optional) — invert result
 - `threshold` (number, optional) — minimum score to pass (for LLM types)
 
-## 5. AgentV JSONL Output Format
+## 5. AgentV Run Bundle Output
 
-Each line in the results JSONL file is an `EvaluationResult` object. In JSONL, field names use snake_case (applied by `toSnakeCaseDeep()`).
+Each run writes `.agentv/results/<run_id>/`. Public persisted fields use
+snake_case. The canonical discovery file is `.internal/index.jsonl`; per-attempt
+sidecars live under each result directory.
 
-### Required fields
+Key artifacts:
 
-- `timestamp` (string, ISO-8601)
-- `test_id` (string)
-- `score` (number, 0.0-1.0, weighted average of all assertion scores)
-- `assertions` (array of `{text, passed, evidence?}`)
-- `output` (string) — final answer/scored result; transcript evidence is available through captured trace/messages when present
-- `execution_status` (string: `ok` | `quality_failure` | `execution_error`)
-
-### Optional fields
-
-- `scores` (array of EvaluatorResult) — per-grader breakdown
-- `input` (Message[]) — input messages
-- `token_usage` (object: `{prompt_tokens, completion_tokens, total_tokens}`)
-- `cost_usd` (number)
-- `duration_ms` (number)
-- `target` (string)
-- `eval_set` (string)
-- `error` (string)
-- `file_changes` (string — unified diff)
-- `mode` (string — `agent` for agent mode)
-
-### `scores[]` entries (EvaluatorResult)
-
-- `name` (string) — grader name
-- `type` (string) — grader kind (kebab-case)
-- `score` (number, 0.0-1.0)
-- `assertions` (array of `{text, passed, evidence?}`)
-- `weight` (number, optional)
-- `pass` (boolean)
-- `details` (object, optional — structured data from script graders)
-- `reasoning` (string, optional)
+- `.internal/index.jsonl` — one row per result aggregate with identity fields,
+  status, score, target metadata, and explicit paths to sidecars.
+- `summary.json` — run-level metadata and aggregate pass/score rollups.
+- `sample-N/grading.json` — aggregate `pass`, `score`, `reason`, recursive
+  `component_results`, and optional `assertion`, `named_scores`, and `metadata`.
+- `sample-N/metrics.json` — token, cost, timing, tool, and transcript metrics.
+- `sample-N/transcript.json` and `sample-N/transcript-raw.jsonl` — normalized
+  and raw transcript data when available.
 
 ## 6. Eval Set Support
 
@@ -366,9 +349,9 @@ LLM grader results are read from disk at `<test-id>/llm_grader_results/<name>.js
 ```
 
 **Output:**
-- `<test-id>/run-1/grading.json` — merged grading with `graders`, `assertions`, `summary.pass_rate`
-- `index.jsonl` — one JSON line per test: `{test_id, score, pass, graders: [...]}`
-- `summary.json` — aggregate stats: `{metadata: {targets}, run_summary: {<target>: {mean, stddev, n}}}`
+- `.internal/index.jsonl` — canonical row index
+- `summary.json` — aggregate run summary
+- per-attempt `grading.json` — aggregate `pass`, `score`, `reason`, and recursive `component_results`
 
 ### Agent-Mode Workflow
 

--- a/skills-data/agentv-bench/references/schemas.md
+++ b/skills-data/agentv-bench/references/schemas.md
@@ -85,80 +85,64 @@ Tracks version progression in Improve mode. Located at workspace root.
 
 ## grading.json
 
-Output from the grader agent. Located at `<case-dir>/run-N/grading.json`.
+Public per-attempt grading output. Located at
+`.agentv/results/<run_id>/<result_dir>/sample-N/grading.json`.
 
-**Important:** The `assertions` array must use the fields `text`, `passed`, and `evidence` — downstream tooling depends on these exact field names.
+`checks` and other SDK/script convenience shapes are normalized into recursive
+`component_results`. Do not document `assertions`, `passed`, `graders`, or
+`evidence` as public grading artifact fields.
 
 ```json
 {
-  "assertions": [
+  "pass": false,
+  "score": 0.67,
+  "reason": "One required spreadsheet check failed.",
+  "component_results": [
     {
-      "text": "The output includes the name 'John Smith'",
-      "passed": true,
-      "evidence": "Found in transcript Step 3: 'Extracted names: John Smith, Sarah Johnson'"
-    },
-    {
-      "text": "The spreadsheet has a SUM formula in cell B10",
-      "passed": false,
-      "evidence": "No spreadsheet was created. The output was a text file."
-    }
-  ],
-  "summary": {
-    "passed": 2,
-    "failed": 1,
-    "total": 3,
-    "pass_rate": 0.67
-  },
-  "execution_metrics": {
-    "tool_calls": {
-      "Read": 5,
-      "Write": 2,
-      "Bash": 8
-    },
-    "total_tool_calls": 15,
-    "total_steps": 6,
-    "errors_encountered": 0,
-    "output_chars": 12450,
-    "transcript_chars": 3200
-  },
-  "timing": {
-    "executor_duration_seconds": 165.0,
-    "grader_duration_seconds": 26.0,
-    "total_duration_seconds": 191.0
-  },
-  "claims": [
-    {
-      "claim": "The form has 12 fillable fields",
-      "type": "factual",
-      "verified": true,
-      "evidence": "Counted 12 fields in field_info.json"
-    }
-  ],
-  "user_notes_summary": {
-    "uncertainties": ["Used 2023 data, may be stale"],
-    "needs_review": [],
-    "workarounds": ["Fell back to text overlay for non-fillable fields"]
-  },
-  "eval_feedback": {
-    "suggestions": [
-      {
-        "assertion": "The output includes the name 'John Smith'",
-        "reason": "A hallucinated document that mentions the name would also pass"
+      "name": "name-check",
+      "type": "llm-rubric",
+      "pass": true,
+      "score": 1,
+      "reason": "The answer includes the expected name.",
+      "assertion": {
+        "text": "The output includes the expected name."
       }
-    ],
-    "overall": "Assertions check presence but not correctness."
+    },
+    {
+      "name": "spreadsheet-check",
+      "type": "script",
+      "pass": false,
+      "score": 0,
+      "reason": "No spreadsheet was created.",
+      "component_results": [
+        {
+          "pass": false,
+          "score": 0,
+          "reason": "Cell B10 did not contain a SUM formula.",
+          "assertion": {
+            "text": "Spreadsheet has SUM formula in B10"
+          }
+        }
+      ]
+    }
+  ],
+  "named_scores": {
+    "spreadsheet": 0
+  },
+  "metadata": {
+    "grader_target": "local-openai-grader"
   }
 }
 ```
 
 **Fields:**
-- `assertions[]`: Graded assertion results with evidence
-- `summary`: Aggregate pass/fail counts
-- `execution_metrics`: Tool usage and output size (from executor's metrics.json)
-- `timing`: Wall clock timing (from timing.json)
-- `claims`: Extracted and verified claims from the output
-- `user_notes_summary`: Issues flagged by the executor
-- `eval_feedback`: (optional) Improvement suggestions for the evals, only present when the grader identifies issues worth raising
+- `pass`: Aggregate pass/fail for the grading component
+- `score`: Aggregate score from 0 to 1
+- `reason`: Human-readable explanation for the aggregate result
+- `component_results`: Recursive child grading components
+- `assertion`: Optional assertion metadata for a leaf component
+- `named_scores`: Optional metric-name to score map
+- `metadata`: Optional grader/runtime metadata
 
 ---
 

--- a/skills-data/agentv-bench/references/subagent-pipeline.md
+++ b/skills-data/agentv-bench/references/subagent-pipeline.md
@@ -30,10 +30,12 @@ specific target, set `subagent_mode_allowed: false` in `.agentv/targets.yaml`:
 ```yaml
 # .agentv/targets.yaml
 targets:
-  - name: my-target
+  - id: my-target
     provider: openai
-    model: ${{ OPENAI_MODEL }}
-    api_key: ${{ OPENAI_API_KEY }}
+    runtime: host
+    config:
+      model: "{{ env.OPENAI_MODEL }}"
+      api_key: "{{ env.OPENAI_API_KEY }}"
     subagent_mode_allowed: false  # forces CLI invocation instead of executor subagent
 ```
 
@@ -43,8 +45,8 @@ even in subagent mode.
 ## CLI Targets: Single Command
 
 For evals with CLI targets, `pipeline run` handles input extraction, target invocation, and
-code grading in one step. When `--out` is omitted, the output directory defaults to
-`.agentv/results/default/<timestamp>` (same convention as `agentv eval`):
+code grading in one step. When `--out` is omitted, the output directory uses the
+canonical `.agentv/results/<run_id>` convention:
 
 ```bash
 # Extract inputs and invoke all CLI targets in parallel:
@@ -70,7 +72,7 @@ opted out via `subagent_mode_allowed: false` in `.agentv/targets.yaml`), fall ba
 ### Step 1: Extract inputs
 
 ```bash
-# Defaults to .agentv/results/default/<timestamp>
+# Defaults to .agentv/results/<run_id>
 agentv pipeline input evals/repro.eval.yaml
 ```
 
@@ -117,7 +119,7 @@ LLM grading → merge and validate).
 Use individual commands when you need control over each step with CLI targets:
 
 ```bash
-# Step 1: Extract inputs (defaults to .agentv/results/default/<timestamp>)
+# Step 1: Extract inputs (defaults to .agentv/results/<run_id>)
 agentv pipeline input evals/repro.eval.yaml
 
 # Step 2: run_tests.py invokes CLI targets (or use pipeline run instead)
@@ -127,7 +129,7 @@ agentv pipeline grade <run-dir>
 
 # Step 4: Subagent does LLM grading, writes results to llm_grader_results/<name>.json per test
 
-# Step 5: Merge scores (writes index.jsonl with full scores[] for dashboard)
+# Step 5: Merge scores into the canonical run bundle
 agentv pipeline bench <run-dir>
 
 # Step 6: Validate
@@ -152,22 +154,22 @@ The agent reads `llm_graders/<name>.json` for each test, grades the response usi
 
 ## Pipeline Bench and Dashboard
 
-`pipeline bench` merges LLM scores into `index.jsonl` with a full `scores[]` array per entry,
-matching the CLI-mode schema. The web dashboard (`agentv results serve`) reads this format
-directly — no separate conversion script is needed. Run `agentv results validate <run-dir>`
-to verify compatibility.
+`pipeline bench` merges LLM scores into the canonical run bundle, including
+`.internal/index.jsonl`, `summary.json`, and per-attempt `grading.json` with
+`component_results`. The web dashboard reads this format directly — no separate
+conversion script is needed. Run `agentv results validate <run-dir>` to verify
+compatibility.
 
 ## Output Structure
 
-The path hierarchy mirrors the CLI mode: `<evalset-name>` comes from the `name` field in
-the eval.yaml. The target is recorded in `manifest.json` — one run = one target.
+The path hierarchy mirrors CLI mode. The target is recorded in run metadata.
 
 ```
-.agentv/results/<experiment>/<timestamp>/
+.agentv/results/<run_id>/
 ├── manifest.json                    ← eval metadata, target, test_ids
-├── index.jsonl                      ← per-test scores
-├── summary.json                   ← aggregate statistics
-└── <evalset-name>/                  ← eval.yaml "name" field, or eval file basename if absent (same as CLI mode)
+├── summary.json                      ← aggregate statistics
+├── .internal/index.jsonl             ← canonical row index
+└── <result-dir>/sample-1/grading.json
     └── <test-id>/                   ← test case id
         ├── input.json               ← test input text + messages
         ├── invoke.json              ← target command or agent instructions

--- a/skills-data/agentv-eval-migrations/SKILL.md
+++ b/skills-data/agentv-eval-migrations/SKILL.md
@@ -16,6 +16,19 @@ v4.42.4-era shape, current shape, migration steps, verification commands, and
 compatibility notes for each major breaking authoring change. Then compare the
 eval file against the current portable contract:
 
+- Treat migrations as rule-based rewrites first. Do not rely on a manual
+  "looks current" pass when the old field has a direct current replacement.
+- Rewrite authored prompt data into top-level `prompts` plus `tests[].vars`;
+  keep `input` only for documented raw-case import compatibility.
+- Move sibling `expected_output` to `vars.expected_output`, then add or keep an
+  explicit assertion that consumes it, usually `llm-rubric` with
+  `{{ expected_output }}`.
+- Rewrite target identity to `id`, keep `provider` for the backend/adapter kind,
+  put provider settings under `config`, and rewrite env references to
+  `{{ env.NAME }}`.
+- Remove `use_target`, `eval_cases`, `evalcases`, `providerPromptMap`, and
+  `provider_prompt_map` from authored eval/config YAML. Current AgentV rejects
+  these fields, so do not preserve them as compatibility aliases.
 - Keep committed eval YAML portable: prompts, cases, assertions, workspace
   templates, repos, hooks, env checks, Docker preflight/container config, and
   `workspace.scope`.

--- a/skills-data/agentv-eval-migrations/references/breaking-changes.md
+++ b/skills-data/agentv-eval-migrations/references/breaking-changes.md
@@ -23,7 +23,7 @@ For a v4.42.4-era eval:
 
 1. Move top-level `execution.target` to top-level `target`.
 2. Move top-level `execution.targets` to top-level `targets`, and rename target
-   object `name` to `label`.
+   object `name` to `id`.
 3. Rename suite/test/turn `assertions` to `assert`.
 4. If a test uses `tests[].execution.assertions` or
    `tests[].execution.evaluators`, rename that nested list to
@@ -56,7 +56,14 @@ For a v4.42.4-era eval:
     assertions where there is a direct mapping.
 18. Keep raw cases under `tests` / `tests: file://...`; run full eval suites
     directly with CLI multi-file selection and tags.
-19. Validate with `bun apps/cli/src/cli.ts validate <eval-file>`.
+19. Move authored prompt input from top-level or `tests[].input` into
+    `prompts` plus `tests[].vars.input`.
+20. Move authored reference answers from sibling `expected_output` into
+    `vars.expected_output`; add or keep an explicit assertion that consumes it.
+21. Rewrite target env interpolation from `${{ NAME }}` to `{{ env.NAME }}`.
+22. Remove `use_target`, `eval_cases`, `evalcases`, `providerPromptMap`, and
+    `provider_prompt_map`; current AgentV rejects them.
+23. Validate with `bun apps/cli/src/cli.ts validate <eval-file>`.
 
 ## Assertions Renamed To `assert`
 
@@ -844,42 +851,50 @@ targets:
 ### Current Shape
 
 Current eval YAML uses top-level `target` or `targets`. Target references use
-`label`; `id` is reserved for provider/backend identity when needed:
+the target `id`; `provider` names the backend or adapter kind:
 
 ```yaml
 target: azure-base
 
 targets:
-  - label: with-skills
-    use_target: default
+  - id: with-skills
+    provider: codex-cli
+    runtime: host
+    config:
+      command: ["codex", "exec", "--json"]
     hooks:
       before_each:
         command: ["setup-plugins.sh", "skills"]
 ```
 
-Current `.agentv/targets.yaml` uses `label` and nests provider settings under
+Current `.agentv/targets.yaml` uses `id` and nests provider settings under
 `config`:
 
 ```yaml
 targets:
-  - label: azure-base
+  - id: azure-base
     provider: azure
+    runtime: host
     config:
-      endpoint: ${{ AZURE_OPENAI_ENDPOINT }}
-      api_key: ${{ AZURE_OPENAI_API_KEY }}
-      model: ${{ AZURE_DEPLOYMENT_NAME }}
+      endpoint: "{{ env.AZURE_OPENAI_ENDPOINT }}"
+      api_key: "{{ env.AZURE_OPENAI_API_KEY }}"
+      model: "{{ env.AZURE_DEPLOYMENT_NAME }}"
 ```
 
 ### Migration Steps
 
 - Eval YAML: `execution.target` -> top-level `target`.
 - Eval YAML: `execution.targets` -> top-level `targets`.
-- Eval target object `name` -> `label`.
-- If an eval-local target object has provider configuration, include a
-  `label`; use `extends` to derive from a base target.
-- Targets file: rename `name` to `label` and move provider-specific settings
-  into `config`.
-- Keep AgentV target extensions such as `grader_target`, `use_target`,
+- Eval target object `name` -> `id`.
+- If an eval-local target object has provider configuration, include a concrete
+  `provider`; `id` is AgentV's stable target identity and `provider` names the
+  backend or adapter kind.
+- Targets file: rename `name` to `id`, move provider-specific settings into
+  `config`, and rewrite environment references from `${{ NAME }}` to
+  `{{ env.NAME }}`.
+- Remove `use_target`; current authored target definitions must resolve to
+  concrete provider objects.
+- Keep supported AgentV target extensions such as `grader_target`,
   `fallback_targets`, `workers`, and `batch_requests` as top-level fields on
   target objects.
 
@@ -888,10 +903,12 @@ targets:
 ```bash
 bun apps/cli/src/cli.ts validate path/to/eval.eval.yaml
 bun apps/cli/src/cli.ts validate .agentv/targets.yaml
-rg -n "execution:|name:|endpoint:|api_key:|model:" path/to/evals .agentv/targets.yaml
+rg -n "execution:|name:|use_target:|\\$\\{\\{|endpoint:|api_key:|model:" path/to/evals .agentv/targets.yaml
 ```
 
-Inspect `name:` matches manually because grader names still exist.
+Inspect `name:`, top-level provider fields, and `${{ ... }}` matches manually
+because grader names, non-target YAML, and historical examples can still use
+similar strings legitimately.
 
 ### Compatibility Notes
 

--- a/skills-data/agentv-eval-writer/SKILL.md
+++ b/skills-data/agentv-eval-writer/SKILL.md
@@ -741,24 +741,24 @@ agentv eval assert <grader-name> --agent-output "..." --agent-input "..."
 agentv import claude --session-id <uuid>
 
 # Re-run only execution errors from a previous run
-agentv eval <file.yaml> --retry-errors .agentv/results/default/<timestamp>/index.jsonl
+agentv eval <file.yaml> --retry-errors .agentv/results/<run_id>/.internal/index.jsonl
 
 # Validate eval file
 agentv validate <file.yaml>
 
 # Compare completed runs
 agentv results compare \
-  .agentv/results/default/<baseline-timestamp>/index.jsonl \
-  .agentv/results/default/<candidate-timestamp>/index.jsonl
+  .agentv/results/<baseline-run-id>/.internal/index.jsonl \
+  .agentv/results/<candidate-run-id>/.internal/index.jsonl
 agentv results combine \
-  .agentv/results/default/<baseline-timestamp> \
-  .agentv/results/default/<candidate-timestamp> \
-  .agentv/results/default/<third-target-timestamp> \
-  --output .agentv/results/default/combined
-agentv results compare .agentv/results/default/combined/index.jsonl
+  .agentv/results/<baseline-run-id> \
+  .agentv/results/<candidate-run-id> \
+  .agentv/results/<third-target-run-id> \
+  --output .agentv/results/combined
+agentv results compare .agentv/results/combined/.internal/index.jsonl
 agentv results compare \
-  .agentv/results/default/<baseline-timestamp>/index.jsonl \
-  .agentv/results/default/<candidate-timestamp>/index.jsonl \
+  .agentv/results/<baseline-run-id>/.internal/index.jsonl \
+  .agentv/results/<candidate-run-id>/.internal/index.jsonl \
   --json
 
 # Author assertions directly in the eval file


### PR DESCRIPTION
## Summary
- align remaining public docs/examples with current Promptfoo-compatible authoring: top-level `prompts`, `tests[].vars`, explicit reference-answer assertions, and `{{ env.* }}` target config
- update AI-facing agentv-bench, eval-writer, and eval-migrations skills for current run-bundle paths, grading artifacts, target identity, and rule-based migration steps
- record live dogfood evidence for the final av-kfik.16 closeout

## Validation
- `git diff --check`
- `bun run validate:examples` (108/108)
- `bun --filter @agentv/web build`
- `bun --filter @agentv/web check:routes`
- `bun run build` before source CLI dogfood

## Live dogfood
- `bun apps/cli/src/cli.ts validate .agentv/tmp/av-kfik-16/promptfoo-contract-dogfood.eval.yaml`
- `bun apps/cli/src/cli.ts eval run .agentv/tmp/av-kfik-16/promptfoo-contract-dogfood.eval.yaml --targets .agentv/tmp/av-kfik-16/targets.yaml --target gemini-live --grader-target gemini-grader --workers 1 --no-cache`
- Run ID: `.agentv/results/2026-07-06T07-18-55-636Z`
- Matrix: 2 prompts x 2 tests x 1 live Gemini target = 4 executions
- Result: PASS, 4/4, mean score 100%, graded by separate live Gemini grader
- Private evidence: EntityProcess/agentv-private `evidence/av-kfik-16-final-docs-dogfood-2026-07-06` at `7b22a44`

## Tracker
- av-kfik.16
- av-kfik.48 coordination
- av-504.6 updated with matrix sidecar-path observation from dogfood
