### PR TITLE
fix(results): hard-remove legacy grading.json compat reads in manifest.ts

### DIFF
--- a/apps/cli/src/commands/results/manifest.ts
+++ b/apps/cli/src/commands/results/manifest.ts
@@ -130,42 +130,12 @@ export interface ManifestHydrationOptions {
 
 type HydratedScore = NonNullable<EvaluationResult['scores']>[number];
 
-function mapGradingAssertions(
-  value: unknown,
-): NonNullable<EvaluationResult['assertions']> | undefined {
-  if (!Array.isArray(value)) {
-    return undefined;
-  }
-  return value.map((assertion) => {
-    const record = assertion as Record<string, unknown>;
-    return {
-      text: String(record.text ?? ''),
-      passed: Boolean(record.passed),
-      evidence: typeof record.evidence === 'string' ? record.evidence : undefined,
-    };
-  });
-}
-
-function readGradingAssertionResults(
-  record: Record<string, unknown>,
-): NonNullable<EvaluationResult['assertions']> | undefined {
-  return mapGradingAssertions(
-    Array.isArray(record.assertion_results) ? record.assertion_results : record.assertions,
-  );
-}
-
 function readNestedGradingScores(record: Record<string, unknown>): unknown {
   if (Array.isArray(record.component_results)) {
     return record.component_results;
   }
   if (Array.isArray(record.scores)) {
     return record.scores;
-  }
-  if (Array.isArray(record.graders)) {
-    return record.graders;
-  }
-  if (Array.isArray(record.evaluators)) {
-    return record.evaluators;
   }
   return undefined;
 }
@@ -209,11 +179,7 @@ function collectComponentAssertions(value: unknown): NonNullable<EvaluationResul
 }
 
 function mapGradingEvaluator(evaluator: Record<string, unknown>): HydratedScore {
-  const pass =
-    typeof evaluator.pass === 'boolean'
-      ? evaluator.pass
-      : evaluator.verdict === 'pass' ||
-        (typeof evaluator.score === 'number' && evaluator.score >= 0.8);
+  const pass = evaluator.pass === true;
   const verdict = pass ? ('pass' as const) : ('fail' as const);
   const details =
     evaluator.details && typeof evaluator.details === 'object' && !Array.isArray(evaluator.details)
@@ -236,7 +202,7 @@ function mapGradingEvaluator(evaluator: Record<string, unknown>): HydratedScore 
       if (nestedAssertions.length > 0) {
         return nestedAssertions;
       }
-      return readGradingAssertionResults(evaluator) ?? [mapComponentAssertion(evaluator)];
+      return [mapComponentAssertion(evaluator)];
     })(),
     scores: mapGradingEvaluators(readNestedGradingScores(evaluator)),
     weight: typeof evaluator.weight === 'number' ? evaluator.weight : undefined,
@@ -401,15 +367,8 @@ function hydrateManifestRecord(
   const gradingAssertions = grading
     ? collectComponentAssertions((grading as unknown as Record<string, unknown>).component_results)
     : undefined;
-  const gradingRecord = grading as
-    | (GradingArtifact & {
-        graders?: readonly Record<string, unknown>[];
-        evaluators?: readonly Record<string, unknown>[];
-      })
-    | undefined;
-  const gradingScores = mapGradingEvaluators(
-    gradingRecord?.component_results ?? gradingRecord?.graders ?? gradingRecord?.evaluators,
-  );
+  const gradingRecord = grading as GradingArtifact | undefined;
+  const gradingScores = mapGradingEvaluators(gradingRecord?.component_results);
 
   return {
     timestamp: record.timestamp,
@@ -426,10 +385,7 @@ function hydrateManifestRecord(
       passed: assertion.passed,
       evidence: assertion.evidence,
     })),
-    scores:
-      // `evaluators` was renamed to `graders` in v4.13 — read both for backwards compat with old artifacts.
-      // TODO: remove `evaluators` fallback once old run directories are no longer in use.
-      gradingScores ?? (record.scores as EvaluationResult['scores']),
+    scores: gradingScores ?? (record.scores as EvaluationResult['scores']),
     tokenUsage: metrics?.tokens
       ? {
           input: metrics.tokens.input,


### PR DESCRIPTION
## Summary

Found while auditing `av-kfik.46.4`/`av-kfik.46.5` (result-artifact contract cleanup). `apps/cli/src/commands/results/manifest.ts` still tolerantly read a pre-major-version `grading.json` shape:

- `assertion_results` as a fallback for assertion detail
- `verdict === 'pass'` / score-threshold guessing as a fallback for deriving `pass`
- `graders`/`evaluators` as legacy aliases for `component_results` — the `evaluators` branch was explicitly commented `"evaluators was renamed to graders in v4.13 — read both for backwards compat... TODO: remove... once old run directories are no longer in use."`

Meanwhile `apps/cli/src/commands/results/validate.ts` already treats all of these same field names (`assertion_results`, `assertions`, `passed`, `evidence`, `verdict`, `graders`, `checks`) as hard validation **errors**. One code path rejected the legacy shape as invalid; another silently read it. Since this major version has no production users yet, there's no on-disk bundle to preserve compatibility for — hard-removing is correct rather than adding test coverage for a fallback that will never be exercised.

## Changes

- Removed `readGradingAssertionResults()`/`mapGradingAssertions()` — the `assertion_results` fallback. Call site now derives directly from the grading component itself (`mapComponentAssertion`), matching what already happens when `component_results` is present.
- Removed the `graders`/`evaluators` branches in `readNestedGradingScores()` and the ad hoc type augmentation in `hydrateManifestRecord()` — both now read only `component_results` (and the separate, still-current `scores` field).
- Simplified `mapGradingEvaluator()`'s `pass` derivation to `evaluator.pass === true` — `pass` is always present per the current `grading.json` contract, so the `verdict`/score-threshold fallback was dead weight.

Dashboard's `EvalDetail.test.ts` already has a test asserting these exact legacy fields (`assertion_results`, `evidence`, `graders`, `checks`) are ignored when parsing a grading artifact — that code path (`parseGradingArtifact`/`parseComponentResult`) was already written correctly with no legacy tolerance, so no changes needed there. No test anywhere exercised `manifest.ts`'s now-removed fallback branches (confirmed via search) — nothing to update/remove on the test side beyond the source itself.

## Test plan

- [x] `bun run typecheck` (workspace) — clean.
- [x] `bunx biome check` on the touched file — clean.
- [x] `bun test apps/cli/test/commands/results` — 252/252 pass.
- [x] `bun test apps/dashboard/src/components/EvalDetail.test.ts` — 5/5 pass (unaffected, confirms Dashboard-side parsing was already correct).
- [x] Live check: ran a real eval (`examples/features/rubric/evals/operators.eval.yaml`, live Azure target + grader), then `results summary`/`results show` against the resulting bundle — both render correctly through the simplified code path (assertions with text/passed/evidence, correct scores).

🤖 Generated with [Claude Code](https://claude.com/claude-code)