### PR TITLE
feat(results): slim index.jsonl target_execution/transcript_summary to sidecars

### DIFF
--- a/apps/cli/test/commands/eval/artifact-writer.test.ts
+++ b/apps/cli/test/commands/eval/artifact-writer.test.ts
@@ -959,28 +959,6 @@ describe('buildIndexArtifactEntry', () => {
           error: 'model drift',
           cost_usd: 0.25,
           execution_status: 'quality_failure',
-          transcript_summary: {
-            total_turns: 1,
-            tool_calls: {
-              file_read: 0,
-              file_write: 0,
-              file_edit: 0,
-              shell: 0,
-              web_fetch: 0,
-              web_search: 0,
-              glob: 0,
-              grep: 0,
-              list_dir: 0,
-              agent_task: 0,
-              unknown: 0,
-            },
-            files_read: [],
-            files_modified: [],
-            shell_commands: [],
-            web_fetches: [],
-            errors: [{ message: 'model drift' }],
-            thinking_blocks: 0,
-          },
         },
       ],
     });
@@ -1643,7 +1621,8 @@ describe('writeArtifactsFromResults', () => {
     });
     expect(runOneResult).not.toHaveProperty('timing');
     expect(runOneResult).not.toHaveProperty('verdict');
-    expect(indexEntry?.samples?.[0]?.transcript_summary).toEqual(runOneResult.transcript_summary);
+    expect(runOneResult.transcript_summary).toBeDefined();
+    expect(indexEntry?.samples?.[0]).not.toHaveProperty('transcript_summary');
 
     const runTwoAnswer = await readFile(
       path.join(paths.testArtifactDir, repeatRowDir, 'sample-2', 'outputs', 'answer.md'),
@@ -1667,7 +1646,8 @@ describe('writeArtifactsFromResults', () => {
     });
     expect(runTwoResult).not.toHaveProperty('timing');
     expect(runTwoResult).not.toHaveProperty('verdict');
-    expect(indexEntry?.samples?.[1]?.transcript_summary).toEqual(runTwoResult.transcript_summary);
+    expect(runTwoResult.transcript_summary).toBeDefined();
+    expect(indexEntry?.samples?.[1]).not.toHaveProperty('transcript_summary');
   });
 
   it('keys prompt-expanded resume checks by authored test id plus prompt id', () => {
@@ -1898,7 +1878,8 @@ describe('writeArtifactsFromResults', () => {
     expect(indexLine).not.toHaveProperty('trace_path');
     expect(indexLine?.transcript_path).toBe(`${rowDir}/sample-1/transcript.json`);
     expect(indexLine?.transcript_raw_path).toBe(`${rowDir}/sample-1/transcript-raw.jsonl`);
-    expect(indexLine?.transcript_summary).toEqual(transcript.transcript_summary);
+    expect(transcript.transcript_summary).toBeDefined();
+    expect(indexLine).not.toHaveProperty('transcript_summary');
     expect(indexLine?.metrics_path).toBe(`${rowDir}/sample-1/metrics.json`);
     expect(indexLine.metrics_path.endsWith(CANONICAL_METRICS_ARTIFACT_PATH)).toBe(true);
 

--- a/apps/cli/test/eval.integration.test.ts
+++ b/apps/cli/test/eval.integration.test.ts
@@ -456,7 +456,15 @@ describe('agentv eval CLI', () => {
       for (const row of canonicalResults) {
         expect(row.transcript_path).toMatch(/sample-1\/transcript\.json$/);
         await expectFileExists(path.join(outputDir, row.transcript_path as string));
-        expect(row.transcript_summary).toBeDefined();
+        expect(row).not.toHaveProperty('transcript_summary');
+        const resultJsonPath = (row.transcript_path as string).replace(
+          /sample-1\/transcript\.json$/,
+          'sample-1/result.json',
+        );
+        const sampleResult = JSON.parse(
+          await readFile(path.join(outputDir, resultJsonPath), 'utf8'),
+        );
+        expect(sampleResult.transcript_summary).toBeDefined();
         expect(row.transcript_raw_path).toMatch(/sample-1\/transcript-raw\.jsonl$/);
         await expectFileExists(path.join(outputDir, row.transcript_raw_path as string));
       }

--- a/packages/core/src/evaluation/run-artifacts.ts
+++ b/packages/core/src/evaluation/run-artifacts.ts
@@ -426,7 +426,8 @@ export type TrialResultArtifact = {
   readonly execution_status?: string;
   readonly failure_stage?: string;
   readonly failure_reason_code?: string;
-  readonly transcript_summary?: TranscriptSummaryWire;
+  /** Compact target-runtime error classification; full detail lives in `sample_path`'s `result.json`. */
+  readonly target_error_kind?: string;
 };
 
 export type TrialAggregationArtifact =
@@ -609,7 +610,8 @@ export interface IndexArtifactEntry {
   readonly error?: string;
   readonly failure_stage?: string;
   readonly failure_reason_code?: string;
-  readonly target_execution?: TargetExecutionWire;
+  /** Compact target-runtime error classification; full envelope lives at `target_execution_path`. */
+  readonly target_error_kind?: string;
   readonly target_execution_path?: string;
   readonly stdout_path?: string;
   readonly stderr_path?: string;
@@ -621,7 +623,6 @@ export interface IndexArtifactEntry {
   readonly answer_path?: string;
   readonly transcript_path?: string;
   readonly transcript_raw_path?: string;
-  readonly transcript_summary?: TranscriptSummaryWire;
   readonly metrics_path?: string;
   readonly file_changes_path?: string;
   readonly environment_path?: string;
@@ -1032,13 +1033,6 @@ function hasPersistedTrialRuns(result: EvaluationResult): boolean {
   return (result.trials ?? []).some((trial) => trial.result !== undefined);
 }
 
-function toTrialTranscriptSummary(trial: TrialResult): TranscriptSummaryWire | undefined {
-  const result = trial.result;
-  return result && resultHasExecutionTraceTranscript(result)
-    ? buildResultTranscriptSummary(result)
-    : undefined;
-}
-
 function toTrialArtifacts(
   trials: readonly TrialResult[] | undefined,
 ): readonly TrialResultArtifact[] | undefined {
@@ -1057,7 +1051,7 @@ function toTrialArtifacts(
     execution_status: trial.executionStatus,
     failure_stage: trial.failureStage,
     failure_reason_code: trial.failureReasonCode,
-    transcript_summary: toTrialTranscriptSummary(trial),
+    target_error_kind: trial.result?.targetExecution?.errorKind,
   }));
 }
 
@@ -2481,7 +2475,7 @@ export function buildIndexArtifactEntry(
     error: result.error,
     failure_stage: result.failureStage,
     failure_reason_code: result.failureReasonCode,
-    target_execution: toTargetExecutionWire(targetExecution),
+    target_error_kind: targetExecution?.errorKind,
     target_execution_path: options.targetExecutionPath
       ? toRelativeArtifactPath(options.outputDir, options.targetExecutionPath)
       : undefined,
@@ -2513,7 +2507,6 @@ export function buildIndexArtifactEntry(
     transcript_raw_path: options.transcriptRawPath
       ? toRelativeArtifactPath(options.outputDir, options.transcriptRawPath)
       : undefined,
-    transcript_summary: options.transcriptPath ? buildResultTranscriptSummary(result) : undefined,
     metrics_path: options.metricsPath
       ? toRelativeArtifactPath(options.outputDir, options.metricsPath)
       : undefined,
@@ -2622,7 +2615,7 @@ export function buildResultIndexArtifact(
     error: result.error,
     failure_stage: result.failureStage,
     failure_reason_code: result.failureReasonCode,
-    target_execution: toTargetExecutionWire(targetExecution),
+    target_error_kind: targetExecution?.errorKind,
     target_execution_path: result.targetExecution
       ? path.posix.join(singleRunDir, TARGET_EXECUTION_ARTIFACT_PATH)
       : undefined,
@@ -2655,8 +2648,6 @@ export function buildResultIndexArtifact(
       isSingleRun && hasTranscript
         ? path.posix.join(singleRunDir, 'transcript-raw.jsonl')
         : undefined,
-    transcript_summary:
-      isSingleRun && hasTranscript ? buildResultTranscriptSummary(result) : undefined,
     artifact_pointers: options?.artifactPointers,
     sample_index: result.sampleIndex,
     retry_index: result.retryIndex,

--- a/packages/core/test/evaluation/target-execution-artifacts.test.ts
+++ b/packages/core/test/evaluation/target-execution-artifacts.test.ts
@@ -83,14 +83,8 @@ describe('target execution artifacts', () => {
       expect(row.target_execution_path).toBeTruthy();
       expect(row.stdout_path).toBeTruthy();
       expect(row.stderr_path).toBeTruthy();
-
-      const targetExecution = row.target_execution as Record<string, unknown>;
-      expect(targetExecution.error_kind).toBe('signal_crash');
-      expect(targetExecution.provider_kind).toBe('cli');
-      expect((targetExecution.artifacts as Record<string, unknown>).stdout_path).toBe(
-        row.stdout_path,
-      );
-      expect(targetExecution.artifacts).toHaveProperty('transcript_path');
+      expect(row.target_error_kind).toBe('signal_crash');
+      expect(row).not.toHaveProperty('target_execution');
 
       const stdoutPath = path.join(outputDir, row.stdout_path as string);
       const stderrPath = path.join(outputDir, row.stderr_path as string);
@@ -100,7 +94,10 @@ describe('target execution artifacts', () => {
       await expect(readFile(stderrPath, 'utf8')).resolves.toContain('segmentation fault');
       const envelope = JSON.parse(await readFile(envelopePath, 'utf8')) as Record<string, unknown>;
       expect(envelope.error_kind).toBe('signal_crash');
+      expect(envelope.provider_kind).toBe('cli');
       expect(envelope.artifacts).toHaveProperty('stderr_path');
+      expect((envelope.artifacts as Record<string, unknown>).stdout_path).toBe('stdout.txt');
+      expect(envelope.artifacts).toHaveProperty('transcript_path');
     } finally {
       await rm(outputDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Part of av-cpl5 (results-artifact-layout tracker). Implements av-cpl5.3: slim `.internal/index.jsonl` rows so they stay a Dashboard-ready manifest without inlining heavy sidecar payloads.

- `IndexArtifactEntry.target_execution` (full `TargetExecutionWire` envelope — command argv, complete stdout/stderr logs, transcript) is dropped from every row. `target_execution_path` (unchanged, already written to `target-execution.json`) remains the sidecar pointer. A new compact `target_error_kind` scalar (row-level and per-sample, in `samples[]`) preserves the one bit of headline signal (`error_kind`) that was previously read out of the inlined envelope, without requiring a sidecar read.
- `IndexArtifactEntry.transcript_summary` and `TrialResultArtifact.transcript_summary` (unbounded `files_read`/`files_modified`/`shell_commands`/`web_fetches`/`errors` lists) are dropped. `transcript_path` (unchanged) still points to the full transcript; each sample's `result.json` sidecar (referenced by `sample_path`) still carries `transcript_summary` in full, and `apps/cli/src/commands/results/serve.ts` already has a fallback (`objectField(trial, 'transcript_summary') ?? objectField(runResult, 'transcript_summary')`) that reads it from there when absent inline — verified this fallback already covers both old (fat) and new (slim) row shapes with no server changes needed.
- Kept `projection_identity` inline as-is (not moved to a sidecar): `writeArtifactsFromResults` reads `projection_identity.id` back off previously-written `index.jsonl` rows on disk (`readExistingIndexRecords` → `existingRecordsByProjectionIdentity`) to decide skip/update/error duplicate-policy across separate `agentv eval` invocations appending to the same run. Moving it to a sidecar would require an N-file read on every append to reconstruct dedup state. It's already compact (fixed set of scalar fields + optional short `issues` list), so it doesn't need the same slimming as `target_execution`/`transcript_summary`.
- `samples[]` (per-trial rollup) keeps its existing compact shape (`sample_path`, `score`, `status`, `scores`, `error`, `cost_usd`, `execution_status`, `failure_stage`, `failure_reason_code`) plus the new `target_error_kind`.

## Handoff notes for av-cpl5.1 / av-cpl5.4

New/changed field names for the docs and dashboard-reader beads to build against:
- `target_error_kind?: string` — new, row-level and per-`samples[]`-entry. Replaces reading `target_execution.error_kind` / `target_execution.errorKind` directly off the row (see `apps/dashboard/src/components/ResultTable.tsx`'s `targetErrorKind()` helper, which still reads the old nested shape — that helper needs updating in av-cpl5.1 to read `target_error_kind` instead; full `target_execution` is no longer present on rows/samples).
- `target_execution` — removed from `IndexArtifactEntry`/`TrialResultArtifact`. Full detail: `target_execution_path` sidecar (unchanged path/shape).
- `transcript_summary` — removed from `IndexArtifactEntry`/`TrialResultArtifact`. Full detail: each sample's `result.json` (path = `<result_dir>/<sample_path>/result.json`); `serve.ts` already falls back there when missing inline.
- `projection_identity` — unchanged/still inline (see rationale above).

## Test plan

- [x] `bun test apps/cli/test/commands/eval/artifact-writer.test.ts` (74 pass) — updated fat-row assertions to match the new slim shape.
- [x] `bun test packages/core/test/evaluation/target-execution-artifacts.test.ts` (1 pass) — updated to assert `target_error_kind` inline and full envelope only via the `target_execution_path` sidecar.
- [x] `bun test apps/cli/test/eval.integration.test.ts -t "rejects removed --export"` (1 pass) — updated to check `transcript_summary` lives in the sample's `result.json`, not the index row.
- [x] `bun test apps/cli/test/commands/results/serve.test.ts` (114 pass, unchanged) — confirms the dashboard-serving backward-compat fallback for `transcript_summary` (old fat rows vs. new slim rows) already works with no server-side changes.
- [x] `bun test packages/core/test/evaluation/` (2253 pass) and `apps/cli/test/commands/eval/ apps/cli/test/commands/results/` (437 pass + 1 pre-existing unrelated failure in `bundle.test.ts`, confirmed failing identically on an untouched sibling worktree at the same base commit — unrelated to this change).
- [x] `bun run typecheck` clean for both `packages/core` and `apps/cli`.
- [x] Live dogfood (real Azure OpenAI LLM target + real Azure LLM-rubric grader, `--threshold 0.8`):
  - `examples/features/rubric/evals/suite.yaml` test `summary-task` against `llm` target → 100% pass; inspected `.internal/index.jsonl`: row has no `target_execution`/`transcript_summary`, all existing sidecar path fields intact.
  - `examples/features/local-cli/evals/suite.yaml` test `cli-provider-echo` against a real CLI-provider agent target (mock CLI subprocess) graded by the same live Azure grader → 100% pass; confirmed `target_execution_path` sidecar (`target-execution.json`, 4.5KB with full command/stdout/stderr/transcript) exists and is loadable, while the index row itself stays slim (whole row ~3KB) with no inlined envelope; confirmed `result.json` sidecar still carries the full `transcript_summary`.

Closes av-cpl5.3 (leaving the bead open per process — coordinator closes after review/merge).