### PR TITLE
dashboard(results): adapt target_error_kind reader to slim index rows

### DIFF
--- a/apps/cli/src/commands/results/manifest.ts
+++ b/apps/cli/src/commands/results/manifest.ts
@@ -68,6 +68,10 @@ export interface ResultManifestRecord {
   readonly aggregation?: Record<string, unknown>;
   readonly execution_status?: string;
   readonly error?: string;
+  /** Compact target-runtime error classification; full envelope lives at `target_execution_path`. */
+  readonly target_error_kind?: string;
+  /** Legacy pre-v5.4 fat index row field accepted when reading older bundles; superseded by `target_error_kind`. */
+  readonly target_execution?: { readonly error_kind?: string; readonly errorKind?: string };
   readonly cost_usd?: number;
   readonly duration_ms?: number;
   readonly token_usage?: {

--- a/apps/cli/src/commands/results/serve.ts
+++ b/apps/cli/src/commands/results/serve.ts
@@ -1203,6 +1203,19 @@ function buildRepeatTrialReadModels(
   });
 }
 
+/**
+ * Compact target-runtime error classification for a row. New bundles carry
+ * `target_error_kind` directly; legacy pre-v5.4 fat rows nested it under
+ * `target_execution` instead.
+ */
+function recordTargetErrorKind(record: ResultManifestRecord): string | undefined {
+  return (
+    record.target_error_kind ??
+    record.target_execution?.error_kind ??
+    record.target_execution?.errorKind
+  );
+}
+
 function attachRunDetailReadModelFields<T extends Record<string, unknown>>(
   results: readonly T[],
   records: readonly ResultManifestRecord[],
@@ -1212,8 +1225,10 @@ function attachRunDetailReadModelFields<T extends Record<string, unknown>>(
     const record = records[index];
     if (!record) return result;
     const samples = buildRepeatTrialReadModels(baseDir, record);
+    const targetErrorKind = recordTargetErrorKind(record);
     return {
       ...result,
+      ...(targetErrorKind && { target_error_kind: targetErrorKind }),
       ...(record.aggregation && { aggregation: record.aggregation }),
       ...(record.eval_path && { eval_path: record.eval_path }),
       ...(record.result_dir && { result_dir: record.result_dir }),

--- a/apps/cli/test/commands/results/serve.test.ts
+++ b/apps/cli/test/commands/results/serve.test.ts
@@ -2412,6 +2412,50 @@ describe('serve app', () => {
       expect(data.results[0]?.samples?.[1]?.tool_calls).toEqual({ Read: 2 });
     });
 
+    it('surfaces the compact target_error_kind field from slim index rows', async () => {
+      const runsDir = localResultsExperimentDir(tempDir);
+      const filename = '2026-03-25T10-10-00-000Z';
+      const runDir = path.join(runsDir, filename);
+      mkdirSync(runDir, { recursive: true });
+      writeFileSync(
+        path.join(runDir, 'index.jsonl'),
+        toJsonl({
+          ...RESULT_EXECUTION_ERROR,
+          target_error_kind: 'timeout',
+        }),
+      );
+
+      const app = createApp([], tempDir, tempDir, undefined, { studioDir });
+      const res = await app.request(`/api/runs/${filename}`);
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as {
+        results: Array<{ target_error_kind?: string }>;
+      };
+      expect(data.results[0]?.target_error_kind).toBe('timeout');
+    });
+
+    it('falls back to the legacy nested target_execution shape on older fat index rows', async () => {
+      const runsDir = localResultsExperimentDir(tempDir);
+      const filename = '2026-03-25T10-11-00-000Z';
+      const runDir = path.join(runsDir, filename);
+      mkdirSync(runDir, { recursive: true });
+      writeFileSync(
+        path.join(runDir, 'index.jsonl'),
+        toJsonl({
+          ...RESULT_EXECUTION_ERROR,
+          target_execution: { error_kind: 'timeout' },
+        }),
+      );
+
+      const app = createApp([], tempDir, tempDir, undefined, { studioDir });
+      const res = await app.request(`/api/runs/${filename}`);
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as {
+        results: Array<{ target_error_kind?: string }>;
+      };
+      expect(data.results[0]?.target_error_kind).toBe('timeout');
+    });
+
     it('loads historical runs without test bundle metadata', async () => {
       const runId = writeLocalRunArtifact(
         tempDir,

--- a/apps/dashboard/src/components/ResultTable.test.tsx
+++ b/apps/dashboard/src/components/ResultTable.test.tsx
@@ -98,3 +98,53 @@ describe('ResultTable repeat-run rendering', () => {
     expect(html).toContain('target timed out');
   });
 });
+
+describe('ResultTable target error kind', () => {
+  function renderErrorColumn(result: EvalResult): string {
+    const model = buildResultTableModel({
+      results: [result],
+      passThreshold: 0.8,
+      state: { visibleColumnIds: ['status', 'test', 'target', 'score', 'error'] },
+    });
+    return renderToStaticMarkup(
+      <ResultRowsTable
+        rows={model.filteredRows}
+        visibleColumns={model.visibleColumns}
+        passThreshold={0.8}
+        selectedRowKey={null}
+        selectedTrialPath={null}
+        repeatGroupsByRowKey={new Map()}
+        expandedRepeatRows={new Set()}
+        onToggleRepeatGroup={() => undefined}
+        onOpenDetail={() => undefined}
+        onOpenTrialDetail={() => undefined}
+      />,
+    );
+  }
+
+  it('reads the compact target_error_kind field on new slim rows', () => {
+    const html = renderErrorColumn({
+      testId: 'billing-lookup',
+      target: 'codex',
+      score: 0,
+      executionStatus: 'execution_error',
+      error: 'target timed out',
+      target_error_kind: 'timeout',
+    });
+
+    expect(html).toContain('[target:timeout] target timed out');
+  });
+
+  it('falls back to the legacy nested target_execution shape on older bundles', () => {
+    const html = renderErrorColumn({
+      testId: 'billing-lookup',
+      target: 'codex',
+      score: 0,
+      executionStatus: 'execution_error',
+      error: 'target timed out',
+      target_execution: { error_kind: 'timeout' },
+    });
+
+    expect(html).toContain('[target:timeout] target timed out');
+  });
+});

--- a/apps/dashboard/src/components/ResultTable.tsx
+++ b/apps/dashboard/src/components/ResultTable.tsx
@@ -643,10 +643,13 @@ function formatTargetError(
 }
 
 function targetErrorKind(value: {
+  target_error_kind?: string;
   targetExecution?: { error_kind?: string; errorKind?: string };
   target_execution?: { error_kind?: string; errorKind?: string };
 }): string | undefined {
   return (
+    value.target_error_kind ??
+    // Legacy pre-v5.4 fat rows/samples nested the error kind under `target_execution`.
     value.target_execution?.error_kind ??
     value.target_execution?.errorKind ??
     value.targetExecution?.error_kind ??

--- a/apps/dashboard/src/lib/types.ts
+++ b/apps/dashboard/src/lib/types.ts
@@ -143,7 +143,11 @@ export interface EvalCaseTrial {
   scores?: ScoreEntry[];
   assertions?: AssertionEntry[];
   error?: string;
+  /** Compact target-runtime error classification; full envelope lives at `target_execution_path`. */
+  target_error_kind?: string;
+  /** Legacy pre-v5.4 fat row field accepted when reading older bundles; superseded by `target_error_kind`. */
   targetExecution?: TargetExecutionEnvelope;
+  /** Legacy pre-v5.4 fat row field accepted when reading older bundles; superseded by `target_error_kind`. */
   target_execution?: TargetExecutionEnvelope;
   target_execution_path?: string;
   stdout_path?: string;
@@ -280,7 +284,11 @@ export interface EvalResult {
   score: number;
   executionStatus?: string;
   error?: string;
+  /** Compact target-runtime error classification; full envelope lives at `target_execution_path`. */
+  target_error_kind?: string;
+  /** Legacy pre-v5.4 fat row field accepted when reading older bundles; superseded by `target_error_kind`. */
   targetExecution?: TargetExecutionEnvelope;
+  /** Legacy pre-v5.4 fat row field accepted when reading older bundles; superseded by `target_error_kind`. */
   target_execution?: TargetExecutionEnvelope;
   target_execution_path?: string;
   stdout_path?: string;


### PR DESCRIPTION
## Summary

Implements `av-cpl5.1` (leaf of parent tracker `av-cpl5`): adapt Dashboard/CLI result readers to the slim `summary.json`/`index.jsonl` shapes shipped in `a983924e` (cases→tests rename) and `16a21b33` (target_execution/transcript_summary → sidecars).

Investigation found most readers (`manifest.ts`, `export.ts`, `projection-bundle.ts`, `summary.ts`, `report.ts`) never referenced the removed `cases[]`/`total_cases`/`total_instances` summary fields or the row-level `target_execution`/`transcript_summary` fields directly, so no changes were needed there. `summaryRunId()` in core already has the `run_id` root/metadata fallback. The trial-level (`samples[]`) `transcript_summary` sidecar fallback in `serve.ts`'s `buildRepeatTrialReadModels` already covered the new schema (reads `result.json` when absent inline).

The one real gap: Dashboard's `ResultTable.tsx` `targetErrorKind()` helper only read the old nested `target_execution.error_kind`/`errorKind` shape, and `serve.ts`'s row read-model never actually passed a row-level target-error signal through to the client at all (for non-repeat rows) — so this was silently broken even before the schema change.

- `apps/cli/src/commands/results/manifest.ts`: type `target_error_kind` (new) and legacy `target_execution` (fat-row fallback) on `ResultManifestRecord`.
- `apps/cli/src/commands/results/serve.ts`: add `recordTargetErrorKind()` compat adapter and wire it into `attachRunDetailReadModelFields` so `results[].target_error_kind` is populated from either the new compact field or the legacy nested envelope.
- `apps/dashboard/src/lib/types.ts`: add `target_error_kind` to `EvalCaseTrial`/`EvalResult`.
- `apps/dashboard/src/components/ResultTable.tsx`: `targetErrorKind()` now prefers `target_error_kind`, falling back to the legacy nested shape.
- Tests: new/legacy coverage in `serve.test.ts` (API-level) and `ResultTable.test.tsx` (render-level).

## Verification

- `bun run build && bun run typecheck` — clean.
- `node_modules/.bin/biome check` on touched files — clean.
- Focused tests: `apps/cli/test/commands/results/**` (249 pass), `apps/dashboard/src/lib/result-table.test.ts` + `ResultTable.test.tsx` + `transcript-timeline.test.tsx` (26 pass).
- **Live dogfood**: ran a real eval (`examples/features/rubric/evals/operators.eval.yaml`) against a live Azure OpenAI target with a live `llm-rubric` grader. Confirmed the produced `summary.json` has the slim shape (`tests[]`, `total_tests`/`passed_tests`/`failed_tests`, no `metadata.run_id`) and `.internal/index.jsonl` rows have no `target_execution`/`transcript_summary`. Verified `agentv results show/summary/report` all work against the bundle.
- **Green (Dashboard, new slim shape)**: started `agentv dashboard`, confirmed `/api/runs` and `/api/runs/:id` render the live bundle correctly.
- **Green (Dashboard, legacy compat)**: hand-built a synthetic legacy fat-shape bundle (`cases[]` summary + row-level `target_execution.error_kind`) and confirmed `/api/runs/:id` correctly derives `target_error_kind: "timeout"` via the new compat fallback.
- **Red** (pre-fix): before the `serve.ts`/`ResultTable.tsx` change, this same legacy-bundle scenario returned no error-kind signal to the client at all — confirmed by inspecting `attachRunDetailReadModelFields` prior to the fix.

## Test plan

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun test apps/cli/test/commands/results/` (249 pass)
- [x] `bun test apps/dashboard/src/lib/result-table.test.ts apps/dashboard/src/components/ResultTable.test.tsx apps/dashboard/src/components/transcript-timeline.test.tsx` (26 pass)
- [x] Live dogfood eval + CLI `results show`/`summary`/`report`
- [x] Dashboard serve API verified against both new slim and synthetic legacy bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)