### PR TITLE
feat(dashboard): filter provider comparison differences

### DIFF
--- a/apps/dashboard/src/components/AnalyticsTab.test.tsx
+++ b/apps/dashboard/src/components/AnalyticsTab.test.tsx
@@ -93,6 +93,128 @@ function compareResponse(): CompareResponse {
   };
 }
 
+function differingCompareResponse(): CompareResponse {
+  return {
+    experiments: ['model-compare'],
+    targets: ['gpt-5.4', 'gpt-5.4-mini'],
+    cells: [
+      {
+        experiment: 'model-compare',
+        target: 'gpt-5.4',
+        eval_count: 2,
+        quality_count: 2,
+        passed_count: 1,
+        pass_rate: 0.5,
+        avg_score: 0.5,
+        tests: [],
+      },
+      {
+        experiment: 'model-compare',
+        target: 'gpt-5.4-mini',
+        eval_count: 2,
+        quality_count: 2,
+        passed_count: 2,
+        pass_rate: 1,
+        avg_score: 1,
+        tests: [],
+      },
+    ],
+    runs: [
+      {
+        run_id: '2026-07-07T14-06-40-813Z',
+        started_at: '2026-07-07T14:06:40.813Z',
+        experiment: 'model-compare',
+        target: '2 providers',
+        targets: ['gpt-5.4', 'gpt-5.4-mini'],
+        source: 'local',
+        eval_count: 4,
+        quality_count: 4,
+        passed_count: 3,
+        pass_rate: 0.75,
+        avg_score: 0.75,
+        tests: [
+          {
+            test_id: 'matching-row',
+            target: 'gpt-5.4',
+            score: 1,
+            passed: true,
+            execution_status: 'ok',
+            answer: 'same answer',
+          },
+          {
+            test_id: 'matching-row',
+            target: 'gpt-5.4-mini',
+            score: 1,
+            passed: true,
+            execution_status: 'ok',
+            answer: 'same answer',
+          },
+          {
+            test_id: 'answer-differs',
+            target: 'gpt-5.4',
+            score: 1,
+            passed: true,
+            execution_status: 'ok',
+            answer: 'alpha answer',
+          },
+          {
+            test_id: 'answer-differs',
+            target: 'gpt-5.4-mini',
+            score: 1,
+            passed: true,
+            execution_status: 'ok',
+            answer: 'beta answer',
+          },
+          {
+            test_id: 'status-differs',
+            target: 'gpt-5.4',
+            score: 1,
+            passed: true,
+            execution_status: 'ok',
+            answer: 'completed',
+          },
+          {
+            test_id: 'status-differs',
+            target: 'gpt-5.4-mini',
+            score: 0,
+            passed: false,
+            execution_status: 'execution_error',
+            answer: 'completed',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function matchingCompareResponse(): CompareResponse {
+  const data = differingCompareResponse();
+  return {
+    ...data,
+    runs: data.runs?.map((run) => ({
+      ...run,
+      tests: [
+        {
+          test_id: 'matching-row',
+          target: 'gpt-5.4',
+          score: 1,
+          passed: true,
+          execution_status: 'ok',
+          answer: 'same answer',
+        },
+        {
+          test_id: 'matching-row',
+          target: 'gpt-5.4-mini',
+          score: 1,
+          passed: true,
+          execution_status: 'ok',
+          answer: 'same answer',
+        },
+      ],
+    })),
+  };
+}
+
 describe('AnalyticsTab provider/model comparison', () => {
   it('renders same-test provider/model outputs side by side', () => {
     const queryClient = new QueryClient();
@@ -111,5 +233,46 @@ describe('AnalyticsTab provider/model comparison', () => {
     expect(html).toContain('AV94NI_OK from gpt-5.4-mini');
     expect(html).toContain('Answer');
     expect(html).toContain('result_dir=exact-token-gpt54');
+  });
+
+  it('filters provider/model comparison rows to differing outputs', () => {
+    const queryClient = new QueryClient();
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={queryClient}>
+        <AnalyticsTab
+          data={differingCompareResponse()}
+          isLoading={false}
+          isError={false}
+          defaultProviderModelDisplayMode="differing"
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(html).toContain('All');
+    expect(html).toContain('Differing');
+    expect(html).toContain('answer-differs');
+    expect(html).toContain('alpha answer');
+    expect(html).toContain('beta answer');
+    expect(html).toContain('status-differs');
+    expect(html).toContain('error');
+    expect(html).not.toContain('matching-row');
+  });
+
+  it('shows an empty state when all provider/model comparison rows match', () => {
+    const queryClient = new QueryClient();
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={queryClient}>
+        <AnalyticsTab
+          data={matchingCompareResponse()}
+          isLoading={false}
+          isError={false}
+          defaultProviderModelDisplayMode="differing"
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(html).toContain('All compared rows match');
+    expect(html).toContain('Switch back to All rows to inspect the full provider/model table.');
+    expect(html).not.toContain('matching-row');
   });
 });

--- a/apps/dashboard/src/components/AnalyticsTab.tsx
+++ b/apps/dashboard/src/components/AnalyticsTab.tsx
@@ -37,13 +37,23 @@ interface AnalyticsTabProps {
   projectId?: string;
   /** Read-only mode. Reserved for surfaces that disable mutating actions. */
   readOnly?: boolean;
+  /** Initial row display for provider/model comparison. */
+  defaultProviderModelDisplayMode?: ProviderModelDisplayMode;
 }
 
 type ViewMode = 'aggregated' | 'per-run';
+type ProviderModelDisplayMode = 'all' | 'differing';
 
 // ── Top-level container ─────────────────────────────────────────────────
 
-export function AnalyticsTab({ data, isLoading, isError, error, projectId }: AnalyticsTabProps) {
+export function AnalyticsTab({
+  data,
+  isLoading,
+  isError,
+  error,
+  projectId,
+  defaultProviderModelDisplayMode = 'all',
+}: AnalyticsTabProps) {
   const [mode, setMode] = useState<ViewMode>('aggregated');
 
   const runsCount = data?.runs?.length ?? 0;
@@ -60,7 +70,13 @@ export function AnalyticsTab({ data, isLoading, isError, error, projectId }: Ana
       {!isLoading && !isError && !underlyingHasData && <EmptyState />}
       {!isLoading && !isError && underlyingHasData && data && (
         <>
-          {mode === 'aggregated' && <AggregatedView data={data} projectId={projectId} />}
+          {mode === 'aggregated' && (
+            <AggregatedView
+              data={data}
+              projectId={projectId}
+              defaultProviderModelDisplayMode={defaultProviderModelDisplayMode}
+            />
+          )}
           {mode === 'per-run' && <PerRunView data={data} />}
         </>
       )}
@@ -162,7 +178,15 @@ function ModeButton({
 
 // ── Aggregated (matrix) view ────────────────────────────────────────────
 
-function AggregatedView({ data, projectId }: { data: CompareResponse; projectId?: string }) {
+function AggregatedView({
+  data,
+  projectId,
+  defaultProviderModelDisplayMode,
+}: {
+  data: CompareResponse;
+  projectId?: string;
+  defaultProviderModelDisplayMode: ProviderModelDisplayMode;
+}) {
   const { experiments, targets, cells } = data;
 
   // Hooks must run on every render regardless of the early-return below,
@@ -192,7 +216,13 @@ function AggregatedView({ data, projectId }: { data: CompareResponse; projectId?
 
   return (
     <div className="space-y-3">
-      {hasProviderModelRun && <ProviderModelComparison data={data} projectId={projectId} />}
+      {hasProviderModelRun && (
+        <ProviderModelComparison
+          data={data}
+          projectId={projectId}
+          defaultDisplayMode={defaultProviderModelDisplayMode}
+        />
+      )}
       <Legend />
       <div className="overflow-x-auto rounded-lg border border-gray-800">
         <table className="w-full text-left text-sm">
@@ -598,16 +628,24 @@ function PerRunCompareView({
 function ProviderModelComparison({
   data,
   projectId,
+  defaultDisplayMode,
 }: {
   data: CompareResponse;
   projectId?: string;
+  defaultDisplayMode: ProviderModelDisplayMode;
 }) {
+  const [displayMode, setDisplayMode] = useState<ProviderModelDisplayMode>(defaultDisplayMode);
   const run = useMemo(
     () => (data.runs ?? []).find((entry) => providerLabelsForRun(entry).length > 1),
     [data.runs],
   );
 
   const model = useMemo(() => (run ? buildProviderModelTable(run) : null), [run]);
+  const rows = useMemo(() => {
+    if (!model) return [];
+    if (displayMode === 'all') return model.rows;
+    return model.rows.filter((row) => providerModelRowDiffers(row, model.providerLabels));
+  }, [displayMode, model]);
 
   if (!run || !model) return null;
 
@@ -620,43 +658,96 @@ function ProviderModelComparison({
             {run.experiment} · {formatTimestamp(run.started_at)}
           </p>
         </div>
-        <PassRatePill rate={run.pass_rate} />
+        <div className="flex flex-wrap items-center gap-3">
+          <ProviderModelDisplayToggle mode={displayMode} onChange={setDisplayMode} />
+          <PassRatePill rate={run.pass_rate} />
+        </div>
       </div>
-      <div className="overflow-x-auto rounded-lg border border-gray-800">
-        <table className="w-full min-w-[760px] text-left text-sm">
-          <thead className="border-b border-gray-800 bg-gray-900/50">
-            <tr>
-              <th className="sticky left-0 z-10 w-52 bg-gray-900/90 px-4 py-3 font-medium text-gray-400 backdrop-blur">
-                Test case
-              </th>
-              {model.providerLabels.map((label) => (
-                <th key={label} className="min-w-[240px] px-4 py-3 font-medium text-gray-300">
-                  {label}
+      {rows.length > 0 ? (
+        <div className="overflow-x-auto rounded-lg border border-gray-800">
+          <table className="w-full min-w-[760px] text-left text-sm">
+            <thead className="border-b border-gray-800 bg-gray-900/50">
+              <tr>
+                <th className="sticky left-0 z-10 w-52 bg-gray-900/90 px-4 py-3 font-medium text-gray-400 backdrop-blur">
+                  Test case
                 </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-800/50">
-            {model.rows.map((row) => (
-              <tr key={row.testId} className="align-top transition-colors hover:bg-gray-900/30">
-                <td className="sticky left-0 z-10 bg-gray-950/90 px-4 py-3 font-medium text-gray-200 backdrop-blur">
-                  {row.testId}
-                </td>
                 {model.providerLabels.map((label) => (
-                  <td key={label} className="px-4 py-3">
-                    <ProviderModelResultCell
-                      run={run}
-                      result={row.resultsByProvider.get(label)}
-                      projectId={projectId}
-                    />
-                  </td>
+                  <th key={label} className="min-w-[240px] px-4 py-3 font-medium text-gray-300">
+                    {label}
+                  </th>
                 ))}
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+            </thead>
+            <tbody className="divide-y divide-gray-800/50">
+              {rows.map((row) => (
+                <tr key={row.testId} className="align-top transition-colors hover:bg-gray-900/30">
+                  <td className="sticky left-0 z-10 bg-gray-950/90 px-4 py-3 font-medium text-gray-200 backdrop-blur">
+                    {row.testId}
+                  </td>
+                  {model.providerLabels.map((label) => (
+                    <td key={label} className="px-4 py-3">
+                      <ProviderModelResultCell
+                        run={run}
+                        result={row.resultsByProvider.get(label)}
+                        projectId={projectId}
+                      />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <Notice
+          headline="All compared rows match"
+          body="Switch back to All rows to inspect the full provider/model table."
+        />
+      )}
     </section>
+  );
+}
+
+function ProviderModelDisplayToggle({
+  mode,
+  onChange,
+}: {
+  mode: ProviderModelDisplayMode;
+  onChange: (mode: ProviderModelDisplayMode) => void;
+}) {
+  return (
+    <fieldset className="inline-flex items-center rounded-lg border border-gray-800 bg-gray-900/50 p-1">
+      <legend className="sr-only">Provider/model rows</legend>
+      <DisplayModeButton active={mode === 'all'} onClick={() => onChange('all')}>
+        All
+      </DisplayModeButton>
+      <DisplayModeButton active={mode === 'differing'} onClick={() => onChange('differing')}>
+        Differing
+      </DisplayModeButton>
+    </fieldset>
+  );
+}
+
+function DisplayModeButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+        active ? 'bg-gray-800 text-cyan-400 shadow-sm' : 'text-gray-400 hover:text-gray-200'
+      }`}
+    >
+      {children}
+    </button>
   );
 }
 
@@ -779,7 +870,7 @@ function providerLabelsForRun(run: CompareRunEntry): string[] {
 
 function buildProviderModelTable(run: CompareRunEntry): {
   providerLabels: string[];
-  rows: Array<{ testId: string; resultsByProvider: Map<string, CompareTestResult> }>;
+  rows: ProviderModelRow[];
 } | null {
   const providerLabels = providerLabelsForRun(run);
   if (providerLabels.length <= 1) return null;
@@ -800,6 +891,41 @@ function buildProviderModelTable(run: CompareRunEntry): {
       resultsByProvider,
     })),
   };
+}
+
+interface ProviderModelRow {
+  testId: string;
+  resultsByProvider: Map<string, CompareTestResult>;
+}
+
+function providerModelRowDiffers(
+  row: ProviderModelRow,
+  providerLabels: readonly string[],
+): boolean {
+  const signatures = new Set<string>();
+  for (const label of providerLabels) {
+    signatures.add(providerModelResultSignature(row.resultsByProvider.get(label)));
+    if (signatures.size > 1) return true;
+  }
+  return false;
+}
+
+function providerModelResultSignature(result: CompareTestResult | undefined): string {
+  if (!result) return 'missing';
+  return JSON.stringify({
+    answer: result.answer ?? '',
+    output: compareOptionalString(result, 'output'),
+    passed: result.passed,
+    score: result.score,
+    state: result.execution_status ?? '',
+    error: compareOptionalString(result, 'error'),
+    errorKind: compareOptionalString(result, 'target_error_kind'),
+  });
+}
+
+function compareOptionalString(result: CompareTestResult, key: string): string {
+  const value = (result as CompareTestResult & Record<string, unknown>)[key];
+  return typeof value === 'string' ? value : '';
 }
 
 function artifactHref(


### PR DESCRIPTION
## Summary

Dashboard reviewers can now switch provider/model comparison from All rows to Differing rows, so matching test cases no longer clutter model selection. The filter stays local to Analytics and derives from the existing `/api/compare` run data, comparing answer/output text, pass/fail, score, execution status, and error state without changing run artifacts. When every compared provider/model row matches, the panel shows an all-matching empty state instead of an empty table.

## Validation

- `bun test apps/dashboard/src/components/AnalyticsTab.test.tsx`
- `bunx biome check apps/dashboard/src/components/AnalyticsTab.tsx apps/dashboard/src/components/AnalyticsTab.test.tsx`
- `bun --filter @agentv/core build && bun --filter @agentv/dashboard build`
- Browser UAT with `agent-browser` against temporary run bundles served through `bun apps/cli/src/cli.ts dashboard --dir ... --single`, covering All mode, Differing mode, and the all-matching empty state.

## Evidence

Private evidence: EntityProcess/agentv-private `evidence/av-9ywp1-differing-filter` at `6073050`.

## Related

- av-9ywp.1

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
